### PR TITLE
fix(infrastructure): Downgrade closure-compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-mocha": "^4.8.0",
     "extract-text-webpack-plugin": "^2.1.2",
     "glob": "^7.1.1",
-    "google-closure-compiler": "^20170626.0.0",
+    "google-closure-compiler": "^20170521.0.0",
     "husky": "^0.14.0",
     "istanbul": "^0.4.4",
     "istanbul-instrumenter-loader": "^2.0.0",


### PR DESCRIPTION
We upgraded it with https://github.com/material-components/material-components-web/pull/905, but it caused tests to fail. (Unclear why these tests did no fail in TravisCI)