### PR TITLE
chore(animation): Rename `exit` to `exit-permanent` to match spec

### DIFF
--- a/packages/mdc-animation/README.md
+++ b/packages/mdc-animation/README.md
@@ -63,7 +63,7 @@ very common example of this is something that fades in and then fades out using 
 @import "@material/animation/functions";
 
 .mdc-thing {
-  transition: mdc-animation-exit(/* $name: */ opacity, /* $duration: */ 175ms, /* $delay: */ 150ms);
+  transition: mdc-animation-exit-permanent(/* $name: */ opacity, /* $duration: */ 175ms, /* $delay: */ 150ms);
   opacity: 0;
   will-change: opacity;
 

--- a/packages/mdc-animation/_functions.scss
+++ b/packages/mdc-animation/_functions.scss
@@ -20,6 +20,6 @@
   @return $name $duration $delay $mdc-animation-deceleration-curve-timing-function;
 }
 
-@function mdc-animation-exit($name, $duration, $delay: 0ms) {
+@function mdc-animation-exit-permanent($name, $duration, $delay: 0ms) {
   @return $name $duration $delay $mdc-animation-acceleration-curve-timing-function;
 }

--- a/packages/mdc-checkbox/mdc-checkbox.scss
+++ b/packages/mdc-checkbox/mdc-checkbox.scss
@@ -30,7 +30,7 @@
 }
 
 @function mdc-checkbox-transition-exit($property, $delay: 0ms, $duration: $mdc-checkbox-transition-duration) {
-  @return mdc-animation-exit($property, $duration, $delay);
+  @return mdc-animation-exit-permanent($property, $duration, $delay);
 }
 
 @mixin mdc-checkbox-cover-element {

--- a/packages/mdc-drawer/_mixins.scss
+++ b/packages/mdc-drawer/_mixins.scss
@@ -112,7 +112,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    transition: mdc-animation-exit(opacity, 120ms);
+    transition: mdc-animation-exit-permanent(opacity, 120ms);
     border-radius: inherit;
     background: currentColor;
     content: "";

--- a/packages/mdc-linear-progress/mdc-linear-progress.scss
+++ b/packages/mdc-linear-progress/mdc-linear-progress.scss
@@ -21,7 +21,7 @@
   width: 100%;
   height: 4px;
   transform: translateZ(0);
-  transition: mdc-animation-exit(opacity, 250ms);
+  transition: mdc-animation-exit-permanent(opacity, 250ms);
   overflow: hidden;
 
   &__bar {
@@ -30,7 +30,7 @@
     width: 100%;
     height: 100%;
     transform-origin: top left;
-    transition: mdc-animation-exit(transform, 250ms);
+    transition: mdc-animation-exit-permanent(transform, 250ms);
   }
 
   &__bar-inner {
@@ -64,7 +64,7 @@
     width: 100%;
     height: 100%;
     transform-origin: top left;
-    transition: mdc-animation-exit(transform, 250ms);
+    transition: mdc-animation-exit-permanent(transform, 250ms);
     background-color: #e6e6e6;
   }
 

--- a/packages/mdc-radio/mdc-radio.scss
+++ b/packages/mdc-radio/mdc-radio.scss
@@ -28,7 +28,7 @@ $mdc-radio-transition-duration: 120ms;
 }
 
 @function mdc-radio-exit($name) {
-  @return mdc-animation-exit($name, $mdc-radio-transition-duration);
+  @return mdc-animation-exit-permanent($name, $mdc-radio-transition-duration);
 }
 
 // postcss-bem-linter: define radio

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -44,8 +44,8 @@
   max-width: calc(100% - #{$dd-arrow-padding});
   height: 32px;
   transition:
-    mdc-animation-exit(border-bottom-color, 150ms),
-    mdc-animation-exit(background-color, 150ms);
+    mdc-animation-exit-permanent(border-bottom-color, 150ms),
+    mdc-animation-exit-permanent(background-color, 150ms);
   border: none;
   border-bottom: 1px solid rgba(black, .12);
   border-radius: 0;
@@ -95,8 +95,8 @@
 
   &__selected-text {
     transition:
-      mdc-animation-exit(opacity, 125ms),
-      mdc-animation-exit(transform, 125ms);
+      mdc-animation-exit-permanent(opacity, 125ms),
+      mdc-animation-exit-permanent(transform, 125ms);
     white-space: nowrap;
     overflow: hidden;
   }

--- a/packages/mdc-snackbar/mdc-snackbar.scss
+++ b/packages/mdc-snackbar/mdc-snackbar.scss
@@ -31,7 +31,7 @@
   padding-right: 24px;
   padding-left: 24px;
   transform: translate(-50%, 100%);
-  transition: mdc-animation-exit(transform, .25s);
+  transition: mdc-animation-exit-permanent(transform, .25s);
   background-color: $mdc-snackbar-background-color;
 
   @include mdc-theme-dark(".mdc-snackbar") {
@@ -111,7 +111,7 @@
     display: flex;
     align-items: center;
     height: 48px;
-    transition: mdc-animation-exit(opacity, .3s);
+    transition: mdc-animation-exit-permanent(opacity, .3s);
     color: $mdc-snackbar-foreground-color;
 
     @include mdc-theme-dark(".mdc-snackbar") {
@@ -142,7 +142,7 @@
 
     min-width: auto;
     height: inherit;
-    transition: mdc-animation-exit(opacity, .3s);
+    transition: mdc-animation-exit-permanent(opacity, .3s);
     opacity: 0;
     visibility: hidden;
 
@@ -157,7 +157,7 @@
 
   &--active &__text,
   &--active &__action-button:not([aria-hidden]) {
-    transition: mdc-animation-exit(opacity, .3s);
+    transition: mdc-animation-exit-permanent(opacity, .3s);
     opacity: 1;
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: We currently don't distinguish between "temporary" and "permanent" exits in mdc-animation. However, the timing function we're using is actually that of "permanent", so we should rename the function to reflect that. This will also allow us to add "temporary" exit in the future.

https://material.io/guidelines/motion/movement.html#movement-movement-in-out-of-screen-bounds