### PR TITLE
fix(ripple): Export getMatchesProperty

### DIFF
--- a/packages/mdc-ripple/index.js
+++ b/packages/mdc-ripple/index.js
@@ -20,7 +20,7 @@ import {supportsCssVariables, getMatchesProperty} from './util';
 
 const MATCHES = getMatchesProperty(HTMLElement.prototype);
 
-export {MDCRippleFoundation};
+export {MDCRippleFoundation, getMatchesProperty};
 
 export class MDCRipple extends MDCComponent {
   static attachTo(root, {isUnbounded = undefined} = {}) {


### PR DESCRIPTION
This will be useful to keep browser compatibility for people implementing components using ripple.