### PR TITLE
fix(ripple): Revert #1098 to fix bounded ripples

### DIFF
--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -471,7 +471,7 @@ export default class MDCRippleFoundation extends MDCFoundation {
     this.frame_ = this.adapter_.computeBoundingRect();
 
     const maxDim = Math.max(this.frame_.height, this.frame_.width);
-    const surfaceDiameter = Math.min(this.frame_.width, this.frame_.height);
+    const surfaceDiameter = Math.sqrt(Math.pow(this.frame_.width, 2) + Math.pow(this.frame_.height, 2));
 
     // 60% of the largest dimension of the surface
     this.initialSize_ = maxDim * MDCRippleFoundation.numbers.INITIAL_ORIGIN_SCALE;

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -93,10 +93,8 @@
     cursor: pointer;
   }
 
-  @media (min-width: $mdc-toolbar-mobile-breakpoint) {
-    &__icon:last-of-type {
-      margin-right: 8px;
-    }
+  &__icon:last-of-type {
+    padding-right: 16px;
   }
 
   &__icon--menu {
@@ -115,6 +113,10 @@
 @media (max-width: $mdc-toolbar-mobile-breakpoint) {
   .mdc-toolbar__icon--menu {
     padding: 16px;
+  }
+
+  .mdc-toolbar__icon:last-child {
+    padding: 16px 8px;
   }
 
   .mdc-toolbar__title {

--- a/test/unit/mdc-ripple/foundation.test.js
+++ b/test/unit/mdc-ripple/foundation.test.js
@@ -253,7 +253,7 @@ testFoundation(`#layout sets ${strings.VAR_FG_SCALE} based on the difference bet
 
   const maxSize = Math.max(width, height);
   const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
-  const surfaceDiameter = Math.min(width, height);
+  const surfaceDiameter = Math.sqrt(Math.pow(width, 2) + Math.pow(height, 2));
   const maxRadius = surfaceDiameter + numbers.PADDING;
   const fgScale = maxRadius / initialSize;
 


### PR DESCRIPTION
This reverts commit 0f1ca3598248c6df7fe456e198ce6519397b0247 and fixes #1184.

Unfortunately this commit caused a major regression for bounded ripples, such as those seen in the button and dialog demos.

![dialogripples](https://user-images.githubusercontent.com/398379/29690980-486251fe-88f7-11e7-8de9-a27b4a7e74ba.gif)
