### PR TITLE
docs(icon-toggle): Fix mis-named adapter API method in README

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-demos/ linguist-documentation
-docs/ linguist-documentation
-framework-examples/ linguist-documentation
+demos/* linguist-documentation
+docs/* linguist-documentation
+framework-examples/* linguist-documentation

--- a/packages/mdc-icon-toggle/README.md
+++ b/packages/mdc-icon-toggle/README.md
@@ -190,7 +190,7 @@ toggle on if true, off if false.
 
 Returns true if the foundation's state is disabled, false otherwise.
 
-##### MDCIconToggleFoundation.toggle(isDisabled: boolean) => void
+##### MDCIconToggleFoundation.setDisabled(isDisabled: boolean) => void
 
 Enables / disables the foundation's state, updating the component via the adapter methods.
 


### PR DESCRIPTION
`setDisabled` was named `toggle`.

Also fix `.gitattributes` file to properly track language statistics for
this repo.

Resolves #200
[ci skip]