### PR TITLE
Fix misaligned title in Typography Demo

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -62,7 +62,6 @@
           <span class="catalog-logo">
             <img src="/images/ic_component_24px_white.svg">
           </span>
-          <!--<a href="#" class="material-icons">menu</a>-->
           <span class="mdc-toolbar__title catalog-title">Material Components Catalog</span>
         </section>
       </div>

--- a/demos/typography.html
+++ b/demos/typography.html
@@ -30,9 +30,6 @@
         padding: 24px;
         border: 1px solid #ddd;
       }
-      .demo-typography--section h2 {
-        margin-left: 0;
-      }
     </style>
   </head>
   <body>
@@ -52,8 +49,8 @@
         <h2 class="mdc-typography--display4">Tt</h2>
       </section>
 
-      <h2 class="mdc-typography--display1">Styles</h2>
       <section class="demo-typography--section mdc-typography">
+        <h2 class="mdc-typography--display1">Styles</h2>
         <h1 class="mdc-typography--display4">Display 4</h1>
         <h1 class="mdc-typography--display3">Display 3</h1>
         <h1 class="mdc-typography--display2">Display 2</h1>
@@ -71,8 +68,8 @@
         <aside class="mdc-typography--body2">Body 2 text, calling something out.</aside>
       </section>
 
-      <h2 class="mdc-typography--display1">Styles with margin adjustments</h2>
       <section class="demo-typography--section mdc-typography">
+        <h2 class="mdc-typography--display1">Styles with margin adjustments</h2>
         <h1 class="mdc-typography--display4 mdc-typography--adjust-margin">Display 4</h1>
         <h1 class="mdc-typography--display3 mdc-typography--adjust-margin">Display 3</h1>
         <h1 class="mdc-typography--display2 mdc-typography--adjust-margin">Display 2</h1>


### PR DESCRIPTION
Remove unnecessary CSS rule in Typography and move header into the section block.
Remove unnecessary comment in the index.
