### PR TITLE
fix(button): Reference `secondary` theme prop instead of `accent`

### DIFF
--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -142,7 +142,10 @@
   line-height: 32px;
 }
 
-@each $theme-style in (primary, accent) {
+@each $theme-style in (primary, secondary) {
+  // Needed for backward compatibility. Theme uses the term "secondary", but button still calls it "accent" for now.
+  $modifier: if($theme-style == "secondary", "accent", $theme-style);
+
   // postcss-bem-linter: ignore
   .mdc-button--#{$theme-style} {
     $theme-value: map-get($mdc-theme-property-values, $theme-style);

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -147,7 +147,7 @@
   $modifier: if($theme-style == "secondary", "accent", $theme-style);
 
   // postcss-bem-linter: ignore
-  .mdc-button--#{$theme-style} {
+  .mdc-button--#{$modifier} {
     $theme-value: map-get($mdc-theme-property-values, $theme-style);
 
     @include mdc-ripple-base;


### PR DESCRIPTION
Build was accidentally broken in PR #1074 due to a non-obvious merge conflict.