### PR TITLE
docs: Preparing component markdown for documentation site.

### DIFF
--- a/.mdc-docsite.yml
+++ b/.mdc-docsite.yml
@@ -7,3 +7,4 @@ site_short_title: Web
 site_description: >
   Material Components for Web is a set of user interface components that help developers build web apps with material design.
 repo_url: https://github.com/material-components/material-components-web/
+repo_stable_branch: master

--- a/.mdc-docsite.yml
+++ b/.mdc-docsite.yml
@@ -1,0 +1,9 @@
+# Doc site configuration.
+# TODO(shyndman): Link to documentation.
+basepath: /web
+site_platform: web
+site_title: Material Components for the Web
+site_short_title: Web
+site_description: >
+  Material Components for Web is a set of user interface components that help developers build web apps with material design.
+repo_url: https://github.com/material-components/material-components-web/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Developed by a core team of engineers and UX designers at Google, these componen
 Material Components for the web is the successor to [Material Design Lite](https://getmdl.io/), and has 3 high-level goals:
 
 - Production-ready components consumable in an a-la-carte fashion
-- Best-in-class performance and adherence to the [Material Design guidelines](https://material.google.com)
+- Best-in-class performance and adherence to the [Material Design guidelines](https://material.io/guidelines)
 - Seamless integration with other JS frameworks and libraries
 
 MDC-Web strives to seamlessly incorporate into a wider range of usage contexts, from simple static websites to complex, JavaScript-heavy applications to hybrid client/server rendering systems. In short, whether you're already heavily invested in another framework or not, it should be easy to incorporate Material Components into your site in a lightweight, idiomatic fashion.
@@ -146,7 +146,7 @@ open http://localhost:8080
 - [Contributing](CONTRIBUTING.md)
 - [Developing MDC-Web Components](docs/developer.md)
 - [Material.io](https://www.material.io) (external site)
-- [Material Design Guidelines](https://material.google.com) (external site)
+- [Material Design Guidelines](https://material.io/guidelines) (external site)
 
 ## Browser Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,6 @@ project.
 
 To jump right in and begin using the library, check out our [Getting Started Guide](./getting-started.md)
 
-If you're interested in a general overview of MDC-Web, check out [developer.md](./developer.md). If
+If you're interested in a general overview of MDC-Web, check out [our developer guide](./developer.md). If
 you want to take a deep dive through our architectural overview, jump right into
-[architecture.md](./architecture.md).
+[architecture](./architecture.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,11 @@
-# MDC-Web Docs
+<!--docs:
+title: "Documentation"
+layout: landing
+section: docs
+path: /docs/
+-->
+
+# Documentation
 
 Welcome to our (very-much-still-in-progress) documentation! As we develop MDC-Web, we will be
 adding and amending this documentation such that it is both easy to get you up-and-running, as well as

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -335,6 +335,6 @@ It is also worth mentioning that **most of this will be opaque to end users.** W
 
 ## Resources
 
-- The [mdc-checkbox](https://github.com/material-components/material-components-web/tree/master/packages/mdc-checkbox) component is an example of a complex UI component which requires foundations and adapters. We also have a [react example](https://github.com/material-components/material-components-web/tree/master/framework-examples/react) where we create a React component using the foundation class.
-- Our [mdc-base](https://github.com/material-components/material-components-web/tree/master/packages/mdc-base) package contains the core Foundation and Component classes which all of our other MDC-Web components derive from. If you're interested in contributing _directly_ to MDC-Web, it's worth a read!
+- The [mdc-checkbox](../packages/mdc-checkbox) component is an example of a complex UI component which requires foundations and adapters. We also have a [react example](https://github.com/material-components/material-components-web/tree/master/framework-examples/react) where we create a React component using the foundation class.
+- Our [mdc-base](../packages/mdc-base) package contains the core Foundation and Component classes which all of our other MDC-Web components derive from. If you're interested in contributing _directly_ to MDC-Web, it's worth a read!
 - As per usual our [contributing docs](https://github.com/material-components/material-components-web/blob/master/CONTRIBUTING.md) contain information about how to actually develop MDC-Web.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,11 +1,11 @@
 # MDC-Web Architecture Overview
 
-The following is an outline of the MDC-Web architecture. Many of the architectural decisions we made were in response to the problems and feedback the team has received around Material Design Lite (MDL), the predecessor to MDC-Web. The goals of the MDC-Web architecture are to not only provide an easy way to provide a material UI for static websites, but for _dynamic websites and frameworks as well_. Essentially, _the goal of MDC-Web is to be the canonical material design implementation for the web platform_. We want MDC-Web to be:
+The following is an outline of the MDC-Web architecture. Many of the architectural decisions we made were in response to the problems and feedback the team has received around Material Design Lite (MDL), the predecessor to MDC-Web. The goals of the MDC-Web architecture are to not only provide an easy way to provide a material UI for static websites, but for _dynamic websites and frameworks as well_. Essentially, _the goal of MDC-Web is to be the canonical Material Design implementation for the web platform_. We want MDC-Web to be:
 
-* Accurate to the [material design spec](https://material.google.com/) with the highest possible fidelity, with graceful degradation in situations where this cannot be achieved.
+* Accurate to the [Material Design guidelines](https://material.io/guidelines/) with the highest possible fidelity, with graceful degradation in situations where this cannot be achieved.
 * Plug-and-play for people who just want to add styles to a static site, just like [Material Design Lite](https://getmdl.io).
 * Modular and un-invasive for developers who want to create more complex, dynamic sites using Material Design.
-* Easy to integrate into third-party libraries and frameworks, with minimal duplication of effort. There should not be N different material design implementations for N different frameworks. We strive for _one_ universal implementation across the web, and want to facilitate library developers who want material design components for their frameworks.
+* Easy to integrate into third-party libraries and frameworks, with minimal duplication of effort. There should not be N different Material Design implementations for N different frameworks. We strive for _one_ universal implementation across the web, and want to facilitate library developers who want Material Design components for their frameworks.
 
 ## No automatic DOM traversal and rendering
 
@@ -127,7 +127,7 @@ class RGBSquare {
   /** destruction lifecycle method */
   destroy() {
     this.root_.removeEventListener('click', this.clickHandler_);
-  }  
+  }
 
   update_() {
     const oldClass = this.colorClass_(this.counter_);
@@ -170,7 +170,7 @@ class RGBSquare {
   /** destruction lifecycle method */
   destroy() {
     SOMEHOW_DEREGISTER_CLICK_HANDLER(this.clickHandler_);
-  }  
+  }
 
   update_() {
     const oldClass = this.colorClass_(this.counter_);
@@ -234,7 +234,7 @@ class RGBSquareFoundation {
   /** destruction lifecycle method */
   destroy() {
     this.adapter_.deregisterClickHandler(this.clickHandler_);
-  }  
+  }
 
   update_() {
     const oldClass = this.colorClass_(this.counter_);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,10 @@
+<!--docs:
+title: "Architecture Overview"
+layout: landing
+section: docs
+path: /docs/architecture-overview/
+-->
+
 # MDC-Web Architecture Overview
 
 The following is an outline of the MDC-Web architecture. Many of the architectural decisions we made were in response to the problems and feedback the team has received around Material Design Lite (MDL), the predecessor to MDC-Web. The goals of the MDC-Web architecture are to not only provide an easy way to provide a material UI for static websites, but for _dynamic websites and frameworks as well_. Essentially, _the goal of MDC-Web is to be the canonical Material Design implementation for the web platform_. We want MDC-Web to be:

--- a/docs/authoring-components.md
+++ b/docs/authoring-components.md
@@ -1,3 +1,10 @@
+<!--docs:
+title: "Authoring Components"
+layout: landing
+section: docs
+path: /docs/authoring-components/
+-->
+
 # Authoring Components
 
 This document serves as a reference for developing components either directly for MDC-Web or

--- a/docs/closure-compiler.md
+++ b/docs/closure-compiler.md
@@ -1,3 +1,10 @@
+<!--docs:
+title: "Annotating for the Closure Compiler"
+layout: landing
+section: docs
+path: /docs/closure-compiler/
+-->
+
 # Annotating MDC-Web for the Closure Compiler
 
 > TL;DR read the section on our [type system](#mdc-web-type-system) and our [closure compiler conventions](#mdc-web-closure-conventions).

--- a/docs/closure-compiler.md
+++ b/docs/closure-compiler.md
@@ -219,6 +219,7 @@ export class MDCAwesomeComponent extends MDCComponent {
 
 #### @typedefs are always `let` declarations, always pascal case, and always end in `Type`
 
+<!--{% raw %} -->
 ```js
 // GOOD
 /**
@@ -250,6 +251,7 @@ let eventDataType;
  */
 let EventData;
 ```
+<!--{% endraw %} -->
 
 Using this convention allows us to write tooling around handling these expressions, such as
 lint rule exceptions, and (in the future) code removal tools.
@@ -266,6 +268,7 @@ objects with semantic keys must be declared as described above. Furthermore:
 - All object keys _must be quoted_
 - All references to object keys _must be done using bracket notation_
 
+<!--{% raw %} -->
 ```js
 // GOOD
 /** @const {!Object<string, string>}  */
@@ -289,6 +292,7 @@ const eventListenerMap = {
   touchstart: (evt) => handleTouchstart(evt),
 };
 ```
+<!--{% endraw %} -->
 
 ```js
 // GOOD
@@ -583,6 +587,7 @@ mostly used to specify the shape of adapters, as mentioned above.
 
 **Example**:
 
+<!--{% raw %} -->
 ```js
 /**
  * @typedef {{
@@ -600,6 +605,7 @@ let ActivationStateType;
  */
 export let MyExportedType;
 ```
+<!--{% endraw %} -->
 
 While these `let` declarations do not do anything at runtime, they are used by closure to
 encapsulate complex types as specified through a [\@typedef statement](https://github.com/google/closure-compiler/wiki/Types-in-the-Closure-Type-System#typedefs). The statements above let both `ActivationStateType` and `MyExportedType` be used as type

--- a/docs/closure-compiler.md
+++ b/docs/closure-compiler.md
@@ -1,5 +1,5 @@
 <!--docs:
-title: "Annotating for the Closure Compiler"
+title: "Closure Compiler Annotations"
 layout: landing
 section: docs
 path: /docs/closure-compiler/

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,3 +1,10 @@
+<!--docs:
+title: "Developing Components"
+layout: landing
+section: docs
+path: /docs/developing-components/
+-->
+
 # Developing MDC-Web Components
 
 MDC-Web strives to seamlessly incorporate into a wide range of usage contexts - from simple static websites to complex, JavaScript-heavy applications to hybrid client/server rendering systems. To make this possible, our new component library is internally split into two parts:

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,10 +1,3 @@
-<!--docs:
-title: "Developing Components"
-layout: landing
-section: docs
-path: /docs/developing-components/
--->
-
 # Developing MDC-Web Components
 
 MDC-Web strives to seamlessly incorporate into a wide range of usage contexts - from simple static websites to complex, JavaScript-heavy applications to hybrid client/server rendering systems. To make this possible, our new component library is internally split into two parts:

--- a/docs/docsite-components.md
+++ b/docs/docsite-components.md
@@ -1,0 +1,9 @@
+---
+# This file is used by the docsite to generate a component index.
+title: "Components"
+layout: landing-no-drawer
+section: components
+path: /catalog/
+---
+
+{% include components-list.html %}

--- a/docs/docsite-index.md
+++ b/docs/docsite-index.md
@@ -1,0 +1,8 @@
+---
+# This file is used by the docsite to generate the platform index page.
+title: "Material Components for the Web"
+layout: "homepage"
+path: /
+---
+
+# Material Components for the Web

--- a/docs/docsite-index.md
+++ b/docs/docsite-index.md
@@ -5,4 +5,21 @@ layout: "homepage"
 path: /
 ---
 
-# Material Components for the Web
+{% contentfor benefits %}
+<ul class="benefits-list">
+  <li class="benefits-list-item">
+    <h3>Pixel-perfect &amp; up to date</h3>
+    <p>Implement <a href="https://material.io/guidelines">Material Design</a> with pixel-perfect components, maintained by Google engineers and designers</p>
+  </li>
+  <li class="benefits-list-item">
+    <h3>Seamless integrations</h3>
+    <p>Use components designed to work in any context, allowing seamless integration with libraries like React, AngularJS, and server-side rendering</p>
+  </li>
+  <li class="benefits-list-item">
+    <h3>Industry standards</h3>
+    <p>Take advantage of components developed with minimal dependencies and tested for flexibility, accessibility, and internationalization</p>
+  </li>
+</ul>
+{% endcontentfor %}
+
+# Getting Started

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -207,7 +207,7 @@ hit the button, and get a pleasant greeting :wave:
 ### Changing the theme
 
 You may have noticed that the button background, as well as the label and underline on focused text
-input fields, defaults to the Indigo 500 (`#673AB7`) color from the [Material Design color palette](https://material.google.com/style/color.html#color-color-palette).
+input fields, defaults to the Indigo 500 (`#673AB7`) color from the [Material Design color palette](https://material.io/guidelines/style/color.html#color-color-palette).
 This is part of the default theme that ships with MDC-Web; it uses Indigo 500 for a primary color, and
 Pink A200 (`#FF4081`) for an accent color. Let's change the theme's primary color.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,11 @@
-# Getting started
+<!--docs:
+title: "Getting Started"
+layout: landing
+section: docs
+path: /docs/getting-started/
+-->
+
+# Getting Started
 
 This guide will help you get started using MDC-Web on your own sites and within your own projects.
 

--- a/docs/integrating-into-frameworks.md
+++ b/docs/integrating-into-frameworks.md
@@ -1,4 +1,12 @@
-# Integrating MDC-Web into frameworks
+<!--docs:
+title: "Integrating MDC-Web into Frameworks"
+navTitle: "Framework Integration"
+layout: landing
+section: docs
+path: /docs/framework-integration/
+-->
+
+# Integrating MDC-Web into Frameworks
 
 MDC-Web was designed to be integrated as easily as possible into any and all web frameworks. This
 document will walk you through strategies for integrating components into various types of

--- a/docs/migrating-from-mdl.md
+++ b/docs/migrating-from-mdl.md
@@ -1,3 +1,11 @@
+<!--docs:
+title: "Migrating from Material Design Lite"
+navTitle: "Migrating from MDL"
+layout: landing
+section: docs
+path: /docs/migrating-from-mdl/
+-->
+
 # Migrating from Material Design Lite
 
 Material Components for the web (MDC-Web) is the successor to the Material Design Lite (MDL) project.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -18,7 +18,7 @@ components, and usually as the page background as well.
 Finally, MDC-Web has a number of text colors, which are used for rendering text and other shapes on top of the primary,
 accent and background colors. These are specified as either dark or light, in order to provide sufficient contrast to
 what's behind them, and have
-[different levels of opacity depending on usage](https://material.google.com/style/color.html#color-color-schemes):
+[different levels of opacity depending on usage](https://material.io/guidelines/style/color.html#color-color-schemes):
 - Primary, used for most text.
 - Secondary, used for text which is lower in the visual hierarchy.
 - Hint, used for text hints (such as those in text fields and labels).
@@ -219,7 +219,7 @@ on. As for the text colors, these will all be automatically calculated from the 
 provide, as part of the Sass definitions in `mdc-theme`. Pretty simple!
 
 > Note: theme colors don't have to be part of the Material palette; you can use any valid color. You may want to read
-the [color section](https://material.google.com/style/color.html) in the Material Design spec to inform your pick of an
+the [color section](https://material.io/guidelines/style/color.html) in the Material Design spec to inform your pick of an
 alternative palette.
 
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,4 +1,11 @@
-# MDC-Web Theming Guide
+<!--docs:
+title: "Theming Guide"
+layout: landing
+section: docs
+path: /docs/theming/
+-->
+
+# Theming Guide
 
 ## Overview
 

--- a/packages/mdc-animation/README.md
+++ b/packages/mdc-animation/README.md
@@ -13,7 +13,9 @@ MDC Animation is a Sass / CSS / JavaScript library which provides a toolbelt for
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/motion/duration-easing.html">Duration & easing</a></li>
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/motion/duration-easing.html">Duration & easing</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-animation/README.md
+++ b/packages/mdc-animation/README.md
@@ -1,6 +1,20 @@
-# mdc-animation
+<!--docs:
+title: "Animation"
+layout: detail
+section: components
+iconId: animation
+path: /animation/
+-->
 
-mdc-animation is a Sass / CSS / JavaScript library which provides a toolbelt for Material Design animation, based off of the [motion guidelines](https://material.google.com/motion/duration-easing.html#duration-easing-common-durations). Currently, it only covers easing curves.
+# Animation
+
+MDC Animation is a Sass / CSS / JavaScript library which provides a toolbelt for Material Design animation, based off of the [motion guidelines](https://material.io/guidelines/motion/duration-easing.html#duration-easing-common-durations). Currently, it only covers easing curves.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/motion/duration-easing.html">Duration & easing</a></li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-animation/README.md
+++ b/packages/mdc-animation/README.md
@@ -3,7 +3,7 @@ title: "Animation"
 layout: detail
 section: components
 iconId: animation
-path: /animation/
+path: /catalog/animation/
 -->
 
 # Animation

--- a/packages/mdc-auto-init/README.md
+++ b/packages/mdc-auto-init/README.md
@@ -1,4 +1,10 @@
-# MDC-Web Auto Init
+<!--docs:
+title: "Auto Init"
+layout: detail
+section: components
+-->
+
+# Auto Init
 
 `mdc-auto-init` is a utility package that provides declarative, DOM-based method of initialization
 for MDC-Web components on simple web sites. Note that for more advanced use-cases and complex sites,

--- a/packages/mdc-auto-init/README.md
+++ b/packages/mdc-auto-init/README.md
@@ -2,6 +2,7 @@
 title: "Auto Init"
 layout: detail
 section: components
+path: /auto-init/
 -->
 
 # Auto Init

--- a/packages/mdc-auto-init/README.md
+++ b/packages/mdc-auto-init/README.md
@@ -2,7 +2,7 @@
 title: "Auto Init"
 layout: detail
 section: components
-path: /auto-init/
+path: /catalog/auto-init/
 -->
 
 # Auto Init

--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -2,7 +2,7 @@
 title: "Base"
 layout: detail
 section: components
-path: /base/
+path: /catalog/base/
 -->
 
 # Base

--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -2,6 +2,7 @@
 title: "Base"
 layout: detail
 section: components
+path: /base/
 -->
 
 # Base

--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -1,6 +1,12 @@
-# mdc-base
+<!--docs:
+title: "Base"
+layout: detail
+section: components
+-->
 
-MDC base contains core foundation and component classes that serve as the base classes for all of MDC-Web's foundation classes and components (respectively).
+# Base
+
+MDC Base contains core foundation and component classes that serve as the base classes for all of MDC-Web's foundation classes and components (respectively).
 
 Most of the time, you shouldn't need to depend on `mdc-base` directly. It is useful however if you'd like to write custom components that follow MDC-Web's pattern and elegantly integrate with the MDC-Web ecosystem.
 

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -3,6 +3,7 @@ title: "Buttons"
 layout: detail
 section: components
 iconId: button
+path: /buttons/
 -->
 
 # Buttons

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -1,9 +1,22 @@
-# MDC Button
+<!--docs:
+title: "Buttons"
+layout: detail
+section: components
+iconId: button
+-->
+
+# Buttons
 
 The MDC Button component is a spec-aligned button component adhering to the
- [Material Design button requirements](https://material.google.com/components/buttons.html).
- It works without JavaScript with basic functionality for all states.
- If you initiate the JavaScript object for a button, then it will be enhanced with ripple effects. (Not yet implemented)
+[Material Design button requirements](https://material.io/guidelines/components/buttons.html).
+It works without JavaScript with basic functionality for all states.
+If you initiate the JavaScript object for a button, then it will be enhanced with ripple effects. (Not yet implemented)
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/buttons.html">Buttons</a></li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -16,7 +16,12 @@ If you initiate the JavaScript object for a button, then it will be enhanced wit
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/buttons.html">Buttons</a></li>
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/buttons.html">Buttons</a>
+  </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/button.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -3,7 +3,7 @@ title: "Buttons"
 layout: detail
 section: components
 iconId: button
-path: /buttons/
+path: /catalog/buttons/
 -->
 
 # Buttons

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -1,8 +1,21 @@
-# mdc-card
+<!--docs:
+title: "Cards"
+layout: detail
+section: components
+iconId: card
+-->
 
-MDC card is a component that implements the
-[Material Design card component](https://material.google.com/components/cards.html), and makes it available to
+# Cards
+
+MDC Card is a component that implements the
+[Material Design card component](https://material.io/guidelines/components/cards.html), and makes it available to
 developers as a set of CSS classes.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/cards.html">Cards</a></li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -3,6 +3,7 @@ title: "Cards"
 layout: detail
 section: components
 iconId: card
+path: /cards/
 -->
 
 # Cards

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -3,7 +3,7 @@ title: "Cards"
 layout: detail
 section: components
 iconId: card
-path: /cards/
+path: /catalog/cards/
 -->
 
 # Cards

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -15,7 +15,12 @@ developers as a set of CSS classes.
 ## Design & API Documentation
 
 <ul class="icon-list">
-  <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/guidelines/components/cards.html">Cards</a></li>
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/cards.html">Cards</a>
+  </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/card.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -3,6 +3,7 @@ title: "Checkboxes"
 layout: detail
 section: components
 iconId: selection_control
+path: /checkboxes/
 -->
 
 # Checkboxes

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -3,7 +3,7 @@ title: "Checkboxes"
 layout: detail
 section: components
 iconId: selection_control
-path: /checkboxes/
+path: /catalog/checkboxes/
 -->
 
 # Checkboxes

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -1,8 +1,23 @@
-# MDC Checkbox
+<!--docs:
+title: "Checkboxes"
+layout: detail
+section: components
+iconId: selection_control
+-->
+
+# Checkboxes
 
 The MDC Checkbox component is a spec-aligned checkbox component adhering to the
-[Material Design checkbox requirements](https://material.google.com/components/selection-controls.html#selection-controls-checkbox).
+[Material Design checkbox requirements](https://material.io/guidelines/components/selection-controls.html#selection-controls-checkbox).
 It works without JavaScript with basic functionality for all states. If you use the JavaScript object for a checkbox, it will add more intricate animation effects when switching between states.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/selection-controls.html#selection-controls-checkbox">Selection Controls – Checkbox</a>
+  </li>
+</ul>
 
 ## Installation
 
@@ -90,7 +105,7 @@ Note that `mdc-checkbox--disabled` is necessary on the root element to prevent h
 ### Using the JS Component
 
 MDC Checkbox ships with a Component / Foundation combo which progressively enhances the checkbox
-state transitions to achieve full parity with the material design motion for switching checkbox
+state transitions to achieve full parity with the Material Design motion for switching checkbox
 states.
 
 #### Including in code

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -18,6 +18,9 @@ It works without JavaScript with basic functionality for all states. If you use 
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/selection-controls.html#selection-controls-checkbox">Selection Controls – Checkbox</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/checkbox.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -194,14 +194,12 @@ The adapter for checkboxes must provide the following functions, with correct si
 | --- | --- |
 | `addClass(className: string) => void` | Adds a class to the root element. |
 | `removeClass(className: string) => void` | Removes a class from the root element. |
-| `registerAnimationEndHandler(handler: EventListener) => void` | Registers an event handler to be called when an `animationend` event is triggered on the root element. Note that you must account for
-vendor prefixes in order for this to work correctly. |
+| `registerAnimationEndHandler(handler: EventListener) => void` | Registers an event handler to be called when an `animationend` event is triggered on the root element. Note that you must account for vendor prefixes in order for this to work correctly. |
 | `deregisterAnimationEndHandler(handler: EventListener) => void` | Deregisters an event handler from an `animationend` event listener. This will only be called with handlers that have previously been passed to `registerAnimationEndHandler` calls. |
 | `registerChangeHandler(handler: EventListener) => void` | Registers an event handler to be called when a `change` event is triggered on the native control (_not_ the root element). |
 | `deregisterChangeHandler(handler: EventListener) => void` | Deregisters an event handler that was previously passed to `registerChangeHandler`. |
 | `getNativeControl() => HTMLInputElement?` | Returns the native checkbox control, if available. Note that if this control is not available, the methods that rely on it will exit gracefully.|
-| `forceLayout() => void` | Force-trigger a layout on the root element. This is needed to restart
-animations correctly. If you find that you do not need to do this, you can simply make it a no-op. |
+| `forceLayout() => void` | Force-trigger a layout on the root element. This is needed to restart animations correctly. If you find that you do not need to do this, you can simply make it a no-op. |
 | `isAttachedToDOM() => boolean` | Returns true if the component is currently attached to the DOM, false otherwise.` |
 
 #### MDCCheckboxFoundation API

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -20,6 +20,9 @@ a dialog should be.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/dialogs.html">Dialogs</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/dialog.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -1,10 +1,25 @@
-# MDC Dialog
+<!--docs:
+title: "Dialogs"
+layout: detail
+section: components
+iconId: dialog
+-->
+
+# Dialogs
 
 The MDC Dialog component is a spec-aligned dialog component adhering to the
 [Material Design dialog pattern](https://material.io/guidelines/components/dialogs.html).
 It implements a modal dialog window. You may notice that full screen components outlined in the dialog spec
 do not appear in MDC Dialog. This is because they have been deemed to be outside of the scope of what
 a dialog should be.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/dialogs.html">Dialogs</a>
+  </li>
+</ul>
 
 ## Installation
 
@@ -14,7 +29,7 @@ npm install --save @material/dialog
 
 ## Dialog usage
 
-Dialogs inform users about a specific task and may contain critical information or require decisions.  
+Dialogs inform users about a specific task and may contain critical information or require decisions.
 
 ```html
 <aside id="my-mdc-dialog"

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -3,7 +3,7 @@ title: "Dialogs"
 layout: detail
 section: components
 iconId: dialog
-path: /dialogs/
+path: /catalog/dialogs/
 -->
 
 # Dialogs

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -3,6 +3,7 @@ title: "Dialogs"
 layout: detail
 section: components
 iconId: dialog
+path: /dialogs/
 -->
 
 # Dialogs

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -211,7 +211,7 @@ MDC Dialog ships with an `MDCDialogFoundation` class that external frameworks an
 use to integrate the component. As with all foundation classes, an adapter object must be provided.
 
 > **NOTE**: Components themselves must manage adding ripples to dialog buttons, should they choose to
-do so. We provide instructions on how to add ripples to buttons within the [mdc-button README](https://github.com/material-components/material-components-web/tree/master/packages/mdc-button#adding-ripples-to-buttons).
+do so. We provide instructions on how to add ripples to buttons within the [mdc-button README](../mdc-button#adding-ripples-to-buttons).
 
 ### Adapter API
 

--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -72,6 +72,7 @@ Permanent drawers can also be set below the toolbar:
         <i class="material-icons mdc-list-item__start-detail" aria-hidden="true">star</i>Star
       </a>
     </nav>
+  </nav>
   <main>
     Page content goes here.
   </main>

--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -3,7 +3,7 @@ title: "Drawers"
 layout: detail
 section: components
 iconId: side_navigation
-path: /drawers/
+path: /catalog/drawers/
 -->
 
 # Drawers

--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -1,9 +1,24 @@
-# MDC Drawer
+<!--docs:
+title: "Drawers"
+layout: detail
+section: components
+iconId: side_navigation
+-->
+
+# Drawers
 
 The MDC Drawer component is a spec-aligned drawer component adhering to the
-[Material Design navigation drawer pattern](https://material.google.com/patterns/navigation-drawer.html).
+[Material Design navigation drawer pattern](https://material.io/guidelines/patterns/navigation-drawer.html).
 It implements permanent, persistent, and temporary drawers. Permanent drawers are CSS-only and require no JavaScript, whereas persistent and temporary drawers require JavaScript to function, in order to respond to
 user interaction.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/patterns/navigation-drawer.html">Navigation drawer</a>
+  </li>
+</ul>
 
 ## Installation
 
@@ -151,7 +166,7 @@ const util = mdc.drawer.util;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the persistent drawer, simply call `attachTo()`
-and pass it a DOM element.  
+and pass it a DOM element.
 
 ```javascript
 mdc.drawer.MDCPersistentDrawer.attachTo(document.querySelector('.mdc-persistent-drawer'));
@@ -341,7 +356,7 @@ const util = mdc.drawer.util;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the temporary drawer, simply call `attachTo()`
-and pass it a DOM element.  
+and pass it a DOM element.
 
 ```javascript
 mdc.drawer.MDCTemporaryDrawer.attachTo(document.querySelector('.mdc-temporary-drawer'));

--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -3,6 +3,7 @@ title: "Drawers"
 layout: detail
 section: components
 iconId: side_navigation
+path: /drawers/
 -->
 
 # Drawers

--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -19,6 +19,15 @@ user interaction.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/patterns/navigation-drawer.html">Navigation drawer</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/persistent-drawer.html">Demo: Persistent Drawer</a>
+  </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/permanent-drawer-above-toolbar.html">Demo: Permanent Drawer Above Toolbar</a>
+  </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/permanent-drawer-below-toolbar.html">Demo: Permanent Drawer Below Toolbar</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-drawer/slidable/README.md
+++ b/packages/mdc-drawer/slidable/README.md
@@ -1,4 +1,4 @@
-# MDC Slideable Drawer
+# Slideable Drawer
 
 The MDC Slideable Drawer is the subclass for drawers that slide: aka Persistent and Temporary drawers.
 It maintains the JavaScript logic for handling touch and transition events. This is not a public API.

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -3,6 +3,7 @@ title: "Elevation"
 layout: detail
 section: components
 iconId: shadow
+path: /elevation/
 -->
 
 # Elevation

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -1,7 +1,14 @@
-# MDC Elevation
+<!--docs:
+title: "Elevation"
+layout: detail
+section: components
+iconId: shadow
+-->
+
+# Elevation
 
 MDC Elevation provides Sass mixins and CSS classes which are used to provide [shadows and
-elevation](https://material.google.com/what-is-material/elevation-shadows.html) to our material
+elevation](https://material.io/guidelines/what-is-material/elevation-shadows.html) to our material
 components.
 
 The elevation values are mapped out in a "z-space" and range from `0` to `24`.
@@ -14,6 +21,14 @@ which was created in collaboration with the designers on the Material Design tea
 > just "z" for short) because it aligns with the technical definition of, and nomenclature for,
 > a 3-d coordinate system. Therefore, we feel it makes more sense than `dp`. However, when we refer
 > to `z-space` (or `z`), that can be used interchangeably with the spec's `dp`.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Shadows & elevation</a>
+  </li>
+</ul>
 
 ## Installation
 
@@ -28,7 +43,7 @@ npm install --save @material/elevation
 MDC Elevation exports an `mdc-elevation` mixin which can be used to set the elevation on a selector.
 It works by assigning the correct elevation value to a selector's `box-shadow` property.
 
-`mdc-elevation` takes one `$z-value` argument which represents the z-space for that given elevation. For example, [cards](https://material.google.com/components/cards.html) have a resting elevation of `2dp`. Implementing that using MDC Elevation looks like the following:
+`mdc-elevation` takes one `$z-value` argument which represents the z-space for that given elevation. For example, [cards](https://material.io/guidelines/components/cards.html) have a resting elevation of `2dp`. Implementing that using MDC Elevation looks like the following:
 
 ```scss
 @import "@material/elevation/mixins";

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -3,7 +3,7 @@ title: "Elevation"
 layout: detail
 section: components
 iconId: shadow
-path: /elevation/
+path: /catalog/elevation/
 -->
 
 # Elevation

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -29,6 +29,9 @@ which was created in collaboration with the designers on the Material Design tea
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/what-is-material/elevation-shadows.html">Shadows & elevation</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/elevation.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -3,7 +3,7 @@ title: "Floating Action Buttons"
 layout: detail
 section: components
 iconId: button
-path: /floating-action-buttons/
+path: /catalog/floating-action-buttons/
 -->
 
 # Floating Action Buttons

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -19,6 +19,9 @@ If you initiate the JavaScript object for a button, then it will be enhanced wit
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/buttons-floating-action-button.html">Floating Action Button</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/fab.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -1,9 +1,24 @@
-# MDC FAB
+<!--docs:
+title: "Floating Action Buttons"
+layout: detail
+section: components
+iconId: button
+-->
+
+# Floating Action Buttons
 
 The MDC FAB component is a spec-aligned button component adhering to the
-[Material Design FAB requirements](https://material.google.com/components/buttons-floating-action-button.html).
+[Material Design FAB requirements](https://material.io/guidelines/components/buttons-floating-action-button.html).
 It works without JavaScript with basic functionality for all states.
 If you initiate the JavaScript object for a button, then it will be enhanced with ripple effects. (Not yet implemented)
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/buttons-floating-action-button.html">Floating Action Button</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -3,6 +3,7 @@ title: "Floating Action Buttons"
 layout: detail
 section: components
 iconId: button
+path: /floating-action-buttons/
 -->
 
 # Floating Action Buttons

--- a/packages/mdc-form-field/README.md
+++ b/packages/mdc-form-field/README.md
@@ -1,4 +1,10 @@
-# MDC Form Field
+<!--docs:
+title: "Form Fields"
+layout: detail
+section: components
+-->
+
+# Form Fields
 
 MDC Form Field provides an `mdc-form-field` helper class for easily making theme-aware, RTL-aware
 form field + label combos. It also provides an `MDCFormField` class for easily making input ripples

--- a/packages/mdc-form-field/README.md
+++ b/packages/mdc-form-field/README.md
@@ -2,6 +2,7 @@
 title: "Form Fields"
 layout: detail
 section: components
+path: /form-fields/
 -->
 
 # Form Fields

--- a/packages/mdc-form-field/README.md
+++ b/packages/mdc-form-field/README.md
@@ -2,7 +2,7 @@
 title: "Form Fields"
 layout: detail
 section: components
-path: /form-fields/
+path: /catalog/form-fields/
 -->
 
 # Form Fields

--- a/packages/mdc-grid-list/README.md
+++ b/packages/mdc-grid-list/README.md
@@ -3,6 +3,7 @@ title: "Grid Lists"
 layout: detail
 section: components
 iconId: card
+path: /grid-lists/
 -->
 
 # Grid Lists

--- a/packages/mdc-grid-list/README.md
+++ b/packages/mdc-grid-list/README.md
@@ -20,6 +20,9 @@ across screen sizes.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/grid-lists.html">Grid lists</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/grid-list.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-grid-list/README.md
+++ b/packages/mdc-grid-list/README.md
@@ -3,7 +3,7 @@ title: "Grid Lists"
 layout: detail
 section: components
 iconId: card
-path: /grid-lists/
+path: /catalog/grid-lists/
 -->
 
 # Grid Lists

--- a/packages/mdc-grid-list/README.md
+++ b/packages/mdc-grid-list/README.md
@@ -1,11 +1,25 @@
-# MDC Grid list
+<!--docs:
+title: "Grid Lists"
+layout: detail
+section: components
+iconId: card
+-->
 
-MDC Grid list provides a RTL-aware Material Design Grid list component adhering to the
+# Grid Lists
+
+MDC Grid List provides a RTL-aware Material Design Grid list component adhering to the
 [Material Design Grid list spec](https://material.io/guidelines/components/grid-lists.html).
 Grid Lists are best suited for presenting homogeneous data, typically images.
 Each item in a grid list is called a **tile**. Tiles maintain consistent width, height, and padding
 across screen sizes.
 
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/grid-lists.html">Grid lists</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-icon-toggle/README.md
+++ b/packages/mdc-icon-toggle/README.md
@@ -3,7 +3,7 @@ title: "Icon Toggle Buttons"
 layout: detail
 section: components
 iconId: button
-path: /icon-toggle-buttons/
+path: /catalog/icon-toggle-buttons/
 -->
 
 # Icon Toggle Buttons

--- a/packages/mdc-icon-toggle/README.md
+++ b/packages/mdc-icon-toggle/README.md
@@ -1,7 +1,22 @@
-# MDC Icon Toggle
+<!--docs:
+title: "Icon Toggle Buttons"
+layout: detail
+section: components
+iconId: button
+-->
 
-MDC Icon Toggle provides a material design icon toggle button. It is fully accessible, and is
+# Icon Toggle Buttons
+
+MDC Icon Toggle provides a Material Design icon toggle button. It is fully accessible, and is
 designed to work with any icon set.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/buttons.html#buttons-toggle-buttons">Toggle buttons</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-icon-toggle/README.md
+++ b/packages/mdc-icon-toggle/README.md
@@ -3,6 +3,7 @@ title: "Icon Toggle Buttons"
 layout: detail
 section: components
 iconId: button
+path: /icon-toggle-buttons/
 -->
 
 # Icon Toggle Buttons

--- a/packages/mdc-icon-toggle/README.md
+++ b/packages/mdc-icon-toggle/README.md
@@ -17,6 +17,9 @@ designed to work with any icon set.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/buttons.html#buttons-toggle-buttons">Toggle buttons</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/icon-toggle.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-layout-grid/README.md
+++ b/packages/mdc-layout-grid/README.md
@@ -3,6 +3,7 @@ title: "Layout Grids"
 layout: detail
 section: components
 iconId: responsive_layout
+path: /layout-grids/
 -->
 
 # Layout Grids

--- a/packages/mdc-layout-grid/README.md
+++ b/packages/mdc-layout-grid/README.md
@@ -3,7 +3,7 @@ title: "Layout Grids"
 layout: detail
 section: components
 iconId: responsive_layout
-path: /layout-grids/
+path: /catalog/layout-grids/
 -->
 
 # Layout Grids

--- a/packages/mdc-layout-grid/README.md
+++ b/packages/mdc-layout-grid/README.md
@@ -20,6 +20,9 @@ It uses [CSS Grid](https://www.w3.org/TR/css-grid-1/) where possible, with a CSS
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-grid">Layout grid guidelines</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/layout-grid.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-layout-grid/README.md
+++ b/packages/mdc-layout-grid/README.md
@@ -1,10 +1,25 @@
-# mdc-layout-grid
+<!--docs:
+title: "Layout Grids"
+layout: detail
+section: components
+iconId: responsive_layout
+-->
 
-MDC layout grid is a CSS-only component that implements the
+# Layout Grids
+
+MDC Layout Grid is a CSS-only component that implements the
 [Material Design layout grid guidelines](https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-grid),
 and makes them available to developers as CSS classes and Sass mixins.
 
 It uses [CSS Grid](https://www.w3.org/TR/css-grid-1/) where possible, with a CSS Flexible Box fallback everywhere else.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-grid">Layout grid guidelines</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -18,6 +18,9 @@ Lists are design to be accessible and RTL aware.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/lists.html">Lists</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/list.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -1,8 +1,23 @@
-# MDC List
+<!--docs:
+title: "Lists"
+layout: detail
+section: components
+iconId: list
+-->
 
-MDC List provides styles which implement [Material Design Lists](https://material.google.com/components/lists.html#) - "A single continuous column of tessellated subdivisions of equal width." Both single-line and two-line lists are supported (with
+# Lists
+
+MDC List provides styles which implement [Material Design Lists](https://material.io/guidelines/components/lists.html) - "A single continuous column of tessellated subdivisions of equal width." Both single-line and two-line lists are supported (with
 three-line lists [coming soon](https://github.com/material-components/material-components-web/issues/31)). MDC
 Lists are design to be accessible and RTL aware.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/lists.html">Lists</a>
+  </li>
+</ul>
 
 ## Installation
 
@@ -65,7 +80,7 @@ Lists can be made more compact by using the `mdc-list--dense` modifier class.
 
 ### Two-line lists
 
-While in theory you can add any number of "lines" to a list item, you can use the `mdc-list--two-line` combined with some extra markup around the text to style a list in the two-line list style as defined by [the spec](https://material.google.com/components/lists.html#lists-specs) (see "Two-line lists").
+While in theory you can add any number of "lines" to a list item, you can use the `mdc-list--two-line` combined with some extra markup around the text to style a list in the two-line list style as defined by [the spec](https://material.io/guidelines/components/lists.html#lists-specs) (see "Two-line lists").
 
 ```html
 <ul class="mdc-list mdc-list--two-line">
@@ -122,17 +137,17 @@ profile pictures, etc.
     <img class="mdc-list-item__start-detail" src="/users/1/profile_pic.png"
          width="56" height="56" alt="Picture of Janet Perkins">
     Janet Perkins
-  </il>
+  </li>
   <li class="mdc-list-item">
     <img class="mdc-list-item__start-detail" src="/users/2/profile_pic.png"
          width="56" height="56" alt="Picture of Mary Johnson">
     Mary Johnson
-  </il>
+  </li>
   <li class="mdc-list-item">
     <img class="mdc-list-item__start-detail" src="/users/3/profile_pic.png"
          width="56" height="56" alt="Picture of Peter Carlsson">
     Peter Carlsson
-  </il>
+  </li>
 </ul>
 ```
 

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -3,7 +3,7 @@ title: "Lists"
 layout: detail
 section: components
 iconId: list
-path: /lists/
+path: /catalog/lists/
 -->
 
 # Lists

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -3,6 +3,7 @@ title: "Lists"
 layout: detail
 section: components
 iconId: list
+path: /lists/
 -->
 
 # Lists

--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -1,9 +1,24 @@
-# MDC Menu
+<!--docs:
+title: "Menus"
+layout: detail
+section: components
+iconId: menu
+-->
+
+# Menus
 
 The MDC Menu component is a spec-aligned menu component adhering to the
-[Material Design menu specification](https://material.google.com/components/menus.html).
+[Material Design menu specification](https://material.io/guidelines/components/menus.html).
 It implements simple menus. Menus require JavaScript to work correctly, but the open and closed states are correct on
 first render.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/menus.html">Menus</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -3,6 +3,7 @@ title: "Menus"
 layout: detail
 section: components
 iconId: menu
+path: /menus/
 -->
 
 # Menus

--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -3,7 +3,7 @@ title: "Menus"
 layout: detail
 section: components
 iconId: menu
-path: /menus/
+path: /catalog/menus/
 -->
 
 # Menus

--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -19,6 +19,9 @@ first render.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/menus.html">Menus</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/simple-menu.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-radio/README.md
+++ b/packages/mdc-radio/README.md
@@ -18,6 +18,9 @@ interaction UX as well as a component-level API for state modification.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/selection-controls.html#selection-controls-radio-button">Selection Controls – Radio buttons</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/radio.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-radio/README.md
+++ b/packages/mdc-radio/README.md
@@ -3,7 +3,7 @@ title: "Radio Buttons"
 layout: detail
 section: components
 iconId: radio_button
-path: /radio-buttons/
+path: /catalog/radio-buttons/
 -->
 
 # Radio Buttons

--- a/packages/mdc-radio/README.md
+++ b/packages/mdc-radio/README.md
@@ -1,8 +1,23 @@
-# MDC Radio
+<!--docs:
+title: "Radio Buttons"
+layout: detail
+section: components
+iconId: radio_button
+-->
 
-The MDC Radio component provides a radio button adhering to the [Material Design Specification](https://material.google.com/components/selection-controls.html#selection-controls-radio-button).
+# Radio Buttons
+
+The MDC Radio Button component provides a radio button adhering to the [Material Design Specification](https://material.io/guidelines/components/selection-controls.html#selection-controls-radio-button).
 It requires no Javascript out of the box, but can be enhanced with Javascript to provide better
 interaction UX as well as a component-level API for state modification.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/selection-controls.html#selection-controls-radio-button">Selection Controls – Radio buttons</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-radio/README.md
+++ b/packages/mdc-radio/README.md
@@ -3,6 +3,7 @@ title: "Radio Buttons"
 layout: detail
 section: components
 iconId: radio_button
+path: /radio-buttons/
 -->
 
 # Radio Buttons

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -1,4 +1,11 @@
-# MDC Ripple
+<!--docs:
+title: "Ripples"
+layout: detail
+section: components
+iconId: ripple
+-->
+
+# Ripples
 
 - [MDC Ripple](#mdc-ripple)
     - [An aside regarding browser support](#an-aside-regarding-browser-support)

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -3,7 +3,7 @@ title: "Ripples"
 layout: detail
 section: components
 iconId: ripple
-path: /ripples/
+path: /catalog/ripples/
 -->
 
 # Ripples

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -66,7 +66,7 @@ Let's say we have a `surface` element that represents a basic surface.
 ```
 
 We also have some basic styles for our surface that
-use [mdc-elevation](https://github.com/material-components/material-components-web/tree/master/packages/mdc-elevation) to raise it up off of its background.
+use [mdc-elevation](../mdc-elevation) to raise it up off of its background.
 
 ```scss
 @import "@material/elevation/mixins";
@@ -393,7 +393,7 @@ build that can handle our usage of CSS variables.
 > TL;DR theme custom variable changes will not propagate to ripples if the browser does not support
 > [CSS 4 color-mod functions](https://drafts.csswg.org/css-color/).
 
-The way that [mdc-theme works](https://github.com/material-components/material-components-web/tree/master/packages/mdc-theme#mdc-theme-prop-mixin) is that it emits two properties: one with the hard-coded sass variable, and another for a
+The way that [mdc-theme works](../mdc-theme#mdc-theme-prop-mixin) is that it emits two properties: one with the hard-coded sass variable, and another for a
 CSS variable that can be interpolated. The problem is that ripple backgrounds need to have an opacity, and currently there's no way to opacify a pre-existing color defined by a CSS variable.
 There is an editor's draft for a `color-mod` function (see link in TL;DR) that _can_ do this:
 

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -3,6 +3,7 @@ title: "Ripples"
 layout: detail
 section: components
 iconId: ripple
+path: /ripples/
 -->
 
 # Ripples

--- a/packages/mdc-rtl/README.md
+++ b/packages/mdc-rtl/README.md
@@ -2,7 +2,7 @@
 title: "RTL"
 layout: detail
 section: components
-path: /rtl/
+path: /catalog/rtl/
 -->
 
 # RTL

--- a/packages/mdc-rtl/README.md
+++ b/packages/mdc-rtl/README.md
@@ -2,6 +2,7 @@
 title: "RTL"
 layout: detail
 section: components
+path: /rtl/
 -->
 
 # RTL

--- a/packages/mdc-rtl/README.md
+++ b/packages/mdc-rtl/README.md
@@ -1,8 +1,22 @@
-# MDC RTL
+<!--docs:
+title: "RTL"
+layout: detail
+section: components
+-->
+
+# RTL
 
 MDC RTL provides sass mixins to assist with RTL / bi-directional layouts within MDC-Web components.
 Because we would like to achieve a standard approach to RTL throughout MDC-Web, we highly recommend
 that any MDC-Web component that needs RTL support leverage this package.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/usability/bidirectionality.html">Bidirectionality</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -1,8 +1,26 @@
-# MDC Select
+<!--docs:
+title: "Select Menus"
+layout: detail
+section: components
+iconId: menu
+-->
 
-MDC Select provides material design single-option and multi-option select menus. It functions analogously to the
+# Select Menus
+
+MDC Select provides Material Design single-option and multi-option select menus. It functions analogously to the
 browser's native `<select>` element, and includes a gracefully degraded version that can be used
 in conjunction with the browser's native element. Both are fully accessible, and fully RTL-aware.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/text-fields.html">Text Fields</a>
+  </li>
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/menus.html">Menus</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -3,7 +3,7 @@ title: "Select Menus"
 layout: detail
 section: components
 iconId: menu
-path: /select-menus/
+path: /catalog/select-menus/
 -->
 
 # Select Menus

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -3,6 +3,7 @@ title: "Select Menus"
 layout: detail
 section: components
 iconId: menu
+path: /select-menus/
 -->
 
 # Select Menus

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -21,6 +21,9 @@ in conjunction with the browser's native element. Both are fully accessible, and
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/menus.html">Menus</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/select.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -3,7 +3,7 @@ title: "Snackbars"
 layout: detail
 section: components
 iconId: toast
-path: /snackbars/
+path: /catalog/snackbars/
 -->
 
 # Snackbars

--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -1,8 +1,23 @@
-# MDC Snackbar
+<!--docs:
+title: "Snackbars"
+layout: detail
+section: components
+iconId: toast
+-->
+
+# Snackbars
 
 The MDC Snackbar component is a spec-aligned snackbar/toast component adhering to the
-[Material Design snackbars & toasts requirements](https://material.google.com/components/snackbars-toasts.html#snackbars-toasts-specs).
+[Material Design snackbars & toasts requirements](https://material.io/guidelines/components/snackbars-toasts.html#snackbars-toasts-specs).
 It requires JavaScript the trigger the display and hide of the snackbar.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/snackbars-toasts.html">Snackbars & toasts</a>
+  </li>
+</ul>
 
 ## Installation
 
@@ -66,7 +81,7 @@ const MDCSnackbarFoundation = mdc.snackbar.MDCSnackbarFoundation;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the snackbar, simply call `attachTo()`
-and pass it a DOM element.  
+and pass it a DOM element.
 
 ```javascript
 mdc.snackbar.MDCSnackbar.attachTo(document.querySelector('.mdc-snackbar'));

--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -18,6 +18,9 @@ It requires JavaScript the trigger the display and hide of the snackbar.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/snackbars-toasts.html">Snackbars & toasts</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/snackbar.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -3,6 +3,7 @@ title: "Snackbars"
 layout: detail
 section: components
 iconId: toast
+path: /snackbars/
 -->
 
 # Snackbars

--- a/packages/mdc-switch/README.md
+++ b/packages/mdc-switch/README.md
@@ -18,6 +18,9 @@ It works without JavaScript.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/selection-controls.html#selection-controls-switch">Selection Controls – Switch</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/switch.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-switch/README.md
+++ b/packages/mdc-switch/README.md
@@ -3,6 +3,7 @@ title: "Switches"
 layout: detail
 section: components
 iconId: switch
+path: /switches/
 -->
 
 # Switches

--- a/packages/mdc-switch/README.md
+++ b/packages/mdc-switch/README.md
@@ -1,8 +1,23 @@
-# MDC Switch
+<!--docs:
+title: "Switches"
+layout: detail
+section: components
+iconId: switch
+-->
+
+# Switches
 
 The MDC Switch component is a spec-aligned switch component adhering to the
 [Material Design Switch requirements](https://material.io/guidelines/components/selection-controls.html#selection-controls-switch).
 It works without JavaScript.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/selection-controls.html#selection-controls-switch">Selection Controls – Switch</a>
+  </li>
+</ul>
 
 ## Installation
 
@@ -13,7 +28,7 @@ npm install --save @material/switch
 ## Usage
 
 ```html
-<div class="mdc-switch">    
+<div class="mdc-switch">
   <input type="checkbox" id="basic-switch" class="mdc-switch__native-control" />
   <div class="mdc-switch__background">
     <div class="mdc-switch__knob"></div>
@@ -24,7 +39,7 @@ npm install --save @material/switch
 
 ### Disabled
 ```html
-<div class="mdc-switch mdc-switch--disabled">    
+<div class="mdc-switch mdc-switch--disabled">
   <input type="checkbox" id="another-basic-switch" class="mdc-switch__native-control" disabled />
   <div class="mdc-switch__background">
     <div class="mdc-switch__knob"></div>

--- a/packages/mdc-switch/README.md
+++ b/packages/mdc-switch/README.md
@@ -3,7 +3,7 @@ title: "Switches"
 layout: detail
 section: components
 iconId: switch
-path: /switches/
+path: /catalog/switches/
 -->
 
 # Switches

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -3,7 +3,7 @@ title: "Text Fields"
 layout: detail
 section: components
 iconId: text_field
-path: /text-fields/
+path: /catalog/text-fields/
 -->
 
 # Text Fields

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -1,8 +1,23 @@
-# MDC Textfield
+<!--docs:
+title: "Text Fields"
+layout: detail
+section: components
+iconId: text_field
+-->
 
-The MDC Textfield component provides a textual input field adhering to the [Material Design Specification](https://material.google.com/components/text-fields.html).
+# Text Fields
+
+The MDC Textfield component provides a textual input field adhering to the [Material Design Specification](https://material.io/guidelines/components/text-fields.html).
 It is fully accessible, ships with RTL support, and includes a gracefully-degraded version that does
 not require any javascript.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/text-fields.html">Text Fields</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -18,6 +18,9 @@ not require any javascript.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/text-fields.html">Text Fields</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/textfield.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -3,11 +3,12 @@ title: "Text Fields"
 layout: detail
 section: components
 iconId: text_field
+path: /text-fields/
 -->
 
 # Text Fields
 
-The MDC Textfield component provides a textual input field adhering to the [Material Design Specification](https://material.io/guidelines/components/text-fields.html).
+The MDC Text Field component provides a textual input field adhering to the [Material Design Specification](https://material.io/guidelines/components/text-fields.html).
 It is fully accessible, ships with RTL support, and includes a gracefully-degraded version that does
 not require any javascript.
 

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -1,6 +1,13 @@
-# mdc-theme
+<!--docs:
+title: "Theme"
+layout: detail
+section: components
+iconId: theme
+-->
 
-MDC theme is a foundational module that provides theming to MDC-Web components, and also makes it available to
+# Theme
+
+MDC Theme is a foundational module that provides theming to MDC-Web components, and also makes it available to
 developers as Sass functions and mixins, as CSS custom properties, and as a set of CSS classes.
 
 The colors in this module are derived from the three theme colors in MDC-Web:

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -3,6 +3,7 @@ title: "Theme"
 layout: detail
 section: components
 iconId: theme
+path: /theme/
 -->
 
 # Theme

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -3,7 +3,7 @@ title: "Theme"
 layout: detail
 section: components
 iconId: theme
-path: /theme/
+path: /catalog/theme/
 -->
 
 # Theme

--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -3,7 +3,7 @@ title: "Toolbars"
 layout: detail
 section: components
 iconId: toolbar
-path: /toolbar/
+path: /catalog/toolbar/
 -->
 
 # Toolbars

--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -30,6 +30,9 @@ height added to their first rows.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/components/toolbars.html">Toolbars</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/toolbar.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -1,4 +1,11 @@
-# MDC Toolbar
+<!--docs:
+title: "Toolbars"
+layout: detail
+section: components
+iconId: toolbar
+-->
+
+# Toolbars
 
 MDC Toolbar acts as a container for multiple rows containing items such as
 application title, navigation menu, and tabs, among other things. Toolbars
@@ -16,6 +23,13 @@ changes as the user scrolls. Flexible is defined as a modifier class of toolbar
 but not a standalone component. Toolbars using this modifier will have additional
 height added to their first rows.
 
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/toolbars.html">Toolbars</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -3,6 +3,7 @@ title: "Toolbars"
 layout: detail
 section: components
 iconId: toolbar
+path: /toolbar/
 -->
 
 # Toolbars

--- a/packages/mdc-typography/README.md
+++ b/packages/mdc-typography/README.md
@@ -2,6 +2,7 @@
 title: "Typography"
 layout: detail
 section: components
+path: /typography/
 -->
 
 # Typography

--- a/packages/mdc-typography/README.md
+++ b/packages/mdc-typography/README.md
@@ -1,8 +1,22 @@
-# mdc-typography
+<!--docs:
+title: "Typography"
+layout: detail
+section: components
+-->
+
+# Typography
 
 MDC typography is a CSS-only component that implements the
-[Material Design typography guidelines](https://material.google.com/style/typography.html), and makes them available to
+[Material Design typography guidelines](https://material.io/guidelines/style/typography.html), and makes them available to
 developers as CSS classes.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/style/typography.html">Typography</a>
+  </li>
+</ul>
 
 ## Installation
 

--- a/packages/mdc-typography/README.md
+++ b/packages/mdc-typography/README.md
@@ -18,6 +18,9 @@ developers as CSS classes.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/guidelines/style/typography.html">Typography</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components-web.appspot.com/typography.html">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-typography/README.md
+++ b/packages/mdc-typography/README.md
@@ -2,7 +2,7 @@
 title: "Typography"
 layout: detail
 section: components
-path: /typography/
+path: /catalog/typography/
 -->
 
 # Typography

--- a/packages/mdc-typography/README.md
+++ b/packages/mdc-typography/README.md
@@ -2,6 +2,7 @@
 title: "Typography"
 layout: detail
 section: components
+iconId: typography
 path: /catalog/typography/
 -->
 


### PR DESCRIPTION
* Front matter introduced. We'll still need `excerpts` fields across the board for SEO.
* Cleaned up headlines and component names in intro sections. The convention is
  now to refer the components as "Upper Case Component". Prefixing all components
  with MDC in headlines seemed a little strange in the doc site context, although I'm happy to discuss if you think otherwise.
* Adds icon-lists where applicable. We now link out to spec in intro paragraphs as well as the link lists, but we'll iron this out before release.
* URLs to spec have been updated across the board to point to material.io.