### PR TITLE
docs(toolbar) Fixed Demo URL 404.

### DIFF
--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -38,7 +38,7 @@ height added to their first rows.
     <a href="https://material.io/guidelines/components/toolbars.html">Material Design guidelines: Toolbars</a>
   </li>
   <li class="icon-list-item icon-list-item--link">
-    <a href="https://material-components-web.appspot.com/toolbar/">Demo</a>
+    <a href="https://material-components-web.appspot.com/toolbar/index.html">Demo</a>
   </li>
 </ul>
 


### PR DESCRIPTION
Supposedly this [commit](https://github.com/material-components/material-components-web/commit/c8f70a64661b7c2f1aa31c188506bf0fb9dc8bd5) should have fixed it, but it didn't.