### PR TITLE
Fix incorrect paths to packages in button documentation

### DIFF
--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -67,14 +67,14 @@ npm install --save @material/button
 
 ### Adding ripples to buttons
 
-To add the ink ripple effect to a button, attach a [ripple](../packages/mdc-ripple) instance to the
+To add the ink ripple effect to a button, attach a [ripple](../mdc-ripple) instance to the
 button element.
 
 ```js
 mdc.ripple.MDCRipple.attachTo(document.querySelector('.mdc-button'));
 ```
 
-You can also do this declaratively when using the [material-components-web](../packages/material-components-web) package.
+You can also do this declaratively when using the [material-components-web](../material-components-web) package.
 
 ```html
 <button class="mdc-button" data-mdc-auto-init="MDCRipple">


### PR DESCRIPTION
Just a minor fix for the package links in the MDC button package documentation.