### PR TITLE
style: Add indentation check to ESLint config

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -9,6 +9,7 @@ parserOptions:
   ecmaVersion: 2015
   sourceType: module
 rules:
+  indent: [error, 2]
   max-len: [error, 120]
   no-new: warn
   quotes: [error, single, {"avoidEscape": true}]

--- a/packages/mdc-checkbox/foundation.js
+++ b/packages/mdc-checkbox/foundation.js
@@ -199,18 +199,18 @@ export default class MDCCheckboxFoundation extends MDCFoundation {
     } = MDCCheckboxFoundation.cssClasses;
 
     switch (oldState) {
-      case TRANSITION_STATE_INIT:
-        if (newState === TRANSITION_STATE_UNCHECKED) {
-          return '';
-        }
+    case TRANSITION_STATE_INIT:
+      if (newState === TRANSITION_STATE_UNCHECKED) {
+        return '';
+      }
         // fallthrough
-      case TRANSITION_STATE_UNCHECKED:
-        return newState === TRANSITION_STATE_CHECKED ? ANIM_UNCHECKED_CHECKED : ANIM_UNCHECKED_INDETERMINATE;
-      case TRANSITION_STATE_CHECKED:
-        return newState === TRANSITION_STATE_UNCHECKED ? ANIM_CHECKED_UNCHECKED : ANIM_CHECKED_INDETERMINATE;
+    case TRANSITION_STATE_UNCHECKED:
+      return newState === TRANSITION_STATE_CHECKED ? ANIM_UNCHECKED_CHECKED : ANIM_UNCHECKED_INDETERMINATE;
+    case TRANSITION_STATE_CHECKED:
+      return newState === TRANSITION_STATE_UNCHECKED ? ANIM_CHECKED_UNCHECKED : ANIM_CHECKED_INDETERMINATE;
       // TRANSITION_STATE_INDETERMINATE
-      default:
-        return newState === TRANSITION_STATE_CHECKED ?
+    default:
+      return newState === TRANSITION_STATE_CHECKED ?
           ANIM_INDETERMINATE_CHECKED : ANIM_INDETERMINATE_UNCHECKED;
     }
   }

--- a/packages/mdc-drawer/util.js
+++ b/packages/mdc-drawer/util.js
@@ -24,14 +24,14 @@ let supportsPassive_;
 export function remapEvent(eventName, globalObj = window) {
   if (!('ontouchstart' in globalObj.document)) {
     switch (eventName) {
-      case 'touchstart':
-        return 'pointerdown';
-      case 'touchmove':
-        return 'pointermove';
-      case 'touchend':
-        return 'pointerup';
-      default:
-        return eventName;
+    case 'touchstart':
+      return 'pointerdown';
+    case 'touchmove':
+      return 'pointermove';
+    case 'touchend':
+      return 'pointerup';
+    default:
+      return eventName;
     }
   }
 

--- a/test/unit/mdc-dialog/foundation.test.js
+++ b/test/unit/mdc-dialog/foundation.test.js
@@ -158,7 +158,7 @@ test('#close deactivates focus trapping on the dialog surface', () => {
 });
 
 test('#accept closes the dialog', () => {
-   const {foundation} = setupTest();
+  const {foundation} = setupTest();
 
   foundation.accept();
   assert.isFalse(foundation.isOpen());
@@ -172,7 +172,7 @@ test('#accept calls accept when shouldNotify is set to true', () => {
 });
 
 test('#cancel closes the dialog', () => {
-   const {foundation} = setupTest();
+  const {foundation} = setupTest();
 
   foundation.cancel();
   assert.isFalse(foundation.isOpen());

--- a/test/unit/mdc-menu/simple.foundation.test.js
+++ b/test/unit/mdc-menu/simple.foundation.test.js
@@ -106,19 +106,19 @@ testFoundation('#open adds the open class to the menu', ({foundation, mockAdapte
 
 testFoundation('#open removes the animation class at the end of the animation',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
-  td.when(mockAdapter.hasClass('mdc-simple-menu--open-from-top-right')).thenReturn(true);
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasClass('mdc-simple-menu--open-from-top-right')).thenReturn(true);
 
-  foundation.open();
-  mockRaf.flush();
-  mockRaf.flush();
-  td.verify(mockAdapter.addClass('mdc-simple-menu--animating'));
+      foundation.open();
+      mockRaf.flush();
+      mockRaf.flush();
+      td.verify(mockAdapter.addClass('mdc-simple-menu--animating'));
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  mockRaf.flush();
-  td.verify(mockAdapter.removeClass('mdc-simple-menu--animating'));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      mockRaf.flush();
+      td.verify(mockAdapter.removeClass('mdc-simple-menu--animating'));
+    });
 
 testFoundation('#open focuses the menu at the end of the animation', ({foundation, mockAdapter, mockRaf}) => {
   td.when(mockAdapter.getAccurateTime()).thenReturn(0);
@@ -147,129 +147,129 @@ testFoundation('#open on a not focused menu does not focust at index 0', ({found
 
 testFoundation('#open anchors the menu on the top left in LTR, given enough room',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.hasAnchor()).thenReturn(true);
-  td.when(mockAdapter.isRtl()).thenReturn(false);
-  td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
-  td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
-  td.when(mockAdapter.getAnchorDimensions()).thenReturn({
-    height: 20, width: 40, top: 20, bottom: 40, left: 20, right: 60,
-  });
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasAnchor()).thenReturn(true);
+      td.when(mockAdapter.isRtl()).thenReturn(false);
+      td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
+      td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
+      td.when(mockAdapter.getAnchorDimensions()).thenReturn({
+        height: 20, width: 40, top: 20, bottom: 40, left: 20, right: 60,
+      });
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
 
-  foundation.open();
-  mockRaf.flush();
-  mockRaf.flush();
+      foundation.open();
+      mockRaf.flush();
+      mockRaf.flush();
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  td.verify(mockAdapter.setTransformOrigin('top left'));
-  td.verify(mockAdapter.setPosition({left: '0', top: '0'}));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      td.verify(mockAdapter.setTransformOrigin('top left'));
+      td.verify(mockAdapter.setPosition({left: '0', top: '0'}));
+    });
 
 testFoundation('#open anchors the menu on the top right in LTR when close to the right edge',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.hasAnchor()).thenReturn(true);
-  td.when(mockAdapter.isRtl()).thenReturn(false);
-  td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
-  td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
-  td.when(mockAdapter.getAnchorDimensions()).thenReturn({
-    height: 20, width: 40, top: 20, bottom: 40, left: 950, right: 990,
-  });
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasAnchor()).thenReturn(true);
+      td.when(mockAdapter.isRtl()).thenReturn(false);
+      td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
+      td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
+      td.when(mockAdapter.getAnchorDimensions()).thenReturn({
+        height: 20, width: 40, top: 20, bottom: 40, left: 950, right: 990,
+      });
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
 
-  foundation.open();
-  mockRaf.flush();
-  mockRaf.flush();
+      foundation.open();
+      mockRaf.flush();
+      mockRaf.flush();
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  td.verify(mockAdapter.setTransformOrigin('top right'));
-  td.verify(mockAdapter.setPosition({right: '0', top: '0'}));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      td.verify(mockAdapter.setTransformOrigin('top right'));
+      td.verify(mockAdapter.setPosition({right: '0', top: '0'}));
+    });
 
 testFoundation('#open anchors the menu on the top right in RTL, given enough room',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.hasAnchor()).thenReturn(true);
-  td.when(mockAdapter.isRtl()).thenReturn(true);
-  td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
-  td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
-  td.when(mockAdapter.getAnchorDimensions()).thenReturn({
-    height: 20, width: 40, top: 20, bottom: 40, left: 500, right: 540,
-  });
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasAnchor()).thenReturn(true);
+      td.when(mockAdapter.isRtl()).thenReturn(true);
+      td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
+      td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
+      td.when(mockAdapter.getAnchorDimensions()).thenReturn({
+        height: 20, width: 40, top: 20, bottom: 40, left: 500, right: 540,
+      });
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
 
-  foundation.open();
-  mockRaf.flush();
-  mockRaf.flush();
+      foundation.open();
+      mockRaf.flush();
+      mockRaf.flush();
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  td.verify(mockAdapter.setTransformOrigin('top right'));
-  td.verify(mockAdapter.setPosition({right: '0', top: '0'}));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      td.verify(mockAdapter.setTransformOrigin('top right'));
+      td.verify(mockAdapter.setPosition({right: '0', top: '0'}));
+    });
 
 testFoundation('#open anchors the menu on the top left in RTL when close to the left edge',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.hasAnchor()).thenReturn(true);
-  td.when(mockAdapter.isRtl()).thenReturn(true);
-  td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
-  td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
-  td.when(mockAdapter.getAnchorDimensions()).thenReturn({
-    height: 20, width: 40, top: 20, bottom: 40, left: 10, right: 50,
-  });
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasAnchor()).thenReturn(true);
+      td.when(mockAdapter.isRtl()).thenReturn(true);
+      td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
+      td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
+      td.when(mockAdapter.getAnchorDimensions()).thenReturn({
+        height: 20, width: 40, top: 20, bottom: 40, left: 10, right: 50,
+      });
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
 
-  foundation.open();
-  mockRaf.flush();
-  mockRaf.flush();
+      foundation.open();
+      mockRaf.flush();
+      mockRaf.flush();
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  td.verify(mockAdapter.setTransformOrigin('top left'));
-  td.verify(mockAdapter.setPosition({left: '0', top: '0'}));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      td.verify(mockAdapter.setTransformOrigin('top left'));
+      td.verify(mockAdapter.setPosition({left: '0', top: '0'}));
+    });
 
 testFoundation('#open anchors the menu on the bottom left in LTR when close to the bottom edge',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.hasAnchor()).thenReturn(true);
-  td.when(mockAdapter.isRtl()).thenReturn(false);
-  td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
-  td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
-  td.when(mockAdapter.getAnchorDimensions()).thenReturn({
-    height: 20, width: 40, top: 900, bottom: 920, left: 10, right: 50,
-  });
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasAnchor()).thenReturn(true);
+      td.when(mockAdapter.isRtl()).thenReturn(false);
+      td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
+      td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
+      td.when(mockAdapter.getAnchorDimensions()).thenReturn({
+        height: 20, width: 40, top: 900, bottom: 920, left: 10, right: 50,
+      });
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
 
-  foundation.open();
-  mockRaf.flush();
-  mockRaf.flush();
+      foundation.open();
+      mockRaf.flush();
+      mockRaf.flush();
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  td.verify(mockAdapter.setTransformOrigin('bottom left'));
-  td.verify(mockAdapter.setPosition({left: '0', bottom: '0'}));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      td.verify(mockAdapter.setTransformOrigin('bottom left'));
+      td.verify(mockAdapter.setPosition({left: '0', bottom: '0'}));
+    });
 
 testFoundation('#open anchors the menu on the top left in LTR when not close to the bottom edge',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.hasAnchor()).thenReturn(true);
-  td.when(mockAdapter.isRtl()).thenReturn(false);
-  td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
-  td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
-  td.when(mockAdapter.getAnchorDimensions()).thenReturn({
-    height: 20, width: 40, top: 900, bottom: 20, left: 10, right: 50,
-  });
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasAnchor()).thenReturn(true);
+      td.when(mockAdapter.isRtl()).thenReturn(false);
+      td.when(mockAdapter.getInnerDimensions()).thenReturn({height: 200, width: 100});
+      td.when(mockAdapter.getWindowDimensions()).thenReturn({height: 1000, width: 1000});
+      td.when(mockAdapter.getAnchorDimensions()).thenReturn({
+        height: 20, width: 40, top: 900, bottom: 20, left: 10, right: 50,
+      });
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
 
-  foundation.open();
-  mockRaf.flush();
-  mockRaf.flush();
+      foundation.open();
+      mockRaf.flush();
+      mockRaf.flush();
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  td.verify(mockAdapter.setTransformOrigin('top left'));
-  td.verify(mockAdapter.setPosition({left: '0', top: '0'}));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      td.verify(mockAdapter.setTransformOrigin('top left'));
+      td.verify(mockAdapter.setPosition({left: '0', top: '0'}));
+    });
 
 testFoundation('#close adds the animation class to start an animation', ({foundation, mockAdapter, mockRaf}) => {
   foundation.close();
@@ -290,19 +290,19 @@ testFoundation('#close removes the open class from the menu', ({foundation, mock
 
 testFoundation('#close removes the animation class at the end of the animation',
     ({foundation, mockAdapter, mockRaf}) => {
-  td.when(mockAdapter.getAccurateTime()).thenReturn(0);
-  td.when(mockAdapter.hasClass('mdc-simple-menu--open')).thenReturn(true);
-  td.when(mockAdapter.hasClass('mdc-simple-menu--open-from-bottom-right')).thenReturn(true);
+      td.when(mockAdapter.getAccurateTime()).thenReturn(0);
+      td.when(mockAdapter.hasClass('mdc-simple-menu--open')).thenReturn(true);
+      td.when(mockAdapter.hasClass('mdc-simple-menu--open-from-bottom-right')).thenReturn(true);
 
-  foundation.close();
-  mockRaf.flush();
-  mockRaf.flush();
-  td.verify(mockAdapter.addClass('mdc-simple-menu--animating'));
+      foundation.close();
+      mockRaf.flush();
+      mockRaf.flush();
+      td.verify(mockAdapter.addClass('mdc-simple-menu--animating'));
 
-  td.when(mockAdapter.getAccurateTime()).thenReturn(500);
-  mockRaf.flush();
-  td.verify(mockAdapter.removeClass('mdc-simple-menu--animating'));
-});
+      td.when(mockAdapter.getAccurateTime()).thenReturn(500);
+      mockRaf.flush();
+      td.verify(mockAdapter.removeClass('mdc-simple-menu--animating'));
+    });
 
 test('#isOpen returns true when the menu is open', () => {
   const {foundation} = setupTest();

--- a/test/unit/mdc-ripple/foundation-activation.test.js
+++ b/test/unit/mdc-ripple/foundation-activation.test.js
@@ -23,17 +23,17 @@ suite('MDCRippleFoundation - Activation Logic');
 
 testFoundation('does nothing if component if isSurfaceDisabled is true',
   ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  foundation.init();
-  mockRaf.flush();
+    const handlers = captureHandlers(adapter);
+    foundation.init();
+    mockRaf.flush();
 
-  td.when(adapter.isSurfaceDisabled()).thenReturn(true);
+    td.when(adapter.isSurfaceDisabled()).thenReturn(true);
 
-  handlers.mousedown();
+    handlers.mousedown();
 
-  td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 0});
-  td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 0});
-});
+    td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 0});
+    td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 0});
+  });
 
 testFoundation('adds activation classes on mousedown', ({foundation, adapter, mockRaf}) => {
   const handlers = captureHandlers(adapter);
@@ -48,38 +48,38 @@ testFoundation('adds activation classes on mousedown', ({foundation, adapter, mo
 
 testFoundation('sets FG position from the coords to the center within surface on mousedown',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const left = 50;
-  const top = 50;
-  const width = 200;
-  const height = 100;
-  const maxSize = Math.max(width, height);
-  const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
-  const pageX = 100;
-  const pageY = 75;
+      const handlers = captureHandlers(adapter);
+      const left = 50;
+      const top = 50;
+      const width = 200;
+      const height = 100;
+      const maxSize = Math.max(width, height);
+      const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
+      const pageX = 100;
+      const pageY = 75;
 
-  td.when(adapter.computeBoundingRect()).thenReturn({width, height, left, top});
-  foundation.init();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width, height, left, top});
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.mousedown({pageX, pageY});
-  mockRaf.flush();
+      handlers.mousedown({pageX, pageY});
+      mockRaf.flush();
 
-  const startPosition = {
-    x: pageX - left - (initialSize / 2),
-    y: pageY - top - (initialSize / 2),
-  };
+      const startPosition = {
+        x: pageX - left - (initialSize / 2),
+        y: pageY - top - (initialSize / 2),
+      };
 
-  const endPosition = {
-    x: (width / 2) - (initialSize / 2),
-    y: (height / 2) - (initialSize / 2),
-  };
+      const endPosition = {
+        x: (width / 2) - (initialSize / 2),
+        y: (height / 2) - (initialSize / 2),
+      };
 
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START,
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START,
       `${startPosition.x}px, ${startPosition.y}px`));
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END,
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END,
       `${endPosition.x}px, ${endPosition.y}px`));
-});
+    });
 
 testFoundation('adds activation classes on touchstart', ({foundation, adapter, mockRaf}) => {
   const handlers = captureHandlers(adapter);
@@ -94,38 +94,38 @@ testFoundation('adds activation classes on touchstart', ({foundation, adapter, m
 
 testFoundation('sets FG position from the coords to the center within surface on touchstart',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const left = 50;
-  const top = 50;
-  const width = 200;
-  const height = 100;
-  const maxSize = Math.max(width, height);
-  const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
-  const pageX = 100;
-  const pageY = 75;
+      const handlers = captureHandlers(adapter);
+      const left = 50;
+      const top = 50;
+      const width = 200;
+      const height = 100;
+      const maxSize = Math.max(width, height);
+      const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
+      const pageX = 100;
+      const pageY = 75;
 
-  td.when(adapter.computeBoundingRect()).thenReturn({width, height, left, top});
-  foundation.init();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width, height, left, top});
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.touchstart({changedTouches: [{pageX, pageY}]});
-  mockRaf.flush();
+      handlers.touchstart({changedTouches: [{pageX, pageY}]});
+      mockRaf.flush();
 
-  const startPosition = {
-    x: pageX - left - (initialSize / 2),
-    y: pageY - top - (initialSize / 2),
-  };
+      const startPosition = {
+        x: pageX - left - (initialSize / 2),
+        y: pageY - top - (initialSize / 2),
+      };
 
-  const endPosition = {
-    x: (width / 2) - (initialSize / 2),
-    y: (height / 2) - (initialSize / 2),
-  };
+      const endPosition = {
+        x: (width / 2) - (initialSize / 2),
+        y: (height / 2) - (initialSize / 2),
+      };
 
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START,
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START,
       `${startPosition.x}px, ${startPosition.y}px`));
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END,
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END,
       `${endPosition.x}px, ${endPosition.y}px`));
-});
+    });
 
 testFoundation('adds activation classes on pointerdown', ({foundation, adapter, mockRaf}) => {
   const handlers = captureHandlers(adapter);
@@ -140,52 +140,52 @@ testFoundation('adds activation classes on pointerdown', ({foundation, adapter, 
 
 testFoundation('sets FG position from the coords to the center within surface on pointerdown',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const left = 50;
-  const top = 50;
-  const width = 200;
-  const height = 100;
-  const maxSize = Math.max(width, height);
-  const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
-  const pageX = 100;
-  const pageY = 75;
+      const handlers = captureHandlers(adapter);
+      const left = 50;
+      const top = 50;
+      const width = 200;
+      const height = 100;
+      const maxSize = Math.max(width, height);
+      const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
+      const pageX = 100;
+      const pageY = 75;
 
-  td.when(adapter.computeBoundingRect()).thenReturn({width, height, left, top});
-  foundation.init();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width, height, left, top});
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.pointerdown({pageX, pageY});
-  mockRaf.flush();
+      handlers.pointerdown({pageX, pageY});
+      mockRaf.flush();
 
-  const startPosition = {
-    x: pageX - left - (initialSize / 2),
-    y: pageY - top - (initialSize / 2),
-  };
+      const startPosition = {
+        x: pageX - left - (initialSize / 2),
+        y: pageY - top - (initialSize / 2),
+      };
 
-  const endPosition = {
-    x: (width / 2) - (initialSize / 2),
-    y: (height / 2) - (initialSize / 2),
-  };
+      const endPosition = {
+        x: (width / 2) - (initialSize / 2),
+        y: (height / 2) - (initialSize / 2),
+      };
 
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START,
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START,
       `${startPosition.x}px, ${startPosition.y}px`));
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END,
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END,
       `${endPosition.x}px, ${endPosition.y}px`));
-});
+    });
 
 testFoundation('adds activation classes on keydown when surface is made active',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  td.when(adapter.isSurfaceActive()).thenReturn(true);
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      td.when(adapter.isSurfaceActive()).thenReturn(true);
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.keydown();
-  mockRaf.flush();
+      handlers.keydown();
+      mockRaf.flush();
 
-  td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL));
-  td.verify(adapter.addClass(cssClasses.FG_ACTIVATION));
-});
+      td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL));
+      td.verify(adapter.addClass(cssClasses.FG_ACTIVATION));
+    });
 
 testFoundation('sets FG position to center on non-pointer activation', ({foundation, adapter, mockRaf}) => {
   const handlers = captureHandlers(adapter);
@@ -257,47 +257,47 @@ testFoundation('sets FG position to center on non-pointer activation', ({foundat
 
 testFoundation('does not redundantly add classes on touchstart followed by mousedown',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
-  mockRaf.flush();
-  handlers.mousedown();
-  mockRaf.flush();
-  td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
-  td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 1});
-});
+      handlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
+      mockRaf.flush();
+      handlers.mousedown();
+      mockRaf.flush();
+      td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
+      td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 1});
+    });
 
 testFoundation('does not redundantly add classes on touchstart followed by pointerstart',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
-  mockRaf.flush();
-  handlers.pointerdown();
-  mockRaf.flush();
-  td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
-  td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 1});
-});
+      handlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
+      mockRaf.flush();
+      handlers.pointerdown();
+      mockRaf.flush();
+      td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
+      td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 1});
+    });
 
 testFoundation('removes deactivation classes on activate to ensure ripples can be retriggered',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.mousedown();
-  mockRaf.flush();
-  handlers.mouseup();
-  mockRaf.flush();
-  handlers.mousedown();
-  mockRaf.flush();
+      handlers.mousedown();
+      mockRaf.flush();
+      handlers.mouseup();
+      mockRaf.flush();
+      handlers.mousedown();
+      mockRaf.flush();
 
-  td.verify(adapter.removeClass(cssClasses.FG_DEACTIVATION));
-});
+      td.verify(adapter.removeClass(cssClasses.FG_DEACTIVATION));
+    });
 
 testFoundation('displays the foreground ripple on activation when unbounded', ({foundation, adapter, mockRaf}) => {
   const handlers = captureHandlers(adapter);
@@ -314,15 +314,15 @@ testFoundation('displays the foreground ripple on activation when unbounded', ({
 
 testFoundation('clears translation custom properties when unbounded in case ripple was switched from bounded',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
+      const handlers = captureHandlers(adapter);
 
-  td.when(adapter.isUnbounded()).thenReturn(true);
-  foundation.init();
-  mockRaf.flush();
+      td.when(adapter.isUnbounded()).thenReturn(true);
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.pointerdown({pageX: 100, pageY: 75});
-  mockRaf.flush();
+      handlers.pointerdown({pageX: 100, pageY: 75});
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START, ''));
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END, ''));
-});
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_START, ''));
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_TRANSLATE_END, ''));
+    });

--- a/test/unit/mdc-ripple/foundation-deactivation.test.js
+++ b/test/unit/mdc-ripple/foundation-deactivation.test.js
@@ -89,51 +89,51 @@ testFoundation('runs deactivation UX on mouseup after mousedown', ({foundation, 
 
 testFoundation('runs deactivation on keyup after keydown when keydown makes surface active',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
-  td.when(adapter.isSurfaceActive()).thenReturn(true);
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
+      td.when(adapter.isSurfaceActive()).thenReturn(true);
 
-  foundation.init();
-  mockRaf.flush();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.keydown({key: 'Space'});
-  mockRaf.flush();
+      handlers.keydown({key: 'Space'});
+      mockRaf.flush();
 
-  handlers.keyup({key: 'Space'});
-  mockRaf.flush();
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.keyup({key: 'Space'});
+      mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
 
-  td.verify(adapter.removeClass(cssClasses.BG_FOCUSED));
-  td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
-  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
-  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION));
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_FOCUSED));
+      td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
+      td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
+      td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION));
+      clock.uninstall();
+    });
 
 testFoundation('does not run deactivation on keyup after keydown if keydown did not make surface active',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
-  td.when(adapter.isSurfaceActive()).thenReturn(false);
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
+      td.when(adapter.isSurfaceActive()).thenReturn(false);
 
-  foundation.init();
-  mockRaf.flush();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.keydown({key: 'Space'});
-  mockRaf.flush();
+      handlers.keydown({key: 'Space'});
+      mockRaf.flush();
 
-  handlers.keyup({key: 'Space'});
-  mockRaf.flush();
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.keyup({key: 'Space'});
+      mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
 
   // Note that all of these should be called 0 times since a keydown that does not make a surface active should never
   // activate it in the first place.
-  td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 0});
-  td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 0});
-  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 0});
-  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 0});
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 0});
+      td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 0});
+      td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 0});
+      td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 0});
+      clock.uninstall();
+    });
 
 testFoundation('runs deactivation UX on public deactivate() call', ({foundation, adapter, mockRaf}) => {
   const clock = lolex.install();
@@ -157,24 +157,24 @@ testFoundation('runs deactivation UX on public deactivate() call', ({foundation,
 
 testFoundation('runs deactivation UX when activation UX timer finishes first (activation held for a long time)',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.mousedown({pageX: 0, pageY: 0});
-  mockRaf.flush();
+      handlers.mousedown({pageX: 0, pageY: 0});
+      mockRaf.flush();
 
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
-  handlers.mouseup();
-  mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.mouseup();
+      mockRaf.flush();
 
-  td.verify(adapter.removeClass(cssClasses.BG_FOCUSED));
-  td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
-  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
-  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION));
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_FOCUSED));
+      td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
+      td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
+      td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION));
+      clock.uninstall();
+    });
 
 testFoundation('clears any pending deactivation UX timers when re-triggered', ({foundation, adapter, mockRaf}) => {
   const handlers = captureHandlers(adapter);
@@ -211,142 +211,142 @@ testFoundation('clears any pending deactivation UX timers when re-triggered', ({
 
 testFoundation('waits until activation UX timer runs before removing active fill classes',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
 
-  foundation.init();
-  mockRaf.flush();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.mousedown({pageX: 0, pageY: 0});
-  mockRaf.flush();
+      handlers.mousedown({pageX: 0, pageY: 0});
+      mockRaf.flush();
 
-  handlers.mouseup();
-  mockRaf.flush();
-  clock.tick(DEACTIVATION_TIMEOUT_MS - 1);
+      handlers.mouseup();
+      mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS - 1);
 
-  td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
-  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 1});
-  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 0});
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
+      td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 1});
+      td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 0});
+      clock.uninstall();
+    });
 
 testFoundation('waits until actual deactivation UX is needed if animation finishes before deactivating',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
 
-  foundation.init();
-  mockRaf.flush();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.mousedown({pageX: 0, pageY: 0});
-  mockRaf.flush();
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.mousedown({pageX: 0, pageY: 0});
+      mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
 
-  td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
-  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 1});
-  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 0});
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
+      td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 1});
+      td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 0});
+      clock.uninstall();
+    });
 
 testFoundation('removes BG_FOCUSED class immediately without waiting for animationend event',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
 
-  foundation.init();
-  mockRaf.flush();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.mousedown({pageX: 0, pageY: 0});
-  mockRaf.flush();
+      handlers.mousedown({pageX: 0, pageY: 0});
+      mockRaf.flush();
 
-  handlers.mouseup();
-  mockRaf.flush();
+      handlers.mouseup();
+      mockRaf.flush();
 
-  td.verify(adapter.removeClass(cssClasses.BG_FOCUSED));
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_FOCUSED));
+      clock.uninstall();
+    });
 
 testFoundation('only re-activates when there are no additional pointer events to be processed',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
+      foundation.init();
+      mockRaf.flush();
 
   // Simulate Android 6 / Chrome latest event flow.
-  handlers.pointerdown({pageX: 0, pageY: 0});
-  mockRaf.flush();
-  handlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
-  mockRaf.flush();
+      handlers.pointerdown({pageX: 0, pageY: 0});
+      mockRaf.flush();
+      handlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
+      mockRaf.flush();
 
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
-  handlers.pointerup();
-  mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.pointerup();
+      mockRaf.flush();
 
   // At this point, the deactivation UX should have run, since the initial activation was triggered by
   // a pointerdown event.
-  td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
-  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
-  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 1});
+      td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
+      td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
+      td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 1});
 
-  handlers.touchend();
-  mockRaf.flush();
+      handlers.touchend();
+      mockRaf.flush();
 
   // Verify that deactivation UX has not been run redundantly
-  td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 1});
-  td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
-  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
-  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 1});
+      td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 1});
+      td.verify(adapter.removeClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
+      td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
+      td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION), {times: 1});
 
-  handlers.mousedown({pageX: 0, pageY: 0});
-  mockRaf.flush();
+      handlers.mousedown({pageX: 0, pageY: 0});
+      mockRaf.flush();
 
   // Verify that activation only happened once, at pointerdown
-  td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
-  td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 1});
+      td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 1});
+      td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 1});
 
-  handlers.mouseup();
-  mockRaf.flush();
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.mouseup();
+      mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
 
   // Finally, verify that since mouseup happened, we can re-activate the ripple.
-  handlers.mousedown({pageX: 0, pageY: 0});
-  mockRaf.flush();
-  td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
-  td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 2});
-  clock.uninstall();
-});
+      handlers.mousedown({pageX: 0, pageY: 0});
+      mockRaf.flush();
+      td.verify(adapter.addClass(cssClasses.BG_ACTIVE_FILL), {times: 2});
+      td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 2});
+      clock.uninstall();
+    });
 
 testFoundation('ensures pointer event deactivation occurs even if activation rAF not run',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.mousedown({pageX: 0, pageY: 0});
-  mockRaf.pendingFrames.shift();
-  handlers.mouseup();
-  mockRaf.flush();
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.mousedown({pageX: 0, pageY: 0});
+      mockRaf.pendingFrames.shift();
+      handlers.mouseup();
+      mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
 
-  td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 1});
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 1});
+      clock.uninstall();
+    });
 
 testFoundation('ensures non-pointer event deactivation does not occurs even if activation rAF not run',
     ({foundation, adapter, mockRaf}) => {
-  const handlers = captureHandlers(adapter);
-  const clock = lolex.install();
-  foundation.init();
-  mockRaf.flush();
+      const handlers = captureHandlers(adapter);
+      const clock = lolex.install();
+      foundation.init();
+      mockRaf.flush();
 
-  handlers.keydown({key: 'Space'});
-  mockRaf.pendingFrames.shift();
-  handlers.keyup({key: 'Space'});
-  mockRaf.flush();
-  clock.tick(DEACTIVATION_TIMEOUT_MS);
+      handlers.keydown({key: 'Space'});
+      mockRaf.pendingFrames.shift();
+      handlers.keyup({key: 'Space'});
+      mockRaf.flush();
+      clock.tick(DEACTIVATION_TIMEOUT_MS);
 
-  td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 0});
-  clock.uninstall();
-});
+      td.verify(adapter.removeClass(cssClasses.BG_FOCUSED), {times: 0});
+      clock.uninstall();
+    });

--- a/test/unit/mdc-ripple/foundation.test.js
+++ b/test/unit/mdc-ripple/foundation.test.js
@@ -63,66 +63,66 @@ testFoundation('#init adds unbounded class when adapter indicates unbounded', ({
 
 testFoundation('#init does not add unbounded class when adapter does not indicate unbounded (default)',
     ({adapter, foundation, mockRaf}) => {
-  foundation.init();
-  mockRaf.flush();
+      foundation.init();
+      mockRaf.flush();
 
-  td.verify(adapter.addClass(cssClasses.UNBOUNDED), {times: 0});
-});
+      td.verify(adapter.addClass(cssClasses.UNBOUNDED), {times: 0});
+    });
 
 testFoundation('#init gracefully exits when css variables are not supported', false,
     ({foundation, adapter, mockRaf}) => {
-  foundation.init();
-  mockRaf.flush();
+      foundation.init();
+      mockRaf.flush();
 
-  td.verify(adapter.addClass(cssClasses.ROOT), {times: 0});
-});
+      td.verify(adapter.addClass(cssClasses.ROOT), {times: 0});
+    });
 
 testFoundation(`#init sets ${strings.VAR_SURFACE_WIDTH} css variable to the clientRect's width`,
     ({foundation, adapter, mockRaf}) => {
-  td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
-  foundation.init();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
+      foundation.init();
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_WIDTH, '200px'));
-});
+      td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_WIDTH, '200px'));
+    });
 
 testFoundation(`#init sets ${strings.VAR_SURFACE_HEIGHT} css variable to the clientRect's height`,
     ({foundation, adapter, mockRaf}) => {
-  td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
-  foundation.init();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
+      foundation.init();
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_HEIGHT, '100px'));
-});
+      td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_HEIGHT, '100px'));
+    });
 
 testFoundation(`#init sets ${strings.VAR_FG_SIZE} to the circumscribing circle's diameter`,
     ({foundation, adapter, mockRaf}) => {
-  const size = 200;
-  td.when(adapter.computeBoundingRect()).thenReturn({width: size, height: size / 2});
-  foundation.init();
-  mockRaf.flush();
-  const initialSize = size * numbers.INITIAL_ORIGIN_SCALE;
+      const size = 200;
+      td.when(adapter.computeBoundingRect()).thenReturn({width: size, height: size / 2});
+      foundation.init();
+      mockRaf.flush();
+      const initialSize = size * numbers.INITIAL_ORIGIN_SCALE;
 
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_SIZE, `${initialSize}px`));
-});
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_SIZE, `${initialSize}px`));
+    });
 
 testFoundation(`#init centers via ${strings.VAR_LEFT} and ${strings.VAR_TOP} when unbounded`,
     ({foundation, adapter, mockRaf}) => {
-  const width = 200;
-  const height = 100;
-  const maxSize = Math.max(width, height);
-  const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
+      const width = 200;
+      const height = 100;
+      const maxSize = Math.max(width, height);
+      const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
 
-  td.when(adapter.computeBoundingRect()).thenReturn({width, height});
-  td.when(adapter.isUnbounded()).thenReturn(true);
-  foundation.init();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width, height});
+      td.when(adapter.isUnbounded()).thenReturn(true);
+      foundation.init();
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_LEFT,
+      td.verify(adapter.updateCssVariable(strings.VAR_LEFT,
       `${Math.round((width / 2) - (initialSize / 2))}px`));
-  td.verify(adapter.updateCssVariable(strings.VAR_TOP,
+      td.verify(adapter.updateCssVariable(strings.VAR_TOP,
       `${Math.round((height / 2) - (initialSize / 2))}px`));
-});
+    });
 
 testFoundation('#init registers events for all types of common interactions', ({foundation, adapter}) => {
   const expectedEvents = [
@@ -212,35 +212,35 @@ testFoundation('#destroy removes all CSS variables', ({foundation, adapter, mock
 
 testFoundation(`#layout sets ${strings.VAR_SURFACE_WIDTH} css variable to the clientRect's width`,
     ({foundation, adapter, mockRaf}) => {
-  td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
-  foundation.layout();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
+      foundation.layout();
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_WIDTH, '200px'));
-});
+      td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_WIDTH, '200px'));
+    });
 
 testFoundation(`#layout sets ${strings.VAR_SURFACE_HEIGHT} css variable to the clientRect's height`,
     ({foundation, adapter, mockRaf}) => {
-  td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
-  foundation.layout();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width: 200, height: 100});
+      foundation.layout();
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_HEIGHT, '100px'));
-});
+      td.verify(adapter.updateCssVariable(strings.VAR_SURFACE_HEIGHT, '100px'));
+    });
 
 testFoundation(`#layout sets ${strings.VAR_FG_SIZE} to the circumscribing circle's diameter`,
     ({foundation, adapter, mockRaf}) => {
-  const width = 200;
-  const height = 100;
-  const maxSize = Math.max(width, height);
-  const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
+      const width = 200;
+      const height = 100;
+      const maxSize = Math.max(width, height);
+      const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
 
-  td.when(adapter.computeBoundingRect()).thenReturn({width, height});
-  foundation.layout();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width, height});
+      foundation.layout();
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_FG_SIZE, `${initialSize}px`));
-});
+      td.verify(adapter.updateCssVariable(strings.VAR_FG_SIZE, `${initialSize}px`));
+    });
 
 testFoundation(`#layout sets ${strings.VAR_FG_SCALE} based on the difference between the ` +
                'proportion of the max radius and the initial size', ({foundation, adapter, mockRaf}) => {
@@ -262,21 +262,21 @@ testFoundation(`#layout sets ${strings.VAR_FG_SCALE} based on the difference bet
 
 testFoundation(`#layout centers via ${strings.VAR_LEFT} and ${strings.VAR_TOP} when unbounded`,
     ({foundation, adapter, mockRaf}) => {
-  const width = 200;
-  const height = 100;
-  const maxSize = Math.max(width, height);
-  const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
+      const width = 200;
+      const height = 100;
+      const maxSize = Math.max(width, height);
+      const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
 
-  td.when(adapter.computeBoundingRect()).thenReturn({width, height});
-  td.when(adapter.isUnbounded()).thenReturn(true);
-  foundation.layout();
-  mockRaf.flush();
+      td.when(adapter.computeBoundingRect()).thenReturn({width, height});
+      td.when(adapter.isUnbounded()).thenReturn(true);
+      foundation.layout();
+      mockRaf.flush();
 
-  td.verify(adapter.updateCssVariable(strings.VAR_LEFT,
+      td.verify(adapter.updateCssVariable(strings.VAR_LEFT,
       `${Math.round((width / 2) - (initialSize / 2))}px`));
-  td.verify(adapter.updateCssVariable(strings.VAR_TOP,
+      td.verify(adapter.updateCssVariable(strings.VAR_TOP,
       `${Math.round((height / 2) - (initialSize / 2))}px`));
-});
+    });
 
 testFoundation('#layout debounces calls within the same frame', ({foundation, mockRaf}) => {
   foundation.layout();

--- a/test/unit/mdc-tabs/mdc-tab-foundation.test.js
+++ b/test/unit/mdc-tabs/mdc-tab-foundation.test.js
@@ -113,61 +113,61 @@ test('#preventsDefaultOnClick returns state of preventsDefaultOnClick', () => {
 });
 
 test('#setPreventDefaultOnClick does not preventDefault if set to false', () => {
-   const {foundation, mockAdapter} = setupTest();
-   const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
-   const evt = {
-     preventDefault: td.func('evt.stopPropagation'),
-   };
+  const {foundation, mockAdapter} = setupTest();
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const evt = {
+    preventDefault: td.func('evt.stopPropagation'),
+  };
 
-   foundation.init();
-   foundation.setPreventDefaultOnClick(false);
+  foundation.init();
+  foundation.setPreventDefaultOnClick(false);
 
-   handlers.click(evt);
-   td.verify(evt.preventDefault(), {times: 0});
+  handlers.click(evt);
+  td.verify(evt.preventDefault(), {times: 0});
 });
 
 test('#setPreventDefaultOnClick calls preventDefault if set to true', () => {
-   const {foundation, mockAdapter} = setupTest();
-   const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
-   const evt = {
-     preventDefault: td.func('evt.stopPropagation'),
-   };
+  const {foundation, mockAdapter} = setupTest();
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const evt = {
+    preventDefault: td.func('evt.stopPropagation'),
+  };
 
-   foundation.init();
-   foundation.setPreventDefaultOnClick(true);
+  foundation.init();
+  foundation.setPreventDefaultOnClick(true);
 
-   handlers.click(evt);
-   td.verify(evt.preventDefault());
+  handlers.click(evt);
+  td.verify(evt.preventDefault());
 });
 
 test('#setPreventDefaultOnClick sets preventDefaultOnClick_ to true. Subsequent clicks ' +
   'call preventDefault()', () => {
-    const {foundation, mockAdapter} = setupTest();
-    const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
-    const evt = {
-      preventDefault: td.func('evt.stopPropagation'),
-    };
+  const {foundation, mockAdapter} = setupTest();
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const evt = {
+    preventDefault: td.func('evt.stopPropagation'),
+  };
 
-    foundation.init();
-    foundation.setPreventDefaultOnClick(true);
+  foundation.init();
+  foundation.setPreventDefaultOnClick(true);
 
-    handlers.click(evt);
-    td.verify(evt.preventDefault());
+  handlers.click(evt);
+  td.verify(evt.preventDefault());
 });
 
 test('#setPreventDefaultOnClick sets preventDefaultOnClick_ to false. Subsequent clicks ' +
   'do not call preventDefault()', () => {
-    const {foundation, mockAdapter} = setupTest();
-    const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
-    const evt = {
-      preventDefault: td.func('evt.stopPropagation'),
-    };
+  const {foundation, mockAdapter} = setupTest();
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const evt = {
+    preventDefault: td.func('evt.stopPropagation'),
+  };
 
-    foundation.init();
-    foundation.setPreventDefaultOnClick(false);
+  foundation.init();
+  foundation.setPreventDefaultOnClick(false);
 
-    handlers.click(evt);
-    td.verify(evt.preventDefault(), {times: 0});
+  handlers.click(evt);
+  td.verify(evt.preventDefault(), {times: 0});
 });
 
 test('#measureSelf sets computedWidth_ and computedLeft_ for tab', () => {


### PR DESCRIPTION
It turns out that ESLint has not been enforcing consistent indentation
within our codebase. This PR adds an explicit indentation check to our
ESLint config to ensure that we are using two spaces to indent, and
fixes any files that deviate from this.