### PR TITLE
chore: Update testdouble to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11850,7 +11850,7 @@
       }
     },
     "testdouble": {
-      "version": "3.2.0",
+      "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.2.0.tgz",
       "integrity": "sha1-mecQqUaQB1ypg6C2esY6a2aBsbY=",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "stylelint-order": "^0.6.0",
     "stylelint-scss": "^2.0.1",
     "stylelint-selector-bem-pattern": "^1.0.0",
-    "testdouble": "^3.2.3",
+    "testdouble": "^3.2.4",
     "to-slug-case": "^1.0.0",
     "validate-commit-msg": "^2.6.1",
     "webpack": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "stylelint-order": "^0.6.0",
     "stylelint-scss": "^2.0.1",
     "stylelint-selector-bem-pattern": "^1.0.0",
-    "testdouble": "3.2.0",
+    "testdouble": "^3.2.3",
     "to-slug-case": "^1.0.0",
     "validate-commit-msg": "^2.6.1",
     "webpack": "^3.0.0",


### PR DESCRIPTION
This is the same as https://github.com/material-components/material-components-web/pull/1058, but I made it the ^ version. I think we can rely on all minor updates to testdouble.

I will also close https://github.com/material-components/material-components-web/pull/849 in favor of this PR