### PR TITLE
docs: remove invalid 'default' attribute from examples

### DIFF
--- a/demos/select.html
+++ b/demos/select.html
@@ -143,7 +143,7 @@
       <section class="example">
         <h2 class="mdc-typography--title">CSS Only</h2>
         <select class="mdc-select">
-          <option value="" default selected>Pick a food group</option>
+          <option value="" selected>Pick a food group</option>
           <option value="grains">Bread, Cereal, Rice, and Pasta</option>
           <option value="vegetables" disabled>Vegetables</option>
           <option value="fruit">Fruit</option>

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -195,7 +195,7 @@ on a mobile device. It does not require any javascript, nor any CSS for `mdc-men
 
 ```html
 <select class="mdc-select">
-  <option value="" default selected>Pick a food</option>
+  <option value="" selected>Pick a food</option>
   <option value="grains">Bread, Cereal, Rice, and Pasta</option>
   <option value="vegetables">Vegetables</option>
   <optgroup label="Fruits">


### PR DESCRIPTION
The 'option' element doesn't have a 'default' attribute.

So, remove the attribute from examples to avoid promoting
non-conforming usage.