### PR TITLE
feat(theme): Add light/dark variants for primary/secondary color, and rename `accent` to `secondary`

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -97,10 +97,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--accent">
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
             Div
@@ -134,10 +134,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--accent" data-demo-no-js>
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--raised mdc-button--accent" data-demo-no-js>
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--raised" tabindex="0" role="button" data-demo-no-js>
             Div
@@ -171,10 +171,10 @@
             Raised with Primary
           </a>
           <a href="/button.html" class="mdc-button mdc-button--accent">
-            Default with Accent
+            Default with Secondary
           </a>
           <a href="/button.html" class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
+            Raised with Secondary
           </a>
         </fieldset>
 
@@ -205,10 +205,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--accent">
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
             Div
@@ -244,10 +244,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--accent">
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
             Div
@@ -280,10 +280,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--accent" data-demo-no-js>
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--raised mdc-button--accent" data-demo-no-js>
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--raised" tabindex="0" role="button" data-demo-no-js>
             Div
@@ -317,10 +317,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--accent">
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--raised mdc-button--accent">
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--raised" tabindex="0" role="button">
             Div
@@ -356,10 +356,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--theme-dark mdc-button--accent" data-demo-no-js>
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--theme-dark mdc-button--raised mdc-button--accent" data-demo-no-js>
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--theme-dark mdc-button--raised" tabindex="0" role="button" data-demo-no-js>
             Div
@@ -393,10 +393,10 @@
             Raised with Primary
           </button>
           <button class="mdc-button mdc-button--theme-dark  mdc-button--accent">
-            Default with Accent
+            Default with Secondary
           </button>
           <button class="mdc-button mdc-button--theme-dark  mdc-button--raised mdc-button--accent">
-            Raised with Accent
+            Raised with Secondary
           </button>
           <div class="mdc-button mdc-button--theme-dark  mdc-button--raised" tabindex="0" role="button">
             Div

--- a/demos/demos.scss
+++ b/demos/demos.scss
@@ -21,7 +21,7 @@
 // Base style
 
 $mdc-theme-primary: #212121 !default;
-$mdc-theme-accent: #64dd17 !default;
+$mdc-theme-secondary: #64dd17 !default;
 
 @import "../packages/material-components-web/material-components-web";
 

--- a/demos/icon-toggle.html
+++ b/demos/icon-toggle.html
@@ -195,7 +195,7 @@
         </div>
 
         <div class="toggle-example">
-          <h2>Accent Colored Icons</h2>
+          <h2>Secondary Colored Icons</h2>
           <div class="demo-wrapper">
             <i class="mdc-icon-toggle mdc-icon-toggle--accent material-icons"
                role="button"

--- a/demos/index.html
+++ b/demos/index.html
@@ -226,7 +226,7 @@
               <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_theme_24px.svg" /></span>
               <a href="theme.html" class="mdc-list-item__text">
                 Theme
-                <span class="mdc-list-item__text__secondary">Using primary and accent colors</span>
+                <span class="mdc-list-item__text__secondary">Using primary and secondary colors</span>
               </a>
           </li>
 

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -167,7 +167,7 @@
                 <span class="mdc-linear-progress__bar-inner"></span>
               </div>
             </div>
-            <figcaption>Accent</figcaption>
+            <figcaption>Secondary Color</figcaption>
           </figure>
 
         </fieldset>

--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -177,8 +177,8 @@
           </div>
           <div
             class="mdc-ripple-surface mdc-ripple-surface--accent
-                   mdc-theme--accent demo-surface mdc-elevation--z2" tabindex="0">
-            Accent
+                   mdc-theme--secondary demo-surface mdc-elevation--z2" tabindex="0">
+            Secondary
           </div>
         </div>
         <div>
@@ -190,8 +190,8 @@
           </div>
           <div
             class="mdc-ripple-surface mdc-ripple-surface--accent
-                   mdc-theme--accent demo-surface mdc-elevation--z2" data-demo-no-js tabindex="0">
-            Accent
+                   mdc-theme--secondary demo-surface mdc-elevation--z2" data-demo-no-js tabindex="0">
+            Secondary
           </div>
         </div>
 

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -449,7 +449,7 @@ limitations under the License
           <div class="demo-note">
             <em>Note: Changing the toolbar's background color here so that the primary indicator can be visible</em>
           </div>
-          <div class="mdc-toolbar mdc-theme--accent-bg">
+          <div class="mdc-toolbar mdc-theme--secondary-bg">
             <div class="mdc-toolbar__row">
               <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
                 <h1 class="mdc-toolbar__title">Title</h1>
@@ -471,7 +471,7 @@ limitations under the License
       <section>
         <fieldset>
           <legend class="mdc-typography--title">Within mdc-toolbar + primary indicator, CSS-Only</legend>
-          <div class="mdc-toolbar mdc-theme--accent-bg">
+          <div class="mdc-toolbar mdc-theme--secondary-bg">
             <div class="mdc-toolbar__row">
               <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
                 <h1 class="mdc-toolbar__title">Title</h1>

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -332,7 +332,7 @@ limitations under the License
       <section>
         <fieldset>
           <legend class="mdc-typography--title">Secondary Color Indicator</legend>
-          <nav id="accent-indicator-tab-bar" class="mdc-tab-bar mdc-tab-bar--indicator-accent">
+          <nav id="secondary-indicator-tab-bar" class="mdc-tab-bar mdc-tab-bar--indicator-accent">
             <a class="mdc-tab mdc-tab--active" href="#one">Item One</a>
             <a class="mdc-tab" href="#two">Item Two</a>
             <a class="mdc-tab" href="#three">Three</a>
@@ -500,7 +500,7 @@ limitations under the License
               </div>
               <div class="mdc-toolbar__section mdc-toolbar__section--align-end">
                 <div>
-                  <nav id="toolbar-tab-bar-accent-indicator" class="mdc-tab-bar mdc-tab-bar--indicator-accent">
+                  <nav id="toolbar-tab-bar-secondary-indicator" class="mdc-tab-bar mdc-tab-bar--indicator-accent">
                     <a class="mdc-tab mdc-tab--active" href="#one">Item One</a>
                     <a class="mdc-tab" href="#two">Item Two</a>
                     <a class="mdc-tab" href="#three">Item Three</a>
@@ -582,9 +582,9 @@ limitations under the License
           window.toolbarTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#toolbar-tab-bar'));
           window.toolbarTabBarModified = new mdc.tabs.MDCTabBar(document.querySelector('#toolbar-tab-bar-modified'));
           window.primaryIndicatorTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#primary-indicator-tab-bar'));
-          window.accentIndicatorTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#accent-indicator-tab-bar'));
+          window.secondaryIndicatorTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#secondary-indicator-tab-bar'));
           window.primaryIndicatorToolbarTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#toolbar-tab-bar-primary-indicator'));
-          window.accentIndicatorToolbarTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#toolbar-tab-bar-accent-indicator'));
+          window.secondaryIndicatorToolbarTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#toolbar-tab-bar-secondary-indicator'));
 
           var dynamicTabBar = window.dynamicTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#dynamic-tab-bar'));
           var dots = document.querySelector('.dots');
@@ -654,9 +654,9 @@ limitations under the License
             window.iconTextTabBar.layout();
             window.toolbarTabBar.layout();
             window.primaryIndicatorTabBar.layout();
-            window.accentIndicatorTabBar.layout();
+            window.secondaryIndicatorTabBar.layout();
             window.primaryIndicatorToolbarTabBar.layout();
-            window.accentIndicatorToolbarTabBar.layout();
+            window.secondaryIndicatorToolbarTabBar.layout();
             window.dynamicTabBar.layout();
             toolbarTabBarModified.layout();
           });

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -331,7 +331,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Accent Color Indicator</legend>
+          <legend class="mdc-typography--title">Secondary Color Indicator</legend>
           <nav id="accent-indicator-tab-bar" class="mdc-tab-bar mdc-tab-bar--indicator-accent">
             <a class="mdc-tab mdc-tab--active" href="#one">Item One</a>
             <a class="mdc-tab" href="#two">Item Two</a>
@@ -343,7 +343,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Accent Color Indicator - CSS-Only</legend>
+          <legend class="mdc-typography--title">Secondary Color Indicator - CSS-Only</legend>
           <nav class="mdc-tab-bar mdc-tab-bar--indicator-accent">
             <a class="mdc-tab mdc-tab--active" href="#one">Item One</a>
             <a class="mdc-tab" href="#two">Item Two</a>
@@ -492,7 +492,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within mdc-toolbar + accent indicator</legend>
+          <legend class="mdc-typography--title">Within mdc-toolbar + secondary color indicator</legend>
           <div class="mdc-toolbar">
             <div class="mdc-toolbar__row">
               <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">
@@ -515,7 +515,7 @@ limitations under the License
 
       <section>
         <fieldset>
-          <legend class="mdc-typography--title">Within mdc-toolbar + accent indicator, CSS-Only</legend>
+          <legend class="mdc-typography--title">Within mdc-toolbar + secondary color indicator, CSS-Only</legend>
           <div class="mdc-toolbar">
             <div class="mdc-toolbar__row">
               <div class="mdc-toolbar__section mdc-toolbar__section--shrink-to-fit mdc-toolbar__section--align-start">

--- a/demos/textfield.html
+++ b/demos/textfield.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <style>
       .mdc-theme--dark {
-        --mdc-theme-primary: var(--mdc-theme-accent, #64dd17);
+        --mdc-theme-primary: var(--mdc-theme-secondary, #64dd17);
         background-color: #303030;
       }
 

--- a/demos/theme.html
+++ b/demos/theme.html
@@ -39,7 +39,7 @@
       .demo-theme__color__block {
         display: inline-block;
         box-sizing: border-box;
-        width: 130px;
+        width: 150px;
         height: 50px;
         line-height: 50px;
         text-align: center;
@@ -107,7 +107,7 @@
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <button class="mdc-button mdc-button--raised mdc-theme--primary-bg mdc-theme--text-primary-on-primary">Primary</button>
-        <button class="mdc-button mdc-button--raised button mdc-theme--accent-bg mdc-theme--text-primary-on-accent">Accent</button>
+        <button class="mdc-button mdc-button--raised button mdc-theme--secondary-bg mdc-theme--text-primary-on-secondary">Secondary</button>
       </section>
 
       <h2 class="mdc-typography--display1">Theme colors</h2>
@@ -115,28 +115,31 @@
       <section class="example">
         <h3 class="mdc-typography--title">Theme colors as text</h3>
         <div class="demo-theme__color">
-          <div class="demo-theme__color__label">Primary</div>
-          <div class="demo-theme__color__block mdc-theme--primary mdc-typography mdc-typography--body2">Lorem ipsum</div>
+          <div class="demo-theme__color__block mdc-theme--primary mdc-typography mdc-typography--body2">Primary</div>
+          <div class="demo-theme__color__block mdc-theme--primary-light mdc-typography mdc-typography--body2">Primary Light</div>
+          <div class="demo-theme__color__block mdc-theme--primary-dark mdc-typography mdc-typography--body2">Primary Dark</div>
         </div>
         <div class="demo-theme__color">
-          <div class="demo-theme__color__label">Accent</div>
-          <div class="demo-theme__color__block mdc-theme--accent mdc-typography mdc-typography--body2">Lorem ipsum</div>
+          <div class="demo-theme__color__block mdc-theme--secondary mdc-typography mdc-typography--body2">Secondary</div>
+          <div class="demo-theme__color__block mdc-theme--secondary-light mdc-typography mdc-typography--body2">Secondary Light</div>
+          <div class="demo-theme__color__block mdc-theme--secondary-dark mdc-typography mdc-typography--body2">Secondary Dark</div>
         </div>
       </section>
 
       <section class="example">
         <h3 class="mdc-typography--title">Theme colors as background</h3>
         <div class="demo-theme__color">
-          <div class="demo-theme__color__label">Primary</div>
-          <div class="demo-theme__color__block mdc-theme--primary-bg"></div>
+          <div class="demo-theme__color__block mdc-theme--primary-bg mdc-theme--text-primary-on-primary">Primary</div>
+          <div class="demo-theme__color__block mdc-theme--primary-light-bg mdc-theme--text-primary-on-primary-light">Primary Light</div>
+          <div class="demo-theme__color__block mdc-theme--primary-dark-bg mdc-theme--text-primary-on-primary-dark">Primary Dark</div>
         </div>
         <div class="demo-theme__color">
-          <div class="demo-theme__color__label">Accent</div>
-          <div class="demo-theme__color__block mdc-theme--accent-bg"></div>
+          <div class="demo-theme__color__block mdc-theme--secondary-bg mdc-theme--text-primary-on-secondary">Secondary</div>
+          <div class="demo-theme__color__block mdc-theme--secondary-light-bg mdc-theme--text-primary-on-secondary-light">Secondary Light</div>
+          <div class="demo-theme__color__block mdc-theme--secondary-dark-bg mdc-theme--text-primary-on-secondary-dark">Secondary Dark</div>
         </div>
         <div class="demo-theme__color">
-          <div class="demo-theme__color__label">Background</div>
-          <div class="demo-theme__color__block mdc-theme--background"></div>
+          <div class="demo-theme__color__block mdc-theme--background mdc-theme--text-primary-on-background">Background</div>
         </div>
       </section>
 
@@ -159,13 +162,13 @@
           <span class="mdc-theme--text-disabled-on-primary">Disabled</span>
           <span class="mdc-theme--text-icon-on-primary material-icons">favorite</span>
         </div>
-        <h3 class="mdc-typography--title">Text on accent</h3>
-        <div class="demo-theme__text-styles mdc-theme--accent-bg mdc-typography mdc-typography--body2">
-          <span class="mdc-theme--text-primary-on-accent">Primary</span>
-          <span class="mdc-theme--text-secondary-on-accent">Secondary</span>
-          <span class="mdc-theme--text-hint-on-accent">Hint</span>
-          <span class="mdc-theme--text-disabled-on-accent">Disabled</span>
-          <span class="mdc-theme--text-icon-on-accent material-icons">favorite</span>
+        <h3 class="mdc-typography--title">Text on secondary</h3>
+        <div class="demo-theme__text-styles mdc-theme--secondary-bg mdc-typography mdc-typography--body2">
+          <span class="mdc-theme--text-primary-on-secondary">Primary</span>
+          <span class="mdc-theme--text-secondary-on-secondary">Secondary</span>
+          <span class="mdc-theme--text-hint-on-secondary">Hint</span>
+          <span class="mdc-theme--text-disabled-on-secondary">Disabled</span>
+          <span class="mdc-theme--text-icon-on-secondary material-icons">favorite</span>
         </div>
         <h3 class="mdc-typography--title">Text on user-defined light background</h3>
         <div class="demo-theme__text-styles demo-theme--custom-light-bg mdc-typography mdc-typography--body2">

--- a/docs/authoring-components.md
+++ b/docs/authoring-components.md
@@ -386,7 +386,7 @@ our [@material/rtl](../packages/mdc-rtl) library to assist us with this.
 ### Support for theming
 
 A component should be able to be altered according to a **theme**. A theme can be defined any way
-you wish. It may be by using _primary_ and _accent_ colors, or you may choose to expose scss
+you wish. It may be by using _primary_ and _secondary_ colors, or you may choose to expose scss
 variables or CSS Custom properties specific to your component. Whichever way you choose, ensure that
 _clients can easily alter common aesthetic elements of your component to make it fit with their
 overall design_. We use [@material/theme](../packages/mdc-theme) for this purpose.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -216,7 +216,7 @@ hit the button, and get a pleasant greeting :wave:
 You may have noticed that the button background, as well as the label and underline on focused text
 input fields, defaults to the Indigo 500 (`#673AB7`) color from the [Material Design color palette](https://material.io/guidelines/style/color.html#color-color-palette).
 This is part of the default theme that ships with MDC-Web; it uses Indigo 500 for a primary color, and
-Pink A200 (`#FF4081`) for an accent color. Let's change the theme's primary color.
+Pink A200 (`#FF4081`) for an secondary color. Let's change the theme's primary color.
 
 A common misconception when implementing Material Design is that the colors you use _must_ come from
 the Material Design color palette. This is not true at all. The only defining guideline for color within Material

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -216,7 +216,7 @@ hit the button, and get a pleasant greeting :wave:
 You may have noticed that the button background, as well as the label and underline on focused text
 input fields, defaults to the Indigo 500 (`#673AB7`) color from the [Material Design color palette](https://material.io/guidelines/style/color.html#color-color-palette).
 This is part of the default theme that ships with MDC-Web; it uses Indigo 500 for a primary color, and
-Pink A200 (`#FF4081`) for an secondary color. Let's change the theme's primary color.
+Pink A200 (`#FF4081`) for a secondary color. Let's change the theme's primary color.
 
 A common misconception when implementing Material Design is that the colors you use _must_ come from
 the Material Design color palette. This is not true at all. The only defining guideline for color within Material

--- a/docs/migrating-from-mdl.md
+++ b/docs/migrating-from-mdl.md
@@ -287,7 +287,7 @@ end-users’ browsers, you can use the custom properties provided by `@material/
 ```css
 :root {
   --mdc-theme-primary: #9c27b0;
-  --mdc-theme-accent: #ffab40;
+  --mdc-theme-secondary: #ffab40;
   --mdc-theme-background: #fff;
 }
 ```

--- a/docs/migrating-from-mdl.md
+++ b/docs/migrating-from-mdl.md
@@ -271,7 +271,7 @@ importing `@material/theme` or any MDC-Web components that rely on it:
 
 ```scss
 $mdc-theme-primary: #9c27b0;
-$mdc-theme-accent: #ffab40;
+$mdc-theme-secondary: #ffab40;
 $mdc-theme-background: #fff;
 
 @import "@material/theme/mdc-theme";

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -209,13 +209,13 @@ however, the text would be dark again, for the same reason. So how _do_ we chang
 ### Step 3: Changing the theme with Sass
 
 The application-wide theme colors that are used as the default across your entire application can be set in Sass.
-This is as easy as defining three variables (`$mdc-theme-primary`, `$mdc-theme-accent` and `$mdc-theme-background`) in
+This is as easy as defining three variables (`$mdc-theme-primary`, `$mdc-theme-secondary` and `$mdc-theme-background`) in
 your Sass file, before importing any MDC-Web modules.
 
 ```scss
 // My main Sass file.
 $mdc-theme-primary: #9c27b0;
-$mdc-theme-accent: #76ff03;
+$mdc-theme-secondary: #76ff03;
 $mdc-theme-background: #fff;
 
 @import "material-components-web/material-components-web";

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -15,15 +15,15 @@ Custom Property, with plans for CDN support as well, once that service is availa
 
 ## Colors
 
-MDC-Web theming, like Material Design theming, uses two main colors: **primary** and **accent**. The primary color is used
-throughout most of the application and components, as the main color for your application. The accent color is used
+MDC-Web theming, like Material Design theming, uses two main colors: **primary** and **secondary**. The primary color is used
+throughout most of the application and components, as the main color for your application. The secondary color is used
 for floating action buttons and other interactive elements, serving as visual contrast to the primary.
 
-In addition to the primary and accent colors, MDC-Web also defines a _background_ color, which is used as a background in
+In addition to the primary and secondary colors, MDC-Web also defines a _background_ color, which is used as a background in
 components, and usually as the page background as well.
 
 Finally, MDC-Web has a number of text colors, which are used for rendering text and other shapes on top of the primary,
-accent and background colors. These are specified as either dark or light, in order to provide sufficient contrast to
+secondary and background colors. These are specified as either dark or light, in order to provide sufficient contrast to
 what's behind them, and have
 [different levels of opacity depending on usage](https://material.io/guidelines/style/color.html#color-color-schemes):
 - Primary, used for most text.
@@ -141,15 +141,23 @@ However, that would not take advantage of MDC-Web's theming and would thus be br
 copied to your CSS rules, adding a maintenance cost.
 
 MDC-Web provides a number of CSS classes as part of the `mdc-theme` module to help you tackle this problem in a more
-maintainable way. Here are the classes that deal with primary, accent and background colors:
+maintainable way. Here are the classes that deal with primary, secondary and background colors:
 
-| Class                   | Description                                                 |
-| ----------------------- | ----------------------------------------------------------- |
-| `mdc-theme--primary`    | Sets the text color to the theme primary color.             |
-| `mdc-theme--accent`     | Sets the text color to the theme accent color.              |
-| `mdc-theme--background` | Sets the background color to the theme background color.    |
-| `mdc-theme--primary-bg` | Sets the background color to the theme primary color.       |
-| `mdc-theme--accent-bg`  | Sets the background color to the theme accent color.        |
+| Class                           | Description                                                             |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `mdc-theme--primary`            | Sets the text color to the theme primary color.                         |
+| `mdc-theme--primary-light`      | Sets the text color to the theme primary color (light variant).         |
+| `mdc-theme--primary-dark`       | Sets the text color to the theme primary color (dark variant).          |
+| `mdc-theme--secondary`          | Sets the text color to the theme secondary color.                       |
+| `mdc-theme--secondary-light`    | Sets the text color to the theme secondary color (light variant).       |
+| `mdc-theme--secondary-dark`     | Sets the text color to the theme secondary color (dark variant).        |
+| `mdc-theme--background`         | Sets the background color to the theme background color.                |
+| `mdc-theme--primary-bg`         | Sets the background color to the theme primary color.                   |
+| `mdc-theme--primary-light-bg`   | Sets the background color to the theme primary color (light variant).   |
+| `mdc-theme--primary-dark-bg`    | Sets the background color to the theme primary color (dark variant).    |
+| `mdc-theme--secondary-bg`       | Sets the background color to the theme secondary color.                 |
+| `mdc-theme--secondary-light-bg` | Sets the background color to the theme secondary color (light variant). |
+| `mdc-theme--secondary-dark-bg`  | Sets the background color to the theme secondary color (dark variant).  |
 
 From here, we can see that we want to apply `mdc-theme--primary-bg` to the cards' media areas:
 
@@ -176,13 +184,23 @@ takes into account the primary color, in order to determine whether to overlay w
 `mdc-theme` provides utility classes for that purpose as well. Namely, for overlaying text on a primary color
 background, there are:
 
-| Class                                  | Description                                                                               |
-| -------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `mdc-theme--text-primary-on-primary`   | Set text to suitable color for primary text on top of a theme primary color background.   |
-| `mdc-theme--text-secondary-on-primary` | Set text to suitable color for secondary text on top of a theme primary color background. |
-| `mdc-theme--text-hint-on-primary`      | Set text to suitable color for hint text on top of a theme primary color background.      |
-| `mdc-theme--text-disabled-on-primary`  | Set text to suitable color for disabled text on top of a theme primary color background.  |
-| `mdc-theme--text-icon-on-primary`      | Set text to suitable color for icons on top of a theme primary color background.          |
+| Class                                        | Description                                                                                               |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `mdc-theme--text-primary-on-primary`         | Set text to suitable color for primary text on top of a theme primary color background.                   |
+| `mdc-theme--text-primary-on-primary-light`   | Set text to suitable color for primary text on top of a theme primary color background (light variant).   |
+| `mdc-theme--text-primary-on-primary-dark`    | Set text to suitable color for primary text on top of a theme primary color background (dark variant).    |
+| `mdc-theme--text-secondary-on-primary`       | Set text to suitable color for secondary text on top of a theme primary color background.                 |
+| `mdc-theme--text-secondary-on-primary-light` | Set text to suitable color for secondary text on top of a theme primary color background (light variant). |
+| `mdc-theme--text-secondary-on-primary-dark`  | Set text to suitable color for secondary text on top of a theme primary color background (dark variant).  |
+| `mdc-theme--text-hint-on-primary`            | Set text to suitable color for hint text on top of a theme primary color background.                      |
+| `mdc-theme--text-hint-on-primary-light`      | Set text to suitable color for hint text on top of a theme primary color background (light variant).      |
+| `mdc-theme--text-hint-on-primary-dark`       | Set text to suitable color for hint text on top of a theme primary color background (dark variant).       |
+| `mdc-theme--text-disabled-on-primary`        | Set text to suitable color for disabled text on top of a theme primary color background.                  |
+| `mdc-theme--text-disabled-on-primary-light`  | Set text to suitable color for disabled text on top of a theme primary color background (light variant).  |
+| `mdc-theme--text-disabled-on-primary-dark`   | Set text to suitable color for disabled text on top of a theme primary color background (dark variant).   |
+| `mdc-theme--text-icon-on-primary`            | Set text to suitable color for icons on top of a theme primary color background.                          |
+| `mdc-theme--text-icon-on-primary-light`      | Set text to suitable color for icons on top of a theme primary color background (light variant).          |
+| `mdc-theme--text-icon-on-primary-dark`       | Set text to suitable color for icons on top of a theme primary color background (dark variant).           |
 
 > Note: `primary`, `secondary`, `hint`, `disabled` and `icon` refer to the text's function. The fact that we use the
 word _primary_ in the different contexts of _primary color_ and _primary function text_ can be confusing at first.
@@ -222,7 +240,7 @@ $mdc-theme-background: #fff;
 ```
 
 These definitions will override the defaults included in the `mdc-theme` module, which every themeable component depends
-on. As for the text colors, these will all be automatically calculated from the primary, accent and background you
+on. As for the text colors, these will all be automatically calculated from the primary, secondary and background you
 provide, as part of the Sass definitions in `mdc-theme`. Pretty simple!
 
 > Note: theme colors don't have to be part of the Material palette; you can use any valid color. You may want to read
@@ -281,11 +299,15 @@ components, they'd use the correct colors as well.
 
 The custom properties used by MDC-Web follow a similar naming convention to the Sass variables and CSS classes:
 
-| Custom property          | Description                 |
-| ------------------------ | --------------------------- |
-| `--mdc-theme-primary`    | The theme primary color.    |
-| `--mdc-theme-accent`     | The theme accent color.     |
-| `--mdc-theme-background` | The theme background color. |
+| Custom property               | Description                                 |
+| ----------------------------- | ------------------------------------------- |
+| `--mdc-theme-primary`         | The theme primary color.                    |
+| `--mdc-theme-primary-light`   | The theme primary color (light variant).    |
+| `--mdc-theme-primary-dark`    | The theme primary color (dark variant).     |
+| `--mdc-theme-secondary`       | The theme secondary color.                  |
+| `--mdc-theme-secondary-light` | The theme secondary color (light variant).  |
+| `--mdc-theme-secondary-dark`  | The theme secondary color (dark variant).   |
+| `--mdc-theme-background`      | The theme background color.                 |
 
 However, if you look closely at the page, we're not quite done yet. The text colors are incorrect: the wind and water
 cards should have dark text, rather than white. So what's happening?
@@ -294,23 +316,43 @@ The problem is that we only set the `--mdc-theme-primary` custom property. Where
 allows for calculating all the related text colors, it's currently not possible to perform those complex contrast
 calculations in CSS. This means you'll also have to set all the related text colors:
 
-| Custom property                            | Description                                                |
-| ------------------------------------------ | ---------------------------------------------------------- |
-| `--mdc-theme-text-primary-on-primary`      | Primary text on top of a theme primary color background.   |
-| `--mdc-theme-text-secondary-on-primary`    | Secondary text on top of a theme primary color background. |
-| `--mdc-theme-text-hint-on-primary`         | Hint text on top of a theme primary color background.      |
-| `--mdc-theme-text-disabled-on-primary`     | Disabled text on top of a theme primary color background.  |
-| `--mdc-theme-text-icon-on-primary`         | Icons on top of a theme primary color background.          |
+| Custom property                               | Description                                                                |
+| --------------------------------------------- | -------------------------------------------------------------------------- |
+| `--mdc-theme-text-primary-on-primary`         | Primary text on top of a theme primary color background.                   |
+| `--mdc-theme-text-primary-on-primary-light`   | Primary text on top of a theme primary color background (light variant).   |
+| `--mdc-theme-text-primary-on-primary-dark`    | Primary text on top of a theme primary color background (dark variant).    |
+| `--mdc-theme-text-secondary-on-primary`       | Secondary text on top of a theme primary color background.                 |
+| `--mdc-theme-text-secondary-on-primary-light` | Secondary text on top of a theme primary color background (light variant). |
+| `--mdc-theme-text-secondary-on-primary-dark`  | Secondary text on top of a theme primary color background (dark variant).  |
+| `--mdc-theme-text-hint-on-primary`            | Hint text on top of a theme primary color background.                      |
+| `--mdc-theme-text-hint-on-primary-light`      | Hint text on top of a theme primary color background (light variant).      |
+| `--mdc-theme-text-hint-on-primary-dark`       | Hint text on top of a theme primary color background (dark variant).       |
+| `--mdc-theme-text-disabled-on-primary`        | Disabled text on top of a theme primary color background.                  |
+| `--mdc-theme-text-disabled-on-primary-light`  | Disabled text on top of a theme primary color background (light variant).  |
+| `--mdc-theme-text-disabled-on-primary-dark`   | Disabled text on top of a theme primary color background (dark variant).   |
+| `--mdc-theme-text-icon-on-primary`            | Icons on top of a theme primary color background.                          |
+| `--mdc-theme-text-icon-on-primary-light`      | Icons on top of a theme primary color background (light variant).          |
+| `--mdc-theme-text-icon-on-primary-dark`       | Icons on top of a theme primary color background (dark variant).           |
 
-The same pattern is followed for text colors on _accent_ and _background_:
+The same pattern is followed for text colors on _secondary_ and _background_:
 
-| Custom property                            | Description                                                |
-| ------------------------------------------ | ---------------------------------------------------------- |
-| `--mdc-theme-text-primary-on-accent`       | Primary text on top of a theme accent color background.    |
-| `--mdc-theme-text-secondary-on-accent`     | Secondary text on top of a theme accent color background.  |
-| `--mdc-theme-text-hint-on-accent`          | Hint text on top of a theme accent color background.       |
-| `--mdc-theme-text-disabled-on-accent`      | Disabled text on top of a theme accent color background.   |
-| `--mdc-theme-text-icon-on-accent`          | Icons on top of a theme accent color background.           |
+| Custom property                                 | Description                                                                  |
+| ------------------------------------------------| ---------------------------------------------------------------------------- |
+| `--mdc-theme-text-primary-on-secondary`         | Primary text on top of a theme secondary color background.                   |
+| `--mdc-theme-text-primary-on-secondary-light`   | Primary text on top of a theme secondary color background (light variant).   |
+| `--mdc-theme-text-primary-on-secondary-dark`    | Primary text on top of a theme secondary color background (dark variant).    |
+| `--mdc-theme-text-secondary-on-secondary`       | Secondary text on top of a theme secondary color background.                 |
+| `--mdc-theme-text-secondary-on-secondary-light` | Secondary text on top of a theme secondary color background (light variant). |
+| `--mdc-theme-text-secondary-on-secondary-dark`  | Secondary text on top of a theme secondary color background (dark variant).  |
+| `--mdc-theme-text-hint-on-secondary`            | Hint text on top of a theme secondary color background.                      |
+| `--mdc-theme-text-hint-on-secondary-light`      | Hint text on top of a theme secondary color background (light variant).      |
+| `--mdc-theme-text-hint-on-secondary-dark`       | Hint text on top of a theme secondary color background (dark variant).       |
+| `--mdc-theme-text-disabled-on-secondary`        | Disabled text on top of a theme secondary color background.                  |
+| `--mdc-theme-text-disabled-on-secondary-light`  | Disabled text on top of a theme secondary color background (light variant).  |
+| `--mdc-theme-text-disabled-on-secondary-dark`   | Disabled text on top of a theme secondary color background (dark variant).   |
+| `--mdc-theme-text-icon-on-secondary`            | Icons on top of a theme secondary color background.                          |
+| `--mdc-theme-text-icon-on-secondary-light`      | Icons on top of a theme secondary color background (light variant).          |
+| `--mdc-theme-text-icon-on-secondary-dark`       | Icons on top of a theme secondary color background (dark variant).           |
 
 | Custom property                            | Description                                                |
 | ------------------------------------------ | ---------------------------------------------------------- |

--- a/framework-examples/aurelia/src/components/button/mdc-button.ts
+++ b/framework-examples/aurelia/src/components/button/mdc-button.ts
@@ -4,7 +4,7 @@ import '@material/button/dist/mdc.button.css';
 @customAttribute('mdc-button')
 @inject(Element)
 export class MdcButton {
-    @bindable() accent = false;
+    @bindable() secondary = false;
     @bindable() raised = false;
 
     constructor(private element: Element) { }
@@ -22,7 +22,7 @@ export class MdcButton {
         this.element.classList.remove(...classes);
     }
 
-    accentChanged(newValue) {
+    secondaryChanged(newValue) {
         if (newValue) {
             this.element.classList.add('mdc-button--accent');
         } else {

--- a/framework-examples/aurelia/src/welcome.html
+++ b/framework-examples/aurelia/src/welcome.html
@@ -5,7 +5,7 @@
         Raised buttons
     </label>
     <label>
-        <mdc-checkbox is-checked.bind="accentButtons" is-indeterminate.bind="isIndeterminate" change.delegate="handleChange()"></mdc-checkbox>
+        <mdc-checkbox is-checked.bind="secondaryButtons" is-indeterminate.bind="isIndeterminate" change.delegate="handleChange()"></mdc-checkbox>
         Colored buttons
     </label>
     <label>
@@ -18,8 +18,8 @@
     </label>
   </section>
   <section>
-      <button mdc-ripple mdc-button="accent.bind: accentButtons; raised.bind: raisedButtons;" disabled.bind="disabledButtons" click.delegate="toggleCheckbox()">toggle raised</button>
-      <button mdc-ripple="unbounded: true;" mdc-button="accent.bind: accentButtons; raised.bind: raisedButtons;" disabled.bind="disabledButtons || isIndeterminate" click.delegate="makeIndeterminate()">make indeterminate</button>
+      <button mdc-ripple mdc-button="secondary.bind: secondaryButtons; raised.bind: raisedButtons;" disabled.bind="disabledButtons" click.delegate="toggleCheckbox()">toggle raised</button>
+      <button mdc-ripple="unbounded: true;" mdc-button="secondary.bind: secondaryButtons; raised.bind: raisedButtons;" disabled.bind="disabledButtons || isIndeterminate" click.delegate="makeIndeterminate()">make indeterminate</button>
   </section>
   <section>
       Change events: ${changeEventCount}

--- a/framework-examples/aurelia/src/welcome.ts
+++ b/framework-examples/aurelia/src/welcome.ts
@@ -1,5 +1,5 @@
 export class Welcome {
-  accentButtons = false;
+  secondaryButtons = false;
   raisedButtons = false;
   isIndeterminate = false;
   changeEventCount: number = 0;

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -111,4 +111,4 @@ The provided modifiers are:
 | `mdc-button--raised`  | Elevates the button and creates a colored background.   |
 | `mdc-button--compact` | Reduces the amount of horizontal padding in the button. |
 | `mdc-button--primary` | Colors the button with the primary color.               |
-| `mdc-button--accent`  | Colors the button with the accent color.                |
+| `mdc-button--accent`  | Colors the button with the secondary color.             |

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -65,8 +65,10 @@
     }
   }
 
-  @each $theme-style in (primary, accent) {
-    &.mdc-button--#{$theme-style} {
+  @each $theme-style in (primary, secondary) {
+    $modifier: if($theme-style == "secondary", "accent", $theme-style);
+
+    &.mdc-button--#{$modifier} {
       @include mdc-ripple-base;
       @include mdc-ripple-bg((pseudo: "::before", theme-style: $theme-style, opacity: .12));
       @include mdc-ripple-fg((pseudo: "::after", theme-style: $theme-style, opacity: .12));
@@ -104,8 +106,10 @@
       @include mdc-elevation(8);
     }
 
-    @each $theme-style in (primary, accent) {
-      &.mdc-button--#{$theme-style} {
+    @each $theme-style in (primary, secondary) {
+      $modifier: if($theme-style == "secondary", "accent", $theme-style);
+
+      &.mdc-button--#{$modifier} {
         @include mdc-ripple-base;
         @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .14));
         @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .14));
@@ -147,16 +151,16 @@
   }
 
   &--accent {
-    @include mdc-theme-prop(color, accent);
+    @include mdc-theme-prop(color, secondary);
 
     @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(color, accent);
+      @include mdc-theme-prop(color, secondary);
     }
 
     // postcss-bem-linter: ignore
     &.mdc-button--raised {
-      @include mdc-theme-prop(background-color, accent);
-      @include mdc-theme-prop(color, text-primary-on-accent);
+      @include mdc-theme-prop(background-color, secondary);
+      @include mdc-theme-prop(color, text-primary-on-secondary);
 
       // postcss-bem-linter: ignore
       &::before {

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -66,6 +66,7 @@
   }
 
   @each $theme-style in (primary, secondary) {
+    // Needed for backward compatibility. Theme uses the term "secondary", but button still calls it "accent" for now.
     $modifier: if($theme-style == "secondary", "accent", $theme-style);
 
     &.mdc-button--#{$modifier} {
@@ -107,6 +108,7 @@
     }
 
     @each $theme-style in (primary, secondary) {
+      // Needed for backward compatibility. Theme uses the term "secondary", but button still calls it "accent" for now.
       $modifier: if($theme-style == "secondary", "accent", $theme-style);
 
       &.mdc-button--#{$modifier} {

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -114,7 +114,7 @@ They only need to match the values set for their corresponding aria attributes.
 
 ### Dialog Action Color ###
 
-Dialog actions use system colors by default, but you can use a contrasting color, such as the palette’s accent color, to distinguish dialog actions from dialog content. To emphasize an action from other contents, add `mdc-dialog__action` to `mdc-button` to apply accent color.
+Dialog actions use system colors by default, but you can use a contrasting color, such as the palette’s secondary color, to distinguish dialog actions from dialog content. To emphasize an action from other contents, add `mdc-dialog__action` to `mdc-button` to apply secondary color.
 
 ```
 <aside class="mdc-dialog">

--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -143,7 +143,7 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     }
 
     &__action {
-      @include mdc-theme-prop(color, accent);
+      @include mdc-theme-prop(color, secondary);
     }
   }
 

--- a/packages/mdc-fab/mdc-fab.scss
+++ b/packages/mdc-fab/mdc-fab.scss
@@ -45,8 +45,8 @@
     -webkit-tap-highlight-color: rgba(0, 0, 0, .18);
   }
 
-  @include mdc-theme-prop(background-color, accent);
-  @include mdc-theme-prop(color, text-primary-on-accent);
+  @include mdc-theme-prop(background-color, secondary);
+  @include mdc-theme-prop(color, text-primary-on-secondary);
   @include mdc-elevation(6);
 
   &--mini {

--- a/packages/mdc-icon-toggle/README.md
+++ b/packages/mdc-icon-toggle/README.md
@@ -109,7 +109,7 @@ as JSON and can contain the following properties:
 ### Theming
 
 `mdc-icon-toggle` ships with two css classes, `mdc-icon-toggle--primary` and
-`mdc-icon-toggle--accent` that allow you to color mdc-icon-toggle based on your primary and accent
+`mdc-icon-toggle--accent` that allow you to color mdc-icon-toggle based on your primary and secondary
 colors, respectively.
 
 ### Listening for change events

--- a/packages/mdc-icon-toggle/mdc-icon-toggle.scss
+++ b/packages/mdc-icon-toggle/mdc-icon-toggle.scss
@@ -81,9 +81,9 @@
 }
 
 .mdc-icon-toggle--accent {
-  @include mdc-theme-prop(color, accent);
-  @include mdc-ripple-bg((pseudo: "::before", theme-style: accent, opacity: .14));
-  @include mdc-ripple-fg((pseudo: "::after", theme-style: accent, opacity: .14));
+  @include mdc-theme-prop(color, secondary);
+  @include mdc-ripple-bg((pseudo: "::before", theme-style: secondary, opacity: .14));
+  @include mdc-ripple-fg((pseudo: "::after", theme-style: secondary, opacity: .14));
 }
 
 .mdc-icon-toggle--disabled {

--- a/packages/mdc-linear-progress/README.md
+++ b/packages/mdc-linear-progress/README.md
@@ -59,7 +59,7 @@ The provided modifiers are:
 | --------------------- | ------------------------------------------------------- |
 | `mdc-linear-progress--indeterminate`   | Puts the linear progress indicator in an indeterminate state. |
 | `mdc-linear-progress--reversed`  | Reverses the direction of the linear progress indicator.   |
-| `mdc-linear-progress--accent` | Colors the button with the accent color. |
+| `mdc-linear-progress--accent` | Colors the button with the secondary color. |
 
 ### Using the Foundation Class
 

--- a/packages/mdc-linear-progress/README.md
+++ b/packages/mdc-linear-progress/README.md
@@ -59,7 +59,7 @@ The provided modifiers are:
 | --------------------- | ------------------------------------------------------- |
 | `mdc-linear-progress--indeterminate`   | Puts the linear progress indicator in an indeterminate state. |
 | `mdc-linear-progress--reversed`  | Reverses the direction of the linear progress indicator.   |
-| `mdc-linear-progress--accent` | Colors the button with the secondary color. |
+| `mdc-linear-progress--accent` | Colors the linear progress indicator with the secondary color. |
 
 ### Using the Foundation Class
 

--- a/packages/mdc-linear-progress/mdc-linear-progress.scss
+++ b/packages/mdc-linear-progress/mdc-linear-progress.scss
@@ -44,7 +44,7 @@
   }
 
   &--accent .mdc-linear-progress__bar-inner {
-    @include mdc-theme-prop(background-color, accent);
+    @include mdc-theme-prop(background-color, secondary);
   }
 
   &__buffering-dots {

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -241,14 +241,14 @@ a ripple:
 ```
 
 There are also modifier classes that can be used for styling ripple surfaces using the configured
-theme's primary and accent colors
+theme's primary and secondary colors
 
 ```html
 <div class="mdc-ripple-surface mdc-ripple-surface--primary my-surface" tabindex="0">
   Surface with a primary-colored ripple.
 </div>
 <div class="mdc-ripple-surface mdc-ripple-surface--accent my-surface" tabindex="0">
-  Surface with an accent-colored ripple.
+  Surface with a secondary-colored ripple.
 </div>
 ```
 

--- a/packages/mdc-ripple/mdc-ripple.scss
+++ b/packages/mdc-ripple/mdc-ripple.scss
@@ -49,8 +49,8 @@
       @include mdc-theme-prop(background-color, primary);
     }
 
-    @include mdc-ripple-bg((pseudo: "::before", theme-style: accent, opacity: .16));
-    @include mdc-ripple-fg((pseudo: "::after", theme-style: accent, opacity: .16));
+    @include mdc-ripple-bg((pseudo: "::before", theme-style: secondary, opacity: .16));
+    @include mdc-ripple-fg((pseudo: "::after", theme-style: secondary, opacity: .16));
   }
 }
 

--- a/packages/mdc-snackbar/mdc-snackbar.scss
+++ b/packages/mdc-snackbar/mdc-snackbar.scss
@@ -132,7 +132,7 @@
   /* stylelint-enable plugin/selector-bem-pattern */
 
   &__action-button {
-    @include mdc-theme-prop(color, accent);
+    @include mdc-theme-prop(color, secondary);
 
     @include mdc-theme-dark(".mdc-snackbar") {
       @include mdc-theme-prop(color, primary);

--- a/packages/mdc-tabs/tab-bar/mdc-tab-bar.scss
+++ b/packages/mdc-tabs/tab-bar/mdc-tab-bar.scss
@@ -97,15 +97,15 @@
 .mdc-tab-bar--indicator-accent,
 .mdc-toolbar .mdc-tab-bar--indicator-accent {
   .mdc-tab-bar__indicator {
-    @include mdc-theme-prop(background-color, accent);
+    @include mdc-theme-prop(background-color, secondary);
 
     @include mdc-theme-dark(".mdc-tab-bar") {
-      @include mdc-theme-prop(background-color, accent);
+      @include mdc-theme-prop(background-color, secondary);
     };
   }
 
   &.mdc-tab-bar:not(.mdc-tab-bar-upgraded) .mdc-tab::after {
-    @include mdc-theme-prop(background-color, accent);
+    @include mdc-theme-prop(background-color, secondary);
   }
 }
 // postcss-bem-linter: end

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -16,12 +16,12 @@ path: /catalog/theme/
   </a>
 </div>-->
 
-This color palette comprises primary and accent colors that can be used for illustration or to develop your brand colors.
+This color palette comprises primary and secondary colors that can be used for illustration or to develop your brand colors.
 
 MDC Theme is a foundational module that themes MDC Web components. The colors in this module are derived from three theme colors:
 
 * Primary: the primary color used in your application, applies to a number of UI elements.
-* Accent: the accent color used in your application, applies to a number of UI elements.
+* Secondary: the secondary color used in your application, applies to a number of UI elements. (Previously called "accent".)
 * Background: the background color for your application, aka the color on top of which your UI is drawn.
 
 and five text styles:
@@ -32,7 +32,7 @@ and five text styles:
 * Disabled: used for text in disabled components and content
 * Icon: used for icons
 
-> **A note about Primary**, don't confuse primary color with primary text. The former refers to the primary theme color, that is used to establish a visual identity and color many parts of your application. The latter refers to the style of text that is most prominent (low opacity, high contrast), and used to display most content.
+> **A note about Primary and Secondary**, don't confuse primary/secondary _color_ with primary/secondary _text_. The former refers to the primary/secondary _theme_ color that is used to establish a visual identity and color many parts of your application. The latter refers to the style of text that is most prominent (low opacity, high contrast), and used to display most content.
 
 Some components can change their appearance when in a Dark Theme context, aka placed on top of a dark background. There are two ways to specify if a component is in a Dark Theme context. The first is to add `mdc-theme--dark` to a *container* element, which holds the component. The second way is to add `<component_name>--theme-dark` modifier class to the actual component element. For example, `mdc-button--theme-dark` would put the MDC Button in a Dark Theme context.
 
@@ -64,25 +64,46 @@ MDC Theme makes it easy to develop your brand colors. You override the default t
 > **A note about Sass variables**, you need to define the three theme color variables before importing mdc-theme or any MDC-Web components that rely on it, like following:
 
 ```scss
-$mdc-theme-primary: #9c27b0;
-$mdc-theme-secondary: #ffab40;
-$mdc-theme-background: #fff;
+$mdc-theme-primary: #9c27b0; // Purple 500
+$mdc-theme-secondary: #ffab40; // Orange A200
+$mdc-theme-background: #fff; // White
 
 @import "@material/theme/mdc-theme";
 ```
 
-The text color, for text placed on top of these selected theme colors, is programmatically computed based on color contrast. We follow the Web Content Accessibility Guidelines 2.0. 
+> **A note about `$mdc-theme-secondary`**: This variable was previously named `$mdc-theme-accent`.
+> For backward compatibility, `$mdc-theme-accent` still exists, but it is **deprecated**.
+> Apps that previously customized `$mdc-theme-accent` will continue to work, but new apps should use
+> `$mdc-theme-secondary` instead.
+
+MDC Theme also exposes _light_ and _dark_ variants of the primary and secondary colors. By default, these values are
+computed by lightening and darkening the main primary/secondary colors in Sass, but you can override them if desired:
+
+```scss
+$mdc-theme-primary-light: #ce93d8; // Purple 200
+$mdc-theme-primary-dark: #6a1b9a; // Purple 800
+$mdc-theme-secondary-light: #ffd180; // Orange A100
+$mdc-theme-secondary-dark: #ff6d00; // Orange A700
+
+@import "@material/theme/mdc-theme";
+```
+
+The text color, for text placed on top of these selected theme colors, is programmatically computed based on color contrast. We follow the Web Content Accessibility Guidelines 2.0.
 
 https://www.w3.org/TR/WCAG20
 
 #### CSS Custom Properties
 
-> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `--mdc-theme-text-hint-on-accent`.
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `secondary`. When you put it all together it would be `--mdc-theme-text-hint-on-secondary`.
 
 CSS Custom property | Description
 --- | ---
 `--mdc-theme-primary` | The theme primary color
-`--mdc-theme-accent` | The theme accent color
+`--mdc-theme-primary-light` | The theme primary color (light variant)
+`--mdc-theme-primary-dark` | The theme primary color (dark variant)
+`--mdc-theme-secondary` | The theme secondary color
+`--mdc-theme-secondary-light` | The theme secondary color (light variant)
+`--mdc-theme-secondary-dark` | The theme secondary color (dark variant)
 `--mdc-theme-background` | The theme background color
 `--mdc-theme-text-<TEXT_STYLE>-on-<THEME_COLOR>` | Text color for TEXT_STYLE on top of THEME_COLOR background
 `--mdc-theme-text-<TEXT_STYLE>-on-light` | Text color for TEXT_STYLE on top of light background
@@ -94,15 +115,23 @@ Some components can change their appearance when a theme-based modifier CSS clas
 
 If you want to modify an element, which is not a Material Design component, you can apply the following modifier CSS classes.
 
-> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `mdc-theme--text-hint-on-accent`.
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `secondary`. When you put it all together it would be `mdc-theme--text-hint-on-secondary`.
 
 CSS Class | Description
 --- | ---
 `mdc-theme--primary` | Sets the text color to the theme primary color
-`mdc-theme--accent` | Sets the text color to the theme accent color
+`mdc-theme--primary-light` | Sets the text color to the theme primary color (light variant)
+`mdc-theme--primary-dark` | Sets the text color to the theme primary color (dark variant)
+`mdc-theme--secondary` | Sets the text color to the theme secondary color
+`mdc-theme--secondary-light` | Sets the text color to the theme secondary color (light variant)
+`mdc-theme--secondary-dark` | Sets the text color to the theme secondary color (dark variant)
 `mdc-theme--background` | Sets the background color to the theme background color
 `mdc-theme--primary-bg` | Sets the background color to the theme primary color
-`mdc-theme--accent-bg` | Sets the background color to the theme accent color
+`mdc-theme--primary-light-bg` | Sets the background color to the theme primary color (light variant)
+`mdc-theme--primary-dark-bg` | Sets the background color to the theme primary color (dark variant)
+`mdc-theme--secondary-bg` | Sets the background color to the theme secondary color
+`mdc-theme--secondary-light-bg` | Sets the background color to the theme secondary color (light variant)
+`mdc-theme--secondary-dark-bg` | Sets the background color to the theme secondary color (dark variant)
 `mdc-theme--text-<TEXT_STYLE>-on-<THEME_COLOR>` | Sets text to a suitable color for TEXT_STYLE on top of THEME_COLOR background
 `mdc-theme--text-<TEXT_STYLE>-on-light` | Sets text to a suitable color for TEXT_STYLE on top of light background
 `mdc-theme--text-<TEXT_STYLE>-on-dark` | Sets text to a suitable color for TEXT_STYLE on top of dark background
@@ -110,7 +139,7 @@ CSS Class | Description
 ### Sass Mixins, Variables, and Functions
 
 Mixin | Description
---- | --- 
+--- | ---
 `mdc-theme-prop($property, $style, $important)` | Applies a theme color to a property
 `mdc-theme-dark($root-selector, $compound)` | Creates a rule that is applied when the current selector is within an Dark Theme context
 
@@ -122,12 +151,16 @@ Creates a rule that is applied when the current selector is within an Dark Theme
 
 These properties can be used as the `$property` argument for `mdc-theme-prop` mixin.
 
-> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `accent`. When you put it all together it would be `text-hint-on-accent`.
+> **A note about `<TEXT_STYLE>` and `<THEME_COLOR>`**, `<TEXT_STYLE>` represents the lowercase name of the text styles listed above, e.g. `hint`. `<THEME_COLOR>` represents the lowercase name of the theme colors listed above, e.g. `secondary`. When you put it all together it would be `text-hint-on-secondary`.
 
 Property Name | Description
 --- | ---
 `primary` | The theme primary color
-`accent` | The theme accent color
+`primary-light` | The theme primary color (light variant)
+`primary-dark` | The theme primary color (dark variant)
+`secondary` | The theme secondary color
+`secondary-light` | The theme secondary color (light variant)
+`secondary-dark` | The theme secondary color (dark variant)
 `background` | The theme background color
 `text-<TEXT_STYLE>-on-<THEME_COLOR>` | TEXT_STYLE on top of THEME_COLOR background
 `text-<TEXT_STYLE>-on-light` | TEXT_STYLE on top of a light background

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -65,7 +65,7 @@ MDC Theme makes it easy to develop your brand colors. You override the default t
 
 ```scss
 $mdc-theme-primary: #9c27b0;
-$mdc-theme-accent: #ffab40;
+$mdc-theme-secondary: #ffab40;
 $mdc-theme-background: #fff;
 
 @import "@material/theme/mdc-theme";

--- a/packages/mdc-theme/_functions.scss
+++ b/packages/mdc-theme/_functions.scss
@@ -17,6 +17,13 @@
 @import "./constants";
 
 /**
+ * Used by the functions below to shift a color's lightness by approximately
+ * one index within its tonal palette.
+ * E.g., shift from Red 500 to Red 400 or Red 600.
+ */
+$_mdc-theme-tonal-offset: 7%;
+
+/**
  * Calculate the luminance for a color.
  * See https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
  */
@@ -55,5 +62,76 @@
 
   @else {
     @return "light";
+  }
+}
+
+/**
+ * Return the given number if $value >= $min and $value <= $max. If $value falls
+ * outside those bounds, return the nearest boundary value ($max or $min).
+ */
+@function mdc-theme-clamp-number_($value, $min, $max) {
+  @return max($min, min($max, $value));
+}
+
+/*
+ * lighten() and darken() require values to be between 0% and 100%.
+ */
+@function mdc-theme-clamp-lighten-amount_($percentage) {
+  @return mdc-theme-clamp-number_($percentage, 0%, 100%);
+}
+
+/**
+ * Darken the given color by approximately the specified number of indexes
+ * within its tonal palette.
+ *
+ * If the color is already very dark, it will be lightened instead of darkened
+ * to ensure that the returned value is visually distinct from the input color.
+ *
+ * If the color is very light, it will be darkened twice as much as usual to
+ * ensure that the returned value is visually distinct from the light variant
+ * (which will actually end up being a dark shade).
+ */
+@function mdc-theme-dark-variant($color, $num-indexes: 2) {
+  $offset: $_mdc-theme-tonal-offset;
+  $amount: $offset * $num-indexes;
+
+  @if mdc-theme-luminance($color) < .2 {
+    @return lighten($color, mdc-theme-clamp-lighten-amount_($amount));
+  }
+
+  @else if mdc-theme-luminance($color) > .8 {
+    @return darken($color, mdc-theme-clamp-lighten-amount_($amount * 2));
+  }
+
+  @else {
+    @return darken($color, mdc-theme-clamp-lighten-amount_($amount));
+  }
+}
+
+/**
+ * Lighten the given color by approximately the specified number of indexes
+ * within its tonal palette.
+ *
+ * If the color is already very light, it will be darkened instead of lightened
+ * to ensure that the returned value is visually distinct from the input color.
+ *
+ * If the color is very dark, it will be lightened twice as much as usual to
+ * ensure that the returned value is visually distinct from the dark variant
+ * (which will actually end up being a light tint).
+ */
+@function mdc-theme-light-variant($color, $num-indexes: 2) {
+  $offset: $_mdc-theme-tonal-offset;
+  $amount: $offset * $num-indexes;
+
+  @if mdc-theme-luminance($color) < .2 {
+    @return lighten($color, mdc-theme-clamp-lighten-amount_($amount * 2));
+  }
+
+  @else if mdc-theme-luminance($color) > .8 {
+    @return darken($color, mdc-theme-clamp-lighten-amount_($amount));
+  }
+
+  @else {
+    @return lighten($color, mdc-theme-clamp-lighten-amount_($amount));
   }
 }

--- a/packages/mdc-theme/_functions.scss
+++ b/packages/mdc-theme/_functions.scss
@@ -65,32 +65,26 @@ $_mdc-theme-tonal-offset: 7%;
   }
 }
 
-/**
- * Return the given number if $value >= $min and $value <= $max. If $value falls
- * outside those bounds, return the nearest boundary value ($max or $min).
- */
+// Return the given number if $value >= $min and $value <= $max. If $value falls
+// outside those bounds, return the nearest boundary value ($max or $min).
 @function mdc-theme-clamp-number_($value, $min, $max) {
   @return max($min, min($max, $value));
 }
 
-/*
- * lighten() and darken() require values to be between 0% and 100%.
- */
+// lighten() and darken() require values to be between 0% and 100%.
 @function mdc-theme-clamp-lighten-amount_($percentage) {
   @return mdc-theme-clamp-number_($percentage, 0%, 100%);
 }
 
-/**
- * Darken the given color by approximately the specified number of indexes
- * within its tonal palette.
- *
- * If the color is already very dark, it will be lightened instead of darkened
- * to ensure that the returned value is visually distinct from the input color.
- *
- * If the color is very light, it will be darkened twice as much as usual to
- * ensure that the returned value is visually distinct from the light variant
- * (which will actually end up being a dark shade).
- */
+// Darken the given color by approximately the specified number of indexes
+// within its tonal palette.
+//
+// If the color is already very dark, it will be lightened instead of darkened
+// to ensure that the returned value is visually distinct from the input color.
+//
+// If the color is very light, it will be darkened twice as much as usual to
+// ensure that the returned value is visually distinct from the light variant
+// (which will actually end up being a dark shade).
 @function mdc-theme-dark-variant($color, $num-indexes: 2) {
   $offset: $_mdc-theme-tonal-offset;
   $amount: $offset * $num-indexes;
@@ -108,17 +102,15 @@ $_mdc-theme-tonal-offset: 7%;
   }
 }
 
-/**
- * Lighten the given color by approximately the specified number of indexes
- * within its tonal palette.
- *
- * If the color is already very light, it will be darkened instead of lightened
- * to ensure that the returned value is visually distinct from the input color.
- *
- * If the color is very dark, it will be lightened twice as much as usual to
- * ensure that the returned value is visually distinct from the dark variant
- * (which will actually end up being a light tint).
- */
+// Lighten the given color by approximately the specified number of indexes
+// within its tonal palette.
+//
+// If the color is already very light, it will be darkened instead of lightened
+// to ensure that the returned value is visually distinct from the input color.
+//
+// If the color is very dark, it will be lightened twice as much as usual to
+// ensure that the returned value is visually distinct from the dark variant
+// (which will actually end up being a light tint).
 @function mdc-theme-light-variant($color, $num-indexes: 2) {
   $offset: $_mdc-theme-tonal-offset;
   $amount: $offset * $num-indexes;

--- a/packages/mdc-theme/_functions.scss
+++ b/packages/mdc-theme/_functions.scss
@@ -16,11 +16,9 @@
 
 @import "./constants";
 
-/**
- * Used by the functions below to shift a color's lightness by approximately
- * one index within its tonal palette.
- * E.g., shift from Red 500 to Red 400 or Red 600.
- */
+// Used by the functions below to shift a color's lightness by approximately
+// one index within its tonal palette.
+// E.g., shift from Red 500 to Red 400 or Red 600.
 $_mdc-theme-tonal-offset: 7%;
 
 /**

--- a/packages/mdc-theme/_functions.scss
+++ b/packages/mdc-theme/_functions.scss
@@ -16,11 +16,6 @@
 
 @import "./constants";
 
-// Used by the functions below to shift a color's lightness by approximately
-// one index within its tonal palette.
-// E.g., shift from Red 500 to Red 400 or Red 600.
-$_mdc-theme-tonal-offset: 7%;
-
 // Calculate the luminance for a color.
 // See https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
 @function mdc-theme-luminance($color) {
@@ -54,68 +49,5 @@ $_mdc-theme-tonal-offset: 7%;
 
   @else {
     @return "light";
-  }
-}
-
-// Return the given number if $value >= $min and $value <= $max. If $value falls
-// outside those bounds, return the nearest boundary value ($max or $min).
-@function mdc-theme-clamp-number_($value, $min, $max) {
-  @return max($min, min($max, $value));
-}
-
-// lighten() and darken() require values to be between 0% and 100%.
-@function mdc-theme-clamp-lighten-amount_($percentage) {
-  @return mdc-theme-clamp-number_($percentage, 0%, 100%);
-}
-
-// Darken the given color by approximately the specified number of indexes
-// within its tonal palette.
-//
-// If the color is already very dark, it will be lightened instead of darkened
-// to ensure that the returned value is visually distinct from the input color.
-//
-// If the color is very light, it will be darkened twice as much as usual to
-// ensure that the returned value is visually distinct from the light variant
-// (which will actually end up being a dark shade).
-@function mdc-theme-dark-variant($color, $num-indexes: 2) {
-  $offset: $_mdc-theme-tonal-offset;
-  $amount: $offset * $num-indexes;
-
-  @if mdc-theme-luminance($color) < .2 {
-    @return lighten($color, mdc-theme-clamp-lighten-amount_($amount));
-  }
-
-  @else if mdc-theme-luminance($color) > .8 {
-    @return darken($color, mdc-theme-clamp-lighten-amount_($amount * 2));
-  }
-
-  @else {
-    @return darken($color, mdc-theme-clamp-lighten-amount_($amount));
-  }
-}
-
-// Lighten the given color by approximately the specified number of indexes
-// within its tonal palette.
-//
-// If the color is already very light, it will be darkened instead of lightened
-// to ensure that the returned value is visually distinct from the input color.
-//
-// If the color is very dark, it will be lightened twice as much as usual to
-// ensure that the returned value is visually distinct from the dark variant
-// (which will actually end up being a light tint).
-@function mdc-theme-light-variant($color, $num-indexes: 2) {
-  $offset: $_mdc-theme-tonal-offset;
-  $amount: $offset * $num-indexes;
-
-  @if mdc-theme-luminance($color) < .2 {
-    @return lighten($color, mdc-theme-clamp-lighten-amount_($amount * 2));
-  }
-
-  @else if mdc-theme-luminance($color) > .8 {
-    @return darken($color, mdc-theme-clamp-lighten-amount_($amount));
-  }
-
-  @else {
-    @return lighten($color, mdc-theme-clamp-lighten-amount_($amount));
   }
 }

--- a/packages/mdc-theme/_mixins.scss
+++ b/packages/mdc-theme/_mixins.scss
@@ -23,7 +23,7 @@
  */
 @mixin mdc-theme-prop($property, $style, $important: false) {
   @if not map-has-key($mdc-theme-property-values, $style) {
-    @error "Invalid style specified! Choose one of #{map-keys($mdc-theme-property-values)}";
+    @error "Invalid style: '#{$style}'. Choose one of: #{map-keys($mdc-theme-property-values)}";
   }
 
   @if $important {

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -23,15 +23,15 @@
 //
 
 $mdc-theme-primary: #3f51b5 !default; // Indigo 500
-$mdc-theme-primary-dark: mdc-theme-dark-variant($mdc-theme-primary) !default;
 $mdc-theme-primary-light: mdc-theme-light-variant($mdc-theme-primary) !default;
+$mdc-theme-primary-dark: mdc-theme-dark-variant($mdc-theme-primary) !default;
 
 // The $mdc-theme-secondary variable is DEPRECATED - it exists purely for backward compatibility.
 // The $mdc-theme-secondary* variables should be used for all new projects.
 $mdc-theme-accent: #ff4081 !default; // Pink A200
 $mdc-theme-secondary: $mdc-theme-accent !default;
-$mdc-theme-secondary-dark: mdc-theme-dark-variant($mdc-theme-secondary) !default;
 $mdc-theme-secondary-light: mdc-theme-light-variant($mdc-theme-secondary) !default;
+$mdc-theme-secondary-dark: mdc-theme-dark-variant($mdc-theme-secondary) !default;
 
 $mdc-theme-background: #fff !default; // White
 
@@ -40,15 +40,12 @@ $mdc-theme-background: #fff !default; // White
 //
 
 $mdc-theme-primary-tone: mdc-theme-light-or-dark($mdc-theme-primary);
-$mdc-theme-primary-dark-tone: mdc-theme-light-or-dark($mdc-theme-primary-dark);
 $mdc-theme-primary-light-tone: mdc-theme-light-or-dark($mdc-theme-primary-light);
+$mdc-theme-primary-dark-tone: mdc-theme-light-or-dark($mdc-theme-primary-dark);
 
-// The $mdc-theme-secondary-tone variable is DEPRECATED - it exists purely for backward compatibility.
-// The $mdc-theme-secondary-tone* variables should be used for all new projects.
-$mdc-theme-accent-tone: mdc-theme-light-or-dark($mdc-theme-secondary);
-$mdc-theme-secondary-tone: $mdc-theme-accent-tone;
-$mdc-theme-secondary-dark-tone: mdc-theme-light-or-dark($mdc-theme-secondary-dark);
+$mdc-theme-secondary-tone: mdc-theme-light-or-dark($mdc-theme-secondary);
 $mdc-theme-secondary-light-tone: mdc-theme-light-or-dark($mdc-theme-secondary-light);
+$mdc-theme-secondary-dark-tone: mdc-theme-light-or-dark($mdc-theme-secondary-dark);
 
 $mdc-theme-background-tone: mdc-theme-light-or-dark($mdc-theme-background);
 
@@ -78,29 +75,65 @@ $mdc-theme-text-colors: (
 //
 
 $mdc-theme-property-values: (
+  // Primary
   primary: $mdc-theme-primary,
-  accent: $mdc-theme-secondary,
+  primary-light: $mdc-theme-primary-light,
+  primary-dark: $mdc-theme-primary-dark,
+  // Secondary
+  secondary: $mdc-theme-secondary,
+  secondary-light: $mdc-theme-secondary-light,
+  secondary-dark: $mdc-theme-secondary-dark,
+  // Background
   background: $mdc-theme-background,
+  // Text-primary on primary background
   text-primary-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), primary),
   text-secondary-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), secondary),
   text-hint-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), hint),
   text-disabled-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), disabled),
   text-icon-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), icon),
-  text-primary-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), primary),
-  text-secondary-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), secondary),
-  text-hint-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), hint),
-  text-disabled-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), disabled),
-  text-icon-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), icon),
+  // Text-primary on primary-light background
+  text-primary-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), primary),
+  text-secondary-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), secondary),
+  text-hint-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), hint),
+  text-disabled-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), disabled),
+  text-icon-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), icon),
+  // Text-primary on primary-dark background
+  text-primary-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), primary),
+  text-secondary-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), secondary),
+  text-hint-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), hint),
+  text-disabled-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), disabled),
+  text-icon-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), icon),
+  // Text-primary on secondary background
+  text-primary-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), primary),
+  text-secondary-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), secondary),
+  text-hint-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), hint),
+  text-disabled-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), disabled),
+  text-icon-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), icon),
+  // Text-primary on secondary-light background
+  text-primary-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), primary),
+  text-secondary-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), secondary),
+  text-hint-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), hint),
+  text-disabled-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), disabled),
+  text-icon-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), icon),
+  // Text-primary on secondary-dark background
+  text-primary-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), primary),
+  text-secondary-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), secondary),
+  text-hint-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), hint),
+  text-disabled-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), disabled),
+  text-icon-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), icon),
+  // Text-primary on background background
   text-primary-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), primary),
   text-secondary-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), secondary),
   text-hint-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), hint),
   text-disabled-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), disabled),
   text-icon-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), icon),
+  // Text-primary on light background
   text-primary-on-light: map-get(map-get($mdc-theme-text-colors, dark), primary),
   text-secondary-on-light: map-get(map-get($mdc-theme-text-colors, dark), secondary),
   text-hint-on-light: map-get(map-get($mdc-theme-text-colors, dark), hint),
   text-disabled-on-light: map-get(map-get($mdc-theme-text-colors, dark), disabled),
   text-icon-on-light: map-get(map-get($mdc-theme-text-colors, dark), icon),
+  // Text-primary on dark background
   text-primary-on-dark: map-get(map-get($mdc-theme-text-colors, light), primary),
   text-secondary-on-dark: map-get(map-get($mdc-theme-text-colors, light), secondary),
   text-hint-on-dark: map-get(map-get($mdc-theme-text-colors, light), hint),

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -16,20 +16,46 @@
 
 @import "./functions";
 
-/*
-  Main theme colors.
-  If you're a user customizing your color scheme in SASS, these are probably the only variables you need to change.
-*/
-$mdc-theme-primary: #3f51b5 !default; /* Indigo 500 */
-$mdc-theme-accent: #ff4081 !default; /* Pink A200 */
-$mdc-theme-background: #fff !default; /* White */
+//
+// Main theme colors for your brand.
+//
+// If you're a user customizing your color scheme in SASS, these are probably the only variables you need to change.
+//
 
-/* Which set of text colors to use for each main theme color (light or dark) */
+$mdc-theme-primary: #3f51b5 !default; // Indigo 500
+$mdc-theme-primary-dark: mdc-theme-dark-variant($mdc-theme-primary) !default;
+$mdc-theme-primary-light: mdc-theme-light-variant($mdc-theme-primary) !default;
+
+// The $mdc-theme-secondary variable is DEPRECATED - it exists purely for backward compatibility.
+// The $mdc-theme-secondary* variables should be used for all new projects.
+$mdc-theme-accent: #ff4081 !default; // Pink A200
+$mdc-theme-secondary: $mdc-theme-accent !default;
+$mdc-theme-secondary-dark: mdc-theme-dark-variant($mdc-theme-secondary) !default;
+$mdc-theme-secondary-light: mdc-theme-light-variant($mdc-theme-secondary) !default;
+
+$mdc-theme-background: #fff !default; // White
+
+//
+// Which set of text colors to use for each main theme color (light or dark).
+//
+
 $mdc-theme-primary-tone: mdc-theme-light-or-dark($mdc-theme-primary);
-$mdc-theme-accent-tone: mdc-theme-light-or-dark($mdc-theme-accent);
+$mdc-theme-primary-dark-tone: mdc-theme-light-or-dark($mdc-theme-primary-dark);
+$mdc-theme-primary-light-tone: mdc-theme-light-or-dark($mdc-theme-primary-light);
+
+// The $mdc-theme-secondary-tone variable is DEPRECATED - it exists purely for backward compatibility.
+// The $mdc-theme-secondary-tone* variables should be used for all new projects.
+$mdc-theme-accent-tone: mdc-theme-light-or-dark($mdc-theme-secondary);
+$mdc-theme-secondary-tone: $mdc-theme-accent-tone;
+$mdc-theme-secondary-dark-tone: mdc-theme-light-or-dark($mdc-theme-secondary-dark);
+$mdc-theme-secondary-light-tone: mdc-theme-light-or-dark($mdc-theme-secondary-light);
+
 $mdc-theme-background-tone: mdc-theme-light-or-dark($mdc-theme-background);
 
-/* Text colors according to light vs dark and text type */
+//
+// Text colors according to light vs dark and text type.
+//
+
 $mdc-theme-text-colors: (
   dark: (
     primary: rgba(black, .87),
@@ -47,21 +73,24 @@ $mdc-theme-text-colors: (
   )
 );
 
-/* Primary text colors for each of the theme colors */
+//
+// Primary text colors for each of the theme colors.
+//
+
 $mdc-theme-property-values: (
   primary: $mdc-theme-primary,
-  accent: $mdc-theme-accent,
+  accent: $mdc-theme-secondary,
   background: $mdc-theme-background,
   text-primary-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), primary),
   text-secondary-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), secondary),
   text-hint-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), hint),
   text-disabled-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), disabled),
   text-icon-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), icon),
-  text-primary-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-accent-tone), primary),
-  text-secondary-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-accent-tone), secondary),
-  text-hint-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-accent-tone), hint),
-  text-disabled-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-accent-tone), disabled),
-  text-icon-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-accent-tone), icon),
+  text-primary-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), primary),
+  text-secondary-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), secondary),
+  text-hint-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), hint),
+  text-disabled-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), disabled),
+  text-icon-on-accent: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), icon),
   text-primary-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), primary),
   text-secondary-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), secondary),
   text-hint-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), hint),

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -26,7 +26,7 @@ $mdc-theme-primary: #3f51b5 !default; // Indigo 500
 $mdc-theme-primary-light: lighten($mdc-theme-primary, 14%) !default;
 $mdc-theme-primary-dark: darken($mdc-theme-primary, 14%) !default;
 
-// The $mdc-theme-secondary variable is DEPRECATED - it exists purely for backward compatibility.
+// The $mdc-theme-accent variable is DEPRECATED - it exists purely for backward compatibility.
 // The $mdc-theme-secondary* variables should be used for all new projects.
 $mdc-theme-accent: #ff4081 !default; // Pink A200
 $mdc-theme-secondary: $mdc-theme-accent !default;

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -85,55 +85,55 @@ $mdc-theme-property-values: (
   secondary-dark: $mdc-theme-secondary-dark,
   // Background
   background: $mdc-theme-background,
-  // Text-primary on primary background
+  // Text-primary on "primary" background
   text-primary-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), primary),
   text-secondary-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), secondary),
   text-hint-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), hint),
   text-disabled-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), disabled),
   text-icon-on-primary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-tone), icon),
-  // Text-primary on primary-light background
+  // Text-primary on "primary-light" background
   text-primary-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), primary),
   text-secondary-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), secondary),
   text-hint-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), hint),
   text-disabled-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), disabled),
   text-icon-on-primary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-light-tone), icon),
-  // Text-primary on primary-dark background
+  // Text-primary on "primary-dark" background
   text-primary-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), primary),
   text-secondary-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), secondary),
   text-hint-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), hint),
   text-disabled-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), disabled),
   text-icon-on-primary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-primary-dark-tone), icon),
-  // Text-primary on secondary background
+  // Text-primary on "secondary" background
   text-primary-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), primary),
   text-secondary-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), secondary),
   text-hint-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), hint),
   text-disabled-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), disabled),
   text-icon-on-secondary: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-tone), icon),
-  // Text-primary on secondary-light background
+  // Text-primary on "secondary-light" background
   text-primary-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), primary),
   text-secondary-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), secondary),
   text-hint-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), hint),
   text-disabled-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), disabled),
   text-icon-on-secondary-light: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-light-tone), icon),
-  // Text-primary on secondary-dark background
+  // Text-primary on "secondary-dark" background
   text-primary-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), primary),
   text-secondary-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), secondary),
   text-hint-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), hint),
   text-disabled-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), disabled),
   text-icon-on-secondary-dark: map-get(map-get($mdc-theme-text-colors, $mdc-theme-secondary-dark-tone), icon),
-  // Text-primary on background background
+  // Text-primary on "background" background
   text-primary-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), primary),
   text-secondary-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), secondary),
   text-hint-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), hint),
   text-disabled-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), disabled),
   text-icon-on-background: map-get(map-get($mdc-theme-text-colors, $mdc-theme-background-tone), icon),
-  // Text-primary on light background
+  // Text-primary on "light" background
   text-primary-on-light: map-get(map-get($mdc-theme-text-colors, dark), primary),
   text-secondary-on-light: map-get(map-get($mdc-theme-text-colors, dark), secondary),
   text-hint-on-light: map-get(map-get($mdc-theme-text-colors, dark), hint),
   text-disabled-on-light: map-get(map-get($mdc-theme-text-colors, dark), disabled),
   text-icon-on-light: map-get(map-get($mdc-theme-text-colors, dark), icon),
-  // Text-primary on dark background
+  // Text-primary on "dark" background
   text-primary-on-dark: map-get(map-get($mdc-theme-text-colors, light), primary),
   text-secondary-on-dark: map-get(map-get($mdc-theme-text-colors, light), secondary),
   text-hint-on-dark: map-get(map-get($mdc-theme-text-colors, light), hint),

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -23,15 +23,15 @@
 //
 
 $mdc-theme-primary: #3f51b5 !default; // Indigo 500
-$mdc-theme-primary-light: mdc-theme-light-variant($mdc-theme-primary) !default;
-$mdc-theme-primary-dark: mdc-theme-dark-variant($mdc-theme-primary) !default;
+$mdc-theme-primary-light: lighten($mdc-theme-primary, 14%) !default;
+$mdc-theme-primary-dark: darken($mdc-theme-primary, 14%) !default;
 
 // The $mdc-theme-secondary variable is DEPRECATED - it exists purely for backward compatibility.
 // The $mdc-theme-secondary* variables should be used for all new projects.
 $mdc-theme-accent: #ff4081 !default; // Pink A200
 $mdc-theme-secondary: $mdc-theme-accent !default;
-$mdc-theme-secondary-light: mdc-theme-light-variant($mdc-theme-secondary) !default;
-$mdc-theme-secondary-dark: mdc-theme-dark-variant($mdc-theme-secondary) !default;
+$mdc-theme-secondary-light: lighten($mdc-theme-secondary, 14%) !default;
+$mdc-theme-secondary-dark: darken($mdc-theme-secondary, 14%) !default;
 
 $mdc-theme-background: #fff !default; // White
 

--- a/packages/mdc-theme/mdc-theme.scss
+++ b/packages/mdc-theme/mdc-theme.scss
@@ -22,7 +22,7 @@
   }
 }
 
-/* Special case, so that .mdc-theme--background changes background color, not text color. */
+// Special case, so that .mdc-theme--background changes background color, not text color.
 .mdc-theme--background {
   @include mdc-theme-prop(background-color, background);
 }
@@ -35,8 +35,8 @@
   }
 }
 
-/* CSS rules for using primary and accent as background colors. */
-@each $style in ("primary", "accent") {
+// CSS rules for using primary and secondary (plus light/dark variants) as background colors.
+@each $style in ("primary", "primary-light", "primary-dark", "secondary", "secondary-light", "secondary-dark") {
   .mdc-theme--#{$style}-bg {
     @include mdc-theme-prop(background-color, $style, true);
   }


### PR DESCRIPTION
* In the spec, "accent" was renamed to "secondary".
* This PR only changes "accent" to "secondary" for variables defined within the `mdc-theme` package. Modifier classes for individual components (e.g., `mdc-button--accent`) remain unchanged for now.
* For backward compatibility, `$mdc-theme-accent` still exists, and `$mdc-theme-secondary` points to it. This ensures that clients that were previously overriding `$mdc-theme-accent` will continue to work.
* Light/dark tonal variants are not yet being used, but will become used soon when we update our components to align with an upcoming version of the spec.

BREAKING CHANGE