### PR TITLE
Capitalize Web in description.

### DIFF
--- a/packages/material-components-web/package.json
+++ b/packages/material-components-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-components-web",
-  "description": "Modular and customizable Material Design UI components for the web",
+  "description": "Modular and customizable Material Design UI components for the Web",
   "version": "0.4.0",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
Web as in World Wide Web, not web.