### PR TITLE
Fix buttons and FABs for gracefully degraded ripples

### DIFF
--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -50,7 +50,10 @@
   user-select: none;
   box-sizing: border-box;
   -webkit-appearance: none;
-  -webkit-tap-highlight-color: rgba(black, .18);
+
+  &:not(.mdc-ripple-upgraded) {
+    -webkit-tap-highlight-color: rgba(black, .18);
+  }
 
   @include mdc-theme-dark {
     @include mdc-ripple-base;
@@ -58,7 +61,9 @@
     @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
     @include mdc-theme-prop(color, text-primary-on-dark);
 
-    -webkit-tap-highlight-color: rgba(white, .18);
+    &:not(.mdc-ripple-upgraded) {
+      -webkit-tap-highlight-color: rgba(white, .18);
+    }
   }
 
   @each $theme-style in (primary, accent) {
@@ -189,4 +194,3 @@
 }
 
 // postcss-bem-linter: end
-

--- a/packages/mdc-fab/mdc-fab.scss
+++ b/packages/mdc-fab/mdc-fab.scss
@@ -39,8 +39,11 @@
   fill: currentColor;
   -moz-appearance: none;
   -webkit-appearance: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, .18);
   overflow: hidden;
+
+  &:not(.mdc-ripple-upgraded) {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, .18);
+  }
 
   @include mdc-theme-prop(background-color, accent);
   @include mdc-theme-prop(color, text-primary-on-accent);
@@ -57,33 +60,6 @@
     @include mdc-theme-prop(color, text-primary-on-light);
     @include mdc-ripple-bg((pseudo: "::before"));
     @include mdc-ripple-fg((pseudo: "::after"));
-  }
-
-  &::before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    transition: mdc-animation-exit(opacity, 120ms);
-    border-radius: inherit;
-    background: rgba(0, 0, 0, .2);
-    content: "";
-    opacity: 0;
-  }
-
-  &:focus::before {
-    transition: mdc-animation-enter(opacity, 120ms);
-    opacity: .12;
-  }
-
-  &:active::before {
-    transition: mdc-animation-enter(opacity, 120ms);
-    opacity: .18;
-  }
-
-  &:active:focus::before {
-    transition-timing-function: $mdc-animation-fast-out-slow-in-timing-function;
   }
 
   &:active,


### PR DESCRIPTION
**_NOTE: THIS PR SHOULD BE REBASED AND MERGED, NOT SQUASHED_**

- Fixes interfering tap highlights for buttons and FABs with ripples on mobile safari.
- Fixes `::before` styling in FAB which was clobbering the ripple's graceful degradation styles.

See commits for more info. 