### PR TITLE
fix(checkbox): Use correct animation end event type in adapter

### DIFF
--- a/packages/mdc-checkbox/index.js
+++ b/packages/mdc-checkbox/index.js
@@ -64,9 +64,9 @@ export class MDCCheckbox extends MDCComponent {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
       registerAnimationEndHandler:
-        (handler) => this.root_.addEventListener(getCorrectEventName(window, 'animation'), handler),
+        (handler) => this.root_.addEventListener(getCorrectEventName(window, 'animationend'), handler),
       deregisterAnimationEndHandler:
-        (handler) => this.root_.removeEventListener(getCorrectEventName(window, 'animation'), handler),
+        (handler) => this.root_.removeEventListener(getCorrectEventName(window, 'animationend'), handler),
       registerChangeHandler: (handler) => this.nativeCb_.addEventListener('change', handler),
       deregisterChangeHandler: (handler) => this.nativeCb_.removeEventListener('change', handler),
       getNativeControl: () => this.nativeCb_,

--- a/test/unit/mdc-checkbox/mdc-checkbox.test.js
+++ b/test/unit/mdc-checkbox/mdc-checkbox.test.js
@@ -48,16 +48,6 @@ function getFixture() {
   `;
 }
 
-const windowObj = td.object({
-  document: {
-    createElement: (str) => ({
-      style: {
-        animation: 'none',
-      },
-    }),
-  },
-});
-
 function setupTest() {
   const root = getFixture();
   const component = new MDCCheckbox(root);
@@ -136,7 +126,7 @@ test('adapter#registerAnimationEndHandler adds an animation end event listener o
   const {root, component} = setupTest();
   const handler = td.func('animationEndHandler');
   component.getDefaultFoundation().adapter_.registerAnimationEndHandler(handler);
-  domEvents.emit(root, getCorrectEventName(windowObj, 'animation'));
+  domEvents.emit(root, getCorrectEventName(window, 'animationend'));
 
   t.doesNotThrow(() => td.verify(handler(td.matchers.anything())));
   t.end();
@@ -145,10 +135,11 @@ test('adapter#registerAnimationEndHandler adds an animation end event listener o
 test('adapter#deregisterAnimationEndHandler removes an animation end event listener on the root el', (t) => {
   const {root, component} = setupTest();
   const handler = td.func('animationEndHandler');
-  root.addEventListener(strings.ANIM_END_EVENT_NAME, handler);
+  const animEndEvtName = getCorrectEventName(window, 'animationend');
+  root.addEventListener(animEndEvtName, handler);
 
   component.getDefaultFoundation().adapter_.deregisterAnimationEndHandler(handler);
-  domEvents.emit(root, strings.ANIM_END_EVENT_NAME);
+  domEvents.emit(root, animEndEvtName);
 
   t.doesNotThrow(() => td.verify(handler(td.matchers.anything()), {times: 0}));
   t.end();


### PR DESCRIPTION
Fixes issue where wrong event type was being used within
`getCorrectEventName` in `register`/`deregisterAnimationEndHandler`
adapter methods in vanilla component. Discovered while working on #205.