### PR TITLE
feat(list): Add interactivity and ink ripple support to mdc-list-item

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+demos/ linguist-documentation
+docs/ linguist-documentation
+framework-examples/ linguist-documentation

--- a/demos/list.html
+++ b/demos/list.html
@@ -966,6 +966,55 @@
             </div>
           </section>
         </section>
+        <section>
+          <h2>Interactive Lists (with ink ripple)</h2>
+          <section>
+            <h3>Example - Interactive List</h3>
+            <nav class="mdc-list" data-demo-interactive-list>
+              <a href="#" class="mdc-list-item">
+                <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+                  network_wifi
+                </i>
+                Wi-Fi
+              </a>
+              <a href="#" class="mdc-list-item">
+                <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+                  bluetooth
+                </i>
+                Bluetooth
+              </a>
+              <a href="#" class="mdc-list-item">
+                <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+                  data_usage
+                </i>
+                Data Usage
+              </a>
+            </nav>
+          </section>
+          <section class="mdc-theme--dark">
+            <h3>Example - Interactive List (Dark Theme)</h3>
+            <nav class="mdc-list" data-demo-interactive-list>
+              <a href="#" class="mdc-list-item">
+                <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+                  network_wifi
+                </i>
+                Wi-Fi
+              </a>
+              <a href="#" class="mdc-list-item">
+                <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+                  bluetooth
+                </i>
+                Bluetooth
+              </a>
+              <a href="#" class="mdc-list-item">
+                <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+                  data_usage
+                </i>
+                Data Usage
+              </a>
+            </nav>
+          </section>
+        </section>
       </div>
     </main>
     <script src="/assets/material-components-web.js"></script>
@@ -980,6 +1029,22 @@
             demoWrapper.removeAttribute('dir');
           }
         });
+
+        // Delay initialization within development until styles have loaded
+        setTimeout(initInteractiveLists, 250);
+
+        function initInteractiveLists() {
+          var interactiveListItems = document.querySelectorAll(
+            '[data-demo-interactive-list] .mdc-list-item'
+          );
+          for (var i = 0, li; li = interactiveListItems[i]; i++) {
+            mdc.ripple.MDCRipple.attachTo(li);
+            // Prevent link clicks from jumping demo to the top of the page
+            li.addEventListener('click', function(evt) {
+              evt.preventDefault();
+            });
+          }
+        }
       })();
     </script>
   </body>

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -174,6 +174,37 @@ details can be configured.
 > NOTE: If using controls such as a switch (_TK!_) within a list detail, you may need to override
 > the width and height styles set on the detail element.
 
+### Using ink ripples for interactive lists
+
+MDC List supports adding ripples to `mdc-list-item` elements, for example in the case of a nav menu.
+To add ripples to lists, simply attach a ripple to all list items. Note that this can be easily done
+via `mdc-auto-init` when using the [material-components-web](../packages/material-components-web).
+
+```html
+<nav class="mdc-list">
+  <a href="/wifi" class="mdc-list-item" data-mdc-auto-init="MDCRipple">
+    <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+      network_wifi
+    </i>
+    Wi-Fi
+  </a>
+  <a href="/bluetooth" class="mdc-list-item" data-mdc-auto-init="MDCRipple">
+    <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+      bluetooth
+    </i>
+    Bluetooth
+  </a>
+  <a href="/data-usage" class="mdc-list-item" data-mdc-auto-init="MDCRipple">
+    <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">
+      data_usage
+    </i>
+    Data Usage
+  </a>
+</nav>
+<script>
+  mdc.autoInit();
+</script>
+```
 
 ### List Dividers
 

--- a/packages/mdc-list/mdc-list.scss
+++ b/packages/mdc-list/mdc-list.scss
@@ -1,47 +1,44 @@
-/**
- * Copyright 2016 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+@import "@material/ripple/mixins";
 @import "@material/rtl/mixins";
 @import "@material/theme/mixins";
 @import "@material/typography/mixins";
 @import "@material/typography/variables";
 
-/**
- * Sets the width and height of a detail element to the specified dimension.
- */
+$mdc-list-side-padding: 16px;
+
+// Sets the width and height of a detail element to the specified dimension.
 @mixin mdc-list-detail-size_($size) {
   width: $size;
   height: $size;
 }
 
-/**
- * Sets the width and height of the start detail element, as well as calculates the margins for
- * the start detail element such that the text is always offset by 72px, which is defined within
- * the spec.
- */
+// Sets the width and height of the start detail element, as well as calculates the margins for
+// the start detail element such that the text is always offset by 72px, which is defined within
+// the spec.
 @mixin mdc-list-start-detail-size_($size) {
   $text-offset: 72px;
-  $side-padding: 16px;
+  $side-padding: $mdc-list-side-padding;
   $margin-value: $text-offset - $side-padding - $size;
 
   @include mdc-list-detail-size_($size);
   @include mdc-rtl-reflexive-box(margin, right, $margin-value, ".mdc-list-item");
 }
 
-/* postcss-bem-linter: define list */
+// postcss-bem-linter: define list
 
 .mdc-list {
   @include mdc-typography(subheading2);
@@ -52,10 +49,10 @@
   }
 
   margin: 0;
-  padding: 8px 16px 0;
+  padding: 8px $mdc-list-side-padding 0;
 
-  /* According to the mocks and stickersheet, the line-height is adjusted to 24px for text content,
-   * same as for subheading1. */
+  // According to the mocks and stickersheet, the line-height is adjusted to 24px for text content,
+  // same as for subheading1.
   line-height: map-get(map-get($mdc-typography-styles, subheading1), line-height);
   list-style-type: none;
 }
@@ -65,9 +62,9 @@
   font-size: .812rem;
 }
 
-/* postcss-bem-linter: end */
+// postcss-bem-linter: end
 
-/* postcss-bem-linter: define list-item */
+// postcss-bem-linter: define list-item
 
 .mdc-list-item {
   display: flex;
@@ -81,7 +78,7 @@
 
   &__end-detail {
     @include mdc-list-detail-size_(24px);
-    @include mdc-rtl-reflexive-property(margin, auto, 16px, ".mdc-list-item");
+    @include mdc-rtl-reflexive-property(margin, auto, $mdc-list-side-padding, ".mdc-list-item");
   }
 
   &__text {
@@ -96,16 +93,16 @@
         @include mdc-theme-prop(color, text-secondary-on-dark);
       }
 
-      /* Match the font size to the primary text when dense */
-      /* stylelint-disable plugin/selector-bem-pattern */
+      // Match the font size to the primary text when dense
+      // stylelint-disable plugin/selector-bem-pattern
       .mdc-list--dense & {
         font-size: inherit;
       }
-      /* stylelint-enable plugin/selector-bem-pattern */
+      // stylelint-enable plugin/selector-bem-pattern
     }
   }
 
-  /* stylelint-disable plugin/selector-bem-pattern */
+  // stylelint-disable plugin/selector-bem-pattern
   .mdc-list--dense & {
     height: 40px;
 
@@ -143,12 +140,43 @@
   .mdc-list--two-line.mdc-list--dense & {
     height: 60px;
   }
-  /* stylelint-enable plugin/selector-bem-pattern */
+  // stylelint-enable plugin/selector-bem-pattern
 }
 
-/* postcss-bem-linter: end */
+// postcss-bem-linter: end //
 
-/* postcss-bem-linter: define list-divider */
+// Override anchor tag styles for the use-case of a list being used for navigation
+// stylelint-disable selector-no-type,selector-no-qualifying-type
+a.mdc-list-item {
+  color: inherit;
+  text-decoration: none;
+}
+// stylelint-enable selector-no-type,selector-no-qualifying-type
+
+.mdc-list-item.mdc-ripple-upgraded {
+  @include mdc-ripple-base;
+  @include mdc-ripple-bg((pseudo: "::before"));
+  @include mdc-ripple-fg((pseudo: "::after"));
+
+  position: relative;
+  // Cause the upgraded list item to cover the entirety of the list, causing ripples to emanate
+  // across the entire list element.
+  left: $mdc-list-side-padding * -1;
+  width: calc(100% + #{$mdc-list-side-padding * 2});
+  padding: 0 $mdc-list-side-padding;
+  overflow: hidden;
+
+  &:focus {
+    outline: none;
+  }
+
+  @include mdc-theme-dark(".mdc-list") {
+    @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .12));
+    @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .12));
+  }
+}
+
+// postcss-bem-linter: define list-divider
 
 .mdc-list-divider {
   height: 0;
@@ -162,19 +190,19 @@
 }
 
 .mdc-list-divider--inset {
-  $mdc-list-divider-inset-amt: /* text offset */ 72px - /* padding offset */ 16px;
+  $mdc-list-divider-inset-amt: /* text offset */ 72px - /* padding offset */ $mdc-list-side-padding;
 
   @include mdc-rtl-reflexive-box(margin, left, $mdc-list-divider-inset-amt, ".mdc-list-group");
 
   width: calc(100% - #{$mdc-list-divider-inset-amt});
 }
 
-/* postcss-bem-linter: end */
+// postcss-bem-linter: end
 
-/* postcss-bem-linter: define list-group */
+// postcss-bem-linter: define list-group
 
 .mdc-list-group {
-  padding: 0 16px;
+  padding: 0 $mdc-list-side-padding;
 
   &__subheader {
     $mdc-list-subheader-virtual-height: 3rem;
@@ -192,12 +220,12 @@
     margin: $mdc-list-subheader-margin 0;
   }
 
-  /* Reset padding on mdc-list since it's already accounted for by the list group. */
-  /* stylelint-disable plugin/selector-bem-pattern */
+  // Reset padding on mdc-list since it's already accounted for by the list group.
+  // stylelint-disable plugin/selector-bem-pattern
   .mdc-list {
     padding: 0;
   }
-  /* stylelint-enable plugin/selector-bem-pattern */
+  // stylelint-enable plugin/selector-bem-pattern
 }
 
-/* postcss-bem-linter: end */
+// postcss-bem-linter: end

--- a/packages/mdc-list/package.json
+++ b/packages/mdc-list/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@material/rtl": "^0.1.0",
     "@material/typography": "^0.1.0",
+    "@material/ripple": "^0.1.1",
     "@material/theme": "^0.1.0"
   }
 }


### PR DESCRIPTION
- Ensure mdc-list-item looks correct when applied to an anchor tag
- Add ripple support to mdc-list-item
- Ensure that list items with ripples show the ripple across the list
  elemeng
- Tech debt: add gitattributes telling github not to include anything in
  demos/, docs/, or framework-examples/ when computing source code
  language statistics

Part of #20