### PR TITLE
chore(demos): Remove redundant CSS ref in HTML

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -17,7 +17,6 @@
     <title>Button - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/card.html
+++ b/demos/card.html
@@ -21,7 +21,6 @@
   <title>Card - Material Compoonents Catalog</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-  <script src="assets/material-components-web.css.js" charset="utf-8"></script>
   <script src="assets/demo-styles.css.js" charset="utf-8"></script>
   <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -20,7 +20,6 @@
     <title>Checkbox - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -17,7 +17,6 @@
     <title>Dialog - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -20,7 +20,6 @@
     <title>Drawer Above Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -20,7 +20,6 @@
     <title>Drawer Below Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/drawer/persistent-drawer.html
+++ b/demos/drawer/persistent-drawer.html
@@ -20,7 +20,6 @@
     <title>Drawer (Persistent) - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -20,7 +20,6 @@
     <title>Drawer (Temporary) - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/elevation.html
+++ b/demos/elevation.html
@@ -20,7 +20,6 @@
     <title>Elevation - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/fab.html
+++ b/demos/fab.html
@@ -17,7 +17,6 @@
     <title>Floating Action Button - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -17,7 +17,6 @@
     <title>Grid List - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/icon-toggle.html
+++ b/demos/icon-toggle.html
@@ -17,7 +17,6 @@
     <title>Icon Toggle - Material Components Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/index.html
+++ b/demos/index.html
@@ -20,7 +20,6 @@
     <title>Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
   </head>

--- a/demos/layout-grid.html
+++ b/demos/layout-grid.html
@@ -20,7 +20,6 @@
     <title>Layout Grid - Material Components</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -16,7 +16,6 @@
     <meta charset="utf-8">
     <title>Linear Progress - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <link href="demos.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -16,7 +16,7 @@
     <meta charset="utf-8">
     <title>Linear Progress - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="demos.css" rel="stylesheet">
+    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">

--- a/demos/list.html
+++ b/demos/list.html
@@ -17,7 +17,6 @@
     <title>List Item - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/radio.html
+++ b/demos/radio.html
@@ -20,7 +20,6 @@
     <title>Radio Button - Material Components Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -20,7 +20,6 @@
     <title>Ripple - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/select.html
+++ b/demos/select.html
@@ -20,7 +20,6 @@
     <title>Select Menu - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -20,7 +20,6 @@
     <title>Simple Menu - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/slider.html
+++ b/demos/slider.html
@@ -20,7 +20,6 @@
     <title>Slider - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -20,7 +20,6 @@
     <title>Snackbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/switch.html
+++ b/demos/switch.html
@@ -17,7 +17,6 @@
     <title>Switch - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -18,7 +18,6 @@ limitations under the License
     <title>MDC-Web Tab Bar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/textfield.html
+++ b/demos/textfield.html
@@ -20,7 +20,6 @@
     <title>Text Field - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/theme.html
+++ b/demos/theme.html
@@ -20,7 +20,6 @@
     <title>Theme - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/demos/toolbar/default-flexible-toolbar.html
+++ b/demos/toolbar/default-flexible-toolbar.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>

--- a/demos/toolbar/default-toolbar.html
+++ b/demos/toolbar/default-toolbar.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>

--- a/demos/toolbar/fixed-toolbar.html
+++ b/demos/toolbar/fixed-toolbar.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -17,7 +17,6 @@
     <title>Toolbar - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
 

--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-	<script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
@@ -79,7 +78,7 @@
         </p>
       </div>
     </main>
-	
+
 	<script src="../assets/material-components-web.js" charset="utf-8"></script>
 	<script>
       var menuEl = document.querySelector('#demo-menu');

--- a/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
+++ b/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>

--- a/demos/toolbar/waterfall-flexible-toolbar.html
+++ b/demos/toolbar/waterfall-flexible-toolbar.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>

--- a/demos/toolbar/waterfall-toolbar-fix-last-row.html
+++ b/demos/toolbar/waterfall-toolbar-fix-last-row.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>

--- a/demos/toolbar/waterfall-toolbar.html
+++ b/demos/toolbar/waterfall-toolbar.html
@@ -17,7 +17,6 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>

--- a/demos/typography.html
+++ b/demos/typography.html
@@ -20,7 +20,6 @@
     <title>Typography - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
     <script src="assets/demo-styles.css.js" charset="utf-8"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
`assets/demo-styles.css.js` already includes the styles present in `assets/material-components-web.css.js`, so remove the latter.