### PR TITLE
chore(hooks): Upgrade from ghooks to husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:min": "mkdirp build && cross-env MDC_ENV=production webpack -p --progress --colors",
     "changelog": "standard-changelog -i CHANGELOG.md -k packages/material-components-web/package.json -w",
     "clean": "del-cli build/**",
+    "commitmsg": "validate-commit-msg",
     "dist": "npm run clean && npm run build && npm run build:min",
     "dev": "npm run clean && cross-env MDC_ENV=development webpack-dev-server --content-base demos --inline --hot --host 0.0.0.0",
     "fix:js": "eslint --fix packages test webpack.config.js karma.conf.js",
@@ -40,8 +41,8 @@
     "eslint-config-google": "^0.7.1",
     "eslint-plugin-tape": "^1.1.0",
     "extract-text-webpack-plugin": "^1.0.1",
-    "ghooks": "^1.3.2",
     "glob": "^7.1.1",
+    "husky": "^0.13.1",
     "isparta-loader": "^2.0.0",
     "istanbul": "^0.4.4",
     "json-loader": "^0.5.4",
@@ -85,9 +86,6 @@
     ]
   },
   "config": {
-    "ghooks": {
-      "commit-msg": "validate-commit-msg"
-    },
     "validate-commit-msg": {
       "helpMessage": "\nNOTE: Please see angular's commit message guidelines (https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit) for information on how to format commit messages.\n\nAs an example, here is a valid commit message: 'docs(slider): Document slider public api'\n\nIf this commit is on a development / WIP branch, you can disable this by running `git commit --no-verify`."
     },


### PR DESCRIPTION
Switches from ghooks to husky. Fixes #229.

- Removed the `ghooks` config section from `package.json`.
- Added a `commitmsg` script entry to `package.json`.
- Uninstalled `ghooks`.
- Installed `husky`.
- The `husky` installation automatically converts the existing git hooks from `ghooks` hooks to their `husky` equivalents.  