### PR TITLE
docs(elevation): Moving CSS Classes ahead of Sass mixins, 

### DIFF
--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -48,7 +48,7 @@ npm install --save @material/elevation
 
 Some components have a set elevation. For example, a raised MDC Button has elevation 2.
 
-However, if you want to set the elevation of an element, which is not an Material Design component, then you
+If you want to set the elevation of an element, which is not a Material Design component, you
 can apply the following CSS classes.
 
 | CSS Class | Description |

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -44,6 +44,13 @@ npm install --save @material/elevation
 
 ## Usage
 
+### CSS Classes
+
+| CSS Class | Description |
+| --------------------------- | - |
+| `mdc-elevation--z<N>` | Sets the elevation to the (N)dp, where 1 <= N <= 24. |
+| `mdc-elevation-transition` | Applies the correct css rules to transition an element between elevations. |
+
 ### Sass Mixins, Variables, and Functions
 
 | Mixin | Description |
@@ -69,10 +76,3 @@ If you need more configurability over your transitions, use the `mdc-elevation-t
   will-change: $mdc-elevation-property, opacity;
 }
 ```
-
-### CSS Classes
-
-| CSS Class | Description |
-| --------------------------- | - |
-| `mdc-elevation--z<N>` | Sets the elevation to the (N)dp, where 1 <= N <= 24. |
-| `mdc-elevation-transition` | Applies the correct css rules to transition an element between elevations. |

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -46,6 +46,11 @@ npm install --save @material/elevation
 
 ### CSS Classes
 
+Some components have a set elevation. For example, a raised MDC Button has elevation 2.
+
+However, if you want to set the elevation of an element, which is not an Material Design component, then you
+can apply the following CSS classes.
+
 | CSS Class | Description |
 | --------------------------- | - |
 | `mdc-elevation--z<N>` | Sets the elevation to the (N)dp, where 1 <= N <= 24. |


### PR DESCRIPTION
since they have heavier usage