### PR TITLE
docs(select): Fix 'for' attribute of a label in demo

### DIFF
--- a/demos/select.html
+++ b/demos/select.html
@@ -75,7 +75,7 @@
         <p>Currently selected: <span id="currently-selected">(none)</span></p>
         <div>
           <input type="checkbox" id="dark-theme">
-          <label for="dark-mode">Dark Theme</label>
+          <label for="dark-theme">Dark Theme</label>
         </div>
         <div>
           <input type="checkbox" id="rtl">


### PR DESCRIPTION
Made "Dark Theme" checkbox selectable by clicking it's label in "select.html" demo