### PR TITLE
chore(infrastructure): Disable SauceLabs temporarily on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# NOTE: All SauceLabs config info is commented out for now, as until we fix our test infrastructure
+# SL will continue to be flaky. Therefore, our tests will run on Firefox ESR using XVFB for the time
+# being.
+
 language: node_js
 node_js:
   - node # stable
@@ -5,25 +9,14 @@ node_js:
 branches:
   only:
     - master
-# TODO: remove when https://github.com/travis-ci/travis-ci/issues/6569 is fixed
 before_install:
   - 'if [[ -z "$SECURE" ]]; then echo "Using Firefox Fallback"; export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi;'
 env:
   global:
-    - SAUCE_USERNAME=material-sauce
-    # SECURE=true. This is used to help us determine whether or not we need to fall back to Firefox.
-    # TODO: remove when https://github.com/travis-ci/travis-ci/issues/6569 is fixed
-    - secure: AxiBF/aKR7YjYP9WYLcAoeFzm4d1XE0loDxk7+K8npWqWTnSnTe8ewrdPPmqHvQaeUqBYHRsFuBTxPXvPYDs2s5s7EUotLVU83Gh3iQw2dmBvuNi81sXlvXbYyJE7qZ/E418bEZBrfNaZ/Mm37ehoLs0+suSy3UjDacfPltObzF7vWedyOmZa5fRVd2/VoX11MMZybGJykUml4jSSg5qrve1P49SgybUaNnvwMMEzGuRi9jwSngvMsHtjS6uCHE/CWNJla3Zt3qjsKBPcwsSZHm/wNEX7frufZ7ReqTZjsMyOidPjlZfH8Yk5fgM610h7noWeav3l0CwsrEgWX0nFdop/3JUfWodqpXWVrTqd1scna4kFvfAcH9qltqXkxlRzetQrURsUiPHC4RkL8E9bUkol++JNhW4Cur287FxP4NVO5Mo3071dwBU7Jh/aQpq0ANJx/js5bZAUIDsEno3uHZe4LLMUBaowU1Jr03wZnis5A7w97kOz0HaUw0W1r5mBo7rB3Fb+CAUnFeVzxoSnkf2npJ1vai8HM7No+qnuV9I/C157LmATyY/UqBScbKe/kk7EeF/YBWfyaeWXxAi68Xmiw4PytAapRn7xfI56hZ28Dc/xdx2uDjPJnu5cKjDjDOxkdSoYO9eG7ZSSbIoD1MskaTjb2y9B6GlAmmSu/I=
+    # - SAUCE_USERNAME=material-sauce
+    # - secure: AxiBF/aKR7YjYP9WYLcAoeFzm4d1XE0loDxk7+K8npWqWTnSnTe8ewrdPPmqHvQaeUqBYHRsFuBTxPXvPYDs2s5s7EUotLVU83Gh3iQw2dmBvuNi81sXlvXbYyJE7qZ/E418bEZBrfNaZ/Mm37ehoLs0+suSy3UjDacfPltObzF7vWedyOmZa5fRVd2/VoX11MMZybGJykUml4jSSg5qrve1P49SgybUaNnvwMMEzGuRi9jwSngvMsHtjS6uCHE/CWNJla3Zt3qjsKBPcwsSZHm/wNEX7frufZ7ReqTZjsMyOidPjlZfH8Yk5fgM610h7noWeav3l0CwsrEgWX0nFdop/3JUfWodqpXWVrTqd1scna4kFvfAcH9qltqXkxlRzetQrURsUiPHC4RkL8E9bUkol++JNhW4Cur287FxP4NVO5Mo3071dwBU7Jh/aQpq0ANJx/js5bZAUIDsEno3uHZe4LLMUBaowU1Jr03wZnis5A7w97kOz0HaUw0W1r5mBo7rB3Fb+CAUnFeVzxoSnkf2npJ1vai8HM7No+qnuV9I/C157LmATyY/UqBScbKe/kk7EeF/YBWfyaeWXxAi68Xmiw4PytAapRn7xfI56hZ28Dc/xdx2uDjPJnu5cKjDjDOxkdSoYO9eG7ZSSbIoD1MskaTjb2y9B6GlAmmSu/I=
 addons:
-  # TODO: remove firefox when https://github.com/travis-ci/travis-ci/issues/6569 is fixed
   firefox: latest
-  sauce_connect: true
-  jwt:
-    secure: Z6mGHTjqv+eICZ+BscNnyzMGKJNwhZSzDS477VassOsCfPJ21idue/iEAzbz78bFKDxNoO+j6YCg/k+YP9/K1vbBRVCAJyWKqOMxo2Hr2lE3Ny4QO56sH0YoSebA85BBDkNNZtwwat8/mzSb8yqQOvYctt1YgnKZVlgHTkjxwygl7lqScvfSCmCAvraHAxdY3vLWpyo7fuz7SJigu1LXsjwKoWUF+rl6K0X+rhOUz1RH/+UHzqAABsszMwNkhu8P5Qlx0OHK6FsJ4vk6GrPtSHvKU/xMymdMMaAR2zVmiGISNT5CMZq+Ws4OLvH+9WOKZsgSa3k9QpJEloGt7qRK6OnYxXfQi9Wi3DXvL5nxDrRMb7b+Vf7H4C+oMq+rq1C1KojL5vbs5YKf080PJNhDiyti3H4AvIZI51X5QWL2pP96xdyJ0KQtYccjId8CIG6N5cHZQ59ShaNrulPdI+Jyp4dulO6MNyZJUYtNmSy1O+A0GejBrSavBXydS1zF4Gwfr7iseL1SPc8vauDYxu6zU34QRB2Ira56P+BgjLqZ6mDARnu/uiytRC4cbR2hr5YuHcn5riCb9w8GwI0l53STh63CoMiB5P+Doj5ZFyJZOId6JSckw3/oqx698oQYuqhJiC88Jt/9Vj9VqBGRk8uOcX4ZRgz4mO/6+2aUg/RaEjU=
-notifications:
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/8bceea29a64b5fb7f608
-    on_success: change
-    on_failure: always
-    on_start: never
+  # sauce_connect: true
+  # jwt:
+  #   secure: Z6mGHTjqv+eICZ+BscNnyzMGKJNwhZSzDS477VassOsCfPJ21idue/iEAzbz78bFKDxNoO+j6YCg/k+YP9/K1vbBRVCAJyWKqOMxo2Hr2lE3Ny4QO56sH0YoSebA85BBDkNNZtwwat8/mzSb8yqQOvYctt1YgnKZVlgHTkjxwygl7lqScvfSCmCAvraHAxdY3vLWpyo7fuz7SJigu1LXsjwKoWUF+rl6K0X+rhOUz1RH/+UHzqAABsszMwNkhu8P5Qlx0OHK6FsJ4vk6GrPtSHvKU/xMymdMMaAR2zVmiGISNT5CMZq+Ws4OLvH+9WOKZsgSa3k9QpJEloGt7qRK6OnYxXfQi9Wi3DXvL5nxDrRMb7b+Vf7H4C+oMq+rq1C1KojL5vbs5YKf080PJNhDiyti3H4AvIZI51X5QWL2pP96xdyJ0KQtYccjId8CIG6N5cHZQ59ShaNrulPdI+Jyp4dulO6MNyZJUYtNmSy1O+A0GejBrSavBXydS1zF4Gwfr7iseL1SPc8vauDYxu6zU34QRB2Ira56P+BgjLqZ6mDARnu/uiytRC4cbR2hr5YuHcn5riCb9w8GwI0l53STh63CoMiB5P+Doj5ZFyJZOId6JSckw3/oqx698oQYuqhJiC88Jt/9Vj9VqBGRk8uOcX4ZRgz4mO/6+2aUg/RaEjU=


### PR DESCRIPTION
- Clean up legacy notifications config

This is a temporary workaround for our CI until #143 and its subsequent
tasks are completed.