### PR TITLE
docs(tabs): fixes package name in installation command

### DIFF
--- a/packages/mdc-tabs/README.md
+++ b/packages/mdc-tabs/README.md
@@ -9,7 +9,7 @@ The MDC Tabs component contains components which are used to create spec-aligned
 ## Installation
 
 ```
-npm install --save @material/tab-bar
+npm install --save @material/tabs
 ```
 
 ## Tabs usage

--- a/packages/mdc-tabs/README.md
+++ b/packages/mdc-tabs/README.md
@@ -85,7 +85,7 @@ ancestor element with attribute `dir="rtl"`.
 #### Dark Mode Support
 
 Like other MDC-Web components, tabs support dark mode either when an
-`mdc-tab--theme-dark` class is attached to the root element, or the element has
+`mdc-tab-bar--theme-dark` class is attached to the root element, or the element has
 an ancestor with class `mdc-theme--dark`.
 
 ```html


### PR DESCRIPTION
The readme of tabs component incorrectly states @material/tab-bar as NPM component name, but it is not available. It is registered under the name @material/tabs.

EDIT: also fixes Dark Mode support class name reference.