### PR TITLE
fix(scripts): Update determine-pkg-versions to use new pkg names

### DIFF
--- a/scripts/determine-pkg-versions.js
+++ b/scripts/determine-pkg-versions.js
@@ -85,7 +85,7 @@ const commitMatches = childProcess
     };
   })
   .filter((info) => Boolean(info) && affectsPackage(info.scope));
-const componentPkgs = updatedPkgs.filter(({name}) => name !== 'material-components-web');
+const componentPkgs = updatedPkgs.filter(({name}) => name.indexOf('@material') === 0);
 const mdcPkg = updatedPkgs.find(({name}) => name === 'material-components-web');
 const newPkgVersions = collectNewPkgVersions(componentPkgs, commitMatches);
 const newMDCVersion = {
@@ -133,7 +133,7 @@ function determineVersion(pkg, commitInfos) {
 function pickBestVersionInfo(pkg) {
   return (currentBest, commitInfo) => {
     const {version, changeType} = currentBest;
-    const pkgComponent = pkg.name.match(/^mdc\-(.+)$/)[1];
+    const pkgComponent = pkg.name.split('/')[1];
     if (commitInfo.scope !== pkgComponent) {
       return currentBest;
     }
@@ -143,7 +143,8 @@ function pickBestVersionInfo(pkg) {
       possibleNewChangeType = semver.major(pkg.version) === 0 ? VersionType.MINOR : VersionType.MAJOR;
     } else if (commitInfo.type === 'feat') {
       possibleNewChangeType = VersionType.MINOR;
-    } else if (commitInfo.type === 'fix') {
+    } else {
+      // fix, docs, style (refers to coding style), refactor (non-breaking change), chore, ...
       possibleNewChangeType = VersionType.PATCH;
     }
     // Note that we assume that pkg.version is valid by the time we get here.


### PR DESCRIPTION
determine-pkg-versions was erroring because it was assumes the `name`
key in each component's package.json to be `mdc-*`, rather than
`@material/*`. This commit fixes that issue.

Additionally, it allows _all_ commit types to constitute at least a
patch version bump. For example, a docs change, chore, or non-breaking
refactor to a component could all be considered worthy of a patch
version update. This ensures that our latest and greatest code and docs
are available on npm whenever we release.

[ci skip]