### PR TITLE
refactor(button): Remove button's dependency on typography, by specifying letter-spacing

### DIFF
--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -19,7 +19,6 @@
 @import "@material/elevation/mixins";
 @import "@material/ripple/mixins";
 @import "@material/theme/mixins";
-@import "@material/typography/mixins";
 
 // postcss-bem-linter: define button
 
@@ -27,7 +26,6 @@
   @include mdc-ripple-base;
   @include mdc-ripple-bg((pseudo: "::before"));
   @include mdc-ripple-fg((pseudo: "::after"));
-  @include mdc-typography(body2);
   @include mdc-theme-prop(color, text-primary-on-light);
 
   display: inline-block;
@@ -39,9 +37,10 @@
   border-radius: 2px;
   outline: none;
   background: transparent;
-  font-size: 14px; // Override font to specifically be px as spec defined pt
+  font-size: 14px;
   font-weight: 500;
-  line-height: 36px; // Override line-height so text aligns centered
+  letter-spacing: .04em;
+  line-height: 36px;
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;

--- a/packages/mdc-button/package.json
+++ b/packages/mdc-button/package.json
@@ -16,7 +16,6 @@
     "@material/animation": "^0.2.3",
     "@material/elevation": "^0.1.9",
     "@material/ripple": "^0.7.0",
-    "@material/theme": "^0.1.5",
-    "@material/typography": "^0.2.2"
+    "@material/theme": "^0.1.5"
   }
 }


### PR DESCRIPTION
This is the same code as [the old pull request](https://github.com/material-components/material-components-web/pull/851), but I closed the old one because I needed to sync this up with master again