### PR TITLE
docs(community-guidelines): how to find work as a member of the community

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 We'd love for you to contribute and make Material Components for the web even better than it is today!
 Here are the guidelines we'd like you to follow:
 
-- [Finding an Issue to Work On](#finding-an-issue-to-work-on)
 - [General Contributing Guidelines](#general-contributing-guidelines)
+- [Finding an Issue to Work On](#finding-an-issue-to-work-on)
 - [Development Process](#development-process)
   - [Setting up your development environment](#setting-up-your-development-environment)
   - [Building Components](#building-components)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We'd love for you to contribute and make Material Components for the web even better than it is today!
 Here are the guidelines we'd like you to follow:
 
-- [Find an Issue to Work On](#find-an-issue-to-work-on)
+- [Finding an Issue to Work On](#finding-an-issue-to-work-on)
 - [General Contributing Guidelines](#general-contributing-guidelines)
 - [Development Process](#development-process)
   - [Setting up your development environment](#setting-up-your-development-environment)
@@ -17,13 +17,13 @@ Here are the guidelines we'd like you to follow:
   - [Releasing MDC-Web](#releasing-mdc-web)
 - ["What's the core team up to?"](#whats-the-core-team-up-to)
 
-## Find an Issue to Work On
-
-Material Components Web uses GitHub to file and track issues. To find an issue you'd like to work on, filter the issues list by the `help wanted` label, or [click here](https://github.com/material-components/material-components-web/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22). If you have found a bug, or would like to request a feature not represented in the list of GitHub issues, please refer to the documentation for [Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#issues-and-bugs)
-
 ## General Contributing Guidelines
 
 The Material Components contributing policies and procedures can be found in the main Material Components documentation repository’s [contributing page](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md).
+
+## Finding an Issue to Work On
+
+Material Components Web uses GitHub to file and track issues. To find an issue you'd like to work on, filter the issues list by the `help wanted` label, or [click here](https://github.com/material-components/material-components-web/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22). If you have found a bug, or would like to request a feature not represented in the list of GitHub issues, please refer to the documentation for [Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#issues-and-bugs)
 
 ## Development Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We'd love for you to contribute and make Material Components for the web even better than it is today!
 Here are the guidelines we'd like you to follow:
 
-
+- [Find an Issue to Work On](#find-an-issue-to-work-on)
 - [General Contributing Guidelines](#general-contributing-guidelines)
 - [Development Process](#development-process)
   - [Setting up your development environment](#setting-up-your-development-environment)
@@ -16,6 +16,10 @@ Here are the guidelines we'd like you to follow:
   - [Submitting Pull Requests](#submitting-pull-requests)
   - [Releasing MDC-Web](#releasing-mdc-web)
 - ["What's the core team up to?"](#whats-the-core-team-up-to)
+
+## Find an Issue to Work On
+
+Material Components Web uses GitHub to file and track issues. To find an issue you'd like to work on, filter the issues list by the `help wanted` label, or [click here](https://github.com/material-components/material-components-web/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22). If you have found a bug, or would like to request a feature not represented in the list of GitHub issues, please refer to the documentation for [Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#issues-and-bugs)
 
 ## General Contributing Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ The Material Components contributing policies and procedures can be found in the
 
 ## Finding an Issue to Work On
 
-Material Components Web uses GitHub to file and track issues. To find an issue you'd like to work on, filter the issues list by the `help wanted` label, or [click here](https://github.com/material-components/material-components-web/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22). If you have found a bug, or would like to request a feature not represented in the list of GitHub issues, please refer to the documentation for [Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#issues-and-bugs)
+Material Components Web uses GitHub to file and track issues. To find an issue you'd like to work on, filter the issues list by the [help wanted](https://github.com/material-components/material-components-web/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) label. If you have found a bug, or would like to request a feature not represented in the list of GitHub issues, please refer to the documentation for [Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#issues-and-bugs)
 
 ## Development Process
 


### PR DESCRIPTION
Addresses the lack of documentation on how to find an issue to work on as a member of the MDC Web community.