### PR TITLE
chore(infrastructure): Add sanity checks to pre-release scripts

### DIFF
--- a/scripts/check-pkg-for-release.js
+++ b/scripts/check-pkg-for-release.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Used within pre-release.sh, this checks a component's package.json
+ * to ensure that if it's a new component (version = "0.0.0"), it will have a proper
+ * "publishConfig.access" property set to "public".
+ * The argument should be the package.json file to check.
+ */
+
+const path = require('path');
+const pkg = require(path.join(process.env.PWD, process.argv[process.argv.length - 1]));
+if (pkg.version !== '0.0.0') {
+  process.exit(0);
+}
+
+const missingPublishConfig = !pkg.publishConfig;
+if (missingPublishConfig || pkg.publishConfig.access !== 'public') {
+  process.exit(1);
+}


### PR DESCRIPTION
It seems that every time we try to release, _something_ goes wrong. This
commit adds sanity checks to our pre-release scripts to try and
minimize surprises:

- Ensures that you are logged in on npm as a material org member
- Ensures that you have SSH access to GitHub (note that checking if you
  can push to MDC-Web is more involved, and requires API auth. This
  should be a simple enough check)
- Ensures that you have gcloud configured properly to deploy our demo site
- Ensures that all new packages have the correct publishConfig specified
  in their package.json files.