### PR TITLE
chore(infrastructure): Re-enable SauceLabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,13 @@
-# NOTE: All SauceLabs config info is commented out for now, as until we fix our test infrastructure
-# SL will continue to be flaky. Therefore, our tests will run on Firefox ESR using XVFB for the time
-# being.
-
 language: node_js
 node_js:
-  - node # stable
-  - '--lts' # LTS: See https://github.com/creationix/nvm/pull/1070
+- node
+- --lts # LTS: See https://github.com/creationix/nvm/pull/1070
 branches:
   only:
-    - master
-before_install:
-  - 'if [[ -z "$SECURE" ]]; then echo "Using Firefox Fallback"; export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi;'
+  - master
 env:
   global:
-    # - SAUCE_USERNAME=material-sauce
-    # - secure: AxiBF/aKR7YjYP9WYLcAoeFzm4d1XE0loDxk7+K8npWqWTnSnTe8ewrdPPmqHvQaeUqBYHRsFuBTxPXvPYDs2s5s7EUotLVU83Gh3iQw2dmBvuNi81sXlvXbYyJE7qZ/E418bEZBrfNaZ/Mm37ehoLs0+suSy3UjDacfPltObzF7vWedyOmZa5fRVd2/VoX11MMZybGJykUml4jSSg5qrve1P49SgybUaNnvwMMEzGuRi9jwSngvMsHtjS6uCHE/CWNJla3Zt3qjsKBPcwsSZHm/wNEX7frufZ7ReqTZjsMyOidPjlZfH8Yk5fgM610h7noWeav3l0CwsrEgWX0nFdop/3JUfWodqpXWVrTqd1scna4kFvfAcH9qltqXkxlRzetQrURsUiPHC4RkL8E9bUkol++JNhW4Cur287FxP4NVO5Mo3071dwBU7Jh/aQpq0ANJx/js5bZAUIDsEno3uHZe4LLMUBaowU1Jr03wZnis5A7w97kOz0HaUw0W1r5mBo7rB3Fb+CAUnFeVzxoSnkf2npJ1vai8HM7No+qnuV9I/C157LmATyY/UqBScbKe/kk7EeF/YBWfyaeWXxAi68Xmiw4PytAapRn7xfI56hZ28Dc/xdx2uDjPJnu5cKjDjDOxkdSoYO9eG7ZSSbIoD1MskaTjb2y9B6GlAmmSu/I=
+  - SAUCE_USERNAME=material-sauce
+  - secure: e4MtddCSnfI/7wT6Vd58w5P5gGVSCIUF9AXWJsGwqfSMosVZ0l1voadWdYCNpLju2qxQFfx48k+ojSCIZq5ZCbwGL8hIJyiTM88pkGSC5iASv0YYkDEIniwz3Pd4Acj0GSGrSa0JkrNyA7rP+7ZAFcizCP8fHdW5pvIq1GJ9vEJttC0pk3OsbX8SLdRjtiOuXHXDOTlZZW9JQv0HyaFvKQNz6hK7KDLn8yq+QFB/17OSPqtMfFUKG83VlddPYTGQKsixl63Bfu+mkJ45D4akS+Gd5Hcg87sKYcXW09+eqE3l5qihRIz3vZXJ8u94heWP4TebV+WeIbrBGGMsNtmqEe7VfOmr5xe+B8wOClUqlpBlu7y0ZFzFxgs31Q0JhsWB6b4vs24Yr6IlPWox7uJckig8XMJX5iFHIHGFEknzAcZBpqSpYkiT2BC8eLaybGwl5VYz23cko3rxHLPxahbMVMW6i5B8XiZozsh4NFKqbERv4bJPPXyybLyR31MOrFMj6hdUd1Gk56RfEulNbCek0aSxuV3Vzxl8+5csTtAdQeqMGImTFDxlmQEoKk8dReOLFxDfNXj7W4YNXpof6YyzXIFelUJ148iODIwE8ET0EJvzR7+mOLmFMKnTWb4Uf8k6Jp4ZZa3zEWzZszG7UfAC4klGoiWhUGS/DpyF0G2BFs8=
 addons:
-  firefox: latest
-  # sauce_connect: true
-  # jwt:
-  #   secure: Z6mGHTjqv+eICZ+BscNnyzMGKJNwhZSzDS477VassOsCfPJ21idue/iEAzbz78bFKDxNoO+j6YCg/k+YP9/K1vbBRVCAJyWKqOMxo2Hr2lE3Ny4QO56sH0YoSebA85BBDkNNZtwwat8/mzSb8yqQOvYctt1YgnKZVlgHTkjxwygl7lqScvfSCmCAvraHAxdY3vLWpyo7fuz7SJigu1LXsjwKoWUF+rl6K0X+rhOUz1RH/+UHzqAABsszMwNkhu8P5Qlx0OHK6FsJ4vk6GrPtSHvKU/xMymdMMaAR2zVmiGISNT5CMZq+Ws4OLvH+9WOKZsgSa3k9QpJEloGt7qRK6OnYxXfQi9Wi3DXvL5nxDrRMb7b+Vf7H4C+oMq+rq1C1KojL5vbs5YKf080PJNhDiyti3H4AvIZI51X5QWL2pP96xdyJ0KQtYccjId8CIG6N5cHZQ59ShaNrulPdI+Jyp4dulO6MNyZJUYtNmSy1O+A0GejBrSavBXydS1zF4Gwfr7iseL1SPc8vauDYxu6zU34QRB2Ira56P+BgjLqZ6mDARnu/uiytRC4cbR2hr5YuHcn5riCb9w8GwI0l53STh63CoMiB5P+Doj5ZFyJZOId6JSckw3/oqx698oQYuqhJiC88Jt/9Vj9VqBGRk8uOcX4ZRgz4mO/6+2aUg/RaEjU=
+  sauce_connect: true

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,82 +19,77 @@ const webpackConfig = require('./webpack.config')[0];
 
 const USING_TRAVISCI = Boolean(process.env.TRAVIS);
 const USING_SL = Boolean(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY);
-const IS_SECURE = Boolean(process.env.SECURE);
 
 const SL_LAUNCHERS = {
   'sl-chrome-stable': {
     base: 'SauceLabs',
     browserName: 'chrome',
     version: 'latest',
-    platform: 'OS X 10.11',
+    platform: 'macOS 10.12',
   },
   'sl-chrome-beta': {
     base: 'SauceLabs',
     browserName: 'chrome',
     version: 'beta',
+    platform: 'macOS 10.12',
   },
   'sl-chrome-previous': {
     base: 'SauceLabs',
     browserName: 'chrome',
     version: 'latest-1',
-    platform: 'OS X 10.11',
+    platform: 'macOS 10.12',
   },
-  // NOTE(traviskaufman): Disabling firefox for now as it has been consistently flaky recently. See
-  // https://github.com/material-components/material-components-web/issues/5
-  // 'sl-firefox-stable': {
-  //   base: 'SauceLabs',
-  //   browserName: 'firefox',
-  //   version: 'latest',
-  //   platform: 'Windows 10'
-  // },
-  // 'sl-firefox-previous': {
-  //   base: 'SauceLabs',
-  //   browserName: 'firefox',
-  //   version: 'latest-1',
-  //   platform: 'Windows 10'
-  // },
+  'sl-firefox-stable': {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: 'latest',
+    platform: 'Windows 10',
+  },
+  'sl-firefox-previous': {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: 'latest-1',
+    platform: 'Windows 10',
+  },
   'sl-ie': {
     base: 'SauceLabs',
     browserName: 'internet explorer',
     version: '11',
     platform: 'Windows 8.1',
   },
-  'sl-android-stable': {
-    base: 'SauceLabs',
-    browserName: 'android',
-    version: '5.0',
-  },
-  // NOTE(traviskaufman): Temporarily disabling these browsers as they are consistently flaky using
-  // Sauce Labs and almost always yield false negatives.
+  // TODO(sgomes): Re-enable Edge and Safari after Sauce Labs problems are fixed.
   // 'sl-edge': {
   //   base: 'SauceLabs',
   //   browserName: 'microsoftedge',
   //   version: 'latest',
-  //   platform: 'Windows 10'
+  //   platform: 'Windows 10',
   // },
   // 'sl-safari-stable': {
   //   base: 'SauceLabs',
   //   browserName: 'safari',
-  //   version: '9',
-  //   platform: 'OS X 10.11'
+  //   version: 'latest',
+  //   platform: 'macOS 10.12',
   // },
   // 'sl-safari-previous': {
   //   base: 'SauceLabs',
   //   browserName: 'safari',
-  //   version: '8',
-  //   platform: 'OS X 10.10'
+  //   version: '9.0',
+  //   platform: 'OS X 10.11',
   // },
-  // 'sl-ios-safari-latest': {
-  //   base: 'SauceLabs',
-  //   browserName: 'iphone',
-  //   platform: 'OS X 10.10',
-  //   version: '9.1'
-  // },
+  'sl-ios-safari-latest': {
+    base: 'SauceLabs',
+    deviceName: 'iPhone Simulator',
+    platformVersion: '10.0',
+    platformName: 'iOS',
+    browserName: 'Safari',
+  },
   // 'sl-ios-safari-previous': {
   //   base: 'SauceLabs',
-  //   browserName: 'iphone',
-  //   version: '8.4'
-  // }
+  //   deviceName: 'iPhone Simulator',
+  //   platformVersion: '9.3',
+  //   platformName: 'iOS',
+  //   browserName: 'Safari',
+  // },
 };
 
 module.exports = function(config) {
@@ -113,7 +108,7 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     browsers: determineBrowsers(),
     browserDisconnectTimeout: 40000,
-    browserNoActivityTimeout: 480000,
+    browserNoActivityTimeout: 120000,
     captureTimeout: 240000,
     concurrency: USING_SL ? 4 : Infinity,
     customLaunchers: SL_LAUNCHERS,
@@ -158,6 +153,8 @@ module.exports = function(config) {
       sauceLabs: {
         testName: 'Material Components Web Unit Tests - CI',
         tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
+        username: process.env.SAUCE_USERNAME,
+        accessKey: process.env.SAUCE_ACCESS_KEY,
         startConnect: false,
       },
       // Attempt to de-flake Sauce Labs tests on TravisCI.
@@ -168,13 +165,5 @@ module.exports = function(config) {
 };
 
 function determineBrowsers() {
-  let browsers = USING_SL ? Object.keys(SL_LAUNCHERS) : ['Chrome'];
-  if (USING_TRAVISCI && !IS_SECURE) {
-    console.warn(
-      'NOTICE: Falling back to firefox browser, as travis-ci JWT addon is currently not working ' +
-      'with Sauce Labs. See - https://github.com/travis-ci/travis-ci/issues/6569'
-    );
-    browsers = ['Firefox'];
-  }
-  return browsers;
+  return USING_SL ? Object.keys(SL_LAUNCHERS) : ['Chrome'];
 }

--- a/test/unit/mdc-form-field/mdc-form-field.test.js
+++ b/test/unit/mdc-form-field/mdc-form-field.test.js
@@ -74,7 +74,7 @@ test('adapter#deregisterInteractionHandler removes an event listener from the ro
 
 test('adapter#activateInputRipple calls activate on the input ripple', () => {
   const {component} = setupTest();
-  const ripple = td.object();
+  const ripple = {activate: td.func('activate')};
   const input = {ripple: ripple};
 
   component.input = input;
@@ -100,7 +100,7 @@ test('adapter#activateInputRipple does not throw if the input has no ripple gett
 
 test('adapter#deactivateInputRipple calls deactivate on the input ripple', () => {
   const {component} = setupTest();
-  const ripple = td.object();
+  const ripple = {deactivate: td.func('deactivate')};
   const input = {ripple: ripple};
 
   component.input = input;


### PR DESCRIPTION
This PR re-enables Sauce Labs for a number of configurations. Certain configurations are currently presenting issues and are disabled while the causes are investigated. If possible, they will be added later.

In the meantime, this will reenable cross-browser testing.