### PR TITLE
fix(button): Remove background-color from raised buttons on dark theme

### DIFF
--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -114,7 +114,6 @@
     }
 
     @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(background-color, primary);
 
       // postcss-bem-linter: ignore
       &::before {


### PR DESCRIPTION
See: #819

This runs contrary to the guidelines, but considering MDC gives full control of button color through class names (and CSS is very flexible), it's likely a non-issue. This also fixes the text color being wrong when a light primary color is used.

**Fair warning**: I tested this by deleting the directive with Chrome devtools. I'm 90% sure my change here has the desired effect, but I haven't yet had a chance to test a fresh compile.