### PR TITLE
Feat: Add ripples to buttons and FABs

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -189,5 +189,26 @@
       </section>
     </main>
     <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script>
+      // Because we load our CSS via webpack, we need to ensure that all of the correct styles
+      // are applied before ripples are attached. Otherwise, ripples may use the computed styles of
+      // elements before our CSS is applied, leading to improper UX.
+      (function() {
+        var pollId = 0;
+        pollId = setInterval(function() {
+          var pos = getComputedStyle(document.querySelector('.mdc-button')).position;
+          if (pos === 'relative') {
+            init();
+            clearInterval(pollId);
+          }
+        }, 250);
+        function init() {
+          var btns = document.querySelectorAll('.mdc-button');
+          for (var i = 0, btn; btn = btns[i]; i++) {
+            mdc.ripple.MDCRipple.attachTo(btn);
+          }
+        }
+      })();
+    </script>
   </body>
 </html>

--- a/demos/fab.html
+++ b/demos/fab.html
@@ -104,5 +104,26 @@
       </section>
     </main>
     <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script>
+      // Because we load our CSS via webpack, we need to ensure that all of the correct styles
+      // are applied before ripples are attached. Otherwise, ripples may use the computed styles of
+      // elements before our CSS is applied, leading to improper UX.
+      (function() {
+        var pollId = 0;
+        pollId = setInterval(function() {
+          var pos = getComputedStyle(document.querySelector('.mdc-fab.material-icons')).position;
+          if (pos === 'relative') {
+            init();
+            clearInterval(pollId);
+          }
+        }, 250);
+        function init() {
+          var fabs = document.querySelectorAll('.mdc-fab');
+          for (var i = 0, fab; fab = fabs[i]; i++) {
+            mdc.ripple.MDCRipple.attachTo(fab);
+          }
+        }
+      })();
+    </script>
   </body>
 </html>

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -45,6 +45,25 @@ npm install --save @material/button
 </button>
 ```
 
+### Adding ripples to buttons
+
+To add the ink ripple effect to a button, attach a [ripple](../packages/mdc-ripple) instance to the
+button element.
+
+```js
+mdc.ripple.MDCRipple.attachTo(document.querySelector('.mdc-button'));
+```
+
+You can also do this declaratively when using the [material-components-web](../packages/material-components-web) package.
+
+```html
+<button class="mdc-button" data-mdc-auto-init="MDCRipple">
+  Flat button
+</button>
+```
+
+Buttons are fully aware of ripple styles, so no DOM or CSS changes are required to use them.
+
 ## Classes
 
 ### Block

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -1,27 +1,27 @@
-/**
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 @import "@material/animation/variables";
 @import "@material/animation/functions";
 @import "@material/elevation/mixins";
+@import "@material/ripple/mixins";
 @import "@material/theme/mixins";
 @import "@material/typography/mixins";
 
-/* postcss-bem-linter: define button */
-/* stylelint-disable declaration-property-unit-whitelist */
+// postcss-bem-linter: define button
 .mdc-button {
   @include mdc-typography(body2);
   @include mdc-theme-prop(color, text-primary-on-light);
@@ -35,9 +35,9 @@
   border-radius: 2px;
   outline: none;
   background: transparent;
-  font-size: 14px; /* Override font to specifically be px as spec defined pt */
+  font-size: 14px; // Override font to specifically be px as spec defined pt
   font-weight: 500;
-  line-height: 36px; /* Override line-height so text aligns centered */
+  line-height: 36px; // Override line-height so text aligns centered
   text-align: center;
   text-transform: uppercase;
   vertical-align: middle;
@@ -49,7 +49,7 @@
     @include mdc-theme-prop(color, text-primary-on-dark);
   }
 
-  /* postcss-bem-linter: ignore */
+  // postcss-bem-linter: ignore
   &::before {
     position: absolute;
     top: 0;
@@ -71,11 +71,9 @@
   &:active::before {
     transition: mdc-animation-enter(opacity, 120ms);
 
-    /*
-      Slightly darker value for visual distinction.
-      This allows a full base that has distinct modes.
-      Progressive enhancement with ripples will provide complete button spec alignment.
-    */
+    // Slightly darker value for visual distinction.
+    // This allows a full base that has distinct modes.
+    // Progressive enhancement with ripples will provide complete button spec alignment.
     opacity: .18;
   }
 
@@ -98,7 +96,7 @@
 
   &--dense {
     height: 32px;
-    font-size: .8125rem; /* 13sp */
+    font-size: .8125rem; // 13sp
     line-height: 32px;
   }
 
@@ -115,15 +113,12 @@
     @include mdc-theme-dark(".mdc-button") {
       @include mdc-theme-prop(background-color, primary);
 
-      /* postcss-bem-linter: ignore */
+      // postcss-bem-linter: ignore
       &::before {
-        /*
-          We are explicitly not fully adhering to Material Design here.
-          This should be the 700-shade when active instead of a black shade.
-          Due to the complexity involved in adhering fully it is being ignored.
-          Instead re-using the existing architecture for shading works just fine.
-          - With <3 from Garbee
-        */
+        // We are explicitly not fully adhering to Material Design here.
+        // This should be the 700-shade when active instead of a black shade.
+        // Due to the complexity involved in adhering fully it is being ignored.
+        // Instead re-using the existing architecture for shading works just fine.
         color: black;
       }
     }
@@ -136,12 +131,12 @@
       @include mdc-theme-prop(color, primary);
     }
 
-    /* postcss-bem-linter: ignore */
+    // postcss-bem-linter: ignore
     &.mdc-button--raised {
       @include mdc-theme-prop(background-color, primary);
       @include mdc-theme-prop(color, text-primary-on-primary);
 
-      /* postcss-bem-linter: ignore */
+      // postcss-bem-linter: ignore
       &::before {
         color: black;
       }
@@ -155,12 +150,12 @@
       @include mdc-theme-prop(color, accent);
     }
 
-    /* postcss-bem-linter: ignore */
+    // postcss-bem-linter: ignore
     &.mdc-button--raised {
       @include mdc-theme-prop(background-color, accent);
       @include mdc-theme-prop(color, text-primary-on-accent);
 
-      /* postcss-bem-linter: ignore */
+      // postcss-bem-linter: ignore
       &::before {
         color: black;
       }
@@ -171,7 +166,6 @@
     padding: 0 8px;
   }
 
-  /* stylelint-disable selector-no-type */
   fieldset:disabled &,
   &:disabled {
     color: rgba(0, 0, 0, .26);
@@ -196,4 +190,33 @@
   }
 }
 
-/* postcss-bem-linter: end */
+// postcss-bem-linter: end
+
+.mdc-button.mdc-ripple-upgraded {
+  @include mdc-ripple-base;
+  @include mdc-ripple-bg((pseudo: "::before"));
+  @include mdc-ripple-fg((pseudo: "::after"));
+
+  overflow: hidden;
+
+  @include mdc-theme-dark(".mdc-button", true) {
+    @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
+    @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
+  }
+
+  @each $theme-style in (primary, accent) {
+    &.mdc-button--#{$theme-style} {
+      @include mdc-ripple-bg((pseudo: "::before", theme-style: $theme-style, opacity: .12));
+      @include mdc-ripple-fg((pseudo: "::after", theme-style: $theme-style, opacity: .12));
+    }
+  }
+}
+
+.mdc-button--raised.mdc-ripple-upgraded {
+  @each $theme-style in (primary, accent) {
+    &.mdc-button--#{$theme-style} {
+      @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
+      @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
+    }
+  }
+}

--- a/packages/mdc-button/package.json
+++ b/packages/mdc-button/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@material/animation": "^0.1.1",
     "@material/elevation": "^0.1.1",
+    "@material/ripple": "^0.1.1",
     "@material/theme": "^0.1.0",
     "@material/typography": "^0.1.0"
   }

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -14,7 +14,7 @@ npm install --save @material/fab
 ## Usage
 
 The demonstrations use the [Material Design Icon Font](https://design.google.com/icons/).
-You may include this to use them as shown or use any other icon method you wish. 
+You may include this to use them as shown or use any other icon method you wish.
 
 ### Default
 
@@ -81,6 +81,27 @@ Developers must position it as-needed within their applications designs.
 
 > **Note** In this example we are using an SVG icon. When you are using SVG icons do _not_ specifiy the `fill` attribute. Fill is set by the components where SVGs may be used.
 
+### Adding ripples to FABs
+
+To add the ink ripple effect to a FAB, attach a [ripple](../packages/mdc-ripple) instance to the
+FAB element.
+
+```js
+mdc.ripple.MDCRipple.attachTo(document.querySelector('.mdc-fab'));
+```
+
+You can also do this declaratively when using the [material-components-web](../packages/material-components-web) package.
+
+```html
+<button class="mdc-fab material-icons" aria-label="Favorite" data-mdc-auto-init="MDCRipple">
+  <span class="mdc-fab__icon">
+    favorite
+  </span>
+</button>
+```
+
+FABs are fully aware of ripple styles, so no DOM or CSS changes are required to use them.
+
 ## Classes
 
 ### Block
@@ -88,7 +109,7 @@ Developers must position it as-needed within their applications designs.
 The block class is `mdc-fab`. This defines the top-level button element.
 
 ### Element
-The button component has a single `span` element added as a child of the button due to buttons not adhering to flexbox rules 
+The button component has a single `span` element added as a child of the button due to buttons not adhering to flexbox rules
 in all browsers. See [this Stackoverflow post](http://stackoverflow.com/posts/35466231/revisions) for details.
 
 ### Modifier

--- a/packages/mdc-fab/mdc-fab.scss
+++ b/packages/mdc-fab/mdc-fab.scss
@@ -1,25 +1,24 @@
-/**
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 @import "@material/animation/functions";
 @import "@material/animation/variables";
 @import "@material/elevation/mixins";
+@import "@material/ripple/mixins";
 @import "@material/theme/mixins";
 
-/* postcss-bem-linter: define fab */
+// postcss-bem-linter: define fab
 .mdc-fab {
   display: inline-flex;
   position: relative;
@@ -98,17 +97,15 @@
     border: 0;
   }
 
-  /*
-    This allows for using SVGs within them to align properly in all browsers.
-    Can remove once: https://bugzilla.mozilla.org/show_bug.cgi?id=1294515 is resolved.
-  */
+  // This allows for using SVGs within them to align properly in all browsers.
+  // Can remove once: https://bugzilla.mozilla.org/show_bug.cgi?id=1294515 is resolved.
 
-  /* stylelint-disable selector-no-type */
-
-  /* postcss-bem-linter: ignore */
+  // stylelint-disable selector-no-type
+  // postcss-bem-linter: ignore
   > svg {
     width: 100%;
   }
+  // stylelint-enable selector-no-type
 
   fieldset:disabled &,
   &:disabled {
@@ -126,4 +123,17 @@
   width: 100%;
 }
 
-/* postcss-bem-linter: end */
+// postcss-bem-linter: end
+
+.mdc-fab.mdc-ripple-upgraded {
+  @include mdc-ripple-base;
+  @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .16));
+  @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .16));
+
+  overflow: hidden;
+}
+
+.mdc-fab--plain.mdc-ripple-upgraded {
+  @include mdc-ripple-bg((pseudo: "::before"));
+  @include mdc-ripple-fg((pseudo: "::after"));
+}

--- a/packages/mdc-fab/package.json
+++ b/packages/mdc-fab/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@material/animation": "^0.1.1",
     "@material/elevation": "^0.1.1",
+    "@material/ripple": "^0.1.1",
     "@material/theme": "^0.1.0"
   }
 }


### PR DESCRIPTION
- Add ink ripple support to standard buttons
- Add ink ripple support to FABs

Note: This PR should be **rebased and merged**, not squashed and merged. This is because it contains two separate commits for FABs and Buttons.