### PR TITLE
Fix Server Side Rendering for Ripple

### DIFF
--- a/packages/mdc-ripple/index.js
+++ b/packages/mdc-ripple/index.js
@@ -18,7 +18,7 @@ import {MDCComponent} from '@material/base';
 import MDCRippleFoundation from './foundation';
 import {supportsCssVariables, getMatchesProperty} from './util';
 
-const MATCHES = getMatchesProperty(HTMLElement.prototype);
+let MATCHES;
 
 export {MDCRippleFoundation};
 
@@ -33,6 +33,9 @@ export class MDCRipple extends MDCComponent {
   }
 
   static createAdapter(instance) {
+    // Allow server side rendering rendering by calling HTMLElement, only when
+    // it's needed
+    MATCHES = MATCHES || getMatchesProperty(HTMLElement.prototype);
     return {
       browserSupportsCssVars: () => supportsCssVariables(window),
       isUnbounded: () => instance.unbounded,


### PR DESCRIPTION
Currently, the Ripple tries to use HTMLElement upon inclusion. However, this breaks SSR because the variable doesn't exist in Node. I moved the computation of MATCHES inside of the function using it (since there's only one) but it's also possible to check if in browser when populating the MATCHES variable