### PR TITLE
Fixed "Title jumps to the next line, out of the toolbar #508"

### DIFF
--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -96,7 +96,7 @@ of the toolbar (respectively).
 ```
 
 Toolbar sections are laid out using flexbox. Each section will take up an equal
-amount of space within the toolbar.
+amount of space within the toolbar by default. But you can accommodate very long section (very long title) by adding `mdc-toolbar__section--shrink-to-fit` to the rest of the section
 
 ### Toolbar title
 
@@ -139,3 +139,4 @@ The provided modifiers are:
 | `mdc-toolbar--fixed`                 | Make toolbar fixed to top of screen.    |
 | `mdc-toolbar__section--align-start`  | Makes section aligns to the start.      |
 | `mdc-toolbar__section--align-end`    | Makes section aligns to the end.        |
+| `mdc-toolbar__section--shrink-to-fit`| Makes section take more space.          |

--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -96,7 +96,7 @@ of the toolbar (respectively).
 ```
 
 Toolbar sections are laid out using flexbox. Each section will take up an equal
-amount of space within the toolbar by default. But you can accommodate very long section (very long title) by adding `mdc-toolbar__section--shrink-to-fit` to the rest of the section
+amount of space within the toolbar by default. But you can accommodate very long section (very long title) by adding `mdc-toolbar__section--shrink-to-fit` to other sections.
 
 ```
 <div class="mdc-toolbar>

--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -98,6 +98,19 @@ of the toolbar (respectively).
 Toolbar sections are laid out using flexbox. Each section will take up an equal
 amount of space within the toolbar by default. But you can accommodate very long section (very long title) by adding `mdc-toolbar__section--shrink-to-fit` to the rest of the section
 
+```
+<div class="mdc-toolbar>
+  <div class="mdc-toolbar__row">
+      <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+        <span class="mdc-toolbar__title">This is a super super super super long title</span>
+      </section>
+      <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit">
+        <a class="material-icons search align-icons" aria-label="Search" alt="Search">search</a>
+      </section>
+  </div>
+</div>
+```
+
 ### Toolbar title
 
 You can use the `mdc-toolbar__title` element to style toolbar text representing
@@ -139,4 +152,4 @@ The provided modifiers are:
 | `mdc-toolbar--fixed`                 | Make toolbar fixed to top of screen.    |
 | `mdc-toolbar__section--align-start`  | Makes section aligns to the start.      |
 | `mdc-toolbar__section--align-end`    | Makes section aligns to the end.        |
-| `mdc-toolbar__section--shrink-to-fit`| Makes section take more space.          |
+| `mdc-toolbar__section--shrink-to-fit`| Makes section takes the width of its content.|

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -74,7 +74,7 @@ $mdc-toolbar-mobile-breakpoint: 599px;
 
   &__title {
     @include mdc-typography(title);
-    
+
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -59,6 +59,7 @@ $mdc-toolbar-mobile-breakpoint: 599px;
     align-items: flex-start;
     justify-content: center;
     z-index: 1;
+    overflow: hidden;
 
     &--align-start {
       justify-content: flex-start;
@@ -74,7 +75,9 @@ $mdc-toolbar-mobile-breakpoint: 599px;
 
   &__title {
     @include mdc-typography(title);
-
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     margin: 0;
     line-height: 1.5rem;
   }

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -101,6 +101,6 @@ $mdc-toolbar-mobile-breakpoint: 599px;
   }
 }
 
-.mdc-toolbar__section-shrink-to-fit {
+.mdc-toolbar__section--shrink-to-fit {
   flex: none;
 }

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -69,7 +69,6 @@ $mdc-toolbar-mobile-breakpoint: 599px;
     &--align-end {
       justify-content: flex-end;
       order: 1;
-      flex: 0;
     }
   }
 

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -98,3 +98,7 @@ $mdc-toolbar-mobile-breakpoint: 599px;
     margin-top: $mdc-toolbar-mobile-row-height;
   }
 }
+
+.mdc-toolbar__section-shrink-to-fit {
+  flex: none;
+}

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -68,6 +68,7 @@ $mdc-toolbar-mobile-breakpoint: 599px;
     &--align-end {
       justify-content: flex-end;
       order: 1;
+      flex: 0;
     }
   }
 

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -74,6 +74,7 @@ $mdc-toolbar-mobile-breakpoint: 599px;
 
   &__title {
     @include mdc-typography(title);
+    
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
Hey,
I tried to fix the toolbar problem with adding a `flex: 0;` style to the `.mdc-toolbar__section--align-end` class as mentioned in the issue #508.
## EDIT
I added a class `mdc-toolbar__section--shrink-to-fit` that fixes the problem as well as some essential css code. Thanks to @yeelan0319.