### PR TITLE
fix(infrastructure): Update publishConfig.ignore to commands.publish ignore.

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,12 @@
 {
   "lerna": "2.0.0-beta.36",
   "version": "independent",
-  "publishConfig": {
-    "ignore": [
-      "*.md"
-    ]
+  "commands": {
+    "publish": {
+      "ignore": [
+        "*.md"
+      ]
+    }
   },
   "packages": [
     "packages/*"

--- a/scripts/lib/get-updated-pkgs.js
+++ b/scripts/lib/get-updated-pkgs.js
@@ -33,7 +33,7 @@ module.exports = function() {
   const origBarDescriptor = Object.getOwnPropertyDescriptor(progressBar, 'bar');
   const lernaCommand = {
     repository,
-    getOptions: () => lernaJson.publishConfig,
+    getOptions: () => lernaJson.commands.publish,
   };
   const collector = new UpdatedPackagesCollector(lernaCommand);
 


### PR DESCRIPTION
This removing the deprecated message when we run `lerna publish`.