### PR TITLE
feat(auto-init): Fire event on mdcAutoInit complete

### DIFF
--- a/packages/mdc-auto-init/README.md
+++ b/packages/mdc-auto-init/README.md
@@ -160,3 +160,10 @@ warning, you could simply pass in a nop.
 ```
 
 This will suppress any warnings about already initialized elements.
+
+### Events
+
+#### MDCAutoInit:End
+Triggered when initialization of all components is complete.
+
+`document.addEventListener("MDCAutoInit:End", () => {...});`

--- a/packages/mdc-auto-init/index.js
+++ b/packages/mdc-auto-init/index.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// import {MDCComponent} from '@material/base';
+
 const registry = Object.create(null);
 
 const CONSOLE_WARN = console.warn.bind(console);
@@ -49,6 +51,8 @@ export default function mdcAutoInit(root = document, warn = CONSOLE_WARN) {
       configurable: true,
     });
   }
+
+  // MDCComponent.emit('MDCAutoInit:End');
 }
 
 mdcAutoInit.register = function(componentName, Ctor, warn = CONSOLE_WARN) {

--- a/packages/mdc-auto-init/index.js
+++ b/packages/mdc-auto-init/index.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// import {MDCComponent} from '@material/base';
-
 const registry = Object.create(null);
 
 const CONSOLE_WARN = console.warn.bind(console);
@@ -25,6 +23,7 @@ const CONSOLE_WARN = console.warn.bind(console);
  */
 export default function mdcAutoInit(root = document, warn = CONSOLE_WARN) {
   const nodes = root.querySelectorAll('[data-mdc-auto-init]');
+  let component = null;
   for (let i = 0, node; (node = nodes[i]); i++) {
     const ctorName = node.dataset.mdcAutoInit;
     if (!ctorName) {
@@ -43,7 +42,7 @@ export default function mdcAutoInit(root = document, warn = CONSOLE_WARN) {
     }
 
     // TODO: Should we make an eslint rule for an attachTo() static method?
-    const component = Ctor.attachTo(node);
+    component = Ctor.attachTo(node);
     Object.defineProperty(node, ctorName, {
       value: component,
       writable: false,
@@ -52,7 +51,9 @@ export default function mdcAutoInit(root = document, warn = CONSOLE_WARN) {
     });
   }
 
-  // MDCComponent.emit('MDCAutoInit:End');
+  if (component !== null) {
+    component.emit('MDCAutoInit:End', {}, true);
+  }
 }
 
 mdcAutoInit.register = function(componentName, Ctor, warn = CONSOLE_WARN) {

--- a/packages/mdc-auto-init/index.js
+++ b/packages/mdc-auto-init/index.js
@@ -26,7 +26,7 @@ const CONSOLE_WARN = console.warn.bind(console);
  * @param {!Object} evtData
  * @param {boolean=} shouldBubble
  */
-function emit(element, evtType, evtData, shouldBubble = false) {
+export function emit(element, evtType, evtData, shouldBubble = false) {
   let evt;
   if (typeof CustomEvent === 'function') {
     evt = new CustomEvent(evtType, {

--- a/packages/mdc-auto-init/index.js
+++ b/packages/mdc-auto-init/index.js
@@ -24,7 +24,7 @@ const CONSOLE_WARN = console.warn.bind(console);
  * @param {!Object} evtData
  * @param {boolean=} shouldBubble
  */
-export function emit(evtType, evtData, shouldBubble = false) {
+function _emit(evtType, evtData, shouldBubble = false) {
   let evt;
   if (typeof CustomEvent === 'function') {
     evt = new CustomEvent(evtType, {
@@ -71,7 +71,7 @@ export default function mdcAutoInit(root = document, warn = CONSOLE_WARN) {
     });
   }
 
-  emit('MDCAutoInit:End', {});
+  _emit('MDCAutoInit:End', {});
 }
 
 mdcAutoInit.register = function(componentName, Ctor, warn = CONSOLE_WARN) {

--- a/packages/mdc-auto-init/index.js
+++ b/packages/mdc-auto-init/index.js
@@ -18,12 +18,6 @@ const registry = Object.create(null);
 
 const CONSOLE_WARN = console.warn.bind(console);
 
-/**
- * Fires a cross-browser-compatible custom event with the given data
- * @param {string} evtType
- * @param {!Object} evtData
- * @param {boolean=} shouldBubble
- */
 function _emit(evtType, evtData, shouldBubble = false) {
   let evt;
   if (typeof CustomEvent === 'function') {

--- a/packages/mdc-auto-init/index.js
+++ b/packages/mdc-auto-init/index.js
@@ -19,14 +19,12 @@ const registry = Object.create(null);
 const CONSOLE_WARN = console.warn.bind(console);
 
 /**
- * Fires a cross-browser-compatible custom event from HTML element or HTML document,
- * with the given data.
- * @param {HTMLElement, HTMLDocument} element
+ * Fires a cross-browser-compatible custom event with the given data
  * @param {string} evtType
  * @param {!Object} evtData
  * @param {boolean=} shouldBubble
  */
-export function emit(element, evtType, evtData, shouldBubble = false) {
+export function emit(evtType, evtData, shouldBubble = false) {
   let evt;
   if (typeof CustomEvent === 'function') {
     evt = new CustomEvent(evtType, {
@@ -38,7 +36,7 @@ export function emit(element, evtType, evtData, shouldBubble = false) {
     evt.initCustomEvent(evtType, shouldBubble, false, evtData);
   }
 
-  element.dispatchEvent(evt);
+  document.dispatchEvent(evt);
 }
 
 /**
@@ -73,7 +71,7 @@ export default function mdcAutoInit(root = document, warn = CONSOLE_WARN) {
     });
   }
 
-  emit(document, 'MDCAutoInit:End', {}, true);
+  emit('MDCAutoInit:End', {});
 }
 
 mdcAutoInit.register = function(componentName, Ctor, warn = CONSOLE_WARN) {

--- a/packages/mdc-auto-init/package.json
+++ b/packages/mdc-auto-init/package.json
@@ -7,5 +7,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git"
+  },
+  "dependencies": {
+    "@material/base": "^0.2.3"
   }
 }

--- a/packages/mdc-auto-init/package.json
+++ b/packages/mdc-auto-init/package.json
@@ -7,8 +7,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git"
-  },
-  "dependencies": {
-    "@material/base": "^0.2.3"
   }
 }

--- a/test/unit/mdc-auto-init/mdc-auto-init.test.js
+++ b/test/unit/mdc-auto-init/mdc-auto-init.test.js
@@ -95,3 +95,7 @@ test('#register warns when registered key is being overridden', () => {
 
   td.verify(warn(contains('(mdc-auto-init) Overriding registration')));
 });
+
+test('#fires event on init complete', () => {
+  // Really not sure what the test should be :(
+});

--- a/test/unit/mdc-auto-init/mdc-auto-init.test.js
+++ b/test/unit/mdc-auto-init/mdc-auto-init.test.js
@@ -97,18 +97,7 @@ test('#register warns when registered key is being overridden', () => {
   td.verify(warn(contains('(mdc-auto-init) Overriding registration')));
 });
 
-test('#emit event from MDCComponent on init complete', () => {
-  const root = setupTest();
-  const handler = td.func('init event handler');
-
-  document.addEventListener('MDCAutoInit:End', handler);
-  mdcAutoInit(root);
-
-  td.verify(handler(td.matchers.isA(Object)));
-});
-
-test('#emit dispatches a custom event from a DOM element with supplied data', () => {
-  const root = document.createElement('div');
+test('#emit dispatches a custom event with supplied data', () => {
   const handler = td.func('eventHandler');
   let evt = null;
 
@@ -117,18 +106,17 @@ test('#emit dispatches a custom event from a DOM element with supplied data', ()
   });
 
   const data = {evtData: true};
-  const type = 'customeventtype';
+  const type = 'MDCAutoInit:End';
 
-  root.addEventListener(type, handler);
-  emit(root, type, data);
+  document.addEventListener(type, handler);
+  emit(type, data);
 
   assert.isOk(evt !== null);
   assert.equal(evt.type, type);
   assert.deepEqual(evt.detail, data);
 });
 
-test('#emit dispatches an event from a DOM element with supplied data - custom events not supported', () => {
-  const root = document.createElement('div');
+test('#emit dispatches an event with supplied data - custom events not supported', () => {
   const handler = td.func('eventHandler');
   let evt = null;
 
@@ -137,13 +125,13 @@ test('#emit dispatches an event from a DOM element with supplied data - custom e
   });
 
   const data = {evtData: true};
-  const type = 'customeventtype';
+  const type = 'MDCAutoInit:End';
 
-  root.addEventListener(type, handler);
+  document.addEventListener(type, handler);
   const {CustomEvent} = window;
   window.CustomEvent = undefined;
   try {
-    emit(root, type, data);
+    emit(type, data);
   } finally {
     window.CustomEvent = CustomEvent;
   }

--- a/test/unit/mdc-auto-init/mdc-auto-init.test.js
+++ b/test/unit/mdc-auto-init/mdc-auto-init.test.js
@@ -126,3 +126,29 @@ test('#emit dispatches a custom event from a DOM element with supplied data', ()
   assert.equal(evt.type, type);
   assert.deepEqual(evt.detail, data);
 });
+
+test('#emit dispatches an event from a DOM element with supplied data - custom events not supported', () => {
+  const root = document.createElement('div');
+  const handler = td.func('eventHandler');
+  let evt = null;
+
+  td.when(handler(td.matchers.isA(Object))).thenDo((evt_) => {
+    evt = evt_;
+  });
+
+  const data = {evtData: true};
+  const type = 'customeventtype';
+
+  root.addEventListener(type, handler);
+  const {CustomEvent} = window;
+  window.CustomEvent = undefined;
+  try {
+    emit(root, type, data);
+  } finally {
+    window.CustomEvent = CustomEvent;
+  }
+
+  assert.isOk(evt !== null);
+  assert.equal(evt.type, type);
+  assert.deepEqual(evt.detail, data);
+});

--- a/test/unit/mdc-auto-init/mdc-auto-init.test.js
+++ b/test/unit/mdc-auto-init/mdc-auto-init.test.js
@@ -18,7 +18,6 @@ import bel from 'bel';
 import td from 'testdouble';
 import {assert} from 'chai';
 import mdcAutoInit from '../../../packages/mdc-auto-init';
-import {emit} from '../../../packages/mdc-auto-init';
 
 class FakeComponent {
   static attachTo(node) {
@@ -97,7 +96,8 @@ test('#register warns when registered key is being overridden', () => {
   td.verify(warn(contains('(mdc-auto-init) Overriding registration')));
 });
 
-test('#emit dispatches a custom event with supplied data', () => {
+test('#dispatches a MDCAutoInit:End event when all components init is done', () => {
+  const root = document.createElement('div');
   const handler = td.func('eventHandler');
   let evt = null;
 
@@ -105,18 +105,17 @@ test('#emit dispatches a custom event with supplied data', () => {
     evt = evt_;
   });
 
-  const data = {evtData: true};
   const type = 'MDCAutoInit:End';
 
   document.addEventListener(type, handler);
-  emit(type, data);
+  mdcAutoInit(root);
 
   assert.isOk(evt !== null);
   assert.equal(evt.type, type);
-  assert.deepEqual(evt.detail, data);
 });
 
-test('#emit dispatches an event with supplied data - custom events not supported', () => {
+test('#dispatches a MDCAutoInit:End event when all components init is done - custom events not supported', () => {
+  const root = document.createElement('div');
   const handler = td.func('eventHandler');
   let evt = null;
 
@@ -124,19 +123,18 @@ test('#emit dispatches an event with supplied data - custom events not supported
     evt = evt_;
   });
 
-  const data = {evtData: true};
   const type = 'MDCAutoInit:End';
 
   document.addEventListener(type, handler);
+
   const {CustomEvent} = window;
   window.CustomEvent = undefined;
   try {
-    emit(type, data);
+    mdcAutoInit(root);
   } finally {
     window.CustomEvent = CustomEvent;
   }
 
   assert.isOk(evt !== null);
   assert.equal(evt.type, type);
-  assert.deepEqual(evt.detail, data);
 });

--- a/test/unit/mdc-auto-init/mdc-auto-init.test.js
+++ b/test/unit/mdc-auto-init/mdc-auto-init.test.js
@@ -96,7 +96,7 @@ test('#register warns when registered key is being overridden', () => {
   td.verify(warn(contains('(mdc-auto-init) Overriding registration')));
 });
 
-test('#dispatches a MDCAutoInit:End event when all components init is done', () => {
+test('#dispatches a MDCAutoInit:End event when all components are initialized', () => {
   const root = document.createElement('div');
   const handler = td.func('eventHandler');
   let evt = null;
@@ -114,7 +114,7 @@ test('#dispatches a MDCAutoInit:End event when all components init is done', () 
   assert.equal(evt.type, type);
 });
 
-test('#dispatches a MDCAutoInit:End event when all components init is done - custom events not supported', () => {
+test('#dispatches a MDCAutoInit:End event when all components are initialized - custom events not supported', () => {
   const root = document.createElement('div');
   const handler = td.func('eventHandler');
   let evt = null;

--- a/test/unit/mdc-auto-init/mdc-auto-init.test.js
+++ b/test/unit/mdc-auto-init/mdc-auto-init.test.js
@@ -115,7 +115,7 @@ test('#emit event from MDCComponent on init complete', () => {
   const root = setupTest();
   const handler = td.func('init event handler');
 
-  root.addEventListener('MDCAutoInit:End', handler);
+  document.addEventListener('MDCAutoInit:End', handler);
   mdcAutoInit(root);
 
   td.verify(handler(td.matchers.isA(Object)));


### PR DESCRIPTION
FIx #954 

@yeelan0319 The dialog component is extending `MDCComponent` so it has direct access to `emit` method. I am not sure how to access the emit method properly in `mdcAutoInit` function. I tried to import `MDCComponent`, but I guess it is not good. 

Also I am not sure what the test should be.
Any help appreciated. 

