### PR TITLE
docs(mdc-ripple): clarify language under JS implementation instructions

### DIFF
--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -168,7 +168,7 @@ const MDCRipple = mdc.ripple.MDCRipple;
 const MDCRippleFoundation = mdc.ripple.MDCRippleFoundation;
 ```
 
-Then, simply attach initialize the ripple with the correct DOM.
+Then, simply initialize the ripple with the correct DOM element.
 
 ```javascript
 const surface = document.querySelector('.surface');


### PR DESCRIPTION
resolves #161 