### PR TITLE
docs(infrastructure): Update instruction to deploy to development server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,9 @@ Each component requires the following items in order to be complete:
 
 You can find much more information with respect to building components within our [authoring components guide](./docs/authoring-components.md)
 
-### Running the development server
+### Running development server
+
+#### Local developement server
 
 ```
 npm run dev
@@ -69,6 +71,15 @@ open http://localhost:8080
 ```
 
 `npm run dev` runs a [webpack-dev-server](https://webpack.github.io/docs/webpack-dev-server.html) instance that uses `demos/` as its content base. This should aid you in initial development of a component. It's served on port 8080.
+
+#### Appengine developement server
+
+```
+MDC_ENV=development npm run build && gcloud app deploy app.yaml --project google.com:mdc-web-dev --version $USER
+gcloud app browse
+```
+
+The above script will build and deploy the app to mdc-web's dev server with your userid as its version number, you can switch to your version by adding $USER-dot to the URL. This would be helpful if we need to share work-in-progress work within teams and designers.
 
 ### Building MDC-Web
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ MDC_ENV=development npm run build && gcloud app deploy app.yaml --project google
 gcloud app browse
 ```
 
-The above script will build and deploy the app to mdc-web's dev server with your userid as its version number, you can switch to your version by adding $USER-dot to the URL. This would be helpful if we need to share work-in-progress work within teams and designers.
+The above script will build and deploy the app to mdc-web's dev server with your userid as its version number, you can switch to your version by prepending `$USER-dot-` to the URL opened when you run `gcloud app browse`. This would be helpful if we need to share work-in-progress work within teams and designers.
 
 ### Building MDC-Web
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ You can find much more information with respect to building components within ou
 
 ### Running development server
 
-#### Local developement server
+#### Local development server
 
 ```
 npm run dev
@@ -72,7 +72,7 @@ open http://localhost:8080
 
 `npm run dev` runs a [webpack-dev-server](https://webpack.github.io/docs/webpack-dev-server.html) instance that uses `demos/` as its content base. This should aid you in initial development of a component. It's served on port 8080.
 
-#### Appengine developement server
+#### Appengine development server
 
 ```
 MDC_ENV=development npm run build && gcloud app deploy app.yaml --project google.com:mdc-web-dev --version $USER


### PR DESCRIPTION
#Background

I was trying to share my WIP with our design team there is not a straightforward way for doing so, I thought it would be great if each of core team have a (their own) dev server, so I went ahead and created one. With this script, you should be able to run build and deploy to a remote server that you can share with designer, core-team. 

One side note, not sure if it make sense to make this internal or external. Let me know if we want to put this on appengine public instead so that we may further share our proof of concept with our communities? 