### PR TITLE
fix(ripple): Provide fallbacks for all custom properties

### DIFF
--- a/packages/mdc-ripple/_keyframes.scss
+++ b/packages/mdc-ripple/_keyframes.scss
@@ -20,12 +20,14 @@
 
 @keyframes mdc-ripple-fg-radius-in {
   from {
-    transform: translate(var(--mdc-ripple-fg-translate-start)) scale(1);
+    transform: translate(0) scale(1);
+    transform: translate(var(--mdc-ripple-fg-translate-start, 0)) scale(1);
     animation-timing-function: $mdc-animation-fast-out-slow-in-timing-function;
   }
 
   to {
-    transform: translate(var(--mdc-ripple-fg-translate-end)) scale(var(--mdc-ripple-fg-scale));
+    transform: translate(0) scale(0);
+    transform: translate(var(--mdc-ripple-fg-translate-end, 0)) scale(var(--mdc-ripple-fg-scale, 0));
   }
 }
 
@@ -52,10 +54,12 @@
 
 @keyframes mdc-ripple-fg-unbounded-transform-deactivate {
   from {
-    transform: var(--mdc-ripple-fg-approx-xf);
+    transform: 0;
+    transform: var(--mdc-ripple-fg-approx-xf, 0);
   }
 
   to {
-    transform: scale(var(--mdc-ripple-fg-scale));
+    transform: scale(0);
+    transform: scale(var(--mdc-ripple-fg-scale, 0));
   }
 }

--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -61,6 +61,7 @@
   // stylelint-disable at-rule-empty-line-before, block-closing-brace-newline-after
   @if ($theme-style) {
     $theme-value: map-get($mdc-theme-property-values, $theme-style);
+    $css-var: $theme-value;
     $css-var: var(--mdc-theme-#{$theme-style}, $theme-value);
 
     background-color: rgba($theme-value, $opacity);
@@ -116,6 +117,7 @@
     left: calc(50% - #{$radius});
     width: $radius * 2;
     height: $radius * 2;
+    transform: scale(0);
     transform: scale(var(--mdc-ripple-fg-scale, 0));
   }
 
@@ -136,10 +138,15 @@
   }
 
   &.mdc-ripple-upgraded--unbounded#{$pseudo} {
+    top: calc(50% - #{$radius / 2});
     top: var(--mdc-ripple-top, calc(50% - #{$radius / 2}));
+    left: calc(50% - #{$radius / 2});
     left: var(--mdc-ripple-left, calc(50% - #{$radius / 2}));
+    width: $radius;
     width: var(--mdc-ripple-fg-size, $radius);
+    height: $radius;
     height: var(--mdc-ripple-fg-size, $radius);
+    transform: scale(0);
     transform: scale(var(--mdc-ripple-fg-scale, 0));
   }
 }
@@ -181,7 +188,9 @@
     &#{$pseudo} {
       top: 0;
       left: 0;
+      width: $radius;
       width: var(--mdc-ripple-fg-size, $radius);
+      height: $radius;
       height: var(--mdc-ripple-fg-size, $radius);
       transform: scale(0);
       transform-origin: center center;
@@ -194,9 +203,13 @@
   }
 
   &.mdc-ripple-upgraded--unbounded#{$pseudo} {
+    top: 0;
     top: var(--mdc-ripple-top, 0);
+    left: 0;
     left: var(--mdc-ripple-left, 0);
+    width: $radius;
     width: var(--mdc-ripple-fg-size, $radius);
+    height: $radius;
     height: var(--mdc-ripple-fg-size, $radius);
     transform: scale(0);
     transform-origin: center center;
@@ -208,7 +221,11 @@
   }
 
   &.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded--foreground-unbounded-activation#{$pseudo} {
+    transform: scale(0);
     transform: scale(var(--mdc-ripple-fg-scale, 0));
+    transition:
+      opacity 110ms linear,
+      transform 0 linear 80ms;
     transition:
       opacity 110ms linear,
       transform var(--mdc-ripple-fg-unbounded-transform-duration, 0) linear 80ms;
@@ -216,6 +233,9 @@
   }
 
   &.mdc-ripple-upgraded--unbounded.mdc-ripple-upgraded--foreground-unbounded-deactivation#{$pseudo} {
+    animation:
+      mdc-ripple-fg-unbounded-opacity-deactivate 0 linear,
+      mdc-ripple-fg-unbounded-transform-deactivate 0 $mdc-animation-fast-out-slow-in-timing-function;
     animation:
       mdc-ripple-fg-unbounded-opacity-deactivate var(--mdc-ripple-fg-unbounded-opacity-duration, 0) linear,
       mdc-ripple-fg-unbounded-transform-deactivate var(--mdc-ripple-fg-unbounded-transform-duration, 0) $mdc-animation-fast-out-slow-in-timing-function;


### PR DESCRIPTION
From #361:

- [x] Ensure all var() lookups have a second parameter
- [X] Ensure all var() lookups have a fallback of some sort for browsers that don't support custom properties
- [X] Run material-components-web generated CSS through postcss-custom-properties. Remove any errors and attempt to reduce warnings as much as possible, while taking into account the limitations of the tool.

While running it through `postcss-custom-properties`  I fixed all warnings except for the `Custom property ignored: not scoped to the top-level :root element` ones. 

Passing `warnings: false` to `postcss-custom-properties` suppresses that specific warning though, resulting in a warning free build.