### PR TITLE
fix(demos): Fix button demo update from #1176 to work in IE 11

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -251,7 +251,10 @@
 
         document.getElementById('toggle-disabled').addEventListener('change', function () {
           var isDisabled = this.checked;
-          [].slice.call(document.querySelectorAll('button')).forEach(button => button.disabled = isDisabled);
+          [].slice.call(document.querySelectorAll('button')).forEach(function(button) {
+            button.disabled = isDisabled;
+          });
+
         });
       })();
     </script>


### PR DESCRIPTION
I did a silly thing earlier today when I updated the button demo page to test disabled buttons - I used a fat arrow directly in a demo page, which will break the page's JS in IE 11. This commit fixes the problem.