### PR TITLE
docs: Fix "Authoring Components" references

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -21,7 +21,7 @@ There are several key design decisions that underpin MDC-Web Foundation:
 
 The aim being to push forward a clear separation of concerns, with the Foundation code being entirely about UI-related matters - as opposed to data-binding, templating, key/input handling, etc. In the case of Vanilla, we take a plain JS approach towards wrapping Foundation and providing the necessary code to make things usable out-of-the-box.
 
-For a tutorial on how to get started building components, check out [How to Build a Component](./how-to-build-a-component.md)
+For a tutorial on how to get started building components, check out [Authoring Components](./authoring-components.md)
 
 For an in-depth look at MDC-Web's architecture, check out [architecture.md](./architecture.md)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -275,4 +275,4 @@ your own code, for maximum flexibility, modularity, and code size reduction.
 
 If you'd like to contribute to
 MDC-Web and build your own components, or extend one of ours to fit your own purposes, check out our
-guide on [how to build a component](./how-to-build-a-component.md).
+guide on [authoring components](./authoring-components.md).

--- a/docs/how-to-build-a-component.md
+++ b/docs/how-to-build-a-component.md
@@ -1,1 +1,0 @@
-_Coming Soon!_


### PR DESCRIPTION
- Remove empty `how-to-build-a-component.md` doc
- Update placeholder links which referenced above doc to point to
  `authoring-components.md`