### PR TITLE
fix:MDCCheckbox add box-sizing: content-box to checkbox component

### DIFF
--- a/packages/mdc-checkbox/mdc-checkbox.scss
+++ b/packages/mdc-checkbox/mdc-checkbox.scss
@@ -54,6 +54,7 @@
 .mdc-checkbox {
   display: inline-block;
   position: relative;
+  box-sizing: content-box;
   width: $mdc-checkbox-size;
   height: $mdc-checkbox-size;
   padding: ($mdc-checkbox-touch-area - $mdc-checkbox-size) / 2;


### PR DESCRIPTION
consider adding the default value of box-sizing to the element
most websites today are using a variation of the global `box-sizing: border-box` https://css-tricks.com/box-sizing/
checkbox fails to work if the page box-sizing is set to `border-box`, adding `content-box` ensure that the element will be rendered as intended regardless of the page global box-sizing value