### PR TITLE
fix(icon-toggle): Remove duplicate "main"

### DIFF
--- a/packages/mdc-icon-toggle/package.json
+++ b/packages/mdc-icon-toggle/package.json
@@ -2,7 +2,6 @@
   "name": "@material/icon-toggle",
   "description": "The Material Components for the web icon toggle component",
   "version": "0.1.3",
-  "main": "index.js",
   "license": "Apache-2.0",
   "keywords": [
     "material components",


### PR DESCRIPTION
The `icon-toggle` package.json file has the `main` property set twice with identical values. This removes one of them.