### PR TITLE
fix(textfield): Adjust labels when initializing pre-filled textfields

### DIFF
--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -16,19 +16,17 @@
 
 import {MDCFoundation} from '@material/base';
 
-const ROOT = 'mdc-textfield';
-
 export default class MDCTextfieldFoundation extends MDCFoundation {
   static get cssClasses() {
     return {
-      ROOT,
-      UPGRADED: `${ROOT}--upgraded`,
-      DISABLED: `${ROOT}--disabled`,
-      FOCUSED: `${ROOT}--focused`,
-      INVALID: `${ROOT}--invalid`,
-      HELPTEXT_PERSISTENT: `${ROOT}-helptext--persistent`,
-      HELPTEXT_VALIDATION_MSG: `${ROOT}-helptext--validation-msg`,
-      LABEL_FLOAT_ABOVE: `${ROOT}__label--float-above`,
+      ROOT: 'mdc-textfield',
+      UPGRADED: 'mdc-textfield--upgraded',
+      DISABLED: 'mdc-textfield--disabled',
+      FOCUSED: 'mdc-textfield--focused',
+      INVALID: 'mdc-textfield--invalid',
+      HELPTEXT_PERSISTENT: 'mdc-textfield-helptext--persistent',
+      HELPTEXT_VALIDATION_MSG: 'mdc-textfield-helptext--validation-msg',
+      LABEL_FLOAT_ABOVE: 'mdc-textfield__label--float-above',
     };
   }
 

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -76,6 +76,11 @@ export default class MDCTextfieldFoundation extends MDCFoundation {
     this.adapter_.registerInputBlurHandler(this.inputBlurHandler_);
     this.adapter_.registerInputInputHandler(this.inputInputHandler_);
     this.adapter_.registerInputKeydownHandler(this.inputKeydownHandler_);
+
+    // Ensure label does not collide with any pre-filled value.
+    if (this.getNativeInput_().value) {
+      this.adapter_.addClassToLabel(MDCTextfieldFoundation.cssClasses.LABEL_FLOAT_ABOVE);
+    }
   }
 
   destroy() {

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -98,6 +98,28 @@ test('#init adds mdc-textfield--upgraded class', () => {
   td.verify(mockAdapter.addClass(cssClasses.UPGRADED));
 });
 
+test('#init adds mdc-textfield__label--float-above class if the input contains a value', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeInput()).thenReturn({
+    value: 'Pre-filled value',
+    disabled: false,
+    checkValidity: () => true,
+  });
+  foundation.init();
+  td.verify(mockAdapter.addClassToLabel(cssClasses.LABEL_FLOAT_ABOVE));
+});
+
+test('#init does not add mdc-textfield__label--float-above class if the input does not contain a value', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeInput()).thenReturn({
+    value: '',
+    disabled: false,
+    checkValidity: () => true,
+  });
+  foundation.init();
+  td.verify(mockAdapter.addClassToLabel(cssClasses.LABEL_FLOAT_ABOVE), {times: 0});
+});
+
 test('on input focuses if input event occurs without any other events', () => {
   const {foundation, mockAdapter} = setupTest();
   let input;


### PR DESCRIPTION
Also change cssClasses getter to use static strings rather than
templates, which will be required for future internal interop.

Fixes #300