### PR TITLE
fix(layout-grid): Prevent overflowing components within cells

### DIFF
--- a/packages/mdc-layout-grid/_mixins.scss
+++ b/packages/mdc-layout-grid/_mixins.scss
@@ -48,6 +48,9 @@
 
   @supports (display: grid) {
     width: auto;
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden;
     grid-column-end: span min($span, map-get($mdc-layout-grid-columns, $size));
   }
 }


### PR DESCRIPTION
- Adding `max-height: 100%` and `max-width: 100%` to prevent overflowing components
- Also adding `overflow:hidden` in case it is still overflowing

Fixes #406