### PR TITLE
chore(build): Transpile JS source of mdc-animation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ const createBannerPlugin = () => new webpack.BannerPlugin([
 module.exports = [{
   name: 'js-components',
   entry: {
+    animation: [path.resolve('./packages/mdc-animation/index.js')],
     autoInit: [path.resolve('./packages/mdc-auto-init/index.js')],
     base: [path.resolve('./packages/mdc-base/index.js')],
     checkbox: [path.resolve('./packages/mdc-checkbox/index.js')],


### PR DESCRIPTION
This fixes browser compatibility issues *(caused by ES moudle syntax)* by letting `@material/animation/dist/mdc.animation` be used instead of `@material/animation`.

If this gets merged, please release a new minor version of the `@material/animation` package.