### PR TITLE
fix(demos): Update first tab bar's layout when toggling RTL

### DIFF
--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -649,6 +649,7 @@
             var mainElement = document.querySelector('#tabs-demo-main-section');
             mainElement.hasAttribute('dir') ? mainElement.removeAttribute('dir') : mainElement.setAttribute('dir', 'rtl');
 
+            window.demoTabBar.layout();
             window.basicTabBar.layout();
             window.tabBarScroller.layout();
             window.tabBarScroller.tabBar.layout();


### PR DESCRIPTION
We were forgetting to call `layout` on the very first tab bar in the page in the logic for the RTL toggle, which causes it to appear to reflect the opposite of what it should in RTL mode.

Fixes #1189 in Tabs demo page.