### PR TITLE
docs(theme): Shorten tables in README, and update markdown

### DIFF
--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -19,30 +19,24 @@ path: /catalog/theme/
 This color palette comprises primary and accent colors that can be used for illustration or to develop your brand colors.
 
 MDC Theme is a foundational module that themes MDC Web components. The colors in this module are derived from three theme colors:
-- Primary: the primary color used in your application. This applies to a number of UI elements, such as app bars.
-- Accent: the accent color used in your application. This applies to UI elements such as FABs.
-- Background: the background color for your application. This is the color on top of which your UI is drawn.
 
-and five text colors:
-- Primary, used for most text
-- Secondary, used for text which is lower in the visual hierarchy
-- Hint, used for text hints (such as those in text fields and labels)
-- Disabled, used for text in disabled components and content
-- Icon, used for icons
+* Primary: the primary color used in your application, applies to a number of UI elements.
+* Accent: the accent color used in your application, applies to a number of UI elements.
+* Background: the background color for your application, aka the color on top of which your UI is drawn.
 
-> **A note about Primary**, don't confuse primary color with primary text. The former refers to the primary 
-> theme color, that is used to establish a visual identity and color many parts of your application. The 
-> latter refers to the style of text that is most prominent (low opacity, high contrast), and used to 
-> display most content.
+and five text styles:
 
-Some components can change their appearance when in a Dark Theme context, aka placed on top of a dark
-background. There are two ways to specify if a component is in a Dark Theme context. The first is to add 
-`mdc-theme--dark` to a *container* element, which holds the component. The second way is to add 
-`<component_name>--theme-dark` modifier class to the actual component element. For example, 
-`mdc-button--theme-dark` would put the MDC Button in a Dark Theme context.
+* Primary: used for most text
+* Secondary: used for text which is lower in the visual hierarchy
+* Hint: used for text hints, such as those in text fields and labels
+* Disabled: used for text in disabled components and content
+* Icon: used for icons
 
-> **A note about Dark Theme context**, don't confuse Dark Theme context with a component that has a dark color. 
-> Dark Theme context means the component sits on top of a dark background.
+> **A note about Primary**, don't confuse primary color with primary text. The former refers to the primary theme color, that is used to establish a visual identity and color many parts of your application. The latter refers to the style of text that is most prominent (low opacity, high contrast), and used to display most content.
+
+Some components can change their appearance when in a Dark Theme context, aka placed on top of a dark background. There are two ways to specify if a component is in a Dark Theme context. The first is to add `mdc-theme--dark` to a *container* element, which holds the component. The second way is to add `<component_name>--theme-dark` modifier class to the actual component element. For example, `mdc-button--theme-dark` would put the MDC Button in a Dark Theme context.
+
+> **A note about Dark Theme context**, don't confuse Dark Theme context with a component that has a dark color. Dark Theme context means the component sits on top of a dark background.
 
 ## Design & API Documentation
 
@@ -65,11 +59,9 @@ npm install --save @material/theme
 
 ### Change Theme Colors
 
-MDC Theme makes it easy to develop your brand colors. You override the default theme color through Sass 
-variables or CSS custom properties. CSS custom properties enables runtime theming.
+MDC Theme makes it easy to develop your brand colors. You override the default theme color through Sass variables or CSS custom properties. CSS custom properties enables runtime theming.
 
-> **A note about Sass variables**, you need to define the three theme color variables before importing mdc-theme
-> or any MDC-Web components that rely on it, like following:
+> **A note about Sass variables**, you need to define the three theme color variables before importing mdc-theme or any MDC-Web components that rely on it, like following:
 
 ```scss
 $mdc-theme-primary: #9c27b0;
@@ -79,130 +71,61 @@ $mdc-theme-background: #fff;
 @import "@material/theme/mdc-theme";
 ```
 
-The text color, for text placed on top of these selected theme colors, is programmatically computed based on
-color contrast. We follow the Web Content Accessibility Guidelines 2.0. 
+The text color, for text placed on top of these selected theme colors, is programmatically computed based on color contrast. We follow the Web Content Accessibility Guidelines 2.0. 
 
 https://www.w3.org/TR/WCAG20
 
-### CSS Custom Properties
+#### CSS Custom Properties
 
-MDC Theme CSS custom properties follow a pattern of mdc-theme--<theme> for color and mdc-theme-text-<text>-on-<theme> for text on a theme background. It covers all three theme colors, and all five text styles. There is also mdc-theme-text-<text>-on-<light/dark>. These properties are referenced when the background color is not a theme color. 
-
-| CSS Custom property                        | Description |
-| ------------------------------------------ | - |
-| `--mdc-theme-primary` | The theme primary color. |
-| `--mdc-theme-accent` | The theme accent color. |
-| `--mdc-theme-background` | The theme background color. |
-| `--mdc-theme-text-primary-on-primary` | Primary text on top of a theme primary color background. |
-| `--mdc-theme-text-secondary-on-primary` | Secondary text on top of a theme primary color background. |
-| `--mdc-theme-text-hint-on-primary` | Hint text on top of a theme primary color background. |
-| `--mdc-theme-text-disabled-on-primary` | Disabled text on top of a theme primary color background. |
-| `--mdc-theme-text-icon-on-primary` | Icons on top of a theme primary color background. |
-| `--mdc-theme-text-primary-on-accent` | Primary text on top of a theme accent color background. |
-| `--mdc-theme-text-secondary-on-accent` | Secondary text on top of a theme accent color background. |
-| `--mdc-theme-text-hint-on-accent` | Hint text on top of a theme accent color background. |
-| `--mdc-theme-text-disabled-on-accent` | Disabled text on top of a theme accent color background. |
-| `--mdc-theme-text-icon-on-accent` | Icons on top of a theme accent color background. |
-| `--mdc-theme-text-primary-on-background` | Primary text on top of the theme background. |
-| `--mdc-theme-text-secondary-on-background` | Secondary text on top of the theme background. |
-| `--mdc-theme-text-hint-on-background` | Hint text on top of the theme background. |
-| `--mdc-theme-text-disabled-on-background` | Disabled text on top of the theme background. |
-| `--mdc-theme-text-icon-on-background` | Icons on top of the theme background. |
-| `--mdc-theme-text-primary-on-light` | Primary text on top of a light-colored background. |
-| `--mdc-theme-text-secondary-on-light` | Secondary text on top of a light-colored background. |
-| `--mdc-theme-text-hint-on-light` | Hint text on top of a light-colored background. |
-| `--mdc-theme-text-disabled-on-light` | Disabled text on top of a light-colored background. |
-| `--mdc-theme-text-icon-on-light` | Icons on top of a light-colored background. |
-| `--mdc-theme-text-primary-on-dark` | Primary text on top of a dark-colored background. |
-| `--mdc-theme-text-secondary-on-dark` | Secondary text on top of a dark-colored background. |
-| `--mdc-theme-text-hint-on-dark` | Hint text on top of a dark-colored background. |
-| `--mdc-theme-text-disabled-on-dark` | Disabled text on top of a dark-colored background. |
-| `--mdc-theme-text-icon-on-dark` | Icons on top of a dark-colored background. |
+CSS Custom property | Description
+--- | ---
+`--mdc-theme-primary` | The theme primary color
+`--mdc-theme-accent` | The theme accent color
+`--mdc-theme-background` | The theme background color
+`--mdc-theme-text-<TEXT_STYLE>-on-<THEME_COLOR>` | Text color for TEXT_STYLE on top of THEME_COLOR background
+`--mdc-theme-text-<TEXT_STYLE>-on-light` | Text color for TEXT_STYLE on top of light background
+`--mdc-theme-text-<TEXT_STYLE>-on-dark` | Text color for TEXT_STYLE on top of dark background
 
 ### CSS Classes
 
-Some components can change their appearance when a theme-based modifier CSS class is applied. For example,
-`mdc-button--primary` will make the MDC Button the primary color. For more documentation on these modifier
-classes, consult the documentation for each component.
+Some components can change their appearance when a theme-based modifier CSS class is applied. For example, `mdc-button--primary` will make the MDC Button the primary color. For more documentation on these modifier classes, consult the documentation for each component.
 
-If you want to modify an element, which is not a Material Design component, you can apply the following
-modifier CSS classes.
+If you want to modify an element, which is not a Material Design component, you can apply the following modifier CSS classes.
 
-| CSS Class | Description |
-| --------------------------------------- | - |
-| `mdc-theme--primary` | Sets the text color to the theme primary color. |
-| `mdc-theme--accent` | Sets the text color to the theme accent color. |
-| `mdc-theme--background` | Sets the background color to the theme background color. |
-| `mdc-theme--primary-bg` | Sets the background color to the theme primary color. |
-| `mdc-theme--accent-bg` | Sets the background color to the theme accent color. |
-| `mdc-theme--text-primary-on-primary` | Sets text to a suitable color for primary text on top of a theme primary color background. |
-| `mdc-theme--text-secondary-on-primary` | Sets text to a suitable color for secondary text on top of a theme primary color background. |
-| `mdc-theme--text-hint-on-primary` | Sets text to a suitable color for hint text on top of a theme primary color background. |
-| `mdc-theme--text-disabled-on-primary` | Sets text to a suitable color for disabled text on top of a theme primary color background. |
-| `mdc-theme--text-icon-on-primary` | Sets text to a suitable color for icons on top of a theme primary color background. |
-| `mdc-theme--text-primary-on-accent` | Sets text to a suitable color for primary text on top of a theme accent color background. |
-| `mdc-theme--text-secondary-on-accent` | Sets text to a suitable color for secondary text on top of a theme accent color background. |
-| `mdc-theme--text-hint-on-accent` | Sets text to a suitable color for hint text on top of a theme accent color background. |
-| `mdc-theme--text-disabled-on-accent` | Sets text to a suitable color for disabled text on top of a theme accent color background. |
-| `mdc-theme--text-icon-on-accent` | Sets text to a suitable color for icons on top of a theme accent color background. |
-| `mdc-theme--text-primary-on-background` | Sets text to a suitable color for primary text on top of the theme background. 
-| `mdc-theme--text-secondary-on-background` | Sets text to a suitable color for secondary text on top of the theme background. |
-| `mdc-theme--text-hint-on-background` | Sets text to a suitable color for hint text on top of the theme background. |
-| `mdc-theme--text-disabled-on-background` | Sets text to a suitable color for disabled text on top of the theme background. |
-| `mdc-theme--text-icon-on-background` | Sets text to a suitable color for icons on top of the theme background. |
-| `mdc-theme--text-primary-on-light` | Sets text to a suitable color for primary text on top of a light-colored background. |
-| `mdc-theme--text-secondary-on-light` | Sets text to a suitable color for secondary text on top of a light-colored background. |
-| `mdc-theme--text-hint-on-light` | Sets text to a suitable color for hint text on top of a light-colored background. |
-| `mdc-theme--text-disabled-on-light` | Sets text to a suitable color for disabled text on top of a light-colored background. |
-| `mdc-theme--text-icon-on-light` | Sets text to a suitable color for icons on top of a light-colored background. |
-| `mdc-theme--text-primary-on-dark` | Sets text to a suitable color for primary text on top of a dark-colored background. |
-| `mdc-theme--text-secondary-on-dark` | Sets text to a suitable color for secondary text on top of a dark-colored background. |
-| `mdc-theme--text-hint-on-dark` | Sets text to a suitable color for hint text on top of a dark-colored background. |
-| `mdc-theme--text-disabled-on-dark` | Sets text to a suitable color for disabled text on top of a dark-colored background. |
-| `mdc-theme--text-icon-on-dark` | Sets text to a suitable color for icons on top of a dark-colored background. |
-
+CSS Class | Description
+--- | ---
+`mdc-theme--primary` | Sets the text color to the theme primary color
+`mdc-theme--accent` | Sets the text color to the theme accent color
+`mdc-theme--background` | Sets the background color to the theme background color
+`mdc-theme--primary-bg` | Sets the background color to the theme primary color
+`mdc-theme--accent-bg` | Sets the background color to the theme accent color
+`mdc-theme--text-<TEXT_STYLE>-on-<THEME_COLOR>` | Sets text to a suitable color for TEXT_STYLE on top of THEME_COLOR background
+`mdc-theme--text-<TEXT_STYLE>-on-light` | Sets text to a suitable color for TEXT_STYLE on top of light background
+`mdc-theme--text-<TEXT_STYLE>-on-dark` | Sets text to a suitable color for TEXT_STYLE on top of dark background
 
 ### Sass Mixins, Variables, and Functions
 
-| Mixin                                           | Description |
-| ----------------------------------------------- | - |
-| `mdc-theme-prop($property, $style, $important)` | Applies a theme color to a property |
-| `mdc-theme-dark($root-selector, $compound)` | Creates a rule that is applied when the current selector is within an Dark Theme context. If you are using the mixin on anything other than the base selector of the component, e.g. `.mdc-button`, you need to specify `$root-selector` as the base selector as a parameter. You can also specify `$compound` to true if the the current selector is a compound selector with the base selector, e.g. a modifier class to the component root element. |
+Mixin | Description
+--- | --- 
+`mdc-theme-prop($property, $style, $important)` | Applies a theme color to a property
+`mdc-theme-dark($root-selector, $compound)` | Creates a rule that is applied when the current selector is within an Dark Theme context
+
+#### `mdc-theme-dark($root-selector, $compound)`
+
+Creates a rule that is applied when the current selector is within an Dark Theme context. If you are using the mixin on anything other than the base selector of the component, e.g. `.mdc-button`, you need to specify `$root-selector` as the base selector as a parameter. You can also specify `$compound` to true if the the current selector is a compound selector with the base selector, e.g. a modifier class to the component root element.
 
 #### `mdc-theme-prop` Properties
 
 These properties can be used as the `$property` argument for `mdc-theme-prop` mixin.
 
-| Property Name                  | Description |
-| ------------------------------ | - |
-| `primary` | The theme primary color. |
-| `accent` | The theme accent color. |
-| `background` | The theme background color. |
-| `text-primary-on-primary`      | Primary text on top of a theme primary color background.   |
-| `text-secondary-on-primary`    | Secondary text on top of a theme primary color background. |
-| `text-hint-on-primary`         | Hint text on top of a theme primary color background.      |
-| `text-disabled-on-primary`     | Disabled text on top of a theme primary color background.  |
-| `text-icon-on-primary`         | Icons on top of a theme primary color background.          |
-| `text-primary-on-accent`       | Primary text on top of a theme accent color background.    |
-| `text-secondary-on-accent`     | Secondary text on top of a theme accent color background.  |
-| `text-hint-on-accent`          | Hint text on top of a theme accent color background.       |
-| `text-disabled-on-accent`      | Disabled text on top of a theme accent color background.   |
-| `text-icon-on-accent`          | Icons on top of a theme accent color background.           |
-| `text-primary-on-background`   | Primary text on top of the theme background.               |
-| `text-secondary-on-background` | Secondary text on top of the theme background.             |
-| `text-hint-on-background`      | Hint text on top of the theme background.                  |
-| `text-disabled-on-background`  | Disabled text on top of the theme background.              |
-| `text-icon-on-background`      | Icons on top of the theme background.                      |
-| `text-primary-on-light`        | Primary text on top of a light-colored background.         |
-| `text-secondary-on-light`      | Secondary text on top of a light-colored background.       |
-| `text-hint-on-light`           | Hint text on top of a light-colored background.            |
-| `text-disabled-on-light`       | Disabled text on top of a light-colored background.        |
-| `text-icon-on-light`           | Icons on top of a light-colored background.                |
-| `text-primary-on-dark`         | Primary text on top of a dark-colored background.          |
-| `text-secondary-on-dark`       | Secondary text on top of a dark-colored background.        |
-| `text-hint-on-dark`            | Hint text on top of a dark-colored background.             |
-| `text-disabled-on-dark`        | Disabled text on top of a dark-colored background.         |
-| `text-icon-on-dark`            | Icons on top of a dark-colored background.                 |
+Property Name | Description
+--- | ---
+`primary` | The theme primary color
+`accent` | The theme accent color
+`background` | The theme background color
+`text-<TEXT_STYLE>-on-<THEME_COLOR>` | TEXT_STYLE on top of THEME_COLOR background
+`text-<TEXT_STYLE>-on-light` | TEXT_STYLE on top of a light background
+`text-<TEXT_STYLE>-on-dark` | TEXT_STYLE on top of a dark background
 
 #### `mdc-theme-luminance`
 

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -77,6 +77,8 @@ https://www.w3.org/TR/WCAG20
 
 #### CSS Custom Properties
 
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. 'hint'. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `--mdc-theme-text-hint-on-accent`.
+
 CSS Custom property | Description
 --- | ---
 `--mdc-theme-primary` | The theme primary color
@@ -91,6 +93,8 @@ CSS Custom property | Description
 Some components can change their appearance when a theme-based modifier CSS class is applied. For example, `mdc-button--primary` will make the MDC Button the primary color. For more documentation on these modifier classes, consult the documentation for each component.
 
 If you want to modify an element, which is not a Material Design component, you can apply the following modifier CSS classes.
+
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. 'hint'. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `mdc-theme--text-hint-on-accent`.
 
 CSS Class | Description
 --- | ---
@@ -117,6 +121,8 @@ Creates a rule that is applied when the current selector is within an Dark Theme
 #### `mdc-theme-prop` Properties
 
 These properties can be used as the `$property` argument for `mdc-theme-prop` mixin.
+
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. 'hint'. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `text-hint-on-accent`.
 
 Property Name | Description
 --- | ---

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -77,7 +77,7 @@ https://www.w3.org/TR/WCAG20
 
 #### CSS Custom Properties
 
-> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. 'hint'. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `--mdc-theme-text-hint-on-accent`.
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `--mdc-theme-text-hint-on-accent`.
 
 CSS Custom property | Description
 --- | ---
@@ -94,7 +94,7 @@ Some components can change their appearance when a theme-based modifier CSS clas
 
 If you want to modify an element, which is not a Material Design component, you can apply the following modifier CSS classes.
 
-> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. 'hint'. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `mdc-theme--text-hint-on-accent`.
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `mdc-theme--text-hint-on-accent`.
 
 CSS Class | Description
 --- | ---
@@ -122,7 +122,7 @@ Creates a rule that is applied when the current selector is within an Dark Theme
 
 These properties can be used as the `$property` argument for `mdc-theme-prop` mixin.
 
-> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. 'hint'. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `text-hint-on-accent`.
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `text-hint-on-accent`.
 
 Property Name | Description
 --- | ---


### PR DESCRIPTION
The markdown needs to work in our internal Google docs as well. The changes in markdown doesn't make any visual changes, it just makes it easier to copy/paste into our internal tool later.

However, shortening the tables makes the README easier to...well...read.