### PR TITLE
fix(elevation): Update _mixins.scss so Sass linter passes

### DIFF
--- a/packages/mdc-elevation/_mixins.scss
+++ b/packages/mdc-elevation/_mixins.scss
@@ -30,8 +30,8 @@
   }
 
   #{$mdc-elevation-property}:
-    #{map-get($mdc-elevation-umbra-map, $z-value)} $mdc-elevation-umbra-color,
-    #{map-get($mdc-elevation-penumbra-map, $z-value)} $mdc-elevation-penumbra-color,
+    #{"#{map-get($mdc-elevation-umbra-map, $z-value)} #{$mdc-elevation-umbra-color}"},
+    #{"#{map-get($mdc-elevation-penumbra-map, $z-value)} #{$mdc-elevation-penumbra-color}"},
     #{map-get($mdc-elevation-ambient-map, $z-value)} $mdc-elevation-ambient-color;
 }
 


### PR DESCRIPTION
If you use https://www.sassmeister.com/ to test the Sass linter, you get this error
> Error: Invalid CSS after "...-penumbra-color": expected ";", was ","

I think the Sass linter doesn't understand variable interpolation + lists. This is a workaround to pass the linter.
