### PR TITLE
fix(infrastructure): Disable webpack-dev-server host checking

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,12 @@ module.exports = [{
     libraryTarget: 'umd',
     library: ['mdc', '[name]'],
   },
+  // See https://github.com/webpack/webpack-dev-server/issues/882
+  // Because we only spin up dev servers temporarily, and all of our assets are publicly
+  // available on GitHub, we can safely disable this check.
+  devServer: {
+    disableHostCheck: true,
+  },
   devtool: IS_DEV ? 'source-map' : false,
   module: {
     rules: [{
@@ -118,6 +124,9 @@ module.exports = [{
     filename: 'material-components-web.' + (IS_PROD ? 'min.' : '') + 'js',
     libraryTarget: 'umd',
     library: 'mdc',
+  },
+  devServer: {
+    disableHostCheck: true,
   },
   devtool: IS_DEV ? 'source-map' : false,
   module: {
@@ -169,6 +178,9 @@ module.exports = [{
     // all other cases, ExtractTextPlugin is used to generate the final css, so this is given a
     // dummy ".css-entry" extension.
     filename: '[name].' + (IS_PROD ? 'min.' : '') + 'css' + (IS_DEV ? '.js' : '-entry'),
+  },
+  devServer: {
+    disableHostCheck: true,
   },
   devtool: IS_DEV ? 'source-map' : false,
   module: {


### PR DESCRIPTION
Changes introduced in the most recent version of WDS hardened CORS
access to resources. This however breaks our development model when
using proxies like ngrok to test across devices. Because all of our
assets are publicly available, and our WDS usage is purely transient,
I believe it's safe to disable this.