### PR TITLE
refactor(fab): Remove ability to customize tap-highlight

### DIFF
--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -22,23 +22,10 @@
   $bg-color: map-get($config, bg-color);
   $fg-color: map-get($config, fg-color);
   $ripple-config: map-get($config, ripple-config);
-  $tap-highlight-color: map-get($config, tap-highlight-color);
 
   @if $ripple-config {
     @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
     @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));
-  }
-
-  @if $tap-highlight-color {
-    @if $ripple-config {
-      &:not(.mdc-ripple-upgraded) {
-        @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
-      }
-    }
-
-    @else {
-      @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
-    }
   }
 
   @if $bg-color {

--- a/packages/mdc-fab/mdc-fab.scss
+++ b/packages/mdc-fab/mdc-fab.scss
@@ -22,17 +22,19 @@
   @include mdc-fab-theme((
     bg-color: secondary,
     fg-color: text-primary-on-secondary,
-    ripple-config: (base-color: white, opacity: .16),
-    tap-highlight-color: rgba(0, 0, 0, .18)
+    ripple-config: (base-color: white, opacity: .16)
   ));
+
+  &:not(.mdc-ripple-upgraded) {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, .18);
+  }
 }
 
 .mdc-fab--plain {
   @include mdc-fab-theme((
     bg-color: white,
     fg-color: text-primary-on-light,
-    ripple-config: (),
-    tap-highlight-color: rgba(0, 0, 0, .18)
+    ripple-config: ()
   ));
 }
 


### PR DESCRIPTION
We are always setting the tap-highlight to the same color.