### PR TITLE
Select Menu not anchored to the control #435

### DIFF
--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -293,7 +293,7 @@ within `componentDidUpdate`.
 | `registerMenuInteractionHandler(type: string, handler: EventListener) => void` | Registers an event listener on the menu component's root element. Note that we will always listen for `MDCSimpleMenu:selected` for change events, and `MDCSimpleMenu:cancel` to know that we need to close the menu. If you are using a different events system, you could check the event type for either one of these strings and take the necessary steps to wire it up. |
 | `deregisterMenuInteractionHandler(type: string, handler: EventListener) => void` | Opposite of `registerMenuInteractionHandler`. |
 | `notifyChange() => void` | Broadcast a change event, similar to the `change` event emitted by an `HTMLSelectElement`. While we use custom events in our implementation for this, you can use any mechanism desired for notifications, such as callbacks, reactive streams, etc. Note that you can also pass data within your event if you'd like via `foundation.getValue()` and `foundation.getSelectedIndex()`. |
-| `computeBoundedContainer() =>  {innerHeight: number, yOffset: number}` | Returns the `innerHeight` property of the `window` element and the `pageYOffset` property of the `window` element. Can be changed in instances where the Select 'Menu' should be constrained to a different area.|
+| `computeBoundedContainer() =>  {innerHeight: number, yOffset: number}` | Returns the `innerHeight` property of the `window` element and the `pageYOffset` property of the `window` element. May be changed in instances where the Select 'Menu' should be constrained to a different area.|
 
 ### The full foundation API
 

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -293,8 +293,7 @@ within `componentDidUpdate`.
 | `registerMenuInteractionHandler(type: string, handler: EventListener) => void` | Registers an event listener on the menu component's root element. Note that we will always listen for `MDCSimpleMenu:selected` for change events, and `MDCSimpleMenu:cancel` to know that we need to close the menu. If you are using a different events system, you could check the event type for either one of these strings and take the necessary steps to wire it up. |
 | `deregisterMenuInteractionHandler(type: string, handler: EventListener) => void` | Opposite of `registerMenuInteractionHandler`. |
 | `notifyChange() => void` | Broadcast a change event, similar to the `change` event emitted by an `HTMLSelectElement`. While we use custom events in our implementation for this, you can use any mechanism desired for notifications, such as callbacks, reactive streams, etc. Note that you can also pass data within your event if you'd like via `foundation.getValue()` and `foundation.getSelectedIndex()`. |
-| `getWindowInnerHeight() => number` | Returns the `innerHeight` property of the `window` element. |
-| `getPageYOffset() => number` | Returns the `pageYOffset` property of the `window` element. |
+| `computeBoundedContainer() =>  {innerHeight: number, yOffset: number}` | Returns the `innerHeight` property of the `window` element and the `pageYOffset` property of the `window` element. Can be changed in instances where the Select 'Menu' should be constrained to a different area.|
 
 ### The full foundation API
 

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -294,6 +294,7 @@ within `componentDidUpdate`.
 | `deregisterMenuInteractionHandler(type: string, handler: EventListener) => void` | Opposite of `registerMenuInteractionHandler`. |
 | `notifyChange() => void` | Broadcast a change event, similar to the `change` event emitted by an `HTMLSelectElement`. While we use custom events in our implementation for this, you can use any mechanism desired for notifications, such as callbacks, reactive streams, etc. Note that you can also pass data within your event if you'd like via `foundation.getValue()` and `foundation.getSelectedIndex()`. |
 | `getWindowInnerHeight() => number` | Returns the `innerHeight` property of the `window` element. |
+| `getPageYOffset() => number` | Returns the `pageYOffset` property of the `window` element. |
 
 ### The full foundation API
 

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -67,6 +67,7 @@ export default class MDCSelectFoundation extends MDCFoundation {
       deregisterMenuInteractionHandler: (/* type: string, handler: EventListener */) => {},
       notifyChange: () => {},
       getWindowInnerHeight: () => /* number */ 0,
+      getPageYoffset: () =>  /* number */ 0,
     };
   }
 
@@ -180,7 +181,7 @@ export default class MDCSelectFoundation extends MDCFoundation {
   open_() {
     const {OPEN} = MDCSelectFoundation.cssClasses;
     const focusIndex = this.selectedIndex_ < 0 ? 0 : this.selectedIndex_;
-    
+
     this.setMenuStylesForOpenAtIndex_(focusIndex);
     this.adapter_.addClass(OPEN);
     this.adapter_.openMenu(focusIndex);
@@ -189,6 +190,7 @@ export default class MDCSelectFoundation extends MDCFoundation {
   setMenuStylesForOpenAtIndex_(index) {
     const innerHeight = this.adapter_.getWindowInnerHeight();
     const {left, top} = this.adapter_.computeBoundingRect();
+    const pageYOffset = this.adapter_.getPageYoffset();
 
     this.adapter_.setMenuElAttr('aria-hidden', 'true');
     this.adapter_.setMenuElStyle('display', 'block');
@@ -198,17 +200,17 @@ export default class MDCSelectFoundation extends MDCFoundation {
     this.adapter_.rmMenuElAttr('aria-hidden');
 
     let adjustedTop = top - itemOffsetTop;
-    const overflowsTop = adjustedTop < 0;
-    const overflowsBottom = adjustedTop + menuHeight > innerHeight;
-    if (overflowsTop) {
-      adjustedTop = 0;
-    } else if (overflowsBottom) {
-      adjustedTop = Math.max(0, innerHeight - menuHeight);
-    }
+    const overflowsTop = adjustedTop < pageYOffset;
+    const overflowsBottom = adjustedTop + menuHeight + pageYOffset > innerHeight;
+    if (overflowsTop && top >= pageYOffset) {
+      adjustedTop = pageYOffset;
+    } else if (overflowsBottom && top <= innerHeight + pageYOffset) {
+      adjustedTop = Math.max(0, innerHeight + pageYOffset - menuHeight);
+    };
 
-    this.adapter_.setMenuElStyle(left: `${left}px`);
-    this.adapter_.setMenuElStyle(this.adapter_.setMenuElStyle(top: `${adjustedTop}px`);
-    this.adapter_.setMenuElStyle(this.adapter_.setMenuElStyle(transformOrigin: `center ${itemOffsetTop}px`);
+    this.adapter_.setMenuElStyle('left', `${left}px`);
+    this.adapter_.setMenuElStyle('top', `${adjustedTop}px`);
+    this.adapter_.setMenuElStyle('transformOrigin', `center ${itemOffsetTop}px`);
   }
 
   close_() {

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -67,7 +67,7 @@ export default class MDCSelectFoundation extends MDCFoundation {
       deregisterMenuInteractionHandler: (/* type: string, handler: EventListener */) => {},
       notifyChange: () => {},
       getWindowInnerHeight: () => /* number */ 0,
-      getPageYoffset: () =>  /* number */ 0,
+      getPageYOffset: () =>  /* number */ 0,
     };
   }
 

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -200,17 +200,17 @@ export default class MDCSelectFoundation extends MDCFoundation {
     this.adapter_.rmMenuElAttr('aria-hidden');
 
     let adjustedTop = top - itemOffsetTop;
-    const overflowsTop = adjustedTop < pageYOffset;
-    const overflowsBottom = adjustedTop + menuHeight + pageYOffset > innerHeight;
-    if (overflowsTop && top >= pageYOffset) {
-      adjustedTop = pageYOffset;
-    } else if (overflowsBottom && top <= innerHeight + pageYOffset) {
-      adjustedTop = Math.max(0, innerHeight + pageYOffset - menuHeight);
+    const overflowsTop = adjustedTop < 0;
+    const overflowsBottom = adjustedTop + menuHeight > innerHeight;
+    if (overflowsTop && top >= 0) {
+      adjustedTop = 0;
+    } else if (overflowsBottom && top <= innerHeight) {
+      adjustedTop = Math.max(0, innerHeight - menuHeight);
     };
 
     this.adapter_.setMenuElStyle('left', `${left}px`);
-    this.adapter_.setMenuElStyle('top', `${adjustedTop}px`);
-    this.adapter_.setMenuElStyle('transformOrigin', `center ${itemOffsetTop}px`);
+    this.adapter_.setMenuElStyle('top', `${adjustedTop + pageYOffset}px`);
+    this.adapter_.setMenuElStyle('transform-origin', `center ${itemOffsetTop}px`);
   }
 
   close_() {
@@ -241,3 +241,4 @@ export default class MDCSelectFoundation extends MDCFoundation {
     }
   }
 }
+

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -180,16 +180,13 @@ export default class MDCSelectFoundation extends MDCFoundation {
   open_() {
     const {OPEN} = MDCSelectFoundation.cssClasses;
     const focusIndex = this.selectedIndex_ < 0 ? 0 : this.selectedIndex_;
-    const {left, top, transformOrigin} = this.computeMenuStylesForOpenAtIndex_(focusIndex);
-
-    this.adapter_.setMenuElStyle('left', left);
-    this.adapter_.setMenuElStyle('top', top);
-    this.adapter_.setMenuElStyle('transform-origin', transformOrigin);
+    
+    this.setMenuStylesForOpenAtIndex_(focusIndex);
     this.adapter_.addClass(OPEN);
     this.adapter_.openMenu(focusIndex);
   }
 
-  computeMenuStylesForOpenAtIndex_(index) {
+  setMenuStylesForOpenAtIndex_(index) {
     const innerHeight = this.adapter_.getWindowInnerHeight();
     const {left, top} = this.adapter_.computeBoundingRect();
 
@@ -201,20 +198,17 @@ export default class MDCSelectFoundation extends MDCFoundation {
     this.adapter_.rmMenuElAttr('aria-hidden');
 
     let adjustedTop = top - itemOffsetTop;
-    const adjustedHeight = menuHeight - itemOffsetTop;
     const overflowsTop = adjustedTop < 0;
-    const overflowsBottom = adjustedTop + adjustedHeight > innerHeight;
+    const overflowsBottom = adjustedTop + menuHeight > innerHeight;
     if (overflowsTop) {
       adjustedTop = 0;
     } else if (overflowsBottom) {
-      adjustedTop = Math.max(0, adjustedTop - adjustedHeight);
+      adjustedTop = Math.max(0, innerHeight - menuHeight);
     }
 
-    return {
-      left: `${left}px`,
-      top: `${adjustedTop}px`,
-      transformOrigin: `center ${itemOffsetTop}px`,
-    };
+    this.adapter_.setMenuElStyle(left: `${left}px`);
+    this.adapter_.setMenuElStyle(this.adapter_.setMenuElStyle(top: `${adjustedTop}px`);
+    this.adapter_.setMenuElStyle(this.adapter_.setMenuElStyle(transformOrigin: `center ${itemOffsetTop}px`);
   }
 
   close_() {

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -190,7 +190,7 @@ export default class MDCSelectFoundation extends MDCFoundation {
   setMenuStylesForOpenAtIndex_(index) {
     const innerHeight = this.adapter_.getWindowInnerHeight();
     const {left, top} = this.adapter_.computeBoundingRect();
-    const pageYOffset = this.adapter_.getPageYoffset();
+    const pageYOffset = this.adapter_.getPageYOffset();
 
     this.adapter_.setMenuElAttr('aria-hidden', 'true');
     this.adapter_.setMenuElStyle('display', 'block');

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -66,8 +66,7 @@ export default class MDCSelectFoundation extends MDCFoundation {
       registerMenuInteractionHandler: (/* type: string, handler: EventListener */) => {},
       deregisterMenuInteractionHandler: (/* type: string, handler: EventListener */) => {},
       notifyChange: () => {},
-      getWindowInnerHeight: () => /* number */ 0,
-      getPageYOffset: () =>  /* number */ 0,
+      computeBoundingContainer: () => /* {innerHeight: number, yOffset: number} */ {},
     };
   }
 
@@ -188,9 +187,8 @@ export default class MDCSelectFoundation extends MDCFoundation {
   }
 
   setMenuStylesForOpenAtIndex_(index) {
-    const innerHeight = this.adapter_.getWindowInnerHeight();
+    const {innerHeight, yOffset} = this.adapter_.computeBoundingContainer();
     const {left, top} = this.adapter_.computeBoundingRect();
-    const pageYOffset = this.adapter_.getPageYOffset();
 
     this.adapter_.setMenuElAttr('aria-hidden', 'true');
     this.adapter_.setMenuElStyle('display', 'block');
@@ -209,7 +207,7 @@ export default class MDCSelectFoundation extends MDCFoundation {
     };
 
     this.adapter_.setMenuElStyle('left', `${left}px`);
-    this.adapter_.setMenuElStyle('top', `${adjustedTop + pageYOffset}px`);
+    this.adapter_.setMenuElStyle('top', `${adjustedTop + yOffset}px`);
     this.adapter_.setMenuElStyle('transform-origin', `center ${itemOffsetTop}px`);
   }
 

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -111,7 +111,9 @@ export class MDCSelect extends MDCComponent {
       registerMenuInteractionHandler: (type, handler) => this.menu_.listen(type, handler),
       deregisterMenuInteractionHandler: (type, handler) => this.menu_.unlisten(type, handler),
       notifyChange: () => this.emit('MDCSelect:change', this),
-      computeBoundingContainer: () => {return {innerHeight: window.innerHeight, yOffset: window.pageYOffset}},
+      computeBoundingContainer: () => {
+        return {innerHeight: window.innerHeight, yOffset: window.pageYOffset};
+      },
     });
   }
 

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -111,8 +111,7 @@ export class MDCSelect extends MDCComponent {
       registerMenuInteractionHandler: (type, handler) => this.menu_.listen(type, handler),
       deregisterMenuInteractionHandler: (type, handler) => this.menu_.unlisten(type, handler),
       notifyChange: () => this.emit('MDCSelect:change', this),
-      getWindowInnerHeight: () => window.innerHeight,
-      getPageYOffset: () => window.pageYOffset,
+      computeBoundingContainer: () => {return {innerHeight: window.innerHeight, yOffset: window.pageYOffset}},
     });
   }
 

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -112,6 +112,7 @@ export class MDCSelect extends MDCComponent {
       deregisterMenuInteractionHandler: (type, handler) => this.menu_.unlisten(type, handler),
       notifyChange: () => this.emit('MDCSelect:change', this),
       getWindowInnerHeight: () => window.innerHeight,
+      getPageYoffset: () => window.pageYOffset,
     });
   }
 

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -14,262 +14,117 @@
  * limitations under the License.
  */
 
-@import "@material/animation/functions";
-@import "@material/typography/mixins";
-@import "@material/theme/mixins";
-@import "@material/rtl/mixins";
+import {MDCComponent} from '@material/base';
+import {MDCSimpleMenu} from '@material/menu';
 
-@mixin mdc-select-dd-arrow-svg-bg_($fill-hex-number: 000000, $opacity: .54) {
-  background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%23#{$fill-hex-number}%22%20fill-rule%3D%22evenodd%22%20opacity%3D%22#{$opacity}%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E);
-}
+import MDCSelectFoundation from './foundation';
 
-// postcss-bem-linter: define select
-.mdc-select {
-  $dd-arrow-padding: 24px;
+export {MDCSelectFoundation};
 
-  @include mdc-typography(subheading2);
-  @include mdc-theme-prop(color, text-primary-on-light);
-  @include mdc-rtl-reflexive-box(padding, right, $dd-arrow-padding);
-
-  // Resets for <select> element
-  appearance: none;
-
-  &::-ms-expand {
-    display: none;
+export class MDCSelect extends MDCComponent {
+  static attachTo(root) {
+    return new MDCSelect(root);
   }
 
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  max-width: calc(100% - #{$dd-arrow-padding});
-  height: 32px;
-  transition:
-    mdc-animation-exit(border-bottom-color, 150ms),
-    mdc-animation-exit(background-color, 150ms);
-  border: none;
-  border-bottom: 1px solid rgba(black, .12);
-  border-radius: 0;
-  background: none;
-  background-repeat: no-repeat;
-  background-position: right center;
-
-  @include mdc-select-dd-arrow-svg-bg_;
-
-  font-family: Roboto, sans-serif;
-  font-size: .936rem;
-  cursor: pointer;
-
-  &:focus {
-    @include mdc-theme-prop(border-bottom-color, primary);
-
-    outline: none;
-    background-color: rgba(black, .06);
+  get value() {
+    return this.foundation_.getValue();
   }
 
-  @include mdc-rtl {
-    background-position: left center;
+  get options() {
+    return this.menu_.items;
   }
 
-  @include mdc-theme-dark {
-    @include mdc-theme-prop(color, text-primary-on-dark);
-    @include mdc-select-dd-arrow-svg-bg_(ffffff);
-
-    border-bottom: 1px solid rgba(white, .12);
-
-    &:focus {
-      @include mdc-theme-prop(border-bottom-color, primary);
-
-      background-color: rgba(white, .09);
-    }
+  get selectedOptions() {
+    return this.root_.querySelectorAll('[aria-selected]');
   }
 
-  &__menu {
-    position: absolute;
-    top: 0;
-    left: 0;
-    max-height: 100%;
-    transform-origin: center center;
-    overflow-y: scroll;
-    z-index: 4; // Should pop up above everything else. temporary-drawer is next highest at 3.
+  get selectedIndex() {
+    return this.foundation_.getSelectedIndex();
   }
 
-  &__selected-text {
-    transition:
-      mdc-animation-exit(opacity, 125ms),
-      mdc-animation-exit(transform, 125ms);
-    white-space: nowrap;
-    overflow: hidden;
+  set selectedIndex(selectedIndex) {
+    this.foundation_.setSelectedIndex(selectedIndex);
   }
-}
 
-.mdc-select--open {
-  .mdc-select__selected-text {
-    transform: translateY(8px);
-    transition:
-      mdc-animation-enter(opacity, 125ms, 125ms),
-      mdc-animation-enter(transform, 125ms, 125ms);
-    opacity: 0;
+  get disabled() {
+    return this.foundation_.isDisabled();
   }
-}
 
-.mdc-select--disabled,
-.mdc-select[disabled] {
-  @include mdc-theme-prop(color, text-disabled-on-light);
-  @include mdc-select-dd-arrow-svg-bg_(000000, .38);
-
-  border-bottom-style: dotted;
-  cursor: default;
-  pointer-events: none;
-  // Imitate native disabled functionality
-  user-select: none;
-}
-
-@each $sel in ("mdc-select--disabled", "mdc-select[disabled]") {
-  .#{$sel} {
-    @include mdc-theme-dark(".mdc-select", true) {
-      @include mdc-theme-prop(color, text-disabled-on-dark);
-      @include mdc-select-dd-arrow-svg-bg_(ffffff, .38);
-
-      border-bottom: 1px dotted rgba(white, .38);
-    }
+  set disabled(disabled) {
+    this.foundation_.setDisabled(disabled);
   }
-}
 
-// postcss-bem-linter: end
+  item(index) {
+    return this.options[index] || null;
+  }
 
-.mdc-select__menu {
-  .mdc-list-item {
-    @include mdc-typography(subheading2);
-    @include mdc-theme-prop(color, text-secondary-on-light);
-
-    &[aria-selected="true"] {
-      @include mdc-theme-prop(color, text-primary-on-light);
-    }
-
-    @include mdc-theme-dark(".mdc-select") {
-      @include mdc-theme-prop(color, text-secondary-on-dark);
-
-      &[aria-selected="true"] {
-        @include mdc-theme-prop(color, text-primary-on-dark);
+  nameditem(key) {
+    // NOTE: IE11 precludes us from using Array.prototype.find
+    for (let i = 0, options = this.options, option; (option = options[i]); i++) {
+      if (option.id === key || option.getAttribute('name') === key) {
+        return option;
       }
     }
+    return null;
   }
 
-  .mdc-list-group,
-  .mdc-list-group > .mdc-list-item:first-child {
-    margin-top: 12px;
+  initialize(menuFactory = (el) => new MDCSimpleMenu(el)) {
+    this.menuEl_ = this.root_.querySelector('.mdc-select__menu');
+    this.menu_ = menuFactory(this.menuEl_);
+    this.selectedText_ = this.root_.querySelector('.mdc-select__selected-text');
   }
 
-  .mdc-list-group {
-    @include mdc-theme-prop(color, text-hint-on-light);
+  getDefaultFoundation() {
+    return new MDCSelectFoundation({
+      addClass: (className) => this.root_.classList.add(className),
+      removeClass: (className) => this.root_.classList.remove(className),
+      setAttr: (attr, value) => this.root_.setAttribute(attr, value),
+      rmAttr: (attr, value) => this.root_.removeAttribute(attr, value),
+      computeBoundingRect: () => this.root_.getBoundingClientRect(),
+      registerInteractionHandler: (type, handler) => this.root_.addEventListener(type, handler),
+      deregisterInteractionHandler: (type, handler) => this.root_.removeEventListener(type, handler),
+      focus: () => this.root_.focus(),
+      makeTabbable: () => {
+        this.root_.tabIndex = 0;
+      },
+      makeUntabbable: () => {
+        this.root_.tabIndex = -1;
+      },
+      getComputedStyleValue: (prop) => window.getComputedStyle(this.root_).getPropertyValue(prop),
+      setStyle: (propertyName, value) => this.root_.style.setProperty(propertyName, value),
+      create2dRenderingContext: () => document.createElement('canvas').getContext('2d'),
+      setMenuElStyle: (propertyName, value) => this.menuEl_.style.setProperty(propertyName, value),
+      setMenuElAttr: (attr, value) => this.menuEl_.setAttribute(attr, value),
+      rmMenuElAttr: (attr) => this.menuEl_.removeAttribute(attr),
+      getMenuElOffsetHeight: () => this.menuEl_.offsetHeight,
+      openMenu: (focusIndex) => this.menu_.show({focusIndex}),
+      isMenuOpen: () => this.menu_.open,
+      setSelectedTextContent: (selectedTextContent) => {
+        this.selectedText_.textContent = selectedTextContent;
+      },
+      getNumberOfOptions: () => this.options.length,
+      getTextForOptionAtIndex: (index) => this.options[index].textContent,
+      getValueForOptionAtIndex: (index) => this.options[index].id || this.options[index].textContent,
+      setAttrForOptionAtIndex: (index, attr, value) => this.options[index].setAttribute(attr, value),
+      rmAttrForOptionAtIndex: (index, attr) => this.options[index].removeAttribute(attr),
+      getOffsetTopForOptionAtIndex: (index) => this.options[index].offsetTop,
+      registerMenuInteractionHandler: (type, handler) => this.menu_.listen(type, handler),
+      deregisterMenuInteractionHandler: (type, handler) => this.menu_.unlisten(type, handler),
+      notifyChange: () => this.emit('MDCSelect:change', this),
+      getWindowInnerHeight: () => window.innerHeight,
+      getPageYOffset: () => window.pageYOffset,
+    });
+  }
 
-    font-weight: normal;
-
-    .mdc-list-item {
-      @include mdc-theme-prop(color, text-primary-on-light);
+  initialSyncWithDOM() {
+    const selectedOption = this.selectedOptions[0];
+    const idx = selectedOption ? this.options.indexOf(selectedOption) : -1;
+    if (idx >= 0) {
+      this.selectedIndex = idx;
     }
-  }
 
-  @include mdc-theme-dark(".mdc-select") {
-    .mdc-list-group {
-      @include mdc-theme-prop(color, text-hint-on-dark);
-
-      .mdc-list-item {
-        @include mdc-theme-prop(color, text-primary-on-dark);
-      }
+    if (this.root_.getAttribute('aria-disabled') === 'true') {
+      this.disabled = true;
     }
   }
 }
-
-// postcss-bem-linter: define multi-select
-.mdc-multi-select {
-  appearance: none;
-  width: 250px;
-  padding: 0;
-  border: 1px solid;
-
-  @include mdc-theme-prop(border-color, text-hint-on-light);
-
-  @include mdc-theme-dark {
-    @include mdc-theme-prop(border-color, text-hint-on-dark);
-  }
-
-  outline: none;
-
-  // stylelint-disable plugin/selector-bem-pattern
-  .mdc-list-group {
-    margin: 16px 0 0;
-    padding: 0 0 0 16px;
-
-    @include mdc-theme-prop(color, text-hint-on-light);
-
-    @include mdc-theme-dark {
-      @include mdc-theme-prop(color, text-hint-on-dark);
-    }
-
-    font-weight: normal;
-
-    &:last-child {
-      margin-bottom: 16px;
-    }
-
-    .mdc-list-divider {
-      margin-left: -16px;
-    }
-  }
-  // stylelint-enable plugin/selector-bem-pattern
-
-  // stylelint-disable plugin/selector-bem-pattern
-  .mdc-list-item {
-    margin: 0 0 0 -16px;
-    padding: 0 16px;
-
-    @include mdc-theme-prop(color, text-primary-on-light);
-
-    @include mdc-theme-dark {
-      @include mdc-theme-prop(color, text-primary-on-dark);
-    }
-
-    &:first-child {
-      margin-top: 12px;
-    }
-
-    &:last-child {
-      margin-bottom: 8px;
-    }
-  }
-  // stylelint-enable plugin/selector-bem-pattern
-
-  // stylelint-disable plugin/selector-bem-pattern
-  .mdc-list-item:checked {
-    background-color: rgba(black, .12);
-
-    @include mdc-theme-prop(background-color, background);
-
-    @include mdc-theme-dark {
-      @include mdc-theme-prop(background-color, text-primary-on-dark);
-    }
-  }
-  // stylelint-enable plugin/selector-bem-pattern
-}
-
-.mdc-multi-select:focus .mdc-list-item:checked {
-  @include mdc-theme-prop(background-color, primary);
-
-  @include mdc-theme-dark {
-    @include mdc-theme-prop(background-color, text-primary-on-dark);
-  }
-}
-
-// height for option elements cannot be controlled
-// with CSS. Use the font-size rule instead.
-
-// stylelint-disable plugin/selector-bem-pattern
-.mdc-list-divider {
-  margin-bottom: 8px;
-  padding-top: 8px;
-  font-size: 0;
-}
-// stylelint-enable plugin/selector-bem-pattern
-
-// postcss-bem-linter: end

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -14,117 +14,262 @@
  * limitations under the License.
  */
 
-import {MDCComponent} from '@material/base';
-import {MDCSimpleMenu} from '@material/menu';
+@import "@material/animation/functions";
+@import "@material/typography/mixins";
+@import "@material/theme/mixins";
+@import "@material/rtl/mixins";
 
-import MDCSelectFoundation from './foundation';
+@mixin mdc-select-dd-arrow-svg-bg_($fill-hex-number: 000000, $opacity: .54) {
+  background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%23#{$fill-hex-number}%22%20fill-rule%3D%22evenodd%22%20opacity%3D%22#{$opacity}%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E);
+}
 
-export {MDCSelectFoundation};
+// postcss-bem-linter: define select
+.mdc-select {
+  $dd-arrow-padding: 24px;
 
-export class MDCSelect extends MDCComponent {
-  static attachTo(root) {
-    return new MDCSelect(root);
+  @include mdc-typography(subheading2);
+  @include mdc-theme-prop(color, text-primary-on-light);
+  @include mdc-rtl-reflexive-box(padding, right, $dd-arrow-padding);
+
+  // Resets for <select> element
+  appearance: none;
+
+  &::-ms-expand {
+    display: none;
   }
 
-  get value() {
-    return this.foundation_.getValue();
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  max-width: calc(100% - #{$dd-arrow-padding});
+  height: 32px;
+  transition:
+    mdc-animation-exit(border-bottom-color, 150ms),
+    mdc-animation-exit(background-color, 150ms);
+  border: none;
+  border-bottom: 1px solid rgba(black, .12);
+  border-radius: 0;
+  background: none;
+  background-repeat: no-repeat;
+  background-position: right center;
+
+  @include mdc-select-dd-arrow-svg-bg_;
+
+  font-family: Roboto, sans-serif;
+  font-size: .936rem;
+  cursor: pointer;
+
+  &:focus {
+    @include mdc-theme-prop(border-bottom-color, primary);
+
+    outline: none;
+    background-color: rgba(black, .06);
   }
 
-  get options() {
-    return this.menu_.items;
+  @include mdc-rtl {
+    background-position: left center;
   }
 
-  get selectedOptions() {
-    return this.root_.querySelectorAll('[aria-selected]');
-  }
+  @include mdc-theme-dark {
+    @include mdc-theme-prop(color, text-primary-on-dark);
+    @include mdc-select-dd-arrow-svg-bg_(ffffff);
 
-  get selectedIndex() {
-    return this.foundation_.getSelectedIndex();
-  }
+    border-bottom: 1px solid rgba(white, .12);
 
-  set selectedIndex(selectedIndex) {
-    this.foundation_.setSelectedIndex(selectedIndex);
-  }
+    &:focus {
+      @include mdc-theme-prop(border-bottom-color, primary);
 
-  get disabled() {
-    return this.foundation_.isDisabled();
-  }
-
-  set disabled(disabled) {
-    this.foundation_.setDisabled(disabled);
-  }
-
-  item(index) {
-    return this.options[index] || null;
-  }
-
-  nameditem(key) {
-    // NOTE: IE11 precludes us from using Array.prototype.find
-    for (let i = 0, options = this.options, option; (option = options[i]); i++) {
-      if (option.id === key || option.getAttribute('name') === key) {
-        return option;
-      }
+      background-color: rgba(white, .09);
     }
-    return null;
   }
 
-  initialize(menuFactory = (el) => new MDCSimpleMenu(el)) {
-    this.menuEl_ = this.root_.querySelector('.mdc-select__menu');
-    this.menu_ = menuFactory(this.menuEl_);
-    this.selectedText_ = this.root_.querySelector('.mdc-select__selected-text');
+  &__menu {
+    position: absolute;
+    top: 0;
+    left: 0;
+    max-height: 100%;
+    transform-origin: center center;
+    overflow-y: scroll;
+    z-index: 4; // Should pop up above everything else. temporary-drawer is next highest at 3.
   }
 
-  getDefaultFoundation() {
-    return new MDCSelectFoundation({
-      addClass: (className) => this.root_.classList.add(className),
-      removeClass: (className) => this.root_.classList.remove(className),
-      setAttr: (attr, value) => this.root_.setAttribute(attr, value),
-      rmAttr: (attr, value) => this.root_.removeAttribute(attr, value),
-      computeBoundingRect: () => this.root_.getBoundingClientRect(),
-      registerInteractionHandler: (type, handler) => this.root_.addEventListener(type, handler),
-      deregisterInteractionHandler: (type, handler) => this.root_.removeEventListener(type, handler),
-      focus: () => this.root_.focus(),
-      makeTabbable: () => {
-        this.root_.tabIndex = 0;
-      },
-      makeUntabbable: () => {
-        this.root_.tabIndex = -1;
-      },
-      getComputedStyleValue: (prop) => window.getComputedStyle(this.root_).getPropertyValue(prop),
-      setStyle: (propertyName, value) => this.root_.style.setProperty(propertyName, value),
-      create2dRenderingContext: () => document.createElement('canvas').getContext('2d'),
-      setMenuElStyle: (propertyName, value) => this.menuEl_.style.setProperty(propertyName, value),
-      setMenuElAttr: (attr, value) => this.menuEl_.setAttribute(attr, value),
-      rmMenuElAttr: (attr) => this.menuEl_.removeAttribute(attr),
-      getMenuElOffsetHeight: () => this.menuEl_.offsetHeight,
-      openMenu: (focusIndex) => this.menu_.show({focusIndex}),
-      isMenuOpen: () => this.menu_.open,
-      setSelectedTextContent: (selectedTextContent) => {
-        this.selectedText_.textContent = selectedTextContent;
-      },
-      getNumberOfOptions: () => this.options.length,
-      getTextForOptionAtIndex: (index) => this.options[index].textContent,
-      getValueForOptionAtIndex: (index) => this.options[index].id || this.options[index].textContent,
-      setAttrForOptionAtIndex: (index, attr, value) => this.options[index].setAttribute(attr, value),
-      rmAttrForOptionAtIndex: (index, attr) => this.options[index].removeAttribute(attr),
-      getOffsetTopForOptionAtIndex: (index) => this.options[index].offsetTop,
-      registerMenuInteractionHandler: (type, handler) => this.menu_.listen(type, handler),
-      deregisterMenuInteractionHandler: (type, handler) => this.menu_.unlisten(type, handler),
-      notifyChange: () => this.emit('MDCSelect:change', this),
-      getWindowInnerHeight: () => window.innerHeight,
-      getPageYoffset: () => window.pageYOffset,
-    });
+  &__selected-text {
+    transition:
+      mdc-animation-exit(opacity, 125ms),
+      mdc-animation-exit(transform, 125ms);
+    white-space: nowrap;
+    overflow: hidden;
   }
+}
 
-  initialSyncWithDOM() {
-    const selectedOption = this.selectedOptions[0];
-    const idx = selectedOption ? this.options.indexOf(selectedOption) : -1;
-    if (idx >= 0) {
-      this.selectedIndex = idx;
-    }
+.mdc-select--open {
+  .mdc-select__selected-text {
+    transform: translateY(8px);
+    transition:
+      mdc-animation-enter(opacity, 125ms, 125ms),
+      mdc-animation-enter(transform, 125ms, 125ms);
+    opacity: 0;
+  }
+}
 
-    if (this.root_.getAttribute('aria-disabled') === 'true') {
-      this.disabled = true;
+.mdc-select--disabled,
+.mdc-select[disabled] {
+  @include mdc-theme-prop(color, text-disabled-on-light);
+  @include mdc-select-dd-arrow-svg-bg_(000000, .38);
+
+  border-bottom-style: dotted;
+  cursor: default;
+  pointer-events: none;
+  // Imitate native disabled functionality
+  user-select: none;
+}
+
+@each $sel in ("mdc-select--disabled", "mdc-select[disabled]") {
+  .#{$sel} {
+    @include mdc-theme-dark(".mdc-select", true) {
+      @include mdc-theme-prop(color, text-disabled-on-dark);
+      @include mdc-select-dd-arrow-svg-bg_(ffffff, .38);
+
+      border-bottom: 1px dotted rgba(white, .38);
     }
   }
 }
+
+// postcss-bem-linter: end
+
+.mdc-select__menu {
+  .mdc-list-item {
+    @include mdc-typography(subheading2);
+    @include mdc-theme-prop(color, text-secondary-on-light);
+
+    &[aria-selected="true"] {
+      @include mdc-theme-prop(color, text-primary-on-light);
+    }
+
+    @include mdc-theme-dark(".mdc-select") {
+      @include mdc-theme-prop(color, text-secondary-on-dark);
+
+      &[aria-selected="true"] {
+        @include mdc-theme-prop(color, text-primary-on-dark);
+      }
+    }
+  }
+
+  .mdc-list-group,
+  .mdc-list-group > .mdc-list-item:first-child {
+    margin-top: 12px;
+  }
+
+  .mdc-list-group {
+    @include mdc-theme-prop(color, text-hint-on-light);
+
+    font-weight: normal;
+
+    .mdc-list-item {
+      @include mdc-theme-prop(color, text-primary-on-light);
+    }
+  }
+
+  @include mdc-theme-dark(".mdc-select") {
+    .mdc-list-group {
+      @include mdc-theme-prop(color, text-hint-on-dark);
+
+      .mdc-list-item {
+        @include mdc-theme-prop(color, text-primary-on-dark);
+      }
+    }
+  }
+}
+
+// postcss-bem-linter: define multi-select
+.mdc-multi-select {
+  appearance: none;
+  width: 250px;
+  padding: 0;
+  border: 1px solid;
+
+  @include mdc-theme-prop(border-color, text-hint-on-light);
+
+  @include mdc-theme-dark {
+    @include mdc-theme-prop(border-color, text-hint-on-dark);
+  }
+
+  outline: none;
+
+  // stylelint-disable plugin/selector-bem-pattern
+  .mdc-list-group {
+    margin: 16px 0 0;
+    padding: 0 0 0 16px;
+
+    @include mdc-theme-prop(color, text-hint-on-light);
+
+    @include mdc-theme-dark {
+      @include mdc-theme-prop(color, text-hint-on-dark);
+    }
+
+    font-weight: normal;
+
+    &:last-child {
+      margin-bottom: 16px;
+    }
+
+    .mdc-list-divider {
+      margin-left: -16px;
+    }
+  }
+  // stylelint-enable plugin/selector-bem-pattern
+
+  // stylelint-disable plugin/selector-bem-pattern
+  .mdc-list-item {
+    margin: 0 0 0 -16px;
+    padding: 0 16px;
+
+    @include mdc-theme-prop(color, text-primary-on-light);
+
+    @include mdc-theme-dark {
+      @include mdc-theme-prop(color, text-primary-on-dark);
+    }
+
+    &:first-child {
+      margin-top: 12px;
+    }
+
+    &:last-child {
+      margin-bottom: 8px;
+    }
+  }
+  // stylelint-enable plugin/selector-bem-pattern
+
+  // stylelint-disable plugin/selector-bem-pattern
+  .mdc-list-item:checked {
+    background-color: rgba(black, .12);
+
+    @include mdc-theme-prop(background-color, background);
+
+    @include mdc-theme-dark {
+      @include mdc-theme-prop(background-color, text-primary-on-dark);
+    }
+  }
+  // stylelint-enable plugin/selector-bem-pattern
+}
+
+.mdc-multi-select:focus .mdc-list-item:checked {
+  @include mdc-theme-prop(background-color, primary);
+
+  @include mdc-theme-dark {
+    @include mdc-theme-prop(background-color, text-primary-on-dark);
+  }
+}
+
+// height for option elements cannot be controlled
+// with CSS. Use the font-size rule instead.
+
+// stylelint-disable plugin/selector-bem-pattern
+.mdc-list-divider {
+  margin-bottom: 8px;
+  padding-top: 8px;
+  font-size: 0;
+}
+// stylelint-enable plugin/selector-bem-pattern
+
+// postcss-bem-linter: end

--- a/test/unit/mdc-select/foundation-events.test.js
+++ b/test/unit/mdc-select/foundation-events.test.js
@@ -37,8 +37,7 @@ function setupTest() {
     left: 100,
     top: 100,
   });
-  td.when(mockAdapter.getWindowInnerHeight()).thenReturn(500);
-  td.when(mockAdapter.getPageYOffset()).thenReturn(0);
+  td.when(mockAdapter.computeBoundingContainer()).thenReturn({innerHeight: 500, yOffset: 0});
   td.when(mockAdapter.getMenuElOffsetHeight()).thenReturn(100);
   const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
   const menuHandlers = captureHandlers(mockAdapter, 'registerMenuInteractionHandler');
@@ -267,7 +266,7 @@ test('when opened clamps the menu position to the top of the window if it cannot
   const mockMenuHeight = mockAdapter.getMenuElOffsetHeight();
 
   foundation.setSelectedIndex(1);
-  td.when(mockAdapter.getWindowInnerHeight()).thenReturn(mockMenuHeight + 100);
+  td.when(mockAdapter.computeBoundingContainer()).thenReturn({innerHeight: mockMenuHeight + 100, yOffset: 0});
   // Bump off offsetHeight to simulate no good possible placement
   td.when(mockAdapter.getMenuElOffsetHeight()).thenReturn(mockMenuHeight + 200);
   td.when(mockAdapter.getOffsetTopForOptionAtIndex(1)).thenReturn(120);

--- a/test/unit/mdc-select/foundation-events.test.js
+++ b/test/unit/mdc-select/foundation-events.test.js
@@ -38,6 +38,7 @@ function setupTest() {
     top: 100,
   });
   td.when(mockAdapter.getWindowInnerHeight()).thenReturn(500);
+  td.when(mockAdapter.getPageYOffset()).thenReturn(0);
   td.when(mockAdapter.getMenuElOffsetHeight()).thenReturn(100);
   const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
   const menuHandlers = captureHandlers(mockAdapter, 'registerMenuInteractionHandler');

--- a/test/unit/mdc-select/foundation-events.test.js
+++ b/test/unit/mdc-select/foundation-events.test.js
@@ -267,10 +267,10 @@ test('when opened clamps the menu position to the top of the window if it cannot
   const mockMenuHeight = mockAdapter.getMenuElOffsetHeight();
 
   foundation.setSelectedIndex(1);
-  td.when(mockAdapter.getWindowInnerHeight()).thenReturn(mockMenuHeight - 10);
+  td.when(mockAdapter.getWindowInnerHeight()).thenReturn(mockMenuHeight + 100);
   // Bump off offsetHeight to simulate no good possible placement
-  td.when(mockAdapter.getMenuElOffsetHeight()).thenReturn(mockMenuHeight + 10);
-  td.when(mockAdapter.getOffsetTopForOptionAtIndex(1)).thenReturn(20);
+  td.when(mockAdapter.getMenuElOffsetHeight()).thenReturn(mockMenuHeight + 200);
+  td.when(mockAdapter.getOffsetTopForOptionAtIndex(1)).thenReturn(120);
   handlers.click(createEvent());
 
   const mockLocation = mockAdapter.computeBoundingRect();

--- a/test/unit/mdc-select/foundation-events.test.js
+++ b/test/unit/mdc-select/foundation-events.test.js
@@ -242,7 +242,7 @@ test('when opened clamps the menu position to the top of the window if it would 
 test('when opened clamps the menu position to the bottom of the window if it would be ' +
           'positioned below the window', () => {
   const {foundation, mockAdapter, handlers} = setupTest();
-  const mockInnerHeight = mockAdapter.getWindowInnerHeight();
+  const mockInnerHeight = mockAdapter.computeBoundingContainer().innerHeight;
   const mockMenuHeight = mockAdapter.getMenuElOffsetHeight();
 
   foundation.setSelectedIndex(1);

--- a/test/unit/mdc-select/foundation.test.js
+++ b/test/unit/mdc-select/foundation.test.js
@@ -37,7 +37,7 @@ test('default adapter returns a complete adapter implementation', () => {
     'isMenuOpen', 'setSelectedTextContent', 'getNumberOfOptions', 'getTextForOptionAtIndex',
     'setAttrForOptionAtIndex', 'rmAttrForOptionAtIndex', 'getOffsetTopForOptionAtIndex',
     'registerMenuInteractionHandler', 'deregisterMenuInteractionHandler', 'notifyChange',
-    'getWindowInnerHeight', 'getValueForOptionAtIndex',
+    'getWindowInnerHeight', 'getValueForOptionAtIndex', 'getPageYOffset',
   ]);
 });
 

--- a/test/unit/mdc-select/foundation.test.js
+++ b/test/unit/mdc-select/foundation.test.js
@@ -37,7 +37,7 @@ test('default adapter returns a complete adapter implementation', () => {
     'isMenuOpen', 'setSelectedTextContent', 'getNumberOfOptions', 'getTextForOptionAtIndex',
     'setAttrForOptionAtIndex', 'rmAttrForOptionAtIndex', 'getOffsetTopForOptionAtIndex',
     'registerMenuInteractionHandler', 'deregisterMenuInteractionHandler', 'notifyChange',
-    'getWindowInnerHeight', 'getValueForOptionAtIndex', 'getPageYOffset',
+    'computeBoundingContainer', 'getValueForOptionAtIndex',
   ]);
 });
 

--- a/test/unit/mdc-select/mdc-select.test.js
+++ b/test/unit/mdc-select/mdc-select.test.js
@@ -362,9 +362,9 @@ test('adapter#notifyChange emits an "MDCSelect:change" custom event from the roo
   component.getDefaultFoundation().adapter_.notifyChange();
 });
 
-test('adapter#getWindowInnerHeight returns window.innerHeight', () => {
+test('adapter#computeBoundingContainer returns window.innerHeight', () => {
   const {component} = setupTest();
-  assert.equal(component.getDefaultFoundation().adapter_.getWindowInnerHeight(), window.innerHeight);
+  assert.equal(component.getDefaultFoundation().adapter_.computeBoundingContainer().innerHeight, window.innerHeight);
 });
 
 test('adapter#getValueForOptionAtIndex returns the id of the option at the given index', () => {


### PR DESCRIPTION
mdc-select.scss line 87 change fixed to absolute. Positioning of Menu in Foundation corrected to handle window scrolling and conditions when Menu would extend beyond Window (see Luke Bergen's comment). New Adapter interface getPageYOffset required to handle scrolling.

This probably requires some additional tests setting up to cover the new cases?

There is one case that this does not cover. That is if the Select is inside a scrollable element e.g. a Scrollable Dialog. The problem is how to detect this without doing a traversal from the control to the window and checking each parent element, which is obviously not very efficient. Perhaps we need an extra option in the api to allow the programmer to indicate when this is necessary?

Martin