### PR TITLE
fix(auto-init): Change markdown code highlighting

### DIFF
--- a/packages/mdc-auto-init/README.md
+++ b/packages/mdc-auto-init/README.md
@@ -147,7 +147,7 @@ function used to warn users when a component is initialized multiple times. By d
 `console.warn()`. However, to skip over already-initialized components without logging a
 warning, you could simply pass in a nop.
 
-```js
+```html
 <script>window.mdc.autoInit(/* root */ document, () => {});</script>
 ```
 


### PR DESCRIPTION
Changes a markdown code highlighting in the documentation of the auto-init component from `js` to `html`.