### PR TITLE
fix(checkbox): Make DOM access lazy to avoid SSR problems.

### DIFF
--- a/packages/mdc-checkbox/constants.js
+++ b/packages/mdc-checkbox/constants.js
@@ -29,15 +29,20 @@ export const cssClasses = {
   ANIM_INDETERMINATE_UNCHECKED: `${ANIM}-indeterminate-unchecked`,
 };
 
+export function dom() {
+  return {
+    ANIM_END_EVENT_NAME: (() => {
+      const el = document.createElement('div');
+      // NOTE: We can immediately assume that the prefix is 'webkit' in browsers that don't
+      // support unprefixed animations since the only browsers up to two major versions back that
+      // don't support unprefixed names are mobile Safari and Android native browser, both of
+      // which use the 'webkit' prefix.
+      return 'animation' in el.style ? 'animationend' : 'webkitAnimationEnd';
+    })(),
+  };
+}
+
 export const strings = {
-  ANIM_END_EVENT_NAME: (() => {
-    const el = document.createElement('div');
-    // NOTE: We can immediately assume that the prefix is 'webkit' in browsers that don't
-    // support unprefixed animations since the only browsers up to two major versions back that
-    // don't support unprefixed names are mobile Safari and Android native browser, both of
-    // which use the 'webkit' prefix.
-    return 'animation' in el.style ? 'animationend' : 'webkitAnimationEnd';
-  })(),
   NATIVE_CONTROL_SELECTOR: `.${ROOT}__native-control`,
   TRANSITION_STATE_INIT: 'init',
   TRANSITION_STATE_CHECKED: 'checked',

--- a/packages/mdc-checkbox/foundation.js
+++ b/packages/mdc-checkbox/foundation.js
@@ -15,7 +15,7 @@
  */
 
 import {MDCFoundation} from '@material/base';
-import {cssClasses, strings, numbers} from './constants';
+import {cssClasses, strings, numbers, dom} from './constants';
 
 const CB_PROTO_PROPS = ['checked', 'indeterminate'];
 
@@ -26,6 +26,11 @@ export default class MDCCheckboxFoundation extends MDCFoundation {
 
   static get strings() {
     return strings;
+  }
+
+  static get dom() {
+    delete MDCCheckboxFoundation.dom;
+    return MDCCheckboxFoundation.dom = dom();
   }
 
   static get numbers() {

--- a/packages/mdc-checkbox/index.js
+++ b/packages/mdc-checkbox/index.js
@@ -30,7 +30,7 @@ export class MDCCheckbox extends MDCComponent {
   }
 
   getDefaultFoundation() {
-    const {ANIM_END_EVENT_NAME} = MDCCheckboxFoundation.strings;
+    const {ANIM_END_EVENT_NAME} = MDCCheckboxFoundation.dom;
     return new MDCCheckboxFoundation({
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/test/unit/mdc-checkbox/mdc-checkbox.test.js
+++ b/test/unit/mdc-checkbox/mdc-checkbox.test.js
@@ -20,7 +20,7 @@ import domEvents from 'dom-events';
 import td from 'testdouble';
 
 import {MDCCheckbox} from '../../../packages/mdc-checkbox';
-import {strings} from '../../../packages/mdc-checkbox/constants';
+import {strings, dom} from '../../../packages/mdc-checkbox/constants';
 
 function getFixture() {
   return bel`
@@ -102,7 +102,7 @@ test('adapter#registerAnimationEndHandler adds an animation end event listener o
   const {root, component} = setupTest();
   const handler = td.func('animationEndHandler');
   component.getDefaultFoundation().adapter_.registerAnimationEndHandler(handler);
-  domEvents.emit(root, strings.ANIM_END_EVENT_NAME);
+  domEvents.emit(root, dom().ANIM_END_EVENT_NAME);
 
   t.doesNotThrow(() => td.verify(handler(td.matchers.anything())));
   t.end();
@@ -111,10 +111,10 @@ test('adapter#registerAnimationEndHandler adds an animation end event listener o
 test('adapter#deregisterAnimationEndHandler removes an animation end event listener on the root el', (t) => {
   const {root, component} = setupTest();
   const handler = td.func('animationEndHandler');
-  root.addEventListener(strings.ANIM_END_EVENT_NAME, handler);
+  root.addEventListener(dom().ANIM_END_EVENT_NAME, handler);
 
   component.getDefaultFoundation().adapter_.deregisterAnimationEndHandler(handler);
-  domEvents.emit(root, strings.ANIM_END_EVENT_NAME);
+  domEvents.emit(root, dom().ANIM_END_EVENT_NAME);
 
   t.doesNotThrow(() => td.verify(handler(td.matchers.anything()), {times: 0}));
   t.end();


### PR DESCRIPTION
So... I'm working on trying out getting SSR working with VueJS 2.0 and my (early) WIP VueJS binding, and the access of `document` in the `constants.js` of many packages for looking up things like `ANIM_END_EVENT_NAME` bombs as one would expect.

Here is a proposed change to the way those "constants" are looked up to be on-demand and lazy loaded once, with mdc-checkbox as the example.

Thoughts on the approach? If you like it, I'm happy to do the same changes for other components.