### PR TITLE
fix(list): Update interactive list's with ripple-upgrade to be narrower

### DIFF
--- a/packages/mdc-list/mdc-list.scss
+++ b/packages/mdc-list/mdc-list.scss
@@ -162,7 +162,7 @@ a.mdc-list-item {
   // Cause the upgraded list item to cover the entirety of the list, causing ripples to emanate
   // across the entire list element.
   left: $mdc-list-side-padding * -1;
-  width: calc(100% + #{$mdc-list-side-padding * 2});
+  width: 100%;
   padding: 0 $mdc-list-side-padding;
   overflow: hidden;
 


### PR DESCRIPTION
Resolves #463, Update interactive list's with ripple-upgrade to be narrower. Padding of list items is 16 + 16 = 32px, so width of list items should be container's width - 32px.