### PR TITLE
fix(ripple): Feature-detect buggy Edge behavior for custom properties

### DIFF
--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -428,11 +428,11 @@ External frameworks and libraries can use the following utility methods when int
 
 #### util.supportsCssVariables(windowObj, forceRefresh = false) => Boolean
 
-Determine whether the current browser supports CSS variables (custom properties).
+Determine whether the current browser supports CSS variables (custom properties). This function caches its result; `forceRefresh` will force recomputation, but is used mainly for testing and should not be necessary in normal use.
 
 #### util.applyPassive(globalObj = window, forceRefresh = false) => object
 
-Determine whether the current browser supports passive event listeners, and if so, use them.
+Determine whether the current browser supports passive event listeners, and if so, use them. This function caches its result; `forceRefresh` will force recomputation, but is used mainly for testing and should not be necessary in normal use.
 
 #### getMatchesProperty(HTMLElementPrototype) => Function
 

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -31,6 +31,7 @@ path: /catalog/ripples/
     - [Using a sentinel element for a ripple](#using-a-sentinel-element-for-a-ripple)
     - [Keyboard interaction for custom UI components](#keyboard-interaction-for-custom-ui-components)
     - [Specifying known element dimensions](#specifying-known-element-dimensions)
+  - [Caveat: Edge](#caveat-edge)
   - [Caveat: Safari](#caveat-safari)
   - [Caveat: Theme Custom Variables](#caveat-theme-custom-variables)
   - [The util API](#the-util-api)
@@ -45,8 +46,8 @@ In order to function correctly, MDC Ripple requires a _browser_ implementation o
 
 Because we rely on scoped, dynamic CSS variables, static pre-processors such as [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) will not work as an adequate polyfill ([...yet?](https://github.com/postcss/postcss-custom-properties/issues/32)).
 
-[Most modern browsers](http://caniuse.com/#feat=css-variables) support CSS variables, so MDC ripple will work just fine. In other cases, MDC ripple will _still work_ if you include it in your codebase. It will simply check if CSS variables are supported upon initialization and if they aren't, gracefully exit. The only exception to this rule is Safari, which does support CSS variables
-but unfortunately ripples are disabled for (see [below](#caveat-safari) for an explanation).
+[Most modern browsers](http://caniuse.com/#feat=css-variables) support CSS variables, so MDC ripple will work just fine. In other cases, MDC ripple will _still work_ if you include it in your codebase. It will simply check if CSS variables are supported upon initialization and if they aren't, gracefully exit. The only exceptions to this rule are Edge and Safari, which do support CSS variables
+but unfortunately ripples are disabled for (see [below](#caveat-edge) for an explanation).
 
 
 ## Installation
@@ -263,7 +264,7 @@ ripple to. The adapter API is as follows:
 
 | Method Signature | Description |
 | --- | --- |
-| `browserSupportsCssVars() => boolean` | Whether or not the given browser supports CSS Variables. When implementing this, please take the [Safari considerations](#caveat-safari) into account. We provide a `supportsCssVariables` function within the `util.js` which we recommend using, as it handles this for you. |
+| `browserSupportsCssVars() => boolean` | Whether or not the given browser supports CSS Variables. When implementing this, please take the [Edge](#caveat-edge) and [Safari](#caveat-safari) considerations into account. We provide a `supportsCssVariables` function within the `util.js` which we recommend using, as it handles this for you. |
 | `isUnbounded() => boolean` | Whether or not the ripple should be considered unbounded. |
 | `isSurfaceActive() => boolean` | Whether or not the surface the ripple is acting upon is [active](https://www.w3.org/TR/css3-selectors/#useraction-pseudos). We use this to detect whether or not a keyboard event has activated the surface the ripple is on. This does not need to make use of `:active` (which is what we do); feel free to supply your own heuristics for it. |
 | `isSurfaceDisabled() => boolean` | Whether or not the ripple is attached to a disabled component. If true, the ripple will not activate. |
@@ -379,6 +380,17 @@ this.ripple_ = new MDCRippleFoundation({
   }
 });
 ```
+
+## Caveat: Edge
+
+> TL;DR ripples are disabled in Edge because of issues with its support of CSS variables in pseudo elements.
+
+Edge introduced CSS variables in version 15.  Unfortunately, there are
+[issues](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/)
+involving its implementation for `::before` and `::after` pseudo-element selectors which cause ripples to
+behave incorrectly.  We feature-detect one of these bugs and do not upgrade ripples if the bug is observed.
+Earlier versions of Edge (and IE) are not affected, as they do not report support for CSS variables at all,
+and as such ripples are never upgraded.
 
 ## Caveat: Safari
 

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -46,9 +46,7 @@ In order to function correctly, MDC Ripple requires a _browser_ implementation o
 
 Because we rely on scoped, dynamic CSS variables, static pre-processors such as [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) will not work as an adequate polyfill ([...yet?](https://github.com/postcss/postcss-custom-properties/issues/32)).
 
-[Most modern browsers](http://caniuse.com/#feat=css-variables) support CSS variables, so MDC ripple will work just fine. In other cases, MDC ripple will _still work_ if you include it in your codebase. It will simply check if CSS variables are supported upon initialization and if they aren't, gracefully exit. The only exceptions to this rule are Edge and Safari, which do support CSS variables
-but unfortunately ripples are disabled for (see [below](#caveat-edge) for an explanation).
-
+Edge and Safari, although they do [support CSS variables](http://caniuse.com/#feat=css-variables), do not support MDC Ripple. See the respective caveats for [Edge](#caveat-edge) and [Safari](#caveat-safari) for an explanation.
 
 ## Installation
 
@@ -385,12 +383,12 @@ this.ripple_ = new MDCRippleFoundation({
 
 > TL;DR ripples are disabled in Edge because of issues with its support of CSS variables in pseudo elements.
 
-Edge introduced CSS variables in version 15.  Unfortunately, there are
-[issues](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/)
-involving its implementation for `::before` and `::after` pseudo-element selectors which cause ripples to
-behave incorrectly.  We feature-detect one of these bugs and do not upgrade ripples if the bug is observed.
-Earlier versions of Edge (and IE) are not affected, as they do not report support for CSS variables at all,
-and as such ripples are never upgraded.
+Edge introduced CSS variables in version 15. Unfortunately, there are
+[known issues](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/)
+involving its implementation for pseudo-elements which cause ripples to behave incorrectly.
+We feature-detect Edge's buggy behavior as it pertains to `::before`, and do not initialize ripples if the bug is
+observed. Earlier versions of Edge (and IE) are not affected, as they do not report support for CSS variables at all,
+and as such ripples are never initialized.
 
 ## Caveat: Safari
 
@@ -428,7 +426,7 @@ to your theme via a custom variable will not propagate to ripples._ We don't see
 
 External frameworks and libraries can use the following utility methods when integrating a component.
 
-#### util.supportsCssVariables(windowObj) => Boolean
+#### util.supportsCssVariables(windowObj, forceRefresh = false) => Boolean
 
 Determine whether the current browser supports CSS variables (custom properties).
 

--- a/packages/mdc-ripple/util.js
+++ b/packages/mdc-ripple/util.js
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-/** @private {boolean|undefined} */
+/**
+ * Stores result from supportsCssVariables to avoid redundant processing to detect CSS custom variable support.
+ * @private {boolean|undefined}
+ */
 let supportsCssVariables_;
 
-/** @private {boolean|undefined} */
+/**
+ * Stores result from applyPassive to avoid redundant processing to detect passive event listener support.
+ * @private {boolean|undefined}
+ */
 let supportsPassive_;
 
 /**

--- a/packages/mdc-ripple/util.js
+++ b/packages/mdc-ripple/util.js
@@ -15,13 +15,21 @@
  */
 
 /** @private {boolean|undefined} */
+let supportsCssVariables_;
+
+/** @private {boolean|undefined} */
 let supportsPassive_;
 
 /**
  * @param {!Window} windowObj
+ * @param {boolean=} forceRefresh
  * @return {boolean|undefined}
  */
-export function supportsCssVariables(windowObj) {
+export function supportsCssVariables(windowObj, forceRefresh = false) {
+  if (typeof supportsCssVariables_ === 'boolean' && !forceRefresh) {
+    return supportsCssVariables_;
+  }
+
   const supportsFunctionPresent = windowObj.CSS && typeof windowObj.CSS.supports === 'function';
   if (!supportsFunctionPresent) {
     return;
@@ -34,7 +42,32 @@ export function supportsCssVariables(windowObj) {
     windowObj.CSS.supports('(--css-vars: yes)') &&
     windowObj.CSS.supports('color', '#00000000')
   );
-  return explicitlySupportsCssVars || weAreFeatureDetectingSafari10plus;
+
+  if (!explicitlySupportsCssVars && !weAreFeatureDetectingSafari10plus) {
+    supportsCssVariables_ = false;
+    return supportsCssVariables_;
+  }
+
+  // Detect versions of Edge with buggy var() support
+  // See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/
+  const document = windowObj.document;
+  const className = 'test-edge-css-var';
+  const styleNode = document.createElement('style');
+  document.head.appendChild(styleNode);
+  const sheet = styleNode.sheet;
+  // Internet Explorer 11 requires indices to always be specified to insertRule
+  sheet.insertRule(`:root { --${className}: 1px solid #000; }`, 0);
+  sheet.insertRule(`.${className} { visibility: hidden; }`, 1);
+  sheet.insertRule(`.${className}::before { border: var(--${className}); }`, 2);
+  const node = document.createElement('div');
+  node.className = className;
+  document.body.appendChild(node);
+  // Bug exists if ::before style ends up propagating to the parent element
+  const hasPseudoVarBug = windowObj.getComputedStyle(node).borderTopStyle === 'solid';
+  node.remove();
+  styleNode.remove();
+  supportsCssVariables_ = !hasPseudoVarBug;
+  return supportsCssVariables_;
 }
 
 //

--- a/packages/mdc-ripple/util.js
+++ b/packages/mdc-ripple/util.js
@@ -22,6 +22,32 @@ let supportsPassive_;
 
 /**
  * @param {!Window} windowObj
+ * @return {boolean}
+ */
+function detectEdgePseudoVarBug(windowObj) {
+  // Detect versions of Edge with buggy var() support
+  // See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/
+  const document = windowObj.document;
+  const className = 'test-edge-css-var';
+  const styleNode = document.createElement('style');
+  document.head.appendChild(styleNode);
+  const sheet = styleNode.sheet;
+  // Internet Explorer 11 requires indices to always be specified to insertRule
+  sheet.insertRule(`:root { --${className}: 1px solid #000; }`, 0);
+  sheet.insertRule(`.${className} { visibility: hidden; }`, 1);
+  sheet.insertRule(`.${className}::before { border: var(--${className}); }`, 2);
+  const node = document.createElement('div');
+  node.className = className;
+  document.body.appendChild(node);
+  // Bug exists if ::before style ends up propagating to the parent element
+  const hasPseudoVarBug = windowObj.getComputedStyle(node).borderTopStyle === 'solid';
+  node.remove();
+  styleNode.remove();
+  return hasPseudoVarBug;
+}
+
+/**
+ * @param {!Window} windowObj
  * @param {boolean=} forceRefresh
  * @return {boolean|undefined}
  */
@@ -43,30 +69,11 @@ export function supportsCssVariables(windowObj, forceRefresh = false) {
     windowObj.CSS.supports('color', '#00000000')
   );
 
-  if (!explicitlySupportsCssVars && !weAreFeatureDetectingSafari10plus) {
+  if (explicitlySupportsCssVars || weAreFeatureDetectingSafari10plus) {
+    supportsCssVariables_ = !detectEdgePseudoVarBug(windowObj);
+  } else {
     supportsCssVariables_ = false;
-    return supportsCssVariables_;
   }
-
-  // Detect versions of Edge with buggy var() support
-  // See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11495448/
-  const document = windowObj.document;
-  const className = 'test-edge-css-var';
-  const styleNode = document.createElement('style');
-  document.head.appendChild(styleNode);
-  const sheet = styleNode.sheet;
-  // Internet Explorer 11 requires indices to always be specified to insertRule
-  sheet.insertRule(`:root { --${className}: 1px solid #000; }`, 0);
-  sheet.insertRule(`.${className} { visibility: hidden; }`, 1);
-  sheet.insertRule(`.${className}::before { border: var(--${className}); }`, 2);
-  const node = document.createElement('div');
-  node.className = className;
-  document.body.appendChild(node);
-  // Bug exists if ::before style ends up propagating to the parent element
-  const hasPseudoVarBug = windowObj.getComputedStyle(node).borderTopStyle === 'solid';
-  node.remove();
-  styleNode.remove();
-  supportsCssVariables_ = !hasPseudoVarBug;
   return supportsCssVariables_;
 }
 

--- a/test/unit/mdc-ripple/helpers.js
+++ b/test/unit/mdc-ripple/helpers.js
@@ -47,3 +47,46 @@ export function captureHandlers(adapter) {
   const handlers = baseCaptureHandlers(adapter, 'registerInteractionHandler');
   return handlers;
 }
+
+// Creates a mock window object with all members necessary to test util.supportsCssVariables
+// in cases where window.CSS.supports indicates the feature is supported.
+export function createMockWindowForCssVariables() {
+  const getComputedStyle = td.func('window.getComputedStyle');
+  const remove = () => mockWindow.appendedNodes--;
+  const mockDoc = {
+    body: {
+      appendChild: () => mockWindow.appendedNodes++,
+    },
+    createElement: td.func('document.createElement'),
+    head: {
+      appendChild: () => mockWindow.appendedNodes++,
+    },
+  };
+  const mockSheet = {
+    insertRule: () => {},
+  };
+
+  td.when(getComputedStyle(td.matchers.anything())).thenReturn({
+    borderTopStyle: 'none',
+  });
+
+  td.when(mockDoc.createElement('div')).thenReturn({
+    remove: remove,
+  });
+
+  td.when(mockDoc.createElement('style')).thenReturn({
+    remove: remove,
+    sheet: mockSheet,
+  });
+
+  const mockWindow = {
+    // Expose count of nodes that have been appended and not removed, to be verified in tests
+    appendedNodes: 0,
+    CSS: {
+      supports: td.func('.supports'),
+    },
+    document: mockDoc,
+    getComputedStyle: getComputedStyle,
+  };
+  return mockWindow;
+}

--- a/test/unit/mdc-tabs/mdc-tab.test.js
+++ b/test/unit/mdc-tabs/mdc-tab.test.js
@@ -44,7 +44,7 @@ test('attachTo returns a component instance', () => {
   assert.isOk(MDCTab.attachTo(getFixture()) instanceof MDCTab);
 });
 
-test('#constructor initializes the root element with a ripple in browsers that support it', () => {
+test('#constructor initializes the root element with a ripple in browsers that support it', function() {
   if (!supportsCssVariables(window, true)) {
     this.skip(); // eslint-disable-line no-invalid-this
     return;
@@ -56,7 +56,7 @@ test('#constructor initializes the root element with a ripple in browsers that s
   raf.restore();
 });
 
-test('#destroy cleans up tab\'s ripple in browsers that support it', () => {
+test('#destroy cleans up tab\'s ripple in browsers that support it', function() {
   if (!supportsCssVariables(window, true)) {
     this.skip(); // eslint-disable-line no-invalid-this
     return;

--- a/test/unit/mdc-tabs/mdc-tab.test.js
+++ b/test/unit/mdc-tabs/mdc-tab.test.js
@@ -44,24 +44,30 @@ test('attachTo returns a component instance', () => {
   assert.isOk(MDCTab.attachTo(getFixture()) instanceof MDCTab);
 });
 
-if (supportsCssVariables(window)) {
-  test('#constructor initializes the root element with a ripple', () => {
-    const raf = createMockRaf();
-    const {root} = setupTest();
-    raf.flush();
-    assert.isOk(root.classList.contains('mdc-ripple-upgraded'));
-    raf.restore();
-  });
+test('#constructor initializes the root element with a ripple in browsers that support it', () => {
+  if (!supportsCssVariables(window, true)) {
+    this.skip(); // eslint-disable-line no-invalid-this
+    return;
+  }
+  const raf = createMockRaf();
+  const {root} = setupTest();
+  raf.flush();
+  assert.isOk(root.classList.contains('mdc-ripple-upgraded'));
+  raf.restore();
+});
 
-  test('#destroy cleans up ripple on tab', () => {
-    const raf = createMockRaf();
-    const {root, component} = setupTest();
-    raf.flush();
-    component.destroy();
-    raf.flush();
-    assert.isNotOk(root.classList.contains('mdc-ripple-upgraded'));
-  });
-}
+test('#destroy cleans up tab\'s ripple in browsers that support it', () => {
+  if (!supportsCssVariables(window, true)) {
+    this.skip(); // eslint-disable-line no-invalid-this
+    return;
+  }
+  const raf = createMockRaf();
+  const {root, component} = setupTest();
+  raf.flush();
+  component.destroy();
+  raf.flush();
+  assert.isNotOk(root.classList.contains('mdc-ripple-upgraded'));
+});
 
 test('#get computedWidth returns computed width of tab', () => {
   const {root, component} = setupTest();


### PR DESCRIPTION
This adds feature detection for buggy var() behavior in Edge WRT pseudo selectors, and will not upgrade ripples if the buggy behavior is found.

Because this adds quite a bit of logic (including DOM operations) to the function, this PR also changes the function to cache its result once a true or false result is obtained, much like we do for various other util functions.  This requires adding an optional force parameter to the function for tests to use.

This PR also updates tests and adds one to test the new case, and adds a section to the README.

Fixes #663.