### PR TITLE
fix(card): Add rounded corners to card component

### DIFF
--- a/packages/mdc-card/mdc-card.scss
+++ b/packages/mdc-card/mdc-card.scss
@@ -27,6 +27,8 @@
   justify-content: flex-end;
   padding: 0;
   box-sizing: border-box;
+  border-radius: 2px;
+  overflow: hidden;
 
   &__primary {
     padding: 16px;


### PR DESCRIPTION
This PR adds a 2px border radius to the card component and sets overflow: hidden; to prevent a contained image from bleeding out over the border.

I did wonder if the 2px border value should be a SCSS variable.

This fixes issue #647