### PR TITLE
fix(infrastructure): correct reason why component is shown in summary table.

### DIFF
--- a/scripts/determine-pkg-versions.js
+++ b/scripts/determine-pkg-versions.js
@@ -141,8 +141,11 @@ function pickBestVersionInfo(pkg) {
       possibleNewChangeType = semver.major(pkg.version) === 0 ? VersionType.MINOR : VersionType.MAJOR;
     } else if (commitInfo.type === 'feat') {
       possibleNewChangeType = VersionType.MINOR;
+    } else if (commitInfo.type === 'docs') {
+      // docs would not cause any change, so it should not put its commit message as reason of version bump.
+      return currentBest;
     } else {
-      // fix, docs, style (refers to coding style), refactor (non-breaking change), chore, ...
+      // fix, style (refers to coding style), refactor (non-breaking change), chore, ...
       possibleNewChangeType = VersionType.PATCH;
     }
     // Note that we assume that pkg.version is valid by the time we get here.


### PR DESCRIPTION
# Background

The reason for version bumping shown in `pre-release.sh` have the following case which it cannot handle properly.

When package version for a component is bumped for its dependency being updated, however, it happens to have one and only one commit msg for `docs(some-component): xxxx`. In the summary table, it will show the reason for this version bump is cased by the documentation update. However, the actual reason this package is selected is because lerna correctly detects its dependency update. 

This used to cause some confusion when we release `0.7.0`.