### PR TITLE
docs: Fix various typos

### DIFF
--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -56,7 +56,7 @@ mdc-base exposes two classes: `MDCComponent` (the default export) which all comp
 
 ### MDCFoundation
 
-MDCFoundation provides the basic mechanisms for implementing a foundation classes. Subclasses are expected to:
+MDCFoundation provides the basic mechanisms for implementing foundation classes. Subclasses are expected to:
 
 - Provide implementations of the proper static getters where necessary.
 - Provide `init()` and `destroy()` lifecycle methods

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -210,7 +210,7 @@ The adapter for checkboxes must provide the following functions, with correct si
 | `deregisterChangeHandler(handler: EventListener) => void` | Deregisters an event handler that was previously passed to `registerChangeHandler`. |
 | `getNativeControl() => HTMLInputElement?` | Returns the native checkbox control, if available. Note that if this control is not available, the methods that rely on it will exit gracefully.|
 | `forceLayout() => void` | Force-trigger a layout on the root element. This is needed to restart animations correctly. If you find that you do not need to do this, you can simply make it a no-op. |
-| `isAttachedToDOM() => boolean` | Returns true if the component is currently attached to the DOM, false otherwise.` |
+| `isAttachedToDOM() => boolean` | Returns true if the component is currently attached to the DOM, false otherwise. |
 
 
 #### MDCCheckboxFoundation API

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -18,7 +18,7 @@ path: /catalog/lists/
 
 MDC List provides styles which implement [Material Design Lists](https://material.io/guidelines/components/lists.html) - "A single continuous column of tessellated subdivisions of equal width." Both single-line and two-line lists are supported (with
 three-line lists [coming soon](https://github.com/material-components/material-components-web/issues/31)). MDC
-Lists are design to be accessible and RTL aware.
+Lists are designed to be accessible and RTL aware.
 
 ## Design & API Documentation
 
@@ -41,7 +41,7 @@ npm install --save @material/list
 
 ### Basic Lists
 
-A basic lists consists simply of the list itself, and list items taking up one line.
+A basic list consists simply of the list itself, and list items taking up one line.
 
 ```html
 <ul class="mdc-list">

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -112,8 +112,7 @@ argument, with which you can specify the following parameters:
 
 | Parameter | Description | Default |
 | --- | --- | --- |
-| `pseudo` | The name of the pseudo-element you want to use to style the ripple. Using pseudo-elements to style ripples obviates the need for any extra DOM and is recommended. However,
-if given `null` it will style the element directly, rather than attaching styles to the pseudo element. | `null` |
+| `pseudo` | The name of the pseudo-element you want to use to style the ripple. Using pseudo-elements to style ripples obviates the need for any extra DOM and is recommended. However, if given `null` it will style the element directly, rather than attaching styles to the pseudo element. | `null` |
 | `radius` | For _bounded_ ripples, specifies radii of the ripple circles. Can be any valid numeric CSS unit. | `100%` |
 | `theme-style` | When provided, will use a style specified by `mdc-theme` to provide colors to the ripple. For example, passing `(theme-style: primary)` would make the ripples the color of the theme's primary color. Note that there are some current limitations here. See [below](#caveat-theme-custom-variables) | `null` |
 | `base-color` | The RGB color (_without_ an alpha component) of the ripple. This will only be used if `theme-style` isn't specified. | `black` |

--- a/packages/mdc-rtl/README.md
+++ b/packages/mdc-rtl/README.md
@@ -96,7 +96,7 @@ will emit the following css:
   padding-right: 4px;
 }
 ```
-*N.B.**: checking for `[dir="rtl"]` on an ancestor element works in most cases, it will sometimes
+**N.B.**: checking for `[dir="rtl"]` on an ancestor element works in most cases, it will sometimes
 lead to false negatives for more complex layouts, e.g.
 
 ```html

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -110,7 +110,7 @@ information to users, as well for validation messages (covered below).
 </p>
 ```
 
-Help text appears on input field focus and disappear on input field blur by default when using
+Help text appears on input field focus and disappears on input field blur by default when using
 the textfield JS component.
 
 #### Persistent help text
@@ -331,7 +331,7 @@ initializes when given an `mdc-textfield--box` root element. Otherwise, the fiel
 
 ### Using the foundation class
 
-Because MDC Textfield is a feature-rich and relatively complex component, it's adapter is a bit more
+Because MDC Textfield is a feature-rich and relatively complex component, its adapter is a bit more
 complicated.
 
 | Method Signature | Description |

--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -18,7 +18,7 @@ path: /catalog/toolbar/
 
 MDC Toolbar acts as a container for multiple rows containing items such as
 application title, navigation menu, and tabs, among other things. Toolbars
-scroll with content by default, but supports fixed behavior as well.
+scroll with content by default, but support fixed behavior as well.
 
 When using the **fixed** pattern, a persistent elevation is added to toolbar.
 When using the **waterfall** pattern, a toolbar will have no elevation when the
@@ -52,7 +52,7 @@ npm install --save @material/toolbar
 
 ## Usage
 
-Wrap the items with `mdc-toolbar` class in following way:
+Wrap the items with `mdc-toolbar` class in the following way:
 
 ```html
 <header class="mdc-toolbar">


### PR DESCRIPTION
I found a few typos while reading through various parts of the docs.  Figured I'd fix them before I forgot where they were.