### PR TITLE
fix template syntax error

### DIFF
--- a/framework-examples/vue/src/v-mdc-checkbox/Checkbox.vue
+++ b/framework-examples/vue/src/v-mdc-checkbox/Checkbox.vue
@@ -16,6 +16,7 @@
             d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
     </svg>
   <div class="mdc-checkbox__mixedmark"></div>
+  </div>
 </div>
 </template>
 

--- a/framework-examples/vue/src/v-mdc-snackbar/Snackbar.vue
+++ b/framework-examples/vue/src/v-mdc-snackbar/Snackbar.vue
@@ -4,6 +4,7 @@
   <div class="mdc-snackbar__text">{{message}}</div>
   <div class="mdc-snackbar__action-wrapper">
     <button type="button" @click="actionClicked" class="mdc-button mdc-snackbar__action-button" :aria-hidden="actionHidden">{{actionText}}</button>
+  </div>
 </div>
 </template>
 


### PR DESCRIPTION
In vuejs 2.2 parsing raise template error if html element has no matching end tag