### PR TITLE
feat(button): Modify button HTML structure and corresponding styles

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -23,20 +23,25 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <style>
-      fieldset {
-        margin: 24px;
-        margin-top: 0;
-        margin-bottom: 16px;
+      .demo-wrapper {
+        padding-bottom: 100px;
       }
-      fieldset .mdc-button {
-        margin: 16px;
-      }
-      .mdc-theme--dark fieldset {
+
+      .mdc-theme--dark.demo-wrapper{
         background-color: #333;
       }
 
-      .mdc-theme--dark fieldset legend {
+      .mdc-theme--dark.demo-wrapper fieldset legend {
         color: #f0f0f0;
+      }
+
+      fieldset {
+        padding: 24px;
+        padding-top: 0;
+        padding-bottom: 16px;
+      }
+      fieldset .mdc-button {
+        margin: 16px;
       }
 
       .hero button {
@@ -49,6 +54,15 @@
         padding: 16px;
         padding-top: 64px;
         padding-bottom: 24px;
+      }
+
+      .mdc-form-field {
+        margin: 50px 0 -20px 30px;
+      }
+
+      .demo-wrapper>fieldset>div{
+        display:flex;
+        justify-content: space-around;
       }
     </style>
   </head>
@@ -66,265 +80,113 @@
     <main class="mdc-toolbar-fixed-adjust">
 
       <section class="hero">
-        <button class="mdc-button button">Flat</button>
-        <button class="mdc-button mdc-button--raised button mdc-button--primary">Raised</button>
+        <button class="mdc-button button">
+          <span class="mdc-button__inner">Flat</span>
+        </button>
+        <button class="mdc-button mdc-button--raised">
+          <span class="mdc-button__inner">Raised</span>
+        </button>
       </section>
 
-      <section>
+      <section class="demo-wrapper">
+        <div class="mdc-form-field">
+          <div class="mdc-checkbox">
+            <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-dark" aria-labelledby="toggle-dark-label" />
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+          <label for="toggle-dark" id="toggle-dark-label">Dark Theme</label>
+        </div>
+
         <fieldset>
-          <legend class="mdc-typography--title">Buttons</legend>
-          <button class="mdc-button">
-            Default
-          </button>
-          <button class="mdc-button mdc-button--raised">
-            Raised
-          </button>
-          <button class="mdc-button mdc-button--dense">
-            Dense Default
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--dense">
-            Dense Raised
-          </button>
-          <button class="mdc-button mdc-button--compact">
-            Compact
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--compact">
-            Compact Raised
-          </button>
-          <button class="mdc-button mdc-button--primary">
-            Default with Primary
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--primary">
-            Raised with Primary
-          </button>
-          <button class="mdc-button mdc-button--accent">
-            Default with Accent
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
-          </button>
-          <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
-            Div
+          <legend class="mdc-typography--title">Text Button (JavaScript Enabled & CSS only)</legend>
+          <div>
+            <button class="mdc-button">
+              <span class="mdc-button__inner">Baseline + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--primary">
+              <span class="mdc-button__inner">Primary + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--accent">
+              <span class="mdc-button__inner">Accent + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--compact">
+              <span class="mdc-button__inner">Compact + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--dense">
+              <span class="mdc-button__inner">Dense + JavaScript</span>
+            </button>
+            <button disabled class="mdc-button">
+              <span class="mdc-button__inner">DISABLED + JavaScript</span>
+            </button>
+          </div>
+          <div>
+            <button class="mdc-button" data-demo-no-js>
+              <span class="mdc-button__inner">Baseline + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--primary" data-demo-no-js>
+              <span class="mdc-button__inner">Primary + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--accent" data-demo-no-js>
+              <span class="mdc-button__inner">Accent + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--compact" data-demo-no-js>
+              <span class="mdc-button__inner">Compact + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--dense" data-demo-no-js>
+              <span class="mdc-button__inner">Dense + CSS Only</span>
+            </button>
+            <button disabled class="mdc-button" data-demo-no-js>
+              <span class="mdc-button__inner">DISABLED + CSS Only</span>
+            </button>
           </div>
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Buttons CSS Only</legend>
-          <button class="mdc-button" data-demo-no-js>
-            Default
-          </button>
-          <button class="mdc-button mdc-button--raised" data-demo-no-js>
-            Raised
-          </button>
-          <button class="mdc-button mdc-button--dense" data-demo-no-js>
-            Dense Default
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--dense" data-demo-no-js>
-            Dense Raised
-          </button>
-          <button class="mdc-button mdc-button--compact" data-demo-no-js>
-            Compact
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--compact" data-demo-no-js>
-            Compact Raised
-          </button>
-          <button class="mdc-button mdc-button--primary" data-demo-no-js>
-            Default with Primary
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--primary" data-demo-no-js>
-            Raised with Primary
-          </button>
-          <button class="mdc-button mdc-button--accent" data-demo-no-js>
-            Default with Accent
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--accent" data-demo-no-js>
-            Raised with Accent
-          </button>
-          <div class="mdc-button mdc-button--raised" tabindex="0" role="button" data-demo-no-js>
-            Div
+          <legend class="mdc-typography--title">Raised Button (JavaScript Enabled & CSS only)</legend>
+          <div>
+            <button class="mdc-button mdc-button--raised">
+              <span class="mdc-button__inner">Baseline + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--primary">
+              <span class="mdc-button__inner">Primary + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--accent">
+              <span class="mdc-button__inner">Accent + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--compact">
+              <span class="mdc-button__inner">Compact + JavaScript</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--dense">
+              <span class="mdc-button__inner">Dense + JavaScript</span>
+            </button>
+            <button disabled class="mdc-button mdc-button--raised">
+              <span class="mdc-button__inner">DISABLED + JavaScript</span>
+            </button>
           </div>
-        </fieldset>
-
-        <fieldset>
-          <legend class="mdc-typography--title">Links with Button Style</legend>
-          <a href="/button.html" class="mdc-button">
-            Default
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--raised">
-            Raised
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--dense">
-            Dense Default
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--raised mdc-button--dense">
-            Dense Raised
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--compact">
-            Compact
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--raised mdc-button--compact">
-            Compact Raised
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--primary">
-            Default with Primary
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--raised mdc-button--primary">
-            Raised with Primary
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--accent">
-            Default with Accent
-          </a>
-          <a href="/button.html" class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
-          </a>
-        </fieldset>
-
-        <fieldset disabled>
-          <legend class="mdc-typography--title">Disabled</legend>
-          <button class="mdc-button">
-            Default
-          </button>
-          <button class="mdc-button mdc-button--raised">
-            Raised
-          </button>
-          <button class="mdc-button mdc-button--dense">
-            Dense Default
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--dense">
-            Dense Raised
-          </button>
-          <button class="mdc-button mdc-button--compact">
-            Compact
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--compact">
-            Compact Raised
-          </button>
-          <button class="mdc-button mdc-button--primary">
-            Default with Primary
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--primary">
-            Raised with Primary
-          </button>
-          <button class="mdc-button mdc-button--accent">
-            Default with Accent
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
-          </button>
-          <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
-            Div
-          </div>
-        </fieldset>
-      </section>
-
-      <section class="mdc-theme--dark">
-        <fieldset>
-          <legend class="mdc-typography--title">Dark Theme - Buttons</legend>
-          <button class="mdc-button">
-            Default
-          </button>
-          <button class="mdc-button mdc-button--raised">
-            Raised
-          </button>
-          <button class="mdc-button mdc-button--dense">
-            Dense Default
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--dense">
-            Dense Raised
-          </button>
-          <button class="mdc-button mdc-button--compact">
-            Compact
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--compact">
-            Compact Raised
-          </button>
-          <button class="mdc-button mdc-button--primary">
-            Default with Primary
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--primary">
-            Raised with Primary
-          </button>
-          <button class="mdc-button mdc-button--accent">
-            Default with Accent
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
-          </button>
-          <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
-            Div
-          </div>
-        </fieldset>
-        <fieldset>
-          <legend class="mdc-typography--title">Dark Theme - Buttons CSS Only</legend>
-          <button class="mdc-button" data-demo-no-js>
-            Default
-          </button>
-          <button class="mdc-button mdc-button--raised" data-demo-no-js>
-            Raised
-          </button>
-          <button class="mdc-button mdc-button--dense" data-demo-no-js>
-            Dense Default
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--dense" data-demo-no-js>
-            Dense Raised
-          </button>
-          <button class="mdc-button mdc-button--compact" data-demo-no-js>
-            Compact
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--compact" data-demo-no-js>
-            Compact Raised
-          </button>
-          <button class="mdc-button mdc-button--primary" data-demo-no-js>
-            Default with Primary
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--primary" data-demo-no-js>
-            Raised with Primary
-          </button>
-          <button class="mdc-button mdc-button--accent" data-demo-no-js>
-            Default with Accent
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--accent" data-demo-no-js>
-            Raised with Accent
-          </button>
-          <div class="mdc-button mdc-button--raised" tabindex="0" role="button" data-demo-no-js>
-            Div
-          </div>
-        </fieldset>
-        <fieldset disabled>
-          <legend class="mdc-typography--title">Dark Theme - Disabled</legend>
-
-          <button class="mdc-button">
-            Default
-          </button>
-          <button class="mdc-button mdc-button--raised">
-            Raised
-          </button>
-          <button class="mdc-button mdc-button--dense">
-            Dense Default
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--dense">
-            Dense Raised
-          </button>
-          <button class="mdc-button mdc-button--compact">
-            Compact
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--compact">
-            Compact Raised
-          </button>
-          <button class="mdc-button mdc-button--primary">
-            Default with Primary
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--primary">
-            Raised with Primary
-          </button>
-          <button class="mdc-button mdc-button--accent">
-            Default with Accent
-          </button>
-          <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
-          </button>
-          <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
-            Div
+          <div>
+            <button class="mdc-button mdc-button--raised" data-demo-no-js>
+              <span class="mdc-button__inner">Baseline + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--primary" data-demo-no-js>
+              <span class="mdc-button__inner">Primary + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--accent" data-demo-no-js>
+              <span class="mdc-button__inner">Accent + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--compact" data-demo-no-js>
+              <span class="mdc-button__inner">Compact + CSS Only</span>
+            </button>
+            <button class="mdc-button mdc-button--raised mdc-button--dense" data-demo-no-js>
+              <span class="mdc-button__inner">Dense + CSS Only</span>
+            </button>
+            <button disabled class="mdc-button mdc-button--raised" data-demo-no-js>
+              <span class="mdc-button__inner">DISABLED + CSS Only</span>
+            </button>
           </div>
         </fieldset>
       </section>
@@ -350,6 +212,14 @@
           }
         }
       })();
+      var demoWrapper = document.querySelector('.demo-wrapper');
+      document.getElementById('toggle-dark').addEventListener('change', function () {
+        if (this.checked) {
+          demoWrapper.classList.add('mdc-theme--dark');
+        } else {
+          demoWrapper.classList.remove('mdc-theme--dark');
+        }
+      });
     </script>
   </body>
 </html>

--- a/demos/card.html
+++ b/demos/card.html
@@ -139,8 +139,12 @@
           <h2 class="mdc-card__subtitle">Subtitle here</h2>
         </section>
         <section class="mdc-card__actions">
-          <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-          <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+          <button class="mdc-button mdc-button--compact mdc-card__action">
+            <span class="mdc-button__inner">Action 1</span>
+          </button>
+          <button class="mdc-button mdc-button--compact mdc-card__action">
+            <span class="mdc-button__inner">Action 2</span>
+          </button>
         </section>
       </div>
     </section>
@@ -182,8 +186,12 @@
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
           </section>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -197,8 +205,12 @@
           </section>
           <section class="mdc-card__media demo-card__16-9-media"></section>
           <section class="mdc-card__actions mdc-card__actions--vertical">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -211,8 +223,12 @@
             <h2 class="mdc-card__subtitle">Subtitle here</h2>
           </section>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -228,8 +244,12 @@
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
           </section>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -241,8 +261,12 @@
             <h2 class="mdc-card__subtitle">Subtitle here</h2>
           </section>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -253,7 +277,9 @@
             <h1 class="mdc-card__title mdc-card__title--large">Title</h1>
           </section>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
           </section>
         </div>
       </div>
@@ -268,8 +294,12 @@
             <img class="mdc-card__media-item" src="images/1-1.jpg"></img>
           </div>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -284,8 +314,12 @@
             <img class="mdc-card__media-item mdc-card__media-item--1dot5x" src="images/1-1.jpg"></img>
           </div>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -300,8 +334,12 @@
             <img class="mdc-card__media-item mdc-card__media-item--2x" src="images/1-1.jpg"></img>
           </div>
           <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">Action 2</span>
+            </button>
           </section>
         </div>
       </div>
@@ -312,8 +350,12 @@
             <img class="mdc-card__media-item mdc-card__media-item--3x" src="images/1-1.jpg"></img>
             <section class="mdc-card__actions mdc-card__actions--vertical">
               <!-- TODO(sgomes): Replace with icon buttons when we have those. -->
-              <button class="mdc-button mdc-button--compact mdc-card__action">A1</button>
-              <button class="mdc-button mdc-button--compact mdc-card__action">A2</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">A1</span>
+            </button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">
+              <span class="mdc-button__inner">A2</span>
+            </button>
             </section>
           </div>
         </div>

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -70,8 +70,11 @@
       	       Please check the left and right side of this element for fun.
       	    </section>
       	    <footer class="mdc-dialog__footer">
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Cancel</button>
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Continue</button>
+      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">
+                <span class="mdc-button__inner">Cancel</span>
+              </button>
+      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">  <span class="mdc-button__inner">Continue</span>
+              </button>
       	    </footer>
       	  </div>
       	</aside>
@@ -94,8 +97,10 @@
     	        Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
     	      </section>
     	      <footer class="mdc-dialog__footer">
-    	        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
-    	        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
+    	        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">  <span class="mdc-button__inner">Decline</span>
+              </button>
+    	        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">  <span class="mdc-button__inner">Accept</span>
+              </button>
     	      </footer>
     	    </div>
     	    <div class="mdc-dialog__backdrop"></div>
@@ -129,16 +134,23 @@
               </ul>
       	    </section>
       	    <footer class="mdc-dialog__footer">
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
+      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">  <span class="mdc-button__inner">Decline</span>
+              </button>
+              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">  <span class="mdc-button__inner">Accept</span>
+              </button>
+            </footer>
       	    </footer>
       	  </div>
       	  <div class="mdc-dialog__backdrop"></div>
       	</aside>
     	</div>
       <section class="example">
-        <button id="default-dialog-activation" class="mdc-button mdc-button--primary mdc-button--raised">Show Dialog</button>
-        <button id="dialog-with-list-activation" class="mdc-button mdc-button--primary mdc-button--raised">Show Scrolling Dialog</button>
+        <button id="default-dialog-activation" class="mdc-button mdc-button--primary mdc-button--raised">
+          <span class="mdc-button__inner">Show Dialog</span>
+        </button>
+        <button id="dialog-with-list-activation" class="mdc-button mdc-button--primary mdc-button--raised">
+          <span class="mdc-button__inner">Show Scrolling Dialog</span>
+        </button>
         <div class="mdc-form-field">
           <div class="mdc-checkbox">
             <input type="checkbox"

--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -98,7 +98,7 @@
       <div class="demo-content">
         <div class="mdc-menu-anchor">
           <button class="mdc-button mdc-button--raised mdc-button--primary toggle">
-            Reveal Menu
+            <span class="mdc-button__inner">Reveal Menu</span>
           </button>
 
           <div class="mdc-simple-menu" style="position: absolute;" tabindex="-1" id="demo-menu">

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -131,7 +131,7 @@
         </div>
         <br/>
 
-        <button type="button" class="mdc-button mdc-button--raised mdc-button--primary" id="toggle-dark-theme">Toggle Dark Theme</button>
+        <button type="button" class="mdc-button mdc-button--raised mdc-button--primary" id="toggle-dark-theme"><span class="mdc-button__inner">Toggle Dark Theme</span></button>
         <br/>
 
         <div class="mdc-textfield">
@@ -146,10 +146,10 @@
         </div>
         <br/>
 
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-snackbar">Show</button>
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-rtl-snackbar">Show RTL</button>
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-start-aligned-snackbar">Show Start Aligned</button>
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-start-aligned-rtl-snackbar">Show Start Aligned (RTL)</button>
+        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-snackbar"><span class="mdc-button__inner">Show</span></button>
+        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-rtl-snackbar"><span class="mdc-button__inner">Show RTL</span></button>
+        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-start-aligned-snackbar"><span class="mdc-button__inner">Show Start Aligned</span></button>
+        <button type="button" class="demo-activate-button mdc-button mdc-button--raised mdc-button--secondary" id="show-start-aligned-rtl-snackbar"><span class="mdc-button__inner">Show Start Aligned (RTL)</span></button>
 
           <div id="mdc-js-snackbar"
                class="mdc-snackbar demo-hidden"

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -168,8 +168,10 @@ limitations under the License
       </section>
 
       <section class="demo-buttons">
-        <button type="button" class="mdc-button mdc-button--raised mdc-button--primary" id="toggle-rtl">Toggle RTL</button>
-        <button type="button" class="mdc-button mdc-button--raised mdc-button--primary" id="toggle-dark-theme">Toggle Dark Theme</button>
+        <button type="button" class="mdc-button mdc-button--raised mdc-button--primary" id="toggle-rtl">
+          <span class="mdc-button__inner">Toggle RTL</span>
+        </button>
+        <button type="button" class="mdc-button mdc-button--raised mdc-button--primary" id="toggle-dark-theme"><span class="mdc-button__inner">Toggle Dark Theme</span></button>
       </section>
 
       <section>

--- a/demos/theme.html
+++ b/demos/theme.html
@@ -106,8 +106,8 @@
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
-        <button class="mdc-button mdc-button--raised mdc-theme--primary-bg mdc-theme--text-primary-on-primary">Primary</button>
-        <button class="mdc-button mdc-button--raised button mdc-theme--accent-bg mdc-theme--text-primary-on-accent">Accent</button>
+        <button class="mdc-button mdc-button--raised mdc-theme--primary-bg"><div class="mdc-button__inner mdc-theme--text-primary-on-primary">Primary</div></button>
+        <button class="mdc-button mdc-button--raised button mdc-theme--accent-bg"><div class="mdc-button__inner mdc-theme--text-primary-on-accent">Accent</div></button>
       </section>
 
       <h2 class="mdc-typography--display1">Theme colors</h2>

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -44,7 +44,7 @@ npm install --save @material/button
 
 ```html
 <button class="mdc-button">
-  Flat button
+  <span class="mdc-button__inner">Flat button</span>
 </button>
 ```
 
@@ -52,7 +52,7 @@ npm install --save @material/button
 
 ```html
 <button class="mdc-button mdc-button--accent">
-  Colored button
+  <span class="mdc-button__inner">Colored button</span>
 </button>
 ```
 
@@ -60,7 +60,7 @@ npm install --save @material/button
 
 ```html
 <button class="mdc-button mdc-button--raised">
-  Raised button
+  <span class="mdc-button__inner">Raised button</span>
 </button>
 ```
 
@@ -68,7 +68,7 @@ npm install --save @material/button
 
 ```html
 <button class="mdc-button mdc-button--raised" disabled>
-  Raised disabled button
+  <span class="mdc-button__inner">Raised disabled button</span>
 </button>
 ```
 
@@ -85,7 +85,7 @@ You can also do this declaratively when using the [material-components-web](../m
 
 ```html
 <button class="mdc-button" data-mdc-auto-init="MDCRipple">
-  Flat button
+  <span class="mdc-button__inner">Flat button</span>
 </button>
 ```
 
@@ -99,7 +99,7 @@ The block class is `mdc-button`. This defines the top-level button element.
 
 ### Element
 
-The button component has no inner elements.
+The button text is wrapped by `mdc-button__inner`.
 
 ### Modifier
 

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -22,57 +22,31 @@
 @import "@material/typography/mixins";
 
 // postcss-bem-linter: define button
-
 .mdc-button {
   @include mdc-ripple-base;
   @include mdc-ripple-bg((pseudo: "::before"));
   @include mdc-ripple-fg((pseudo: "::after"));
-  @include mdc-theme-prop(color, text-primary-on-light);
-  @include mdc-typography-base;
 
   display: inline-block;
   position: relative;
   min-width: 64px;
   height: 36px;
-  padding: 0 16px;
+  padding: 0;
   border: none;
   border-radius: 2px;
   outline: none;
   background: transparent;
-  font-size: 14px;
-  font-weight: 500;
-  letter-spacing: .04em;
-  line-height: 36px;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
   overflow: hidden;
-  vertical-align: middle;
-  user-select: none;
-  box-sizing: border-box;
-  -webkit-appearance: none;
 
-  &:not(.mdc-ripple-upgraded) {
-    -webkit-tap-highlight-color: rgba(black, .18);
-  }
+  &__inner {
+    @include mdc-theme-prop(color, text-primary-on-light);
+    @include mdc-typography(button);
 
-  @include mdc-theme-dark {
-    @include mdc-ripple-base;
-    @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
-    @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
-    @include mdc-theme-prop(color, text-primary-on-dark);
-
-    &:not(.mdc-ripple-upgraded) {
-      -webkit-tap-highlight-color: rgba(white, .18);
-    }
-  }
-
-  @each $theme-style in (primary, accent) {
-    &.mdc-button--#{$theme-style} {
-      @include mdc-ripple-base;
-      @include mdc-ripple-bg((pseudo: "::before", theme-style: $theme-style, opacity: .12));
-      @include mdc-ripple-fg((pseudo: "::after", theme-style: $theme-style, opacity: .12));
-    }
+    position: relative;
+    width: 100%;
+    height: 100%;
+    padding: 0 16px;
+    box-sizing: border-box;
   }
 
   // postcss-bem-linter: ignore
@@ -89,97 +63,49 @@
     border: 0;
   }
 
-  &--dense {
-    height: 32px;
-    font-size: .8125rem; // 13sp
-    line-height: 32px;
-  }
-
-  // TODO(cristobalchao): Disable ink wash on hover and alter elevation instead for raised surfaces.
-  &--raised {
-    @include mdc-elevation(2);
-    @include mdc-elevation-transition;
-
-    min-width: 88px;
-
-    &:active {
-      @include mdc-elevation(8);
-    }
-
-    @each $theme-style in (primary, accent) {
-      &.mdc-button--#{$theme-style} {
-        @include mdc-ripple-base;
-        @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
-        @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
-      }
-    }
-
-    @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(background-color, primary);
-      @include mdc-theme-prop(color, text-primary-on-primary);
-
-      // postcss-bem-linter: ignore
-      &::before {
-        // We are explicitly not fully adhering to Material Design here.
-        // This should be the 700-shade when active instead of a black shade.
-        // Due to the complexity involved in adhering fully it is being ignored.
-        // Instead re-using the existing architecture for shading works just fine.
-        color: black;
-      }
-    }
-  }
-
-  &--primary {
-    @include mdc-theme-prop(color, primary);
-
-    @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(color, primary);
-    }
-
-    // postcss-bem-linter: ignore
-    &.mdc-button--raised {
-      @include mdc-theme-prop(background-color, primary);
-      @include mdc-theme-prop(color, text-primary-on-primary);
-
-      // postcss-bem-linter: ignore
-      &::before {
-        color: black;
-      }
-    }
-  }
-
-  &--accent {
-    @include mdc-theme-prop(color, accent);
-
-    @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(color, accent);
-    }
-
-    // postcss-bem-linter: ignore
-    &.mdc-button--raised {
-      @include mdc-theme-prop(background-color, accent);
-      @include mdc-theme-prop(color, text-primary-on-accent);
-
-      // postcss-bem-linter: ignore
-      &::before {
-        color: black;
-      }
-    }
-  }
-
-  &--compact {
-    padding: 0 8px;
-  }
-
   fieldset:disabled &,
   &:disabled {
-    color: rgba(0, 0, 0, .26);
     cursor: default;
     pointer-events: none;
 
-    @include mdc-theme-dark(".mdc-button") {
-      color: rgba(255, 255, 255, .3);
+    // postcss-bem-linter: ignore
+    .mdc-button__inner {
+      color: rgba(0, 0, 0, .26);
+
+      @include mdc-theme-dark(".mdc-button") {
+        color: rgba(255, 255, 255, .3);
+      }
     }
+  }
+
+  &:not(.mdc-ripple-upgraded) {
+    -webkit-tap-highlight-color: rgba(black, .18);
+  }
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-ripple-base;
+    @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
+    @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
+
+    &__inner {
+      @include mdc-theme-prop(color, text-primary-on-dark);
+    }
+
+    &:not(.mdc-ripple-upgraded) {
+      -webkit-tap-highlight-color: rgba(white, .18);
+    }
+  }
+}
+
+// TODO(cristobalchao): Disable ink wash on hover and alter elevation instead for raised surfaces.
+.mdc-button--raised {
+  @include mdc-elevation(2);
+  @include mdc-elevation-transition;
+
+  min-width: 88px;
+
+  &:active {
+    @include mdc-elevation(8);
   }
 
   fieldset:disabled &--raised,
@@ -193,6 +119,71 @@
       background-color: rgba(255, 255, 255, .12);
     }
   }
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-theme-prop(background-color, primary);
+
+    .mdc-button__inner {
+      @include mdc-theme-prop(color, text-primary-on-primary);
+    }
+  }
 }
 
+.mdc-button--compact {
+  .mdc-button__inner {
+    padding: 0 8px;
+  }
+}
+
+.mdc-button--dense {
+  .mdc-button__inner {
+    height: 32px;
+    font-size: .8125rem; // 13sp
+    line-height: 32px;
+  }
+}
+
+@each $theme-style in (primary, accent) {
+  .mdc-button--#{$theme-style} {
+    @include mdc-ripple-base;
+    @include mdc-ripple-bg((pseudo: "::before", theme-style: $theme-style, opacity: .12));
+    @include mdc-ripple-fg((pseudo: "::after", theme-style: $theme-style, opacity: .12));
+
+    .mdc-button__inner {
+      @include mdc-theme-prop(color, $theme-style);
+    }
+
+    @include mdc-theme-dark(".mdc-button") {
+      @include mdc-ripple-base;
+      @include mdc-ripple-bg((pseudo: "::before", theme-style: $theme-style, opacity: .12));
+      @include mdc-ripple-fg((pseudo: "::after", theme-style: $theme-style, opacity: .12));
+
+      .mdc-button__inner {
+        @include mdc-theme-prop(color, $theme-style);
+      }
+    }
+
+    &.mdc-button--raised {
+      @include mdc-ripple-base;
+      @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
+      @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
+      @include mdc-theme-prop(background-color, $theme-style);
+
+      .mdc-button__inner {
+        @include mdc-theme-prop(color, text-primary-on-#{$theme-style});
+      }
+
+      @include mdc-theme-dark(".mdc-button") {
+        @include mdc-ripple-base;
+        @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
+        @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
+        @include mdc-theme-prop(background-color, $theme-style);
+
+        .mdc-button__inner {
+          @include mdc-theme-prop(color, text-primary-on-#{$theme-style});
+        }
+      }
+    }
+  }
+}
 // postcss-bem-linter: end

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -52,8 +52,12 @@ npm install --save @material/card
     commodo consequat.
   </section>
   <section class="mdc-card__actions">
-    <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-    <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+    <button class="mdc-button mdc-button--compact mdc-card__action">
+      <span class="mdc-button__inner">Action 1</span>
+    </button>
+    <button class="mdc-button mdc-button--compact mdc-card__action">
+      <span class="mdc-button__inner">Action 2</span>
+    </button>
   </section>
 </div>
 ```
@@ -84,8 +88,12 @@ Cards can use a dark theme by either having the `mdc-card--theme-dark` option di
     <h2 class="mdc-card__subtitle">Subtitle here</h2>
   </section>
   <section class="mdc-card__actions">
-    <button class="mdc-button mdc-button--theme-dark mdc-button--compact mdc-card__action">Action 1</button>
-    <button class="mdc-button mdc-button--theme-dark mdc-button--compact mdc-card__action">Action 2</button>
+    <button class="mdc-button mdc-button--compact mdc-card__action">
+      <span class="mdc-button__inner">Action 1</span>
+    </button>
+    <button class="mdc-button mdc-button--compact mdc-card__action">
+      <span class="mdc-button__inner">Action 2</span>
+    </button>
   </section>
 </div>
 ```
@@ -100,8 +108,12 @@ Or by using the `mdc-theme--dark` global modifier class that affects all childre
       <h2 class="mdc-card__subtitle">Subtitle here</h2>
     </section>
     <section class="mdc-card__actions">
-      <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-      <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+      <button class="mdc-button mdc-button--compact mdc-card__action">
+        <span class="mdc-button__inner">Action 1</span>
+      </button>
+      <button class="mdc-button mdc-button--compact mdc-card__action">
+        <span class="mdc-button__inner">Action 2</span>
+      </button>
     </section>
   </div>
 </body>
@@ -136,8 +148,12 @@ This area is used for showing rich media in cards, and optionally as a container
 
 ```html
 <section class="mdc-card__actions">
-  <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-  <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+  <button class="mdc-button mdc-button--compact mdc-card__action">
+    <span class="mdc-button__inner">Action 1</span>
+  </button>
+  <button class="mdc-button mdc-button--compact mdc-card__action">
+    <span class="mdc-button__inner">Action 2</span>
+  </button>
 </section>
 ```
 
@@ -150,8 +166,12 @@ You can use the `mdc-card__actions--vertical` option to lay actions out vertical
 
 ```html
 <section class="mdc-card__actions mdc-card__actions--vertical">
-  <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-  <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+  <button class="mdc-button mdc-button--compact mdc-card__action">
+    <span class="mdc-button__inner">Action 1</span>
+  </button>
+  <button class="mdc-button mdc-button--compact mdc-card__action">
+    <span class="mdc-button__inner">Action 2</span>
+  </button>
 </section>
 ```
 
@@ -206,7 +226,9 @@ You can stack multiple card blocks horizontally instead of vertically, by placin
     <h2 class="mdc-card__subtitle">Subtitle here</h2>
   </section>
   <section class="mdc-card__actions">
-    <button class="mdc-button mdc-button--compact mdc-card__action">Action</button>
+    <button class="mdc-button mdc-button--compact mdc-card__action">
+      <span class="mdc-button__inner">Action</span>
+    </button>
   </section>
 </div>
 ```

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -59,8 +59,12 @@ Dialogs inform users about a specific task and may contain critical information 
       Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
     </section>
     <footer class="mdc-dialog__footer">
-      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
-      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
+      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">
+        <span class="mdc-button__inner">Cancel</span>
+      </button>
+      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">
+        <span class="mdc-button__inner">Continue</span>
+      </button>
     </footer>
   </div>
   <div class="mdc-dialog__backdrop"></div>
@@ -101,8 +105,12 @@ Some dialogs will not be tall enough to accomodate everything you would like to 
         </ul>
       </section>
       <footer class="mdc-dialog__footer">
-        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
-        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
+        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">
+          <span class="mdc-button__inner">Cancel</span>
+        </button>
+        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">
+          <span class="mdc-button__inner">Continue</span>
+        </button>
       </footer>
     </div>
     <div class="mdc-dialog__backdrop"></div>


### PR DESCRIPTION
Close #985 

BREAKING CHANGE: Modify `mdc-button` HTML to have a wrapper `mdc-button__inner`. All existing implementations need to add this extra layer to apply correct styles.