### PR TITLE
fix(grid): .mdc-grid-tile__support-text does not cut off the text overflow.

### DIFF
--- a/packages/mdc-grid-list/mdc-grid-list.scss
+++ b/packages/mdc-grid-list/mdc-grid-list.scss
@@ -171,13 +171,13 @@ $mdc-grid-list-tile-secondary-icon-size: 24px;
     font-size: 1rem;
     font-weight: #{map-get($mdc-typography-font-weight-values, medium)};
     line-height: 1rem;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+
+    @include mdc-typography-overflow-ellipsis;
   }
 
   &__support-text {
     @include mdc-typography(body1);
+    @include mdc-typography-overflow-ellipsis;
 
     display: block;
     margin: 0;


### PR DESCRIPTION
Fixes and closes #944 