### PR TITLE
fix(drawer): allow custom click events on drawer

### DIFF
--- a/packages/mdc-drawer/slidable/foundation.js
+++ b/packages/mdc-drawer/slidable/foundation.js
@@ -60,7 +60,6 @@ export class MDCSlidableDrawerFoundation extends MDCFoundation {
 
     this.inert_ = false;
 
-    this.drawerClickHandler_ = (evt) => evt.stopPropagation();
     this.componentTouchStartHandler_ = (evt) => this.handleTouchStart_(evt);
     this.componentTouchMoveHandler_ = (evt) => this.handleTouchMove_(evt);
     this.componentTouchEndHandler_ = (evt) => this.handleTouchEnd_(evt);
@@ -90,14 +89,12 @@ export class MDCSlidableDrawerFoundation extends MDCFoundation {
       this.isOpen_ = false;
     }
 
-    this.adapter_.registerDrawerInteractionHandler('click', this.drawerClickHandler_);
     this.adapter_.registerDrawerInteractionHandler('touchstart', this.componentTouchStartHandler_);
     this.adapter_.registerInteractionHandler('touchmove', this.componentTouchMoveHandler_);
     this.adapter_.registerInteractionHandler('touchend', this.componentTouchEndHandler_);
   }
 
   destroy() {
-    this.adapter_.deregisterDrawerInteractionHandler('click', this.drawerClickHandler_);
     this.adapter_.deregisterDrawerInteractionHandler('touchstart', this.componentTouchStartHandler_);
     this.adapter_.deregisterInteractionHandler('touchmove', this.componentTouchMoveHandler_);
     this.adapter_.deregisterInteractionHandler('touchend', this.componentTouchEndHandler_);

--- a/packages/mdc-drawer/temporary/foundation.js
+++ b/packages/mdc-drawer/temporary/foundation.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {MDCSlidableDrawerFoundation} from '../slidable';
-import {cssClasses, strings} from './constants';
+import { MDCSlidableDrawerFoundation } from '../slidable';
+import { cssClasses, strings } from './constants';
 
 export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFoundation {
   static get cssClasses() {
@@ -29,7 +29,7 @@ export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFound
   static get defaultAdapter() {
     return Object.assign(MDCSlidableDrawerFoundation.defaultAdapter, {
       isDrawer: () => false,
-      updateCssVariable: (/* value: string */) => {},
+      updateCssVariable: (/* value: string */) => { },
     });
   }
 
@@ -41,10 +41,10 @@ export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFound
       MDCTemporaryDrawerFoundation.cssClasses.OPEN);
 
     this.componentClickHandler_ = (evt) => {
-      if(evt.srcElement.classList.contains("mdc-temporary-drawer")){
+      if (evt.srcElement.classList.contains('mdc-temporary-drawer')) {
         this.close();
       }
-    }
+    };
   }
 
   init() {

--- a/packages/mdc-drawer/temporary/foundation.js
+++ b/packages/mdc-drawer/temporary/foundation.js
@@ -40,7 +40,11 @@ export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFound
       MDCTemporaryDrawerFoundation.cssClasses.ANIMATING,
       MDCTemporaryDrawerFoundation.cssClasses.OPEN);
 
-    this.componentClickHandler_ = () => this.close();
+    this.componentClickHandler_ = (evt) => {
+      if(evt.srcElement.classList.contains("mdc-temporary-drawer")){
+        this.close();
+      }
+    }
   }
 
   init() {

--- a/packages/mdc-drawer/temporary/foundation.js
+++ b/packages/mdc-drawer/temporary/foundation.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { MDCSlidableDrawerFoundation } from '../slidable';
-import { cssClasses, strings } from './constants';
+import {MDCSlidableDrawerFoundation} from '../slidable';
+import {cssClasses, strings} from './constants';
 
 export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFoundation {
   static get cssClasses() {


### PR DESCRIPTION
Remove stopPropagation() on click to allow custom click events outside of mdc. Instead of always
closing temporary drawer on click, the drawer only closes when clicking outside of the drawer onto
the background.