### PR TITLE
feat(theme): step 01: accent color defaults to primary color

### DIFF
--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -21,7 +21,7 @@
   If you're a user customizing your color scheme in SASS, these are probably the only variables you need to change.
 */
 $mdc-theme-primary: #3f51b5 !default; /* Indigo 500 */
-$mdc-theme-accent: #ff4081 !default; /* Pink A200 */
+$mdc-theme-accent: $mdc-theme-primary !default;
 $mdc-theme-background: #fff !default; /* White */
 
 /* Which set of text colors to use for each main theme color (light or dark) */

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -19,6 +19,7 @@
 /*
   Main theme colors.
   If you're a user customizing your color scheme in SASS, these are probably the only variables you need to change.
+  NOTE: Using a distinct secondary (accent) color is optional, but recommended.
 */
 $mdc-theme-primary: #3f51b5 !default; /* Indigo 500 */
 $mdc-theme-accent: $mdc-theme-primary !default;


### PR DESCRIPTION
Designers felt that it doesn't make sense to provide a specific default value for accent color, because it has a low likelihood of looking good with your brand's custom primary color.

Instead, accent color should default to primary color.

Fixes #1099