### PR TITLE
style: Replace stylelint `order/declaration-block-properties-order` rule with `order/properties-order` and update scss to match

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -19,7 +19,7 @@ rules:
   # attribute strings are normally quoted within the DOM.
   string-quotes: double
   # https://github.com/sasstools/sass-lint/blob/develop/lib/config/property-sort-orders/smacss.yml
-  order/declaration-block-properties-specified-order:
+  order/properties-order:
     - display
     - position
     - top

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "stylefmt": "^5.0.2",
     "stylelint": "^7.8.0",
     "stylelint-config-standard": "^16.0.0",
-    "stylelint-order": "^0.4.2",
+    "stylelint-order": "^0.4.3",
     "stylelint-scss": "^1.4.1",
     "stylelint-selector-bem-pattern": "^1.0.0",
     "testdouble": "^2.1.1",

--- a/packages/mdc-drawer/persistent/mdc-persistent-drawer.scss
+++ b/packages/mdc-drawer/persistent/mdc-persistent-drawer.scss
@@ -29,6 +29,7 @@ $mdc-persistent-drawer-dark-theme-bg-color: #212121 !default;
 
 .mdc-persistent-drawer {
   @include mdc-drawer-base_;
+
   width: 0;
 
   &__drawer {
@@ -47,24 +48,23 @@ $mdc-persistent-drawer-dark-theme-bg-color: #212121 !default;
     @include mdc-slideable-drawer;
 
     @include mdc-rtl(".mdc-persistent-drawer") {
-        @include mdc-slideable-drawer-rtl;
+      @include mdc-slideable-drawer-rtl;
     }
 
     display: inline-flex;
     flex-direction: column;
     box-sizing: border-box;
+    width: $mdc-persistent-drawer-width;
     overflow: hidden;
     touch-action: none;
-    width: $mdc-persistent-drawer-width;
   }
 
   &--animating {
-
     .mdc-persistent-drawer__drawer {
       transition: $mdc-slidable-drawer-transition;
     }
 
-    &.mdc-persistent-drawer--open .mdc-persistent-drawer__drawer  {
+    &.mdc-persistent-drawer--open .mdc-persistent-drawer__drawer {
       transition: $mdc-slidable-drawer-transition-open;
     }
   }

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -60,8 +60,8 @@ $mdc-toolbar-mobile-breakpoint: 599px;
     flex: 1;
     align-items: flex-start;
     justify-content: center;
-    z-index: 1;
     min-width: 0;
+    z-index: 1;
 
     &--align-start {
       justify-content: flex-start;
@@ -79,10 +79,10 @@ $mdc-toolbar-mobile-breakpoint: 599px;
 
     margin: 0;
     line-height: 1.5rem;
-    z-index: 1;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    z-index: 1;
   }
 }
 
@@ -123,10 +123,10 @@ $mdc-toolbar-mobile-breakpoint: 599px;
     .mdc-toolbar__title {
       @include mdc-typography(display1);
 
-      line-height: 1.5rem;
       transform: translateY($mdc-toolbar-row-height * ($mdc-toolbar-ratio-to-extend-flexible - 1));
       transform: translateY(calc(#{$mdc-toolbar-row-height} * (var(--mdc-toolbar-ratio-to-extend-flexible, #{$mdc-toolbar-ratio-to-extend-flexible}) - 1)));
       font-weight: #{map-get($mdc-typography-font-weight-values, normal)};
+      line-height: 1.5rem;
 
       @media (max-width: $mdc-toolbar-mobile-breakpoint) {
         transform: translateY($mdc-toolbar-mobile-row-height * ($mdc-toolbar-ratio-to-extend-flexible - 1));


### PR DESCRIPTION
* Updated stylelint-order to 0.4.3 latest
* Fixed any files which cause the new lint rule to fail
* Replaced the rule with the above plugin, using the properties-order array to preserve the order of our current properties.

Resolves:
https://github.com/material-components/material-components-web/issues/559