### PR TITLE
Closure Test Infrastructure + mdc-animation annotations

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -18,7 +18,7 @@ rules:
   no-unused-vars:
     - error
     # Account for closure compiler conventions. See docs/closure-compiler.md
-    # Ingores: MDC[PascalCase]Adapter (records), [PascalCase]Type (typedefs)
+    # Ignores: MDC[PascalCase]Adapter (records), [PascalCase]Type (typedefs)
     - varsIgnorePattern: ^(?:(?:MDC(?:(?:[A-Z][a-z0-9]+)+)Adapter)|(?:(?:(?:[A-Z][a-z0-9]+)+)Type))$
 
   # TODO: Enable once https://github.com/material-components/material-components-web/milestone/4

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,12 +15,17 @@ rules:
   no-var: error
   curly: error
   no-floating-decimal: error
-  no-unused-vars: error
-  # Disabling jsdoc rules for the time being, but should be discussed as to whether or not this is
-  # something we should add in. For closure compatibility, we can investigate using something like
-  # https://github.com/angular/tsickle with .dts files.
+  no-unused-vars:
+    - error
+    # Account for closure compiler conventions. See docs/closure-compiler.md
+    # Ingores: MDC[PascalCase]Adapter (records), [PascalCase]Type (typedefs)
+    - varsIgnorePattern: ^(?:(?:MDC(?:(?:[A-Z][a-z0-9]+)+)Adapter)|(?:(?:(?:[A-Z][a-z0-9]+)+)Type))$
+
+  # TODO: Enable once https://github.com/material-components/material-components-web/milestone/4
+  # is complete
   require-jsdoc: off
   valid-jsdoc: off
+
   prefer-const: error
 
   # Rules for our mocha unit tests. Note that even though we use mocha, we model our unit tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ packages/*/dist
 *.log
 .idea
 *.sw*
+.closure-tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         sauce_connect: true
         jwt:
           secure: e4MtddCSnfI/7wT6Vd58w5P5gGVSCIUF9AXWJsGwqfSMosVZ0l1voadWdYCNpLju2qxQFfx48k+ojSCIZq5ZCbwGL8hIJyiTM88pkGSC5iASv0YYkDEIniwz3Pd4Acj0GSGrSa0JkrNyA7rP+7ZAFcizCP8fHdW5pvIq1GJ9vEJttC0pk3OsbX8SLdRjtiOuXHXDOTlZZW9JQv0HyaFvKQNz6hK7KDLn8yq+QFB/17OSPqtMfFUKG83VlddPYTGQKsixl63Bfu+mkJ45D4akS+Gd5Hcg87sKYcXW09+eqE3l5qihRIz3vZXJ8u94heWP4TebV+WeIbrBGGMsNtmqEe7VfOmr5xe+B8wOClUqlpBlu7y0ZFzFxgs31Q0JhsWB6b4vs24Yr6IlPWox7uJckig8XMJX5iFHIHGFEknzAcZBpqSpYkiT2BC8eLaybGwl5VYz23cko3rxHLPxahbMVMW6i5B8XiZozsh4NFKqbERv4bJPPXyybLyR31MOrFMj6hdUd1Gk56RfEulNbCek0aSxuV3Vzxl8+5csTtAdQeqMGImTFDxlmQEoKk8dReOLFxDfNXj7W4YNXpof6YyzXIFelUJ148iODIwE8ET0EJvzR7+mOLmFMKnTWb4Uf8k6Jp4ZZa3zEWzZszG7UfAC4klGoiWhUGS/DpyF0G2BFs8=
+      script: npm run pretest && npm run test:unit && npm run posttest
       after_success:
         - codecov
     # Unit tests on LTS
@@ -24,6 +25,7 @@ matrix:
         sauce_connect: true
         jwt:
           secure: e4MtddCSnfI/7wT6Vd58w5P5gGVSCIUF9AXWJsGwqfSMosVZ0l1voadWdYCNpLju2qxQFfx48k+ojSCIZq5ZCbwGL8hIJyiTM88pkGSC5iASv0YYkDEIniwz3Pd4Acj0GSGrSa0JkrNyA7rP+7ZAFcizCP8fHdW5pvIq1GJ9vEJttC0pk3OsbX8SLdRjtiOuXHXDOTlZZW9JQv0HyaFvKQNz6hK7KDLn8yq+QFB/17OSPqtMfFUKG83VlddPYTGQKsixl63Bfu+mkJ45D4akS+Gd5Hcg87sKYcXW09+eqE3l5qihRIz3vZXJ8u94heWP4TebV+WeIbrBGGMsNtmqEe7VfOmr5xe+B8wOClUqlpBlu7y0ZFzFxgs31Q0JhsWB6b4vs24Yr6IlPWox7uJckig8XMJX5iFHIHGFEknzAcZBpqSpYkiT2BC8eLaybGwl5VYz23cko3rxHLPxahbMVMW6i5B8XiZozsh4NFKqbERv4bJPPXyybLyR31MOrFMj6hdUd1Gk56RfEulNbCek0aSxuV3Vzxl8+5csTtAdQeqMGImTFDxlmQEoKk8dReOLFxDfNXj7W4YNXpof6YyzXIFelUJ148iODIwE8ET0EJvzR7+mOLmFMKnTWb4Uf8k6Jp4ZZa3zEWzZszG7UfAC4klGoiWhUGS/DpyF0G2BFs8=
+      script: npm run pretest && npm run test:unit && npm run posttest
     # Closure compiler type checking. Note that TravisCI has Java 7 enabled by default which should
     # work for using closure.
     - node_js: node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,33 @@
 language: node_js
-node_js:
-- node
-- --lts # LTS: See https://github.com/creationix/nvm/pull/1070
 branches:
   only:
-  - master
-env:
-  global:
-  - SAUCE_USERNAME=material-sauce
-addons:
-  sauce_connect: true
-  jwt:
-    secure: e4MtddCSnfI/7wT6Vd58w5P5gGVSCIUF9AXWJsGwqfSMosVZ0l1voadWdYCNpLju2qxQFfx48k+ojSCIZq5ZCbwGL8hIJyiTM88pkGSC5iASv0YYkDEIniwz3Pd4Acj0GSGrSa0JkrNyA7rP+7ZAFcizCP8fHdW5pvIq1GJ9vEJttC0pk3OsbX8SLdRjtiOuXHXDOTlZZW9JQv0HyaFvKQNz6hK7KDLn8yq+QFB/17OSPqtMfFUKG83VlddPYTGQKsixl63Bfu+mkJ45D4akS+Gd5Hcg87sKYcXW09+eqE3l5qihRIz3vZXJ8u94heWP4TebV+WeIbrBGGMsNtmqEe7VfOmr5xe+B8wOClUqlpBlu7y0ZFzFxgs31Q0JhsWB6b4vs24Yr6IlPWox7uJckig8XMJX5iFHIHGFEknzAcZBpqSpYkiT2BC8eLaybGwl5VYz23cko3rxHLPxahbMVMW6i5B8XiZozsh4NFKqbERv4bJPPXyybLyR31MOrFMj6hdUd1Gk56RfEulNbCek0aSxuV3Vzxl8+5csTtAdQeqMGImTFDxlmQEoKk8dReOLFxDfNXj7W4YNXpof6YyzXIFelUJ148iODIwE8ET0EJvzR7+mOLmFMKnTWb4Uf8k6Jp4ZZa3zEWzZszG7UfAC4klGoiWhUGS/DpyF0G2BFs8=
-after_success:
-  - codecov
+    - master
+matrix:
+  include:
+    # Unit tests on Node Stable
+    - node_js: node
+      env:
+        global:
+          - SAUCE_USERNAME=material-sauce
+      addons:
+        sauce_connect: true
+        jwt:
+          secure: e4MtddCSnfI/7wT6Vd58w5P5gGVSCIUF9AXWJsGwqfSMosVZ0l1voadWdYCNpLju2qxQFfx48k+ojSCIZq5ZCbwGL8hIJyiTM88pkGSC5iASv0YYkDEIniwz3Pd4Acj0GSGrSa0JkrNyA7rP+7ZAFcizCP8fHdW5pvIq1GJ9vEJttC0pk3OsbX8SLdRjtiOuXHXDOTlZZW9JQv0HyaFvKQNz6hK7KDLn8yq+QFB/17OSPqtMfFUKG83VlddPYTGQKsixl63Bfu+mkJ45D4akS+Gd5Hcg87sKYcXW09+eqE3l5qihRIz3vZXJ8u94heWP4TebV+WeIbrBGGMsNtmqEe7VfOmr5xe+B8wOClUqlpBlu7y0ZFzFxgs31Q0JhsWB6b4vs24Yr6IlPWox7uJckig8XMJX5iFHIHGFEknzAcZBpqSpYkiT2BC8eLaybGwl5VYz23cko3rxHLPxahbMVMW6i5B8XiZozsh4NFKqbERv4bJPPXyybLyR31MOrFMj6hdUd1Gk56RfEulNbCek0aSxuV3Vzxl8+5csTtAdQeqMGImTFDxlmQEoKk8dReOLFxDfNXj7W4YNXpof6YyzXIFelUJ148iODIwE8ET0EJvzR7+mOLmFMKnTWb4Uf8k6Jp4ZZa3zEWzZszG7UfAC4klGoiWhUGS/DpyF0G2BFs8=
+      after_success:
+        - codecov
+    # Unit tests on LTS
+    - node_js: --lts # LTS: See https://github.com/creationix/nvm/pull/1070
+      env:
+        global:
+          - SAUCE_USERNAME=material-sauce
+      addons:
+        sauce_connect: true
+        jwt:
+          secure: e4MtddCSnfI/7wT6Vd58w5P5gGVSCIUF9AXWJsGwqfSMosVZ0l1voadWdYCNpLju2qxQFfx48k+ojSCIZq5ZCbwGL8hIJyiTM88pkGSC5iASv0YYkDEIniwz3Pd4Acj0GSGrSa0JkrNyA7rP+7ZAFcizCP8fHdW5pvIq1GJ9vEJttC0pk3OsbX8SLdRjtiOuXHXDOTlZZW9JQv0HyaFvKQNz6hK7KDLn8yq+QFB/17OSPqtMfFUKG83VlddPYTGQKsixl63Bfu+mkJ45D4akS+Gd5Hcg87sKYcXW09+eqE3l5qihRIz3vZXJ8u94heWP4TebV+WeIbrBGGMsNtmqEe7VfOmr5xe+B8wOClUqlpBlu7y0ZFzFxgs31Q0JhsWB6b4vs24Yr6IlPWox7uJckig8XMJX5iFHIHGFEknzAcZBpqSpYkiT2BC8eLaybGwl5VYz23cko3rxHLPxahbMVMW6i5B8XiZozsh4NFKqbERv4bJPPXyybLyR31MOrFMj6hdUd1Gk56RfEulNbCek0aSxuV3Vzxl8+5csTtAdQeqMGImTFDxlmQEoKk8dReOLFxDfNXj7W4YNXpof6YyzXIFelUJ148iODIwE8ET0EJvzR7+mOLmFMKnTWb4Uf8k6Jp4ZZa3zEWzZszG7UfAC4klGoiWhUGS/DpyF0G2BFs8=
+    # Closure compiler type checking. Note that TravisCI has Java 7 enabled by default which should
+    # work for using closure.
+    - node_js: node
+      # Make more clear that this job is for running closure tests
+      env:
+        - CLOSURE=1
+      script: npm run test:closure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ npm run fix # Runs both of the above commands in parallel
 npm run test:watch # Runs karma on Chrome, re-running when source files change
 
 npm test # Lints all files, runs karma, and then runs coverage enforcement checks.
+npm run test:closure # Runs closure build tests against all closurized files
 ```
 
 #### Running Tests across browsers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,8 @@ npm run fix # Runs both of the above commands in parallel
 
 npm run test:watch # Runs karma on Chrome, re-running when source files change
 
-npm test # Lints all files, runs karma, and then runs coverage enforcement checks.
+npm test # Lints all files, runs karma, runs closure tests, and then runs coverage enforcement checks.
+npm run test:unit # Only runs the karma tests
 npm run test:closure # Runs closure build tests against all closurized files
 ```
 

--- a/closure_externs.js
+++ b/closure_externs.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable */
+
+/**
+ * @fileoverview This file is where any externs for third party libraries we use should be placed
+ * so that closure can type-check them.
+ *
+ * Closure historically works using "namespaces", e.g.
+ *
+ * // fileA.js
+ * goog.provide('app.a');
+ * app.a.return5 = () => 5;
+ *
+ * // fileB.js
+ *
+ * goog.provide('app.b');
+ * goog.require('app.a');
+ * app.b.return10 = () => app.a.return5() * 2;
+ *
+ * The way that closure reconciles this with path-based module loading systems
+ * such as CommonJS and ES2015 is by using the `goog:` prefix to load any `goog.provide()`'d
+ * modules using path-based module loading methods.
+ *
+ * For example, given this source file:
+ *
+ * goog.provide('app.util');
+ * app.util.someMethod = () => // ...
+ *
+ * It can be imported using ES2015 in closure via the following:
+ *
+ * import {someMethod} from 'goog:app.util';
+ * // use someMethod
+ *
+ * Our convention here is as follows:
+ *
+ * - All third party modules should be `goog.provide()`'d using the namespace
+ *   `mdc.thirdparty.<CAMEL_CASE_MODULE_NAME>`. E.g. 'focus-trap' is provided as
+ *   `goog.provide('mdc.thirdparty.focusTrap')`.
+ * - Any default exports from a module MUST be attached to the namespace as a property
+ *   named `default`. This is so our module rewrite script can handle default exports from
+ *   third-party modules.
+ *
+ * @see https://developers.google.com/closure/compiler/docs/api-tutorial3
+ */
+
+/**
+ * Externs for focus-trap. Used by mdc-dialog.
+ * @see http://npmjs.com/focus-trap
+ */
+
+goog.provide('mdc.thirdparty.focusTrap')
+
+/**
+ * @typedef {{
+ *   onActivate: (!Function|undefined),
+ *   onDeactivate: (!Function|undefined),
+ *   initialFocus: (!Element|string|!Function|undefined),
+ *   fallbackFocus: (!Element|string|!Function|undefined),
+ *   escapeDeactivates: (boolean|undefined),
+ *   clickOutsideDeactivates: (boolean|undefined),
+ *   returnFocusOnDeactivate: (boolean|undefined),
+ * }}
+ */
+let FocusTrapCreateOptions;
+
+/**
+ * @typedef {{
+ *   returnFocus: (boolean|undefined),
+ *   onDeactivate: (?Function|boolean|undefined),
+ * }}
+ */
+let FocusTrapDeactivateOptions;
+
+/** @record */
+class FocusTrapInstance {
+  activate() {}
+
+  /**
+   * @param {FocusTrapDeactivateOptions=} deactivateOptions
+   */
+  deactivate(deactivateOptions = undefined) {}
+
+  pause() {}
+
+  unpause() {}
+}
+
+/**
+ * The createFocusTrap function.
+ * @param {!Element} element
+ * @param {FocusTrapCreateOptions=} createOptions
+ */
+mdc.thirdparty.focusTrap.default;

--- a/closure_externs.js
+++ b/closure_externs.js
@@ -33,8 +33,8 @@
  * app.b.return10 = () => app.a.return5() * 2;
  *
  * The way that closure reconciles this with path-based module loading systems
- * such as CommonJS and ES2015 is by using the `goog:` prefix to load any `goog.provide()`'d
- * modules using path-based module loading methods.
+ * such as CommonJS and ES2015 is by using the `goog:` prefix to load any modules exported via
+ * `goog.provide()` using path-based module loading methods.
  *
  * For example, given this source file:
  *
@@ -48,7 +48,7 @@
  *
  * Our convention here is as follows:
  *
- * - All third party modules should be `goog.provide()`'d using the namespace
+ * - All third party modules should exported via `goog.provide()` using the namespace
  *   `mdc.thirdparty.<CAMEL_CASE_MODULE_NAME>`. E.g. 'focus-trap' is provided as
  *   `goog.provide('mdc.thirdparty.focusTrap')`.
  * - Any default exports from a module MUST be attached to the namespace as a property

--- a/docs/closure-compiler.md
+++ b/docs/closure-compiler.md
@@ -690,6 +690,13 @@ class MyComponent extends MDCComponent {
 
 While this may seem very foreign coming from outside of closure, it is a [common idiom used by closure code](https://github.com/google/closure-compiler/wiki/Types-in-the-Closure-Type-System#typedefs).
 
+## Handling third-party code
+
+Some of our components rely on third-party modules. These modules must be typed as **externs**
+within `closure_externs.js`. In most cases, you will not need to worry about doing this, as a core
+team member will most likely assist you with it. However, the details of typing these modules can
+be found within that file.
+
 ## Where to go for more help
 
 If you're working on an issue for MDC-Web and find yourself wrestling with closure, please don't

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "pretest": "npm run lint",
     "test": "karma start --single-run",
     "posttest": "istanbul report --root coverage text-summary && istanbul check-coverage --lines 95 --statements 95 --branches 95 --functions 95",
-    "test:watch": "karma start --auto-watch"
+    "test:watch": "karma start --auto-watch",
+    "test:closure": "./scripts/closure-test.sh"
   },
   "devDependencies": {
     "ascii-table": "0.0.9",
@@ -29,7 +30,11 @@
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
+    "babel-traverse": "^6.24.1",
+    "babel-types": "^6.24.1",
+    "babylon": "^6.16.1",
     "bel": "^4.4.3",
+    "camel-case": "^3.0.0",
     "chai": "^3.5.0",
     "cli-table": "^0.3.1",
     "codecov": "^2.1.0",
@@ -44,6 +49,7 @@
     "eslint-plugin-mocha": "^4.8.0",
     "extract-text-webpack-plugin": "2.0.0-rc.3",
     "glob": "^7.1.1",
+    "google-closure-compiler": "^20170409.0.0",
     "husky": "^0.13.1",
     "istanbul": "^0.4.4",
     "istanbul-instrumenter-loader": "^2.0.0",
@@ -65,6 +71,8 @@
     "npm-run-all": "^3.1.2",
     "postcss-loader": "^1.2.2",
     "raw-loader": "^0.5.1",
+    "recast": "^0.12.3",
+    "resolve": "^1.3.2",
     "sass-loader": "^4.1.1",
     "semver": "^5.3.0",
     "standard-changelog": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "lint": "npm-run-all --parallel lint:*",
     "postinstall": "lerna bootstrap",
     "pretest": "npm run lint",
-    "test": "karma start --single-run",
+    "test": "npm run test:unit && npm run test:closure",
     "posttest": "istanbul report --root coverage text-summary && istanbul check-coverage --lines 95 --statements 95 --branches 95 --functions 95",
     "test:watch": "karma start --auto-watch",
+    "test:unit": "karma start --single-run",
     "test:closure": "./scripts/closure-test.sh"
   },
   "devDependencies": {
@@ -152,5 +153,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "closureWhitelist": []
+  "closureWhitelist": [
+    "mdc-animation"
+  ]
 }

--- a/packages/mdc-animation/index.js
+++ b/packages/mdc-animation/index.js
@@ -14,76 +14,96 @@
  * limitations under the License.
  */
 
+/**
+ * @typedef {{
+ *   noPrefix: string,
+ *   webkitPrefix: string
+ * }}
+ */
+let VendorPropertyMapType;
+
+/** @const {Object<string, !VendorPropertyMapType>} */
 const eventTypeMap = {
-  animationstart: {
+  'animationstart': {
     noPrefix: 'animationstart',
     webkitPrefix: 'webkitAnimationStart',
     styleProperty: 'animation',
   },
-  animationend: {
+  'animationend': {
     noPrefix: 'animationend',
     webkitPrefix: 'webkitAnimationEnd',
     styleProperty: 'animation',
   },
-  animationiteration: {
+  'animationiteration': {
     noPrefix: 'animationiteration',
     webkitPrefix: 'webkitAnimationIteration',
     styleProperty: 'animation',
   },
-  transitionend: {
+  'transitionend': {
     noPrefix: 'transitionend',
     webkitPrefix: 'webkitTransitionEnd',
     styleProperty: 'transition',
   },
 };
 
+/** @const {Object<string, !VendorPropertyMapType>} */
 const cssPropertyMap = {
-  animation: {
+  'animation': {
     noPrefix: 'animation',
     webkitPrefix: '-webkit-animation',
   },
-  transform: {
+  'transform': {
     noPrefix: 'transform',
     webkitPrefix: '-webkit-transform',
   },
-  transition: {
+  'transition': {
     noPrefix: 'transition',
     webkitPrefix: '-webkit-transition',
   },
 };
 
+/**
+ * @param {!Object} windowObj
+ * @return {boolean}
+ */
 function hasProperShape(windowObj) {
-  return (windowObj.document !== undefined && typeof windowObj.document.createElement === 'function');
+  return (windowObj['document'] !== undefined && typeof windowObj['document']['createElement'] === 'function');
 }
 
+/**
+ * @param {string} eventType
+ * @return {boolean}
+ */
 function eventFoundInMaps(eventType) {
   return (eventType in eventTypeMap || eventType in cssPropertyMap);
 }
 
-// If 'animation' or 'transition' exist as style property, webkit prefix isn't necessary. Since we are unable to
-// see the event types on the element, we must rely on the corresponding style properties.
+/**
+ * @param {string} eventType
+ * @param {!Object<string, !VendorPropertyMapType>} map
+ * @param {!Element} el
+ * @return {string}
+ */
 function getJavaScriptEventName(eventType, map, el) {
   return map[eventType].styleProperty in el.style ? map[eventType].noPrefix : map[eventType].webkitPrefix;
 }
 
-// Helper function to determine browser prefix for CSS3 animation events
-// and property names
-//
-// Parameters:
-// windowObject: Object -- Contains Document with a `createElement()` method
-// eventType: string -- The type of animation
-//
-// returns the value of the event as a string, prefixed if necessary.
-// If proper arguments are not supplied, this function will return
-// the property or event type without webkit prefix.
-//
+/**
+ * Helper function to determine browser prefix for CSS3 animation events
+ * and property names.
+ * @param {!Object} windowObj
+ * @param {string} eventType
+ * @return {string}
+ */
 function getAnimationName(windowObj, eventType) {
   if (!hasProperShape(windowObj) || !eventFoundInMaps(eventType)) {
     return eventType;
   }
 
-  const map = eventType in eventTypeMap ? eventTypeMap : cssPropertyMap;
-  const el = windowObj.document.createElement('div');
+  const map = /** @type {!Object<string, !VendorPropertyMapType>} */ (
+    eventType in eventTypeMap ? eventTypeMap : cssPropertyMap
+  );
+  const el = windowObj['document']['createElement']('div');
   let eventName = '';
 
   if (map === eventTypeMap) {
@@ -97,19 +117,21 @@ function getAnimationName(windowObj, eventType) {
 
 // Public functions to access getAnimationName() for JavaScript events or CSS
 // property names.
-//
-// Parameters:
-// windowObject: Object -- Contains Document with a `createElement()` method
-// eventType: string -- The type of animation
-//
-// returns the value of the event as a string, prefixed if necessary.
-// If proper arguments are not supplied, this function will return
-// the property or event type without webkit prefix.
-//
+
+/**
+ * @param {!Object} windowObj
+ * @param {string} eventType
+ * @return {string}
+ */
 export function getCorrectEventName(windowObj, eventType) {
   return getAnimationName(windowObj, eventType);
 }
 
+/**
+ * @param {!Object} windowObj
+ * @param {string} eventType
+ * @return {string}
+ */
 export function getCorrectPropertyName(windowObj, eventType) {
   return getAnimationName(windowObj, eventType);
 }

--- a/packages/mdc-drawer/slidable/foundation.js
+++ b/packages/mdc-drawer/slidable/foundation.js
@@ -229,7 +229,7 @@ export class MDCSlidableDrawerFoundation extends MDCFoundation {
     return newPos;
   }
 
-  isRootTransitioningEventTarget_(el) {
+  isRootTransitioningEventTarget_() {
     // Classes extending MDCSlidableDrawerFoundation should implement this method to return true or false
     // if the event target is the root event target currently transitioning.
     return false;

--- a/packages/mdc-form-field/foundation.js
+++ b/packages/mdc-form-field/foundation.js
@@ -48,7 +48,7 @@ export default class MDCFormFieldFoundation extends MDCFoundation {
     this.adapter_.deregisterInteractionHandler('click', this.clickHandler_);
   }
 
-  handleClick_(evt) {
+  handleClick_() {
     this.adapter_.activateInputRipple();
     requestAnimationFrame(() => this.adapter_.deactivateInputRipple());
   }

--- a/packages/mdc-menu/simple/foundation.js
+++ b/packages/mdc-menu/simple/foundation.js
@@ -72,7 +72,7 @@ export default class MDCSimpleMenuFoundation extends MDCFoundation {
     this.clickHandler_ = (evt) => this.handlePossibleSelected_(evt);
     this.keydownHandler_ = (evt) => this.handleKeyboardDown_(evt);
     this.keyupHandler_ = (evt) => this.handleKeyboardUp_(evt);
-    this.documentClickHandler_ = (evt) => {
+    this.documentClickHandler_ = () => {
       this.adapter_.notifyCancel();
       this.close();
     };

--- a/scripts/closure-test.sh
+++ b/scripts/closure-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+##
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+set -e
+
+function log() {
+  echo -e "\033[36m[closure-test]\033[0m" "$@"
+}
+
+CLOSURE_TMP=.closure-tmp
+CLOSURE_PKGDIR=$CLOSURE_TMP/packages
+JS_SRCS=$CLOSURE_PKGDIR/**/*.js
+CLOSURIZED_PKGS=$(node -e "console.log(require('./package.json').closureWhitelist.join(' '))")
+
+if [ -z "$CLOSURIZED_PKGS" ]; then
+  echo "No closurized packages to test!"
+  exit 0
+fi
+
+log "Prepping whitelisted packages for JS compilation"
+
+rm -fr $CLOSURE_TMP/**
+mkdir -p $CLOSURE_PKGDIR
+for pkg in $CLOSURIZED_PKGS; do
+  cp -r "packages/$pkg" $CLOSURE_PKGDIR
+done
+rm -fr $CLOSURE_PKGDIR/**/{node_modules,dist}
+
+log "Rewriting all import statements to be closure compatible"
+node scripts/rewrite-import-statements-for-closure-test.js $CLOSURE_PKGDIR
+
+log "Testing packages"
+echo ''
+
+set +e
+for pkg in $CLOSURIZED_PKGS; do
+  # Note that the jscomp_error flags turn all default warnings into errors, so that
+  # closure exits with a non-zero status if any of them are caught.
+  # Also note that we disable accessControls checks due to
+  # https://github.com/google/closure-compiler/issues/2261
+  CMD="java -jar node_modules/google-closure-compiler/compiler.jar \
+  --externs closure_externs.js \
+  --compilation_level ADVANCED \
+  --js $JS_SRCS \
+  --language_out ECMASCRIPT5_STRICT \
+  --dependency_mode STRICT \
+  --module_resolution LEGACY \
+  --js_module_root $CLOSURE_PKGDIR \
+  --entry_point $CLOSURE_PKGDIR/$pkg/index \
+  --checks_only \
+  --jscomp_error checkTypes \
+  --jscomp_error conformanceViolations \
+  --jscomp_error functionParams \
+  --jscomp_error globalThis \
+  --jscomp_error invalidCasts \
+  --jscomp_error misplacedTypeAnnotation \
+  --jscomp_error nonStandardJsDocs \
+  --jscomp_error suspiciousCode \
+  --jscomp_error uselessCode \
+  --jscomp_off accessControls
+  "
+  $CMD
+
+  if [ $? -eq 0 ]; then
+    echo -e "\033[32;1mPASS\033[0m" "$pkg"
+  else
+    # Add extra space after compiler output
+    echo ''
+    echo -e "\033[31;1mFAIL\033[0m" "$pkg"
+    echo "Failed with the following command:"
+    echo $CMD
+    exit 1
+  fi
+done
+set -e
+
+echo ''
+echo '✨  All tests pass! ✨'

--- a/scripts/rewrite-import-statements-for-closure-test.js
+++ b/scripts/rewrite-import-statements-for-closure-test.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Rewrites import statements such that:
+ *
+ * ```js
+ * import [<SPECIFIERS> from] '@material/$PKG[/files...]';
+ * ```
+ * becomes
+ * ```js
+ * import [<SPECIFIERS> from] 'mdc-$PKG/<RESOLVED_FILE_PATH>';
+ * ```
+ * The RESOLVED_FILE_PATH is the file that node's module resolution algorithm would have resolved the import
+ * source to.
+ *
+ * This script also handles third-party dependencies, e.g.
+ *
+ * ```js
+ * import {thing1, thing2} from 'third-party-lib';
+ * ```
+ *
+ * becomes
+ *
+ * ```js
+ * import {thing1, thing2} from 'goog:mdc.thirdparty.thirdPartyLib';
+ * ```
+ *
+ * and
+ *
+ * ```js
+ * import someDefaultExport from 'third-party-lib';
+ * ```
+ *
+ * becomes
+ *
+ * ```js
+ * import {default as someDefaultExport} from 'goog:mdc.thirdparty.thirdPartyLib'
+ * ```
+ *
+ * This is so closure is able to properly build and check our files without breaking when it encounters
+ * node modules. Note that while closure does have a --module_resolution NODE flag
+ * (https://github.com/google/closure-compiler/wiki/JS-Modules#node-resolution-mode), it has inherent problems
+ * that prevents us from using it. See:
+ * - https://github.com/google/closure-compiler/issues/2386
+ *
+ * Note that for third-party modules, they must be defined in closure_externs.js. See that file for more info.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const {default: traverse} = require('babel-traverse');
+const babylon = require('babylon');
+const camelCase = require('camel-case');
+const glob = require('glob');
+const recast = require('recast');
+const resolve = require('resolve');
+const t = require('babel-types');
+
+main(process.argv);
+
+function main(argv) {
+  if (argv.length < 3) {
+    console.error('Missing root directory path');
+    process.exit(1);
+  }
+
+  const rootDir = path.resolve(process.argv[2]);
+  const srcFiles = glob.sync(`${rootDir}/**/*.js`);
+  srcFiles.forEach((srcFile) => transform(srcFile, rootDir));
+}
+
+function transform(srcFile, rootDir) {
+  const src = fs.readFileSync(srcFile, 'utf8');
+  const ast = recast.parse(src, {
+    parser: {
+      parse: (code) => babylon.parse(code, {sourceType: 'module'}),
+    },
+  });
+
+  traverse(ast, {
+    'ImportDeclaration'({node}) {
+      rewriteImportDeclaration(node, srcFile, rootDir);
+    },
+  });
+
+  const {code: outputCode} = recast.print(ast, {
+    objectCurlySpacing: false,
+    quote: 'single',
+    trailingComma: {
+      objects: true,
+      arrays: true,
+      parameters: false,
+    },
+  });
+
+  fs.writeFileSync(srcFile, outputCode, 'utf8');
+  console.log(`[rewrite] ${srcFile}`);
+}
+
+function rewriteImportDeclaration(node, srcFile, rootDir) {
+  let importSource = node.source.value;
+  const pathParts = importSource.split('/');
+  const isMDCImport = pathParts[0] === '@material';
+  if (isMDCImport) {
+    const modName = pathParts[1];  // @material/<modName>
+    const atMaterialReplacementPath = `${rootDir}/mdc-${modName}`;
+    const rewrittenImportSource = [atMaterialReplacementPath].concat(pathParts.slice(2)).join('/');
+    importSource = rewrittenImportSource;
+  }
+
+  patchNodeForImportSource(importSource, srcFile, node);
+}
+
+function patchNodeForImportSource(importSource, srcFile, node) {
+  let resolvedImportSource = importSource;
+  // See: https://nodejs.org/api/modules.html#modules_all_together (step 3)
+  const wouldLoadAsFileOrDir = ['./', '/', '../'].some((s) => importSource.indexOf(s) === 0);
+  const isThirdPartyModule = !wouldLoadAsFileOrDir;
+  if (isThirdPartyModule) {
+    assert(importSource.indexOf('@material') < 0, '@material/* import sources should have already been rewritten');
+    patchDefaultImportIfNeeded(node);
+    resolvedImportSource = `goog:mdc.thirdparty.${camelCase(importSource)}`;
+  } else {
+    const needsClosureModuleRootResolution = path.isAbsolute(importSource);
+    if (needsClosureModuleRootResolution) {
+      resolvedImportSource = path.relative(rootDir, resolve.sync(importSource, {
+        basedir: path.dirname(srcFile),
+      }));
+    }
+  }
+  node.source = t.stringLiteral(resolvedImportSource);
+}
+
+function patchDefaultImportIfNeeded(node) {
+  const defaultImportSpecifierIndex = node.specifiers.findIndex(t.isImportDefaultSpecifier);
+  if (defaultImportSpecifierIndex >= 0) {
+    const defaultImportSpecifier = node.specifiers[defaultImportSpecifierIndex];
+    const defaultPropImportSpecifier = t.importSpecifier(defaultImportSpecifier.local, t.identifier('default'));
+    node.specifiers[defaultImportSpecifierIndex] = defaultPropImportSpecifier;
+  }
+}

--- a/test/unit/mdc-animation/mdc-animation.test.js
+++ b/test/unit/mdc-animation/mdc-animation.test.js
@@ -23,7 +23,7 @@ import {getCorrectPropertyName} from '../../../packages/mdc-animation';
 // Has no properties without a prefix
 const legacyWindowObj = td.object({
   document: {
-    createElement: (str) => ({
+    createElement: () => ({
       style: {
         'webkitTransform': 'nah',
       },
@@ -36,7 +36,7 @@ suite('MDCAnimation');
 test('#getCorrectEventName does not prefix events when not necessary', () => {
   const windowObj = td.object({
     document: {
-      createElement: (str) => ({
+      createElement: () => ({
         style: {
           animation: 'none',
         },

--- a/test/unit/mdc-drawer/slidable.foundation.test.js
+++ b/test/unit/mdc-drawer/slidable.foundation.test.js
@@ -26,7 +26,7 @@ function setupTest(isRootTransitioningEventTarget) {
 
   class MDCFakeSlideableDrawerFoundation extends MDCSlidableDrawerFoundation {
 
-    isRootTransitioningEventTarget_(el) {
+    isRootTransitioningEventTarget_() {
       return isRootTransitioningEventTarget;
     }
   }

--- a/test/unit/mdc-menu/simple.foundation.test.js
+++ b/test/unit/mdc-menu/simple.foundation.test.js
@@ -23,7 +23,7 @@ import {createMockRaf} from '../helpers/raf';
 import MDCSimpleMenuFoundation from '../../../packages/mdc-menu/simple/foundation';
 import {cssClasses, strings, numbers} from '../../../packages/mdc-menu/simple/constants';
 
-function setupTest(isCssVarsSupported = true) {
+function setupTest() {
   const {foundation, mockAdapter} = setupFoundationTest(MDCSimpleMenuFoundation);
   const size = {width: 500, height: 200};
   const itemYParams = {top: 100, height: 20};


### PR DESCRIPTION
**This PR should be _Rebased and Merged_, not squashed and merged**

---

### chore(infrastructure): Create closure build test infrastructure

- Add scripts/closure-test.sh script to perform compilation tests on all
  of our closurized packages.
- Add scripts/rewrite-import-statements-for-closure-test.js to rewrite
  all package import statements to be compatible with closure
- Add closure_externs.js file to support third-party module loading by
  closure
- Add documentation regarding closure externs to closure-compiler.md
- Update TravisCI configuration to run closure build tests in parallel
  with our existing CI scripts.
- Add ignore vars pattern to ESLint unused var config
- Fix all uncaught unused var errors (why they weren't caught before is
  quite confusing...)

Resolves #327

NOTE: Tested rewrite import statements logic by hacking
closurization into `mdc-base` and `mdc-textfield`, and using
`focus-trap` as a third-party dep within `mdc-textfield` to verify
everything was working correctly. Furthermore, focus-trap has been
typed already to save other contributors the trouble of doing so :)

---

### feat(animation): Annotate for closure compiler

Resolves #332