### PR TITLE
perf(infrastructure): Cut build time in half with opt-in env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "commitmsg": "validate-commit-msg",
     "dist": "npm run clean && npm run build && npm run build:min",
     "dev": "npm run clean && cross-env MDC_ENV=development webpack-dev-server --content-base demos --inline --hot --host 0.0.0.0",
+    "dev:fast": "cross-env MDC_BUILD=fast npm run dev",
     "fix:js": "eslint --fix packages test webpack.config.js karma.conf.js",
     "fix:css": "stylefmt -r packages/**/*.scss",
     "fix": "npm-run-all --parallel fix:*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "commitmsg": "validate-commit-msg",
     "dist": "npm run clean && npm run build && npm run build:min",
     "dev": "npm run clean && cross-env MDC_ENV=development webpack-dev-server --content-base demos --inline --hot --host 0.0.0.0",
-    "dev:fast": "cross-env MDC_BUILD=fast npm run dev",
     "fix:js": "eslint --fix packages test webpack.config.js karma.conf.js",
     "fix:css": "stylefmt -r packages/**/*.scss",
     "fix": "npm-run-all --parallel fix:*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,8 +27,8 @@ const PUBLIC_PATH = '/assets/';
 const IS_DEV = process.env.MDC_ENV === 'development';
 const IS_PROD = process.env.MDC_ENV === 'production';
 const IS_FAST_BUILD = process.env.MDC_BUILD === 'fast';
-const GENERATE_SOURCE_MAPS = IS_DEV && !IS_FAST_BUILD;
-const DEVTOOL = GENERATE_SOURCE_MAPS ? 'source-map' : false;
+const GENERATE_SOURCE_MAPS = IS_DEV && !IS_FAST_BUILD && !process.env.MDC_GENERATE_SOURCE_MAPS;
+const DEVTOOL = process.env.MDC_DEVTOOL || (GENERATE_SOURCE_MAPS ? 'source-map' : false);
 
 const banner = [
   '/*!',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const PUBLIC_PATH = '/assets/';
 const IS_DEV = process.env.MDC_ENV === 'development';
 const IS_PROD = process.env.MDC_ENV === 'production';
 const IS_FAST_BUILD = process.env.MDC_BUILD === 'fast';
-const GENERATE_SOURCE_MAPS = IS_DEV && !IS_FAST_BUILD && !process.env.MDC_GENERATE_SOURCE_MAPS;
+const GENERATE_SOURCE_MAPS = IS_DEV && !IS_FAST_BUILD && process.env.MDC_GENERATE_SOURCE_MAPS !== 'false';
 const DEVTOOL = process.env.MDC_DEVTOOL || (GENERATE_SOURCE_MAPS ? 'source-map' : false);
 
 const banner = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,9 +26,10 @@ const OUT_PATH = path.resolve('./build');
 const PUBLIC_PATH = '/assets/';
 const IS_DEV = process.env.MDC_ENV === 'development';
 const IS_PROD = process.env.MDC_ENV === 'production';
-const IS_FAST_BUILD = process.env.MDC_BUILD === 'fast';
-const GENERATE_SOURCE_MAPS = IS_DEV && !IS_FAST_BUILD && process.env.MDC_GENERATE_SOURCE_MAPS !== 'false';
-const DEVTOOL = process.env.MDC_DEVTOOL || (GENERATE_SOURCE_MAPS ? 'source-map' : false);
+const GENERATE_SOURCE_MAPS =
+    process.env.MDC_GENERATE_SOURCE_MAPS === 'true' ||
+    (process.env.MDC_GENERATE_SOURCE_MAPS !== 'false' && IS_DEV);
+const DEVTOOL = GENERATE_SOURCE_MAPS ? 'source-map' : false;
 
 const banner = [
   '/*!',
@@ -60,7 +61,7 @@ const CSS_LOADER_CONFIG = [
     loader: 'postcss-loader',
     options: {
       sourceMap: GENERATE_SOURCE_MAPS,
-      plugins: () =>[require('autoprefixer')({grid: false})],
+      plugins: () => [require('autoprefixer')({grid: false})],
     },
   },
   {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,9 @@ const OUT_PATH = path.resolve('./build');
 const PUBLIC_PATH = '/assets/';
 const IS_DEV = process.env.MDC_ENV === 'development';
 const IS_PROD = process.env.MDC_ENV === 'production';
+const IS_FAST_BUILD = process.env.MDC_BUILD === 'fast';
+const GENERATE_SOURCE_MAPS = IS_DEV && !IS_FAST_BUILD;
+const DEVTOOL = GENERATE_SOURCE_MAPS ? 'source-map' : false;
 
 const banner = [
   '/*!',
@@ -50,20 +53,20 @@ const CSS_LOADER_CONFIG = [
   {
     loader: 'css-loader',
     options: {
-      sourceMap: true,
+      sourceMap: GENERATE_SOURCE_MAPS,
     },
   },
   {
     loader: 'postcss-loader',
     options: {
-      sourceMap: IS_DEV,
+      sourceMap: GENERATE_SOURCE_MAPS,
       plugins: () =>[require('autoprefixer')({grid: false})],
     },
   },
   {
     loader: 'sass-loader',
     options: {
-      sourceMap: true,
+      sourceMap: GENERATE_SOURCE_MAPS,
       includePaths: glob.sync('packages/*/node_modules').map((d) => path.join(__dirname, d)),
     },
   },
@@ -106,7 +109,7 @@ module.exports = [{
   devServer: {
     disableHostCheck: true,
   },
-  devtool: IS_DEV ? 'source-map' : false,
+  devtool: DEVTOOL,
   module: {
     rules: [{
       test: /\.js$/,
@@ -133,7 +136,7 @@ module.exports = [{
   devServer: {
     disableHostCheck: true,
   },
-  devtool: IS_DEV ? 'source-map' : false,
+  devtool: DEVTOOL,
   module: {
     rules: [{
       test: /\.js$/,
@@ -190,7 +193,7 @@ module.exports = [{
   devServer: {
     disableHostCheck: true,
   },
-  devtool: IS_DEV ? 'source-map' : false,
+  devtool: DEVTOOL,
   module: {
     rules: [{
       test: /\.scss$/,
@@ -220,7 +223,7 @@ if (IS_DEV) {
     devServer: {
       disableHostCheck: true,
     },
-    devtool: 'source-map',
+    devtool: DEVTOOL,
     module: {
       rules: [{
         test: /\.scss$/,


### PR DESCRIPTION
A new `GENERATE_SOURCE_MAPS=false` env var disables source map generation in dev mode, which cuts build and recompile times in half.

Invoked like so:

```bash
GENERATE_SOURCE_MAPS=false npm run dev
```