### PR TITLE
chore: Fix codecov flakes

### DIFF
--- a/test/unit/mdc-drawer/util.test.js
+++ b/test/unit/mdc-drawer/util.test.js
@@ -46,6 +46,14 @@ test('remapEvent returns the mapped event name for mapped events, if browser doe
   assert.equal(utils.remapEvent('touchend', mockWindow), 'pointerup');
 });
 
+test('remapEvent returns the original event name if browser does not support touch event name is not a ' +
+     'known touch event', () => {
+  const mockWindow = {
+    document: {},
+  };
+  assert.equal(utils.remapEvent('notAPointerEvent', mockWindow), 'notAPointerEvent');
+});
+
 test('getTransformPropertyName returns "transform" for browsers that support it', () => {
   const mockWindow = {
     document: {

--- a/test/unit/mdc-menu/simple.foundation.test.js
+++ b/test/unit/mdc-menu/simple.foundation.test.js
@@ -748,6 +748,25 @@ test('on spacebar keydown prevents default on the event', () => {
   clock.uninstall();
 });
 
+testFoundation('on document click cancels and closes the menu', ({foundation, mockAdapter, mockRaf}) => {
+  let documentClickHandler;
+  td.when(mockAdapter.registerDocumentClickHandler(td.matchers.isA(Function))).thenDo((handler) => {
+    documentClickHandler = handler;
+  });
+
+  foundation.init();
+  foundation.open();
+  mockRaf.flush();
+
+  documentClickHandler();
+  mockRaf.flush();
+
+  td.verify(mockAdapter.removeClass(cssClasses.OPEN));
+  td.verify(mockAdapter.notifyCancel());
+
+  mockRaf.restore();
+});
+
 testFoundation('should cancel animation after destroy', ({foundation, mockAdapter, mockRaf}) => {
   foundation.init();
   mockRaf.flush();


### PR DESCRIPTION
These particular tests seem to fluctuate on CodeCov between being
covered and not being covered, which can lead to false negatives and
strange reporting on PRs that do not touch these files. This commit adds
tests that explicitly cover these cases.