### PR TITLE
docs: Add eng outline doc info to CONTRIBUTING, Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,10 @@ and potential API or affects on other APIs (where applicable). The more detailed
 the easier it will be for us to understand and evaluate it. [This Meta.SE answer](http://meta.stackexchange.com/a/259196) also contains great general guidelines for writing
 feature requests.
 
-While we are in the early stages of development of MDC-Web, you can see our current progress on [master](https://github.com/material-components/material-components-web/tree/master) as well as an overview of the direction we're headed in our [developer guide](https://github.com/material-components/material-components-web/blob/master/docs/DEVELOPER.md).
+If you'd like to work on a component, please ensure that you *submit an Engineering Outline before
+submitting a pull request*. You can read more about this in our [contributing docs](https://github.com/material-components/material-components-web/blob/master/CONTRIBUTING.md#building-components).
+
+MDC-Web is still under active development. You can see our current progress on [master](https://github.com/material-components/material-components-web/tree/master) as well as an overview of the direction we're headed in our [developer guide](https://github.com/material-components/material-components-web/blob/master/docs/DEVELOPER.md).
 
 If you're interested in information for a specific component, check out our [component issues](https://github.com/material-components/material-components-web/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Av2-component) to see which milestone it's associated with and subscribe to updates to it. If an issue has the `in-tracker` label, you can also take a look at our [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1664011) for a rough estimate of when we'll get to it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,15 @@ cd material-components-web && npm i
 
 Each component requires the following items in order to be complete:
 
+- An **Engineering Outline Document**, which should be linked to in a comment on the GitHub issue
+  where we're tracking the component. This way, the core team can review and sign off on the
+  outline doc. Outline docs should be signed off on _before_ submitting a PR.
+  Please [copy this google doc template](https://docs.google.com/document/d/1Kybm7XJDTy0KUcuMaw5bzirQNBsDqCPCae8U_ag_a1k/edit?usp=sharing) in order to make your outline.
+
+  We have found that enforcing an eng outline doc has allowed us to speed up development by
+  offering more informed feedback on component implementations. This results in components that
+  take into account all of the concepts MDC Web components should account for (RTL, a11y,
+  etc.) before they even reach the PR stage, meaning faster review and merge times :smile:.
 - A **foundation class** which is integrated into actual components
 - A **component class** using vanilla JS + SCSS
 - A **README.md** in its subdir which contains developer documentation on the component, including usage.


### PR DESCRIPTION
The MDC-Web Core Team has recently introduced the concept of
"Engineering Outlines" into our process of developing component. These
function as more lightweight versions of "design documents", where we
can get a good sense of how an engineer plans on approaching a component
from an implementation perspective. We've found this practice extremely
useful for us, and have decided to require it as part of developing new
components. This PR adds information on eng outlines being a requirement, as well as where to find the template for them, in our CONTRIBUTING
and issue template docs.