### PR TITLE
Fix typo in mdc-tabs readme example

### DIFF
--- a/packages/mdc-tabs/README.md
+++ b/packages/mdc-tabs/README.md
@@ -156,7 +156,7 @@ provides a minimal example of how to do so using JavaScript, also shown below.
 
 #### Script:
 ```js
-var dynamicTabBar = window.dynamicTabBar = new mdc.tabBar.MDCTabBar(document.querySelector('#dynamic-tab-bar'));
+var dynamicTabBar = window.dynamicTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#dynamic-tab-bar'));
 var dots = document.querySelector('.dots');
 var panels = document.querySelector('.panels');
 


### PR DESCRIPTION
This PR fixes a small typo in the dynamic tab bar example in the readme of mdc-tabs. The package is incorrectly referred to as `mdc.tabBar` instead of `mdc.tabs`.