### PR TITLE
chore(demos): Normalize demo page markup

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -1,27 +1,30 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License
-  -->
+-->
 <html>
   <head>
     <meta charset="utf-8">
     <title>Button - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       fieldset {
         margin: 24px;
@@ -63,8 +66,8 @@
         </section>
       </div>
     </header>
-    <main class="mdc-toolbar-fixed-adjust">
 
+    <main class="mdc-toolbar-fixed-adjust">
       <section class="hero">
         <button class="mdc-button button">Flat</button>
         <button class="mdc-button mdc-button--raised button mdc-button--primary">Raised</button>
@@ -292,7 +295,6 @@
         </fieldset>
         <fieldset disabled>
           <legend class="mdc-typography--title">Dark Theme (mdc-theme--dark) - Disabled</legend>
-
           <button class="mdc-button">
             Default
           </button>
@@ -368,7 +370,6 @@
         </fieldset>
         <fieldset disabled>
           <legend class="mdc-typography--title">Dark Theme (mdc-button--theme-dark) - Disabled</legend>
-
           <button class="mdc-button mdc-button--theme-dark ">
             Default
           </button>
@@ -404,9 +405,9 @@
           </div>
         </fieldset>
       </section>
-
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+
+    <script src="/assets/material-components-web.js"></script>
     <script>
       // Because we load our CSS via webpack, we need to ensure that all of the correct styles
       // are applied before ripples are attached. Otherwise, ripples may use the computed styles of

--- a/demos/card.html
+++ b/demos/card.html
@@ -15,326 +15,324 @@
   limitations under the License
 -->
 <html>
-
-<head>
-  <meta charset="utf-8">
-  <title>Card - Material Compoonents Catalog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-  <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-  <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-  <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
-  <style>
-    .hero .demo-card {
-      width: 320px;
-      background-color: white;
-    }
-
-    .hero {
-      min-height: 480px;
-    }
-
-    .demo-card {
-      max-width: 21.875rem;
-      /* 350sp */
-      margin-bottom: 48px;
-    }
-
-    @media(min-width: 768px) {
-      .demo-card {
-        margin-bottom: 24px;
+  <head>
+    <meta charset="utf-8">
+    <title>Card - Material Compoonents Catalog</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <style>
+      .hero .demo-card {
+        width: 320px;
+        background-color: white;
       }
-    }
 
-    .demo-card--with-avatar .mdc-card__primary {
-      position: relative;
-    }
+      .hero {
+        min-height: 480px;
+      }
 
-    .demo-card--with-avatar .demo-card__avatar {
-      position: absolute;
-      background: #bdbdbd;
-      height: 2.5rem;
-      /* 40sp */
-      width: 2.5rem;
-      /* 40sp */
-      border-radius: 50%;
-    }
+      .demo-card {
+        max-width: 21.875rem;
+        /* 350sp */
+        margin-bottom: 48px;
+      }
 
-    .demo-card--with-avatar .mdc-card__title,
-    .demo-card--with-avatar .mdc-card__subtitle {
-      margin-left: 56px;
-    }
+      @media(min-width: 768px) {
+        .demo-card {
+          margin-bottom: 24px;
+        }
+      }
 
-    [dir="rtl"] .demo-card--with-avatar .mdc-card__title,
-    [dir="rtl"] .demo-card--with-avatar .mdc-card__subtitle {
-      margin-right: 56px;
-      margin-left: initial;
-    }
+      .demo-card--with-avatar .mdc-card__primary {
+        position: relative;
+      }
 
-    .demo-card__16-9-media {
-      background-image: url("images/16-9.jpg");
-      background-size: cover;
-      background-repeat: no-repeat;
-      height: 12.313rem;
-      /* 197sp, for 16:9 ratio with 350sp demo card width */
-    }
+      .demo-card--with-avatar .demo-card__avatar {
+        position: absolute;
+        background: #bdbdbd;
+        height: 2.5rem;
+        /* 40sp */
+        width: 2.5rem;
+        /* 40sp */
+        border-radius: 50%;
+      }
 
-    .demo-card--small .mdc-card__media {
-      background-image: url("images/1-1.jpg");
-      background-size: cover;
-      background-repeat: no-repeat;
-      height: 10.938rem;
-      /* 175sp, for 1:1 ratio with 175sp demo card width */
-    }
+      .demo-card--with-avatar .mdc-card__title,
+      .demo-card--with-avatar .mdc-card__subtitle {
+        margin-left: 56px;
+      }
 
-    .demo-card--bg-demo {
-      height: 21.875rem;
-      /* 350sp */
-      background-image: url("images/1-1.jpg");
-      background-size: cover;
-      background-repeat: no-repeat;
-    }
+      [dir="rtl"] .demo-card--with-avatar .mdc-card__title,
+      [dir="rtl"] .demo-card--with-avatar .mdc-card__subtitle {
+        margin-right: 56px;
+        margin-left: initial;
+      }
 
-    .demo-card--bg-demo .mdc-card__primary,
-    .demo-card--bg-demo .mdc-card__actions {
-      background: rgba(0, 0, 0, .4);
-    }
+      .demo-card__16-9-media {
+        background-image: url("images/16-9.jpg");
+        background-size: cover;
+        background-repeat: no-repeat;
+        height: 12.313rem;
+        /* 197sp, for 16:9 ratio with 350sp demo card width */
+      }
 
-    #demo-wrapper {
-      margin: 24px;
-      display: flex;
-      flex-flow: row wrap;
-      align-content: left;
-      justify-content: left;
-    }
+      .demo-card--small .mdc-card__media {
+        background-image: url("images/1-1.jpg");
+        background-size: cover;
+        background-repeat: no-repeat;
+        height: 10.938rem;
+        /* 175sp, for 1:1 ratio with 175sp demo card width */
+      }
 
-    #demo-wrapper .demo-card {
-      margin: 24px;
-      min-width: 320px;
-    }
+      .demo-card--bg-demo {
+        height: 21.875rem;
+        /* 350sp */
+        background-image: url("images/1-1.jpg");
+        background-size: cover;
+        background-repeat: no-repeat;
+      }
 
-  </style>
-</head>
+      .demo-card--bg-demo .mdc-card__primary,
+      .demo-card--bg-demo .mdc-card__actions {
+        background: rgba(0, 0, 0, .4);
+      }
 
-<body>
-  <header class="mdc-toolbar mdc-toolbar--fixed">
-    <div class="mdc-toolbar__row">
-      <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
-        <span class="catalog-back">
-          <a href="/" class="mdc-toolbar__icon--menu"><i class="material-icons">&#xE5C4;</i></a>
-        </span>
-        <span class="mdc-toolbar__title catalog-title">Card</span>
-      </section>
-    </div>
-  </header>
-  <main>
-    <div class="mdc-toolbar-fixed-adjust"></div>
-    <section class="hero">
-      <div class="mdc-card demo-card">
-        <section class="mdc-card__media demo-card__16-9-media"></section>
-        <section class="mdc-card__primary">
-          <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
-          <h2 class="mdc-card__subtitle">Subtitle here</h2>
-        </section>
-        <section class="mdc-card__actions">
-          <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-          <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+      #demo-wrapper {
+        margin: 24px;
+        display: flex;
+        flex-flow: row wrap;
+        align-content: left;
+        justify-content: left;
+      }
+
+      #demo-wrapper .demo-card {
+        margin: 24px;
+        min-width: 320px;
+      }
+
+    </style>
+  </head>
+
+  <body>
+    <header class="mdc-toolbar mdc-toolbar--fixed">
+      <div class="mdc-toolbar__row">
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+          <span class="catalog-back">
+            <a href="/" class="mdc-toolbar__icon--menu"><i class="material-icons">&#xE5C4;</i></a>
+          </span>
+          <span class="mdc-toolbar__title catalog-title">Card</span>
         </section>
       </div>
-    </section>
+    </header>
+    <main>
+      <div class="mdc-toolbar-fixed-adjust"></div>
+      <section class="hero">
+        <div class="mdc-card demo-card">
+          <section class="mdc-card__media demo-card__16-9-media"></section>
+          <section class="mdc-card__primary">
+            <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
+            <h2 class="mdc-card__subtitle">Subtitle here</h2>
+          </section>
+          <section class="mdc-card__actions">
+            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+          </section>
+        </div>
+      </section>
 
-    <section class="example">
-        <div class="mdc-form-field">
-          <div class="mdc-checkbox">
-            <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
-            <div class="mdc-checkbox__background">
-              <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-              </svg>
-              <div class="mdc-checkbox__mixedmark"></div>
+      <section class="example">
+          <div class="mdc-form-field">
+            <div class="mdc-checkbox">
+              <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
+              <div class="mdc-checkbox__background">
+                <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                  <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                </svg>
+                <div class="mdc-checkbox__mixedmark"></div>
+              </div>
+            </div>
+            <label for="toggle-rtl" id="toggle-rtl-label">Toggle RTL</label>
+          </div>
+      </section>
+
+      <section class="demo-typography--section mdc-typography" id="demo-wrapper">
+        <div>
+          <div class="mdc-card demo-card">
+            <section class="mdc-card__media demo-card__16-9-media"></section>
+            <section class="mdc-card__supporting-text">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card demo-card--with-avatar">
+            <section class="mdc-card__primary">
+              <div class="demo-card__avatar"></div>
+              <h1 class="mdc-card__title">Title</h1>
+              <h2 class="mdc-card__subtitle">Subhead</h2>
+            </section>
+            <section class="mdc-card__media demo-card__16-9-media"></section>
+            <section class="mdc-card__supporting-text">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+            </section>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card demo-card--with-avatar">
+            <section class="mdc-card__primary">
+              <div class="demo-card__avatar"></div>
+              <h1 class="mdc-card__title">Title</h1>
+              <h2 class="mdc-card__subtitle">Subhead</h2>
+            </section>
+            <section class="mdc-card__media demo-card__16-9-media"></section>
+            <section class="mdc-card__actions mdc-card__actions--vertical">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card">
+            <section class="mdc-card__media demo-card__16-9-media"></section>
+            <section class="mdc-card__primary">
+              <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
+              <h2 class="mdc-card__subtitle">Subtitle here</h2>
+            </section>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card">
+            <section class="mdc-card__primary">
+              <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
+              <h2 class="mdc-card__subtitle">Subtitle here</h2>
+            </section>
+            <section class="mdc-card__supporting-text">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            </section>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card mdc-card--theme-dark demo-card demo-card--bg-demo">
+            <section class="mdc-card__primary">
+              <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
+              <h2 class="mdc-card__subtitle">Subtitle here</h2>
+            </section>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card demo-card--small">
+            <section class="mdc-card__media">
+              <h1 class="mdc-card__title mdc-card__title--large">Title</h1>
+            </section>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card">
+            <div class="mdc-card__horizontal-block">
+              <section class="mdc-card__primary">
+                <h1 class="mdc-card__title mdc-card__title--large">Title here</h1>
+                <h2 class="mdc-card__subtitle">Subtitle here</h2>
+              </section>
+              <img class="mdc-card__media-item" src="images/1-1.jpg">
+            </div>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card">
+            <div class="mdc-card__horizontal-block">
+              <section class="mdc-card__primary">
+                <h1 class="mdc-card__title mdc-card__title--large">Title here</h1>
+                <h2 class="mdc-card__subtitle">Subtitle here</h2>
+              </section>
+              <img class="mdc-card__media-item mdc-card__media-item--1dot5x" src="images/1-1.jpg">
+            </div>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card">
+            <div class="mdc-card__horizontal-block">
+              <section class="mdc-card__primary">
+                <h1 class="mdc-card__title mdc-card__title--large">Title here</h1>
+                <h2 class="mdc-card__subtitle">Subtitle here</h2>
+              </section>
+              <img class="mdc-card__media-item mdc-card__media-item--2x" src="images/1-1.jpg">
+            </div>
+            <section class="mdc-card__actions">
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
+              <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
+            </section>
+          </div>
+        </div>
+
+        <div>
+          <div class="mdc-card demo-card">
+            <div class="mdc-card__horizontal-block">
+              <img class="mdc-card__media-item mdc-card__media-item--3x" src="images/1-1.jpg">
+              <section class="mdc-card__actions mdc-card__actions--vertical">
+                <!-- TODO(sgomes): Replace with icon buttons when we have those. -->
+                <button class="mdc-button mdc-button--compact mdc-card__action">A1</button>
+                <button class="mdc-button mdc-button--compact mdc-card__action">A2</button>
+              </section>
             </div>
           </div>
-          <label for="toggle-rtl" id="toggle-rtl-label">Toggle RTL</label>
         </div>
-    </section>
 
-    <section class="demo-typography--section mdc-typography" id="demo-wrapper">
-      <div>
-        <div class="mdc-card demo-card">
-          <section class="mdc-card__media demo-card__16-9-media"></section>
-          <section class="mdc-card__supporting-text">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
-          </section>
-        </div>
-      </div>
+      </section>
 
-      <div>
-        <div class="mdc-card demo-card demo-card--with-avatar">
-          <section class="mdc-card__primary">
-            <div class="demo-card__avatar"></div>
-            <h1 class="mdc-card__title">Title</h1>
-            <h2 class="mdc-card__subtitle">Subhead</h2>
-          </section>
-          <section class="mdc-card__media demo-card__16-9-media"></section>
-          <section class="mdc-card__supporting-text">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
-          </section>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card demo-card--with-avatar">
-          <section class="mdc-card__primary">
-            <div class="demo-card__avatar"></div>
-            <h1 class="mdc-card__title">Title</h1>
-            <h2 class="mdc-card__subtitle">Subhead</h2>
-          </section>
-          <section class="mdc-card__media demo-card__16-9-media"></section>
-          <section class="mdc-card__actions mdc-card__actions--vertical">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card">
-          <section class="mdc-card__media demo-card__16-9-media"></section>
-          <section class="mdc-card__primary">
-            <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
-            <h2 class="mdc-card__subtitle">Subtitle here</h2>
-          </section>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card">
-          <section class="mdc-card__primary">
-            <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
-            <h2 class="mdc-card__subtitle">Subtitle here</h2>
-          </section>
-          <section class="mdc-card__supporting-text">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </section>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card mdc-card--theme-dark demo-card demo-card--bg-demo">
-          <section class="mdc-card__primary">
-            <h1 class="mdc-card__title mdc-card__title--large">Title goes here</h1>
-            <h2 class="mdc-card__subtitle">Subtitle here</h2>
-          </section>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-button--theme-dark mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card demo-card--small">
-          <section class="mdc-card__media">
-            <h1 class="mdc-card__title mdc-card__title--large">Title</h1>
-          </section>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card">
-          <div class="mdc-card__horizontal-block">
-            <section class="mdc-card__primary">
-              <h1 class="mdc-card__title mdc-card__title--large">Title here</h1>
-              <h2 class="mdc-card__subtitle">Subtitle here</h2>
-            </section>
-            <img class="mdc-card__media-item" src="images/1-1.jpg">
-          </div>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card">
-          <div class="mdc-card__horizontal-block">
-            <section class="mdc-card__primary">
-              <h1 class="mdc-card__title mdc-card__title--large">Title here</h1>
-              <h2 class="mdc-card__subtitle">Subtitle here</h2>
-            </section>
-            <img class="mdc-card__media-item mdc-card__media-item--1dot5x" src="images/1-1.jpg">
-          </div>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card">
-          <div class="mdc-card__horizontal-block">
-            <section class="mdc-card__primary">
-              <h1 class="mdc-card__title mdc-card__title--large">Title here</h1>
-              <h2 class="mdc-card__subtitle">Subtitle here</h2>
-            </section>
-            <img class="mdc-card__media-item mdc-card__media-item--2x" src="images/1-1.jpg">
-          </div>
-          <section class="mdc-card__actions">
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 1</button>
-            <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
-          </section>
-        </div>
-      </div>
-
-      <div>
-        <div class="mdc-card demo-card">
-          <div class="mdc-card__horizontal-block">
-            <img class="mdc-card__media-item mdc-card__media-item--3x" src="images/1-1.jpg">
-            <section class="mdc-card__actions mdc-card__actions--vertical">
-              <!-- TODO(sgomes): Replace with icon buttons when we have those. -->
-              <button class="mdc-button mdc-button--compact mdc-card__action">A1</button>
-              <button class="mdc-button mdc-button--compact mdc-card__action">A2</button>
-            </section>
-          </div>
-        </div>
-      </div>
-
-    </section>
-
-  </main>
-  <script>
-    // var formField = new mdc.formField.MDCFormField(document.querySelector('.mdc-form-field'));
-    // var cb = mdc.checkbox.MDCCheckbox.attachTo(document.querySelector('.mdc-checkbox'));
-    // formField.input = cb;
-    var demoWrapper = document.getElementById('demo-wrapper');
-    document.getElementById('toggle-rtl').addEventListener('change', function () {
-      if (this.checked) {
-        demoWrapper.setAttribute('dir', 'rtl');
-      } else {
-        demoWrapper.removeAttribute('dir');
-      }
-    });
-  </script>
-</body>
-
+    </main>
+    <script>
+      // var formField = new mdc.formField.MDCFormField(document.querySelector('.mdc-form-field'));
+      // var cb = mdc.checkbox.MDCCheckbox.attachTo(document.querySelector('.mdc-checkbox'));
+      // formField.input = cb;
+      var demoWrapper = document.getElementById('demo-wrapper');
+      document.getElementById('toggle-rtl').addEventListener('change', function () {
+        if (this.checked) {
+          demoWrapper.setAttribute('dir', 'rtl');
+        } else {
+          demoWrapper.removeAttribute('dir');
+        }
+      });
+    </script>
+  </body>
 </html>

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -19,16 +19,13 @@
     <meta charset="utf-8">
     <title>Checkbox - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
-
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style media="screen">
-
-
       .mdc-theme--dark, .section-dark-theme {
         background: #262626;
         color: white;
@@ -326,7 +323,7 @@
       </section>
 
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function(global) {
         'use strict';

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2017 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,18 +19,18 @@
     <meta charset="utf-8">
     <title>Dialog - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
-    	.demo-body {
-    	  padding: 24px;
-    	  margin: 0;
-    	  box-sizing: border-box;
-    	}
+      .demo-body {
+        padding: 24px;
+        margin: 0;
+        box-sizing: border-box;
+      }
       .demo-content > button {
         margin-bottom: 6px;
       }
@@ -71,61 +74,61 @@
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <aside class="catalog-dialog-demo mdc-dialog mdc-dialog--open">
-      	  <div class="mdc-dialog__surface">
-      	    <header class="mdc-dialog__header">
-      	      <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
-      	        Are you happy?
-      	      </h2>
-      	    </header>
-      	    <section id="mdc-dialog-default-description" class="mdc-dialog__body">
-      	       Please check the left and right side of this element for fun.
-      	    </section>
-      	    <footer class="mdc-dialog__footer">
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Cancel</button>
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Continue</button>
-      	    </footer>
-      	  </div>
-      	</aside>
+          <div class="mdc-dialog__surface">
+            <header class="mdc-dialog__header">
+              <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
+                Are you happy?
+              </h2>
+            </header>
+            <section id="mdc-dialog-default-description" class="mdc-dialog__body">
+              Please check the left and right side of this element for fun.
+            </section>
+            <footer class="mdc-dialog__footer">
+              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Cancel</button>
+              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Continue</button>
+            </footer>
+          </div>
+        </aside>
       </section>
 
       <div class="demo-body">
         <aside id="mdc-dialog-default"
-        	  class="mdc-dialog"
-        	  role="alertdialog"
-        	  aria-hidden="true"
-        	  aria-labelledby="mdc-dialog-default-label"
-        	  aria-describedby="mdc-dialog-default-description">
-    	    <div class="mdc-dialog__surface">
-    	      <header class="mdc-dialog__header">
-    	        <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
-    	          Use Google's location service?
-    	        </h2>
-    	      </header>
-    	      <section id="mdc-dialog-default-description" class="mdc-dialog__body">
-    	        Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
-    	      </section>
-    	      <footer class="mdc-dialog__footer">
-    	        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
-    	        <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
-    	      </footer>
-    	    </div>
-    	    <div class="mdc-dialog__backdrop"></div>
-      	</aside>
+               class="mdc-dialog"
+               role="alertdialog"
+               aria-hidden="true"
+               aria-labelledby="mdc-dialog-default-label"
+               aria-describedby="mdc-dialog-default-description">
+          <div class="mdc-dialog__surface">
+            <header class="mdc-dialog__header">
+              <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
+                Use Google's location service?
+              </h2>
+            </header>
+            <section id="mdc-dialog-default-description" class="mdc-dialog__body">
+              Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
+            </section>
+            <footer class="mdc-dialog__footer">
+              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
+              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
+            </footer>
+          </div>
+          <div class="mdc-dialog__backdrop"></div>
+        </aside>
 
-      	<aside id="mdc-dialog-with-list"
-        	  class="mdc-dialog"
-        	  role="alertdialog"
-         	  aria-hidden="true"
-        	  aria-labelledby="mdc-dialog-with-list-label"
-        	  aria-describedby="mdc-dialog-with-list-description">
-      	  <div class="mdc-dialog__surface">
-      	    <header class="mdc-dialog__header">
-      	      <h2 id="mdc-dialog-with-list-label" class="mdc-dialog__header__title">
-      	        Choose a Ringtone
-      	      </h2>
-      	    </header>
-      	    <section id="mdc-dialog-with-list-description" class="mdc-dialog__body mdc-dialog__body--scrollable">
-      	     	<ul class="mdc-list">
+        <aside id="mdc-dialog-with-list"
+               class="mdc-dialog"
+               role="alertdialog"
+               aria-hidden="true"
+               aria-labelledby="mdc-dialog-with-list-label"
+               aria-describedby="mdc-dialog-with-list-description">
+          <div class="mdc-dialog__surface">
+            <header class="mdc-dialog__header">
+              <h2 id="mdc-dialog-with-list-label" class="mdc-dialog__header__title">
+                Choose a Ringtone
+              </h2>
+            </header>
+            <section id="mdc-dialog-with-list-description" class="mdc-dialog__body mdc-dialog__body--scrollable">
+              <ul class="mdc-list">
                 <li class="mdc-list-item">None</li>
                 <li class="mdc-list-item">Callisto</li>
                 <li class="mdc-list-item">Ganymede</li>
@@ -138,30 +141,30 @@
                 <li class="mdc-list-item">Marimba</li>
                 <li class="mdc-list-item">Schwifty</li>
               </ul>
-      	    </section>
-      	    <footer class="mdc-dialog__footer">
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
-      	      <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
-      	    </footer>
-      	  </div>
-      	  <div class="mdc-dialog__backdrop"></div>
-      	</aside>
-    	</div>
+            </section>
+            <footer class="mdc-dialog__footer">
+              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
+              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept">Accept</button>
+            </footer>
+          </div>
+          <div class="mdc-dialog__backdrop"></div>
+        </aside>
+      </div>
       <section class="example">
         <button id="default-dialog-activation" class="mdc-button mdc-button--primary mdc-button--raised">Show Dialog</button>
         <button id="dialog-with-list-activation" class="mdc-button mdc-button--primary mdc-button--raised">Show Scrolling Dialog</button>
         <div class="mdc-form-field">
           <div class="mdc-checkbox">
             <input type="checkbox"
-                 id="toggle-rtl"
-                 class="mdc-checkbox__native-control"/>
+                   id="toggle-rtl"
+                   class="mdc-checkbox__native-control"/>
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark"
                   viewBox="0 0 24 24">
                 <path class="mdc-checkbox__checkmark__path"
-                     fill="none"
-                     stroke="white"
-                     d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                      fill="none"
+                      stroke="white"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>
@@ -181,7 +184,7 @@
                 </h2>
               </header>
               <section id="mdc-dialog-default-description" class="mdc-dialog__body">
-                 Please check the left and right side of this element for fun.
+                Please check the left and right side of this element for fun.
               </section>
               <footer class="mdc-dialog__footer">
                 <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Cancel</button>
@@ -203,7 +206,7 @@
                 </h2>
               </header>
               <section id="mdc-dialog-default-description" class="mdc-dialog__body">
-                 Please check the left and right side of this element for fun.
+                Please check the left and right side of this element for fun.
               </section>
               <footer class="mdc-dialog__footer">
                 <button type="button" class="mdc-button mdc-button--theme-dark mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Cancel</button>
@@ -214,7 +217,7 @@
         </div>
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function() {
         var dialog = new mdc.dialog.MDCDialog(document.querySelector('#mdc-dialog-default'));
@@ -228,11 +231,11 @@
           dialog.lastFocusedTarget = evt.target;
           dialog.show();
         });
-      	var dialogScrollable = new mdc.dialog.MDCDialog(document.querySelector('#mdc-dialog-with-list'));
-      	document.querySelector('#dialog-with-list-activation').addEventListener('click', function (evt) {
-      	  dialogScrollable.lastFocusedTarget = evt.target;
+        var dialogScrollable = new mdc.dialog.MDCDialog(document.querySelector('#mdc-dialog-with-list'));
+        document.querySelector('#dialog-with-list-activation').addEventListener('click', function (evt) {
+          dialogScrollable.lastFocusedTarget = evt.target;
           dialogScrollable.show();
-      	});
+        });
       })();
     </script>
     <script>

--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -19,57 +19,58 @@
     <meta charset="utf-8">
     <title>Drawer Above Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
-    /* Ensure layout covers the entire screen. */
-    html {
-      height: 100%;
-    }
+      /* Ensure layout covers the entire screen. */
+      html {
+        height: 100%;
+      }
 
-    /* Place drawer and content side by side. */
-    .demo-body {
-      display: flex;
-      flex-direction: row;
-      padding: 0;
-      margin: 0;
-      box-sizing: border-box;
-      min-height: 100%;
-      width: 100%;
-    }
+      /* Place drawer and content side by side. */
+      .demo-body {
+        display: flex;
+        flex-direction: row;
+        padding: 0;
+        margin: 0;
+        box-sizing: border-box;
+        min-height: 100%;
+        width: 100%;
+      }
 
-    /* Stack toolbar and main on top of each other. */
-    .demo-content {
-      display: inline-flex;
-      flex-direction: column;
-      flex-grow: 1;
-      height: 100%;
-      box-sizing: border-box;
-    }
+      /* Stack toolbar and main on top of each other. */
+      .demo-content {
+        display: inline-flex;
+        flex-direction: column;
+        flex-grow: 1;
+        height: 100%;
+        box-sizing: border-box;
+      }
 
-    /* Place drawer above toolbar shadow. */
-    .mdc-permanent-drawer {
-      z-index: 2;
-    }
+      /* Place drawer above toolbar shadow. */
+      .mdc-permanent-drawer {
+        z-index: 2;
+      }
 
-    .demo-main {
-      padding-left: 16px;
-    }
+      .demo-main {
+        padding-left: 16px;
+      }
 
-    .extra-content-wrapper {
-      padding: 10px;
-    }
+      .extra-content-wrapper {
+        padding: 10px;
+      }
 
-    #extra-wide-content {
-      width: 200vw;
-    }
+      #extra-wide-content {
+        width: 200vw;
+      }
 
-    #extra-tall-content {
-      height: 200vh;
-    }
+      #extra-tall-content {
+        height: 200vh;
+      }
     </style>
   </head>
   <body class="demo-body mdc-typography">

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -19,50 +19,51 @@
     <meta charset="utf-8">
     <title>Drawer Below Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
-    /* Ensure layout covers the entire screen. */
-    html {
-      height: 100%;
-    }
+      /* Ensure layout covers the entire screen. */
+      html {
+        height: 100%;
+      }
 
-    /* Stack toolbar and content on top of each other. */
-    .demo-body {
-      display: flex;
-      flex-direction: column;
-      padding: 0;
-      margin: 0;
-      box-sizing: border-box;
-      min-height: 100%;
-    }
+      /* Stack toolbar and content on top of each other. */
+      .demo-body {
+        display: flex;
+        flex-direction: column;
+        padding: 0;
+        margin: 0;
+        box-sizing: border-box;
+        min-height: 100%;
+      }
 
-    /* Place drawer and main next to each other. */
-    .demo-content {
-      display: flex;
-      flex: 1 1 auto;
-      height: 100%;
-      box-sizing: border-box;
-    }
+      /* Place drawer and main next to each other. */
+      .demo-content {
+        display: flex;
+        flex: 1 1 auto;
+        height: 100%;
+        box-sizing: border-box;
+      }
 
-    .demo-main {
-      padding-left: 16px;
-    }
+      .demo-main {
+        padding-left: 16px;
+      }
 
-    .extra-content-wrapper {
-      padding: 10px;
-    }
+      .extra-content-wrapper {
+        padding: 10px;
+      }
 
-    #extra-wide-content {
-      width: 200vw;
-    }
+      #extra-wide-content {
+        width: 200vw;
+      }
 
-    #extra-tall-content {
-      height: 200vh;
-    }
+      #extra-tall-content {
+        height: 200vh;
+      }
     </style>
   </head>
   <body class="mdc-typography demo-body">

--- a/demos/drawer/persistent-drawer.html
+++ b/demos/drawer/persistent-drawer.html
@@ -19,40 +19,41 @@
     <meta charset="utf-8">
     <title>Drawer (Persistent) - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
-    /* Ensure layout covers the entire screen. */
-    html {
-      height: 100%;
-    }
+      /* Ensure layout covers the entire screen. */
+      html {
+        height: 100%;
+      }
 
-    /* Place drawer and content side by side. */
-    .demo-body {
-      display: flex;
-      flex-direction: row;
-      padding: 0;
-      margin: 0;
-      box-sizing: border-box;
-      height: 100%;
-      width: 100%;
-    }
+      /* Place drawer and content side by side. */
+      .demo-body {
+        display: flex;
+        flex-direction: row;
+        padding: 0;
+        margin: 0;
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+      }
 
-    /* Stack toolbar and main on top of each other. */
-    .demo-content {
-      display: inline-flex;
-      flex-direction: column;
-      flex-grow: 1;
-      height: 100%;
-      box-sizing: border-box;
-    }
+      /* Stack toolbar and main on top of each other. */
+      .demo-content {
+        display: inline-flex;
+        flex-direction: column;
+        flex-grow: 1;
+        height: 100%;
+        box-sizing: border-box;
+      }
 
-    .demo-main {
-      padding-left: 16px;
-    }
+      .demo-main {
+        padding-left: 16px;
+      }
     </style>
   </head>
   <body class="demo-body mdc-typography">
@@ -106,7 +107,7 @@
         <p class="mdc-typography--body1">Click the menu icon above to open and close the drawer.</p>
       </main>
 
-      <script src="../assets/material-components-web.js" charset="utf-8"></script>
+      <script src="/assets/material-components-web.js"></script>
       <script>
         var drawerEl = document.querySelector('.mdc-persistent-drawer');
         var MDCPersistentDrawer = mdc.drawer.MDCPersistentDrawer;

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -19,22 +19,23 @@
     <meta charset="utf-8">
     <title>Drawer (Temporary) - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
-    .demo-body {
-      padding: 0;
-      margin: 0;
-      box-sizing: border-box;
-    }
+      .demo-body {
+        padding: 0;
+        margin: 0;
+        box-sizing: border-box;
+      }
 
-    .demo-main {
-      padding-left: 16px;
-      overflow: auto;
-    }
+      .demo-main {
+        padding-left: 16px;
+        overflow: auto;
+      }
     </style>
   </head>
   <body class="mdc-typography demo-body">
@@ -91,7 +92,7 @@
       <p class="mdc-typography--body1">Click the menu icon above to open.</p>
     </main>
 
-    <script src="../assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       var drawerEl = document.querySelector('.mdc-temporary-drawer');
       var MDCTemporaryDrawer = mdc.drawer.MDCTemporaryDrawer;

--- a/demos/elevation.html
+++ b/demos/elevation.html
@@ -19,12 +19,12 @@
     <meta charset="utf-8">
     <title>Elevation - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .demo-surfaces {
         padding-top: 48px;

--- a/demos/fab.html
+++ b/demos/fab.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +19,12 @@
     <meta charset="utf-8">
     <title>Floating Action Button - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       /* Make the demo look a little bit better */
       fieldset {
@@ -162,7 +165,7 @@
         </fieldset>
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       // Because we load our CSS via webpack, we need to ensure that all of the correct styles
       // are applied before ripples are attached. Otherwise, ripples may use the computed styles of

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +19,12 @@
     <meta charset="utf-8">
     <title>Grid List - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .demo-grid-tile-content {
         background-image: url("images/16-9.jpg");
@@ -722,7 +725,7 @@
       </section>
 
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script type="text/javascript">
       function initGridList() {
         var nodes = document.querySelectorAll('.mdc-grid-list');

--- a/demos/icon-toggle.html
+++ b/demos/icon-toggle.html
@@ -1,27 +1,30 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License
-  -->
+-->
 <html class="mdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Icon Toggle - Material Components Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css">
     <style>
       .mdc-theme--dark {
@@ -290,7 +293,7 @@
         </div>
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function() {
         'use strict';

--- a/demos/images/ic_shadow_24px.svg
+++ b/demos/images/ic_shadow_24px.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+     width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
 <g id="XMLID_190_">
-	<g id="XMLID_111_">
-		<path id="XMLID_128_" d="M6,2v16h16V2H6z M20,16H8V4h12V16z"/>
-		<polygon id="XMLID_176_" points="4,4 2,4 2,22 20,22 20,20 4,20 		"/>
-	</g>
-	<rect id="XMLID_113_" fill="none" width="24" height="24"/>
+  <g id="XMLID_111_">
+    <path id="XMLID_128_" d="M6,2v16h16V2H6z M20,16H8V4h12V16z"/>
+    <polygon id="XMLID_176_" points="4,4 2,4 2,22 20,22 20,20 4,20"/>
+  </g>
+  <rect id="XMLID_113_" fill="none" width="24" height="24"/>
 </g>
 </svg>

--- a/demos/index.html
+++ b/demos/index.html
@@ -19,10 +19,11 @@
     <meta charset="utf-8">
     <title>Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
   </head>
   <body>
     <header class="mdc-toolbar mdc-toolbar--fixed">
@@ -39,216 +40,216 @@
       <nav class="mdc-toolbar-fixed-adjust">
         <ul class="catalog-list mdc-list mdc-list--two-line">
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
-              <a href="button.html" class="mdc-list-item__text">
-                Button
-                <span class="mdc-list-item__text__secondary">Raised and flat buttons</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
+            <a href="button.html" class="mdc-list-item__text">
+              Button
+              <span class="mdc-list-item__text__secondary">Raised and flat buttons</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
-              <a href="card.html" class="mdc-list-item__text">
-                Card
-                <span class="mdc-list-item__text__secondary">Various card layout styles</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
+            <a href="card.html" class="mdc-list-item__text">
+              Card
+              <span class="mdc-list-item__text__secondary">Various card layout styles</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_selection_control_24px.svg" /></span>
-              <a href="checkbox.html" class="mdc-list-item__text">
-                Checkbox
-                <span class="mdc-list-item__text__secondary">Multi-selection controls</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_selection_control_24px.svg" /></span>
+            <a href="checkbox.html" class="mdc-list-item__text">
+              Checkbox
+              <span class="mdc-list-item__text__secondary">Multi-selection controls</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_dialog_24px.svg" /></span>
-              <a href="dialog.html" class="mdc-list-item__text">
-                Dialog
-                <span class="mdc-list-item__text__secondary">Secondary text</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_dialog_24px.svg" /></span>
+            <a href="dialog.html" class="mdc-list-item__text">
+              Dialog
+              <span class="mdc-list-item__text__secondary">Secondary text</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
-              <a href="drawer/temporary-drawer.html" class="mdc-list-item__text">
-                Drawer
-                <span class="mdc-list-item__text__secondary">Temporary</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
+            <a href="drawer/temporary-drawer.html" class="mdc-list-item__text">
+              Drawer
+              <span class="mdc-list-item__text__secondary">Temporary</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
-              <a href="drawer/persistent-drawer.html" class="mdc-list-item__text">
-                Drawer
-                <span class="mdc-list-item__text__secondary">Persistent</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
+            <a href="drawer/persistent-drawer.html" class="mdc-list-item__text">
+              Drawer
+              <span class="mdc-list-item__text__secondary">Persistent</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
-              <a href="drawer/permanent-drawer-above-toolbar.html" class="mdc-list-item__text">
-                Drawer
-                <span class="mdc-list-item__text__secondary">Permanent drawer above toolbar</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
+            <a href="drawer/permanent-drawer-above-toolbar.html" class="mdc-list-item__text">
+              Drawer
+              <span class="mdc-list-item__text__secondary">Permanent drawer above toolbar</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
-              <a href="drawer/permanent-drawer-below-toolbar.html" class="mdc-list-item__text">
-                Drawer
-                <span class="mdc-list-item__text__secondary">Permanent drawer below toolbar</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
+            <a href="drawer/permanent-drawer-below-toolbar.html" class="mdc-list-item__text">
+              Drawer
+              <span class="mdc-list-item__text__secondary">Permanent drawer below toolbar</span>
+            </a>
           </li>
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_shadow_24px.svg" /></span>
-              <a href="elevation.html" class="mdc-list-item__text">
-                Elevation
-                <span class="mdc-list-item__text__secondary">Shadow for different elevations</span>
-              </a>
-          </li>
-
-          <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
-              <a href="fab.html" class="mdc-list-item__text">
-                Floating action button
-                <span class="mdc-list-item__text__secondary">The primary action in an application</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_shadow_24px.svg" /></span>
+            <a href="elevation.html" class="mdc-list-item__text">
+              Elevation
+              <span class="mdc-list-item__text__secondary">Shadow for different elevations</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
-              <a href="grid-list.html" class="mdc-list-item__text">
-                Grid list
-                <span class="mdc-list-item__text__secondary">2D grid layouts</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
+            <a href="fab.html" class="mdc-list-item__text">
+              Floating action button
+              <span class="mdc-list-item__text__secondary">The primary action in an application</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_component_24px.svg" /></span>
-              <a href="icon-toggle.html" class="mdc-list-item__text">
-                Icon toggle
-                <span class="mdc-list-item__text__secondary">Toggling icon states</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
+            <a href="grid-list.html" class="mdc-list-item__text">
+              Grid list
+              <span class="mdc-list-item__text__secondary">2D grid layouts</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
-              <a href="layout-grid.html" class="mdc-list-item__text">
-                Layout grid
-                <span class="mdc-list-item__text__secondary">Grid and gutter support</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_component_24px.svg" /></span>
+            <a href="icon-toggle.html" class="mdc-list-item__text">
+              Icon toggle
+              <span class="mdc-list-item__text__secondary">Toggling icon states</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_progress_activity.svg" /></span>
-              <a href="linear-progress.html" class="mdc-list-item__text">
-                Linear progress
-                <span class="mdc-list-item__text__secondary">Fills from 0% to 100%, represented by bars</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
+            <a href="layout-grid.html" class="mdc-list-item__text">
+              Layout grid
+              <span class="mdc-list-item__text__secondary">Grid and gutter support</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_list_24px.svg" /></span>
-              <a href="list.html" class="mdc-list-item__text">
-                List
-                <span class="mdc-list-item__text__secondary">Item layouts in lists</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_progress_activity.svg" /></span>
+            <a href="linear-progress.html" class="mdc-list-item__text">
+              Linear progress
+              <span class="mdc-list-item__text__secondary">Fills from 0% to 100%, represented by bars</span>
+            </a>
+          </li>
+
+          <li class="mdc-list-item">
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_list_24px.svg" /></span>
+            <a href="list.html" class="mdc-list-item__text">
+              List
+              <span class="mdc-list-item__text__secondary">Item layouts in lists</span>
+            </a>
           </li>
 
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_radio_button_24px.svg" /></span>
-              <a href="radio.html" class="mdc-list-item__text">
-                Radio buttons
-                <span class="mdc-list-item__text__secondary">Single selection controls</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_radio_button_24px.svg" /></span>
+            <a href="radio.html" class="mdc-list-item__text">
+              Radio buttons
+              <span class="mdc-list-item__text__secondary">Single selection controls</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_ripple_24px.svg" /></span>
-              <a href="ripple.html" class="mdc-list-item__text">
-                Ripple
-                <span class="mdc-list-item__text__secondary">Touch ripple</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_ripple_24px.svg" /></span>
+            <a href="ripple.html" class="mdc-list-item__text">
+              Ripple
+              <span class="mdc-list-item__text__secondary">Touch ripple</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
-              <a href="select.html" class="mdc-list-item__text">
-                Select
-                <span class="mdc-list-item__text__secondary">Popover selection menus</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
+            <a href="select.html" class="mdc-list-item__text">
+              Select
+              <span class="mdc-list-item__text__secondary">Popover selection menus</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
-              <a href="simple-menu.html" class="mdc-list-item__text">
-                Simple Menu
-                <span class="mdc-list-item__text__secondary">Pop over menus</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
+            <a href="simple-menu.html" class="mdc-list-item__text">
+              Simple Menu
+              <span class="mdc-list-item__text__secondary">Pop over menus</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/slider.svg" /></span>
-              <a href="slider.html" class="mdc-list-item__text">
-                Slider
-                <span class="mdc-list-item__text__secondary">Range Controls</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/slider.svg" /></span>
+            <a href="slider.html" class="mdc-list-item__text">
+              Slider
+              <span class="mdc-list-item__text__secondary">Range Controls</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toast_24px.svg" /></span>
-              <a href="snackbar.html" class="mdc-list-item__text">
-                Snackbar
-                <span class="mdc-list-item__text__secondary">Transient messages</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toast_24px.svg" /></span>
+            <a href="snackbar.html" class="mdc-list-item__text">
+              Snackbar
+              <span class="mdc-list-item__text__secondary">Transient messages</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_switch_24px.svg" /></span>
-              <a href="switch.html" class="mdc-list-item__text">
-                Switch
-                <span class="mdc-list-item__text__secondary">On off switches</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_switch_24px.svg" /></span>
+            <a href="switch.html" class="mdc-list-item__text">
+              Switch
+              <span class="mdc-list-item__text__secondary">On off switches</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_tabs_24px.svg" /></span>
-              <a href="tabs.html" class="mdc-list-item__text">
-                Tabs
-                <span class="mdc-list-item__text__secondary">Tabs with support for icon and text labels</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_tabs_24px.svg" /></span>
+            <a href="tabs.html" class="mdc-list-item__text">
+              Tabs
+              <span class="mdc-list-item__text__secondary">Tabs with support for icon and text labels</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_text_field_24px.svg" /></span>
-              <a href="textfield.html" class="mdc-list-item__text">
-                Text field
-                <span class="mdc-list-item__text__secondary">Single and multiline text fields</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_text_field_24px.svg" /></span>
+            <a href="textfield.html" class="mdc-list-item__text">
+              Text field
+              <span class="mdc-list-item__text__secondary">Single and multiline text fields</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_theme_24px.svg" /></span>
-              <a href="theme.html" class="mdc-list-item__text">
-                Theme
-                <span class="mdc-list-item__text__secondary">Using primary and accent colors</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_theme_24px.svg" /></span>
+            <a href="theme.html" class="mdc-list-item__text">
+              Theme
+              <span class="mdc-list-item__text__secondary">Using primary and accent colors</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toolbar_24px.svg" /></span>
-              <a href="toolbar/index.html" class="mdc-list-item__text">
-                Toolbar
-                <span class="mdc-list-item__text__secondary">Header and footers</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toolbar_24px.svg" /></span>
+            <a href="toolbar/index.html" class="mdc-list-item__text">
+              Toolbar
+              <span class="mdc-list-item__text__secondary">Header and footers</span>
+            </a>
           </li>
 
           <li class="mdc-list-item">
-              <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_typography_24px.svg" /></span>
-              <a href="typography.html" class="mdc-list-item__text">
-                Typography
-                <span class="mdc-list-item__text__secondary">Type hierarchy</span>
-              </a>
+            <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_typography_24px.svg" /></span>
+            <a href="typography.html" class="mdc-list-item__text">
+              Typography
+              <span class="mdc-list-item__text__secondary">Type hierarchy</span>
+            </a>
           </li>
         </ul>
       </nav>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
   </body>
 </html>

--- a/demos/layout-grid.html
+++ b/demos/layout-grid.html
@@ -19,12 +19,12 @@
     <meta charset="utf-8">
     <title>Layout Grid - Material Components</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
     .demo-grid {
       background-color: #DDDDDD;

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -1,26 +1,30 @@
 <!DOCTYPE html>
 <!--
   Copyright 2017 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License
-  -->
+-->
 <html>
   <head>
     <meta charset="utf-8">
     <title>Linear Progress - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <link href="demos.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       fieldset {
         margin: 24px;
@@ -175,7 +179,7 @@
       </section>
 
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       var determinates = document.querySelectorAll('.mdc-linear-progress');
       for (var i = 0, determinate; determinate = determinates[i]; i++) {

--- a/demos/list.html
+++ b/demos/list.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +19,12 @@
     <meta charset="utf-8">
     <title>List Item - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-list,
       .mdc-list-group {

--- a/demos/radio.html
+++ b/demos/radio.html
@@ -19,13 +19,13 @@
     <meta charset="utf-8">
     <title>Radio Button - Material Components Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
-    <style type="text/css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <style>
       .mdc-theme--dark {
         background-color: #303030;
       }
@@ -233,7 +233,7 @@
         </div>
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function(global) {
         'use strict';

--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -19,19 +19,19 @@
     <meta charset="utf-8">
     <title>Ripple - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <script>
       if (!window.CSS || !window.CSS.supports ||
         !window.CSS.supports('--css-vars', 'yes') && !(window.CSS.supports('color', '#00000000'))) {
         document.documentElement.classList.add('unsupported');
       }
     </script>
-    <style type="text/css">
+    <style>
       .demo-surface {
         display: flex;
         align-items: center;
@@ -208,7 +208,7 @@
 
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function(global) {
         [].forEach.call(document.querySelectorAll('.mdc-ripple-surface:not([data-demo-no-js])'), function(surface) {

--- a/demos/select.html
+++ b/demos/select.html
@@ -19,13 +19,13 @@
     <meta charset="utf-8">
     <title>Select Menu - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
-    <style type="text/css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <style>
       .mdc-theme--dark {
         background-color: #303030;
       }
@@ -175,7 +175,7 @@
       </section>
 
     </main>
-    <script src="assets/material-components-web.js"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function() {
         var MDCSelect = mdc.select.MDCSelect;

--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -18,13 +18,13 @@
   <head>
     <meta charset="utf-8">
     <title>Simple Menu - Material Components Catalog</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       html,
       body,
@@ -153,7 +153,7 @@
       </div>
     </main>
 
-    <script src="../assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       var menuEl = document.querySelector('#demo-menu');
       var menu = new mdc.menu.MDCSimpleMenu(menuEl);

--- a/demos/slider.html
+++ b/demos/slider.html
@@ -19,12 +19,12 @@
     <meta charset="utf-8">
     <title>Slider - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       #hero-slider-wrapper {
         margin: 0 auto;
@@ -219,7 +219,7 @@
         </div>
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function() {
         setTimeout(function() {

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -19,12 +19,12 @@
     <meta charset="utf-8">
     <title>Snackbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       /* initialize it off screen. */
       .loading .example .mdc-snackbar { transform: translateY(200%); }
@@ -198,7 +198,7 @@
         </div>
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function(global) {
         'use strict';

--- a/demos/switch.html
+++ b/demos/switch.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +19,12 @@
     <meta charset="utf-8">
     <title>Switch - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       section.example  {
         margin-bottom: 0.5rem;
@@ -130,6 +133,6 @@
       </section>
 
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
   </body>
 </html>

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <!--
-Copyright 2017 Google Inc. All rights reserved.
+  Copyright 2017 Google Inc. All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-https://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License
 -->
 <html>
   <head>
     <meta charset="utf-8">
     <title>MDC-Web Tab Bar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       fieldset {
         padding: 24px;
@@ -570,7 +572,7 @@ limitations under the License
       </section>
 
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function() {
         setTimeout(function () {

--- a/demos/textfield.html
+++ b/demos/textfield.html
@@ -19,12 +19,12 @@
     <meta charset="utf-8">
     <title>Text Field - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-theme--dark {
         --mdc-theme-primary: var(--mdc-theme-accent, #64dd17);
@@ -283,7 +283,7 @@
         </div>
       </section>
     </main>
-    <script src="assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script>
       (function() {
         var tfs = document.querySelectorAll(

--- a/demos/theme.html
+++ b/demos/theme.html
@@ -19,12 +19,12 @@
     <meta charset="utf-8">
     <title>Theme - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .demo-theme__color {
         display: inline-flex;

--- a/demos/toolbar/default-flexible-toolbar.html
+++ b/demos/toolbar/default-flexible-toolbar.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {
@@ -76,7 +81,7 @@
     <footer>
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
-    <script src="../assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script type="text/javascript">
       (function() {
         var pollId = 0;

--- a/demos/toolbar/default-toolbar.html
+++ b/demos/toolbar/default-toolbar.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {

--- a/demos/toolbar/fixed-toolbar.html
+++ b/demos/toolbar/fixed-toolbar.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,11 +19,11 @@
     <meta charset="utf-8">
     <title>Toolbar - Material Compoonents Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .demo-container {

--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-	<script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {
@@ -35,38 +40,37 @@
       }
       #demo-menu {
         margin-top: 8px;
-	margin-right: 8px;
+        margin-right: 8px;
       }
     </style>
   </head>
   <body class="mdc-typography mdc-toolbar-demo">
     <header class="mdc-toolbar mdc-toolbar--fixed">
-	  <div class="mdc-toolbar__row">
-		<section class="mdc-toolbar__section mdc-toolbar__section--align-start">
-		  <a href="#" class="material-icons mdc-toolbar__icon--menu">menu</a>
-		  <span class="mdc-toolbar__title">Title</span>
-		</section>
-		<section class="mdc-toolbar__section mdc-toolbar__section--align-end" role="toolbar">
-		  <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Download" alt="Download">file_download</a>
-		  <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Print this page" alt="Print this page">print</a>
-		  <div class="mdc-menu-anchor">
-			<a href="#" class="material-icons mdc-toolbar__icon toggle" aria-label="Bookmark this page" alt="Bookmark this page">more_vert</a>
-			<div class="mdc-simple-menu" tabindex="-1" id="demo-menu">
-			  <ul class="mdc-simple-menu__items mdc-list" role="menu" aria-hidden="true" style="transform: scale(1, 1);">
-				<li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.069s;">Back</li>
-				<li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.124s;">Forward</li>
-				<li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.179s;">Reload</li>
-				<li class="mdc-list-divider" role="separator"></li>
+      <div class="mdc-toolbar__row">
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+          <a href="#" class="material-icons mdc-toolbar__icon--menu">menu</a>
+          <span class="mdc-toolbar__title">Title</span>
+        </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end" role="toolbar">
+          <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Download" alt="Download">file_download</a>
+          <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Print this page" alt="Print this page">print</a>
+          <div class="mdc-menu-anchor">
+          <a href="#" class="material-icons mdc-toolbar__icon toggle" aria-label="Bookmark this page" alt="Bookmark this page">more_vert</a>
+          <div class="mdc-simple-menu" tabindex="-1" id="demo-menu">
+            <ul class="mdc-simple-menu__items mdc-list" role="menu" aria-hidden="true" style="transform: scale(1, 1);">
+            <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.069s;">Back</li>
+            <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.124s;">Forward</li>
+            <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.179s;">Reload</li>
+            <li class="mdc-list-divider" role="separator"></li>
+            <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.236s;">Save As...</li>
+            </ul>
+          </div>
+          </div>
+        </section>
+      </div>
+    </header>
 
-				<li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.236s;">Save As...</li>
-			  </ul>
-			</div>
-		  </div>
-		</section>
-	  </div>
-	</header>
     <main>
-
       <div class="mdc-toolbar-fixed-adjust">
         <p class="demo-paragraph">
           Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
@@ -79,9 +83,9 @@
         </p>
       </div>
     </main>
-	
-	<script src="../assets/material-components-web.js" charset="utf-8"></script>
-	<script>
+
+    <script src="/assets/material-components-web.js"></script>
+    <script>
       var menuEl = document.querySelector('#demo-menu');
       var menu = new mdc.menu.MDCSimpleMenu(menuEl);
       var toggle = document.querySelector('.toggle');

--- a/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
+++ b/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {
@@ -79,7 +84,7 @@
     <footer>
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
-    <script src="../assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script type="text/javascript">
       (function() {
         var pollId = 0;

--- a/demos/toolbar/waterfall-flexible-toolbar.html
+++ b/demos/toolbar/waterfall-flexible-toolbar.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {
@@ -79,7 +84,7 @@
     <footer>
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
-    <script src="../assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script type="text/javascript">
       (function() {
         var pollId = 0;

--- a/demos/toolbar/waterfall-toolbar-fix-last-row.html
+++ b/demos/toolbar/waterfall-toolbar-fix-last-row.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {
@@ -87,7 +92,7 @@
     <footer>
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
-    <script src="../assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script type="text/javascript">
       (function() {
         var pollId = 0;

--- a/demos/toolbar/waterfall-toolbar.html
+++ b/demos/toolbar/waterfall-toolbar.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <!--
   Copyright 2016 Google Inc. All rights reserved.
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
+
       https://www.apache.org/licenses/LICENSE-2.0
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +19,11 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="../assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="../assets/demo-styles.css.js" charset="utf-8"></script>
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .mdc-toolbar-demo {
@@ -62,7 +67,7 @@
         </p>
       </div>
     </main>
-    <script src="../assets/material-components-web.js" charset="utf-8"></script>
+    <script src="/assets/material-components-web.js"></script>
     <script type="text/javascript">
       (function() {
         var pollId = 0;

--- a/demos/typography.html
+++ b/demos/typography.html
@@ -19,12 +19,12 @@
     <meta charset="utf-8">
     <title>Typography - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png" />
-    <script src="assets/material-components-web.css.js" charset="utf-8"></script>
-    <script src="assets/demo-styles.css.js" charset="utf-8"></script>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+    <script src="/assets/material-components-web.css.js"></script>
+    <script src="/assets/demo-styles.css.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       .demo-typography--section {
         margin: 24px;


### PR DESCRIPTION
- Replace tab chars with two spaces
- Normalize indentation depth
- Normalize formatting of copyright notice
- Ensure all pages have `<link rel="icon">`
- Remove closing `/` on `<link rel="icon">`
- Remove `minimum-scale=1` from `<meta name="viewport">` in `simple-menu.html`
- Remove unnecessary `type="text/css"` from `<style>` elements
- Remove unnecessary `charset="utf-8"` attribute from `<script>` elements
- Normalize order of attributes on `<link>` elements
- Normalize order of `<link>` elements
- Add missing font includes
- Use absolute paths for JS/CSS includes (e.g., `/assets/...` instead of `../assets/...`)