### PR TITLE
fix(button): Sets text on raised buttons on dark theme to text-primary-on-primary

### DIFF
--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -115,6 +115,7 @@
 
     @include mdc-theme-dark(".mdc-button") {
       @include mdc-theme-prop(background-color, primary);
+      @include mdc-theme-prop(color, text-primary-on-primary);
 
       // postcss-bem-linter: ignore
       &::before {


### PR DESCRIPTION
Resolves #819, Raised buttons on dark theme should default to the
primary color, which means their text should be text-primary-on-primary