### PR TITLE
fix(grid): Supoort title overflow not concatenating(#944)

### DIFF
--- a/packages/mdc-grid-list/mdc-grid-list.scss
+++ b/packages/mdc-grid-list/mdc-grid-list.scss
@@ -183,6 +183,9 @@ $mdc-grid-list-tile-secondary-icon-size: 24px;
     margin: 0;
     margin-top: 4px;
     padding: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   &__icon {


### PR DESCRIPTION
https://github.com/material-components/material-components-web/issues/944#issuecomment-315866959