### PR TITLE
Fix (Dialog) Closing Animations not running #433

### DIFF
--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -211,8 +211,11 @@ do so. We provide instructions on how to add ripples to buttons within the [mdc-
 | `deregisterSurfaceInteractionHandler(evt: string, handler: EventListener) => void` | Deregisters an event handler from the dialog surface element. |
 | `registerDocumentKeydownHandler(handler: EventListener) => void` | Registers an event handler on the `document` object for a `keydown` event. |
 | `deregisterDocumentKeydownHandler(handler: EventListener) => void` | Deregisters an event handler on the `document` object for a `keydown` event. |
+| `registerTransitionEndHandler: (handler: EventListener) => void` | Registers an event handler to be called when a transitionend event is triggered on the dialog container sub-element element. |
+| `deregisterTransitionEndHandler: (handler: EventListener) => void` | Deregisters an event handler from a transitionend event listener. This will only be called with handlers that have previously been passed to registerTransitionEndHandler calls. |
 | `notifyAccept() => {}` | Broadcasts an event denoting that the user has accepted the dialog. |
 | `notifyCancel() => {}` | Broadcasts an event denoting that the user has cancelled the dialog. |
+| `isDialog(el: Element) => boolean` | Returns boolean indicating whether the provided element is the dialog surface element. |
 | `trapFocusOnSurface() => {}` | Sets up the DOM which the dialog is contained in such that focusability is restricted to the elements on the dialog surface (see [Handling Focus Trapping](#handling-focus-trapping) below for more details). |
 | `untrapFocusOnSurface() => {}` | Removes any affects of focus trapping on the dialog surface from the DOM (see [Handling Focus Trapping](#handling-focus-trapping) below for more details). |
 

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -18,7 +18,6 @@ Dialogs inform users about a specific task and may contain critical information 
 
 ```html
 <aside id="my-mdc-dialog"
-  style="visibility:hidden"
   class="mdc-dialog"
   role="alertdialog"
   aria-labelledby="my-mdc-dialog-label"
@@ -49,7 +48,6 @@ Some dialogs will not be tall enough to accomodate everything you would like to 
 
 ```html
   <aside id="mdc-dialog-with-list"
-    style="visibility:hidden"
     class="mdc-dialog"
     role="alertdialog"
     aria-labelledby="mdc-dialog-with-list-label"

--- a/packages/mdc-dialog/constants.js
+++ b/packages/mdc-dialog/constants.js
@@ -17,6 +17,7 @@
 export const cssClasses = {
   ROOT: 'mdc-dialog',
   OPEN: 'mdc-dialog--open',
+  ANIMATING: 'mdc-dialog--animating',
   BACKDROP: 'mdc-dialog__backdrop',
   SCROLL_LOCK: 'mdc-dialog-scroll-lock',
   ACCEPT_BTN: 'mdc-dialog__footer__button--accept',

--- a/packages/mdc-dialog/foundation.js
+++ b/packages/mdc-dialog/foundation.js
@@ -45,7 +45,7 @@ export default class MDCDialogFoundation extends MDCFoundation {
       notifyCancel: () => {},
       trapFocusOnSurface: () => {},
       untrapFocusOnSurface: () => {},
-      isDialog: (/* el: Element */) => /* boolean */ false
+      isDialog: (/* el: Element */) => /* boolean */ false,
     };
   }
 

--- a/packages/mdc-dialog/foundation.js
+++ b/packages/mdc-dialog/foundation.js
@@ -30,7 +30,6 @@ export default class MDCDialogFoundation extends MDCFoundation {
     return {
       addClass: (/* className: string */) => {},
       removeClass: (/* className: string */) => {},
-      setStyle: (/* propertyName: string, value: string */) => {},
       addBodyClass: (/* className: string */) => {},
       removeBodyClass: (/* className: string */) => {},
       eventTargetHasClass: (/* target: EventTarget, className: string */) => /* boolean */ false,
@@ -40,16 +39,18 @@ export default class MDCDialogFoundation extends MDCFoundation {
       deregisterSurfaceInteractionHandler: (/* evt: string, handler: EventListener */) => {},
       registerDocumentKeydownHandler: (/* handler: EventListener */) => {},
       deregisterDocumentKeydownHandler: (/* handler: EventListener */) => {},
+      registerTransitionEndHandler: (/* handler: EventListener */) => {},
+      deregisterTransitionEndHandler: (/* handler: EventListener */) => {},
       notifyAccept: () => {},
       notifyCancel: () => {},
       trapFocusOnSurface: () => {},
       untrapFocusOnSurface: () => {},
+      isDialog: (/* el: Element */) => /* boolean */ false
     };
   }
 
   constructor(adapter) {
     super(Object.assign(MDCDialogFoundation.defaultAdapter, adapter));
-
     this.isOpen_ = false;
     this.componentClickHandler_ = () => this.cancel(true);
     this.dialogClickHandler_ = (evt) => this.handleDialogClick_(evt);
@@ -58,34 +59,43 @@ export default class MDCDialogFoundation extends MDCFoundation {
         this.cancel(true);
       }
     };
-  }
+    this.transitionEndHandler_ = (evt) => this.handleTransitionEnd_(evt);
+  };
 
   destroy() {
-    this.close();
+    // Ensure that dialog is cleaned up when destroyed
+    if (this.isOpen_) {
+      this.adapter_.deregisterSurfaceInteractionHandler('click', this.dialogClickHandler_);
+      this.adapter_.deregisterDocumentKeydownHandler(this.documentKeydownHandler_);
+      this.adapter_.deregisterInteractionHandler('click', this.componentClickHandler_);
+      this.adapter_.untrapFocusOnSurface();
+      this.adapter_.deregisterTransitionEndHandler(this.transitionEndHandler_);
+      this.adapter_.removeClass(MDCDialogFoundation.cssClasses.ANIMATING);
+      this.adapter_.removeClass(MDCDialogFoundation.cssClasses.OPEN);
+      this.enableScroll_();
+    }
   }
 
   open() {
     this.isOpen_ = true;
     this.disableScroll_();
-    this.adapter_.setStyle('visibility', 'visible');
-    this.adapter_.addClass(MDCDialogFoundation.cssClasses.OPEN);
-    this.adapter_.trapFocusOnSurface();
-
     this.adapter_.registerDocumentKeydownHandler(this.documentKeydownHandler_);
     this.adapter_.registerSurfaceInteractionHandler('click', this.dialogClickHandler_);
     this.adapter_.registerInteractionHandler('click', this.componentClickHandler_);
+    this.adapter_.registerTransitionEndHandler(this.transitionEndHandler_);
+    this.adapter_.addClass(MDCDialogFoundation.cssClasses.ANIMATING);
+    this.adapter_.addClass(MDCDialogFoundation.cssClasses.OPEN);
   }
 
   close() {
     this.isOpen_ = false;
-    this.adapter_.untrapFocusOnSurface();
-    this.adapter_.removeClass(MDCDialogFoundation.cssClasses.OPEN);
-    this.adapter_.setStyle('visibility', 'hidden');
-    this.enableScroll_();
-
     this.adapter_.deregisterSurfaceInteractionHandler('click', this.dialogClickHandler_);
     this.adapter_.deregisterDocumentKeydownHandler(this.documentKeydownHandler_);
     this.adapter_.deregisterInteractionHandler('click', this.componentClickHandler_);
+    this.adapter_.untrapFocusOnSurface();
+    this.adapter_.registerTransitionEndHandler(this.transitionEndHandler_);
+    this.adapter_.addClass(MDCDialogFoundation.cssClasses.ANIMATING);
+    this.adapter_.removeClass(MDCDialogFoundation.cssClasses.OPEN);
   }
 
   isOpen() {
@@ -117,6 +127,18 @@ export default class MDCDialogFoundation extends MDCFoundation {
       this.cancel(true);
     }
   }
+
+  handleTransitionEnd_(ev) {
+    if (this.adapter_.isDialog(ev.target)) {
+      this.adapter_.deregisterTransitionEndHandler(this.transitionEndHandler_);
+      this.adapter_.removeClass(MDCDialogFoundation.cssClasses.ANIMATING);
+      if (this.isOpen_) {
+        this.adapter_.trapFocusOnSurface();
+      } else {
+        this.enableScroll_();
+      };
+    };
+  };
 
   disableScroll_() {
     this.adapter_.addBodyClass(cssClasses.SCROLL_LOCK);

--- a/packages/mdc-dialog/index.js
+++ b/packages/mdc-dialog/index.js
@@ -67,7 +67,6 @@ export class MDCDialog extends MDCComponent {
     return new MDCDialogFoundation({
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
-      setStyle: (prop, val) => this.root_.style.setProperty(prop, val),
       addBodyClass: (className) => document.body.classList.add(className),
       removeBodyClass: (className) => document.body.classList.remove(className),
       eventTargetHasClass: (target, className) => target.classList.contains(className),
@@ -77,10 +76,13 @@ export class MDCDialog extends MDCComponent {
       deregisterSurfaceInteractionHandler: (evt, handler) => this.dialogSurface_.removeEventListener(evt, handler),
       registerDocumentKeydownHandler: (handler) => document.addEventListener('keydown', handler),
       deregisterDocumentKeydownHandler: (handler) => document.removeEventListener('keydown', handler),
+      registerTransitionEndHandler: (handler) => this.dialogSurface_.addEventListener('transitionend', handler),
+      deregisterTransitionEndHandler: (handler) => this.dialogSurface_.removeEventListener('transitionend', handler),
       notifyAccept: () => this.emit('MDCDialog:accept'),
       notifyCancel: () => this.emit('MDCDialog:cancel'),
       trapFocusOnSurface: () => this.focusTrap_.activate(),
       untrapFocusOnSurface: () => this.focusTrap_.deactivate(),
+      isDialog: (el) => el === this.dialogSurface_,
     });
   }
 }

--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -30,10 +30,30 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
 .mdc-dialog {
   display: flex;
   position: fixed;
+  top: 0;
+  left: 0;
   align-items: center;
   justify-content: center;
-  opacity: 0;
-  z-index: -1;
+  width: 100%;
+  height: 100%;
+  visibility: hidden;
+  z-index: 2;
+
+  &__backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+
+    @include mdc-theme-prop(background-color, text-primary-on-light);
+
+    opacity: 0;
+    z-index: -1;
+
+  }
 
   &__surface {
     display: inline-flex;
@@ -45,7 +65,6 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     min-width: 640px;
     max-width: 865px;
     transform: translateY(150px) scale(.8);
-    transition: mdc-animation-enter(opacity, 120ms), mdc-animation-enter(transform, 120ms);
     border-radius: 2px;
 
     @include mdc-theme-prop(background-color, background);
@@ -62,22 +81,6 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     }
 
     opacity: 0;
-  }
-
-  &__backdrop {
-    display: flex;
-    position: fixed;
-    top: 0;
-    left: 0;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-
-    @include mdc-theme-prop(background-color, text-primary-on-light);
-
-    opacity: 0;
-    z-index: -1;
   }
 
   &__header {
@@ -143,29 +146,36 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
       line-height: 24px;
     }
   }
-}
 
-.mdc-dialog--open {
-  display: flex;
-  top: 0;
-  left: 0;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  opacity: 1;
-  z-index: 2;
+  &--animating {
+    visibility: visible;
 
-  .mdc-dialog__surface {
-    transform: translateY(0) scale(1);
-    transition: mdc-animation-enter(opacity, 120ms), mdc-animation-enter(transform, 120ms);
-    opacity: 1;
+    .mdc-dialog__backdrop {
+      transition: mdc-animation-enter(opacity, 120ms);
+    }
+
+    .mdc-dialog--open .mdc-dialog__surface {
+      transition: mdc-animation-enter(opacity, 120ms), mdc-animation-enter(transform, 120ms);
+    }
+
+    .mdc-dialog__surface {
+      transition: mdc-animation-enter(opacity, 120ms), mdc-animation-enter(transform, 120ms);
+    }
   }
 
-  .mdc-dialog__backdrop {
-    transition: mdc-animation-enter(opacity, 120ms);
-    opacity: .3;
+  &--open {
+    visibility: visible;
+
+    .mdc-dialog__backdrop {
+      opacity: .3;
+    }
+
+    .mdc-dialog__surface {
+      transform: translateY(0) scale(1);
+      opacity: 1;
+    }
   }
+
 }
 
 // postcss-bem-linter: end

--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -52,7 +52,6 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
 
     opacity: 0;
     z-index: -1;
-
   }
 
   &__surface {
@@ -134,7 +133,6 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     padding: 8px;
   }
 
-  // TODO: Replace with breakpoint variable
   @media (max-width: 640px) {
     min-width: 280px;
 
@@ -175,7 +173,6 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
       opacity: 1;
     }
   }
-
 }
 
 // postcss-bem-linter: end

--- a/test/unit/mdc-dialog/foundation.test.js
+++ b/test/unit/mdc-dialog/foundation.test.js
@@ -49,6 +49,7 @@ function setupTest() {
 
 test('#destroy closes the dialog to perform any necessary cleanup', () => {
   const {foundation, mockAdapter} = setupTest();
+  foundation.open();
   foundation.destroy();
 
   td.verify(mockAdapter.removeClass(cssClasses.OPEN));
@@ -113,6 +114,7 @@ test('#open adds the animation class to start an animation', () => {
   const {foundation, mockAdapter} = setupTest();
 
   foundation.open();
+
   td.verify(mockAdapter.addClass(cssClasses.ANIMATING));
 });
 
@@ -120,13 +122,20 @@ test('#open adds scroll lock class to the body', () => {
   const {foundation, mockAdapter} = setupTest();
 
   foundation.open();
+
   td.verify(mockAdapter.addBodyClass(cssClasses.SCROLL_LOCK));
 });
 
 test('#close removes the scroll lock class from the body', () => {
   const {foundation, mockAdapter} = setupTest();
 
+  foundation.open();
+  td.when(mockAdapter.registerTransitionEndHandler(td.callback)).thenCallback({target: {}});
+  td.when(mockAdapter.isDialog(td.matchers.isA(Object))).thenReturn(true);
   foundation.close();
+  td.when(mockAdapter.registerTransitionEndHandler(td.callback)).thenCallback({target: {}});
+  td.when(mockAdapter.isDialog(td.matchers.isA(Object))).thenReturn(true);
+
   td.verify(mockAdapter.removeBodyClass(cssClasses.SCROLL_LOCK));
 });
 
@@ -134,6 +143,8 @@ test('#open activates focus trapping on the dialog surface', () => {
   const {foundation, mockAdapter} = setupTest();
 
   foundation.open();
+  td.when(mockAdapter.registerTransitionEndHandler(td.callback)).thenCallback({target: {}});
+  td.when(mockAdapter.isDialog(td.matchers.isA(Object))).thenReturn(true);
 
   td.verify(mockAdapter.trapFocusOnSurface());
 });

--- a/test/unit/mdc-dialog/mdc-dialog.test.js
+++ b/test/unit/mdc-dialog/mdc-dialog.test.js
@@ -207,20 +207,22 @@ test('adapter#deregisterDocumentKeydownHandler removes a "keydown" handler from 
 
 test('adapter#registerTransitionEndHandler adds a transition end event listener on the dialog element', () => {
   const {root, component} = setupTest();
+  const surface = root.querySelector(strings.DIALOG_SURFACE_SELECTOR);
   const handler = td.func('transitionEndHandler');
   component.getDefaultFoundation().adapter_.registerTransitionEndHandler(handler);
-  domEvents.emit(root, 'transitionend');
+  domEvents.emit(surface, 'transitionend');
 
   td.verify(handler(td.matchers.anything()));
 });
 
 test('adapter#deregisterTransitionEndHandler removes a transition end event listener on the dialog element', () => {
   const {root, component} = setupTest();
+  const surface = root.querySelector(strings.DIALOG_SURFACE_SELECTOR);
   const handler = td.func('transitionEndHandler');
-  root.addEventListener('transitionend', handler);
+  surface.addEventListener('transitionend', handler);
 
   component.getDefaultFoundation().adapter_.deregisterTransitionEndHandler(handler);
-  domEvents.emit(root, 'transitionend');
+  domEvents.emit(surface, 'transitionend');
 
   td.verify(handler(td.matchers.anything()), {times: 0});
 });

--- a/test/unit/mdc-dialog/mdc-dialog.test.js
+++ b/test/unit/mdc-dialog/mdc-dialog.test.js
@@ -28,7 +28,6 @@ function getFixture() {
     <div>
       <button class="open-dialog">click</button>
       <aside id="my-dialog" class="mdc-dialog"
-        style="visibility:hidden;"
         role="alertdialog"
         aria-hidden="true"
         aria-labelledby="my-dialog-label"
@@ -129,12 +128,6 @@ test('adapter#removeClass removes a class from the root element', () => {
   assert.isNotOk(root.classList.contains('foo'));
 });
 
-test('adapter#setStyle sets a style property to the given value on the root element', () => {
-  const {root, component} = setupTest();
-  component.getDefaultFoundation().adapter_.setStyle('background-color', 'red');
-  assert.equal(root.style.backgroundColor, 'red');
-});
-
 test('adapter#addBodyClass adds a class to the body, locking the background scroll', () => {
   const {component} = setupTest();
   component.getDefaultFoundation().adapter_.addBodyClass('mdc-dialog--scroll-lock');
@@ -212,6 +205,26 @@ test('adapter#deregisterDocumentKeydownHandler removes a "keydown" handler from 
   td.verify(handler(td.matchers.anything()), {times: 0});
 });
 
+test('adapter#registerTransitionEndHandler adds a transition end event listener on the dialog element', () => {
+  const {root, component} = setupTest();
+  const handler = td.func('transitionEndHandler');
+  component.getDefaultFoundation().adapter_.registerTransitionEndHandler(handler);
+  domEvents.emit(root, 'transitionend');
+
+  td.verify(handler(td.matchers.anything()));
+});
+
+test('adapter#deregisterTransitionEndHandler removes a transition end event listener on the dialog element', () => {
+  const {root, component} = setupTest();
+  const handler = td.func('transitionEndHandler');
+  root.addEventListener('transitionend', handler);
+
+  component.getDefaultFoundation().adapter_.deregisterTransitionEndHandler(handler);
+  domEvents.emit(root, 'transitionend');
+
+  td.verify(handler(td.matchers.anything()), {times: 0});
+});
+
 test('adapter#eventTargetHasClass returns whether or not the className is in the target\'s classList', () => {
   const {component} = setupTest();
   const target = bel`<div class="existent-class"></div>`;
@@ -285,4 +298,15 @@ test('adapter#untrapFocusOnSurface calls deactivate() on a properly configured f
   util.createFocusTrapInstance = createFocusTrapInstance;
 
   td.verify(fakeFocusTrapInstance.deactivate());
+});
+
+test('adapter#isDialog returns true for the dialog surface element', () => {
+  const {root, component} = setupTest();
+  const dialog = root.querySelector(strings.DIALOG_SURFACE_SELECTOR);
+  assert.isOk(component.getDefaultFoundation().adapter_.isDialog(dialog));
+});
+
+test('adapter#isDialog returns false for a non-dialog surface element', () => {
+  const {root, component} = setupTest();
+  assert.isNotOk(component.getDefaultFoundation().adapter_.isDialog(root));
 });


### PR DESCRIPTION
-  Refactor scss to include Animating class.
-  Modify foundation to use Animating class and transitionEnd event for opening and closing Dialog. Alter open close and destroy methods appropriately.
-  Move style="visibility:hidden" attribute into scss so that it is not required in html.

Resolves #433

BREAKING CHANGES: 
-  Dialogs do not require a style="visibility:hidden" attribute in html.
-  registerTransitionEndHandler, deregisterTransitionEndHandler, and isDialog methods must be implemented by the adapter