### PR TITLE
fix(dialog): MDC Dialog does not have 8dp padding between side-by-side buttons

### DIFF
--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -131,6 +131,14 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     align-items: center;
     justify-content: flex-end;
     padding: 8px;
+
+    &__button {
+      margin-right: 8px;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
   }
 
   // TODO: Replace with breakpoint variable


### PR DESCRIPTION
This should fix #661 

This is my first PR so let me know if something else is needed. Thanks in advance.