### PR TITLE
fix(mdc-slider): .mdc-slider__thumb-container should set #user-select property to none

### DIFF
--- a/packages/mdc-slider/mdc-slider.scss
+++ b/packages/mdc-slider/mdc-slider.scss
@@ -131,6 +131,7 @@ $mdc-slider-dark-theme-grey: #5c5c5c;
     // is considered "clicking on the thumb".
     height: 100%;
     will-change: transform;
+    user-select: none;
   }
 
   &__thumb {


### PR DESCRIPTION
Fixes and closes #945 