### PR TITLE
refactor(fab): Break theme mixin into three mixins, to decouple code

### DIFF
--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -150,18 +150,22 @@ CSS Class | Description
 
 ### Sass Mixins
 
-#### `mdc-fab-theme($config)`
+The following mixins are intended for advanced users. By default a FAB will inherit its color from the theme.
+These mixins will override the color of the container, ink, or ripple. You can use all of them if you want to 
+completely customize a FAB. Or you can use only one of them, e.g. if you only need to override the ripple color.
+It is up to you to pick container, ink, and ripple colors that work together, and meet accessibility standards.
 
-Generates theme-related CSS properties from the given config map.
+#### `mdc-fab-container-color($color)`
 
-All properties are optional. Properties that are `null` or unspecified will not be emitted.
+Changes the FAB's container color to the given color.
 
-Property | Description
---- | ---
-`bg-color` | Background color of the FAB
-`fg-color` | Foreground color of the icon
-`ripple-config` | Ripple configuration (see the [mdc-ripple README][ripple-readme])
-`tap-highlight-color` | Color of the [`-webkit-tap-highlight-color`][tap-highlight] property (for mobile devices that support it)
+#### `mdc-fab-ink-color($color)`
+
+Changes the FAB's ink color to the given color.
+
+#### `mdc-fab-ripple($ripple-config)`
+
+Changes the FAB's ripple to the given ripple configuration (see the [mdc-ripple README][ripple-readme]).
 
 [ripple-readme]: https://github.com/material-components/material-components-web/blob/master/packages/mdc-ripple/README.md
 [tap-highlight]: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color

--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -18,23 +18,17 @@
 @import "@material/ripple/mixins";
 @import "@material/theme/mixins";
 
-@mixin mdc-fab-theme($config) {
-  $bg-color: map-get($config, bg-color);
-  $fg-color: map-get($config, fg-color);
-  $ripple-config: map-get($config, ripple-config);
+@mixin mdc-fab-container-color($color) {
+  @include mdc-theme-prop(background-color, $color);
+}
 
-  @if $ripple-config {
-    @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
-    @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));
-  }
+@mixin mdc-fab-ink-color($color) {
+  @include mdc-theme-prop(color, $color);
+}
 
-  @if $bg-color {
-    @include mdc-theme-prop(background-color, $bg-color);
-  }
-
-  @if $fg-color {
-    @include mdc-theme-prop(color, $fg-color);
-  }
+@mixin mdc-fab-ripple($ripple-config) {
+  @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
+  @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));
 }
 
 @mixin mdc-fab-base_ {

--- a/packages/mdc-fab/mdc-fab.scss
+++ b/packages/mdc-fab/mdc-fab.scss
@@ -19,11 +19,9 @@
 
 .mdc-fab {
   @include mdc-fab-base_;
-  @include mdc-fab-theme((
-    bg-color: secondary,
-    fg-color: text-primary-on-secondary,
-    ripple-config: (base-color: white, opacity: .16)
-  ));
+  @include mdc-fab-container-color(secondary);
+  @include mdc-fab-ink-color(text-primary-on-secondary);
+  @include mdc-fab-ripple((base-color: white, opacity: .16));
 
   &:not(.mdc-ripple-upgraded) {
     -webkit-tap-highlight-color: rgba(0, 0, 0, .18);
@@ -31,11 +29,9 @@
 }
 
 .mdc-fab--plain {
-  @include mdc-fab-theme((
-    bg-color: white,
-    fg-color: text-primary-on-light,
-    ripple-config: ()
-  ));
+  @include mdc-fab-container-color(white);
+  @include mdc-fab-ink-color(text-primary-on-light);
+  @include mdc-fab-ripple(()); //default dark ripple
 }
 
 .mdc-fab--mini {

--- a/packages/mdc-fab/mdc-fab.scss
+++ b/packages/mdc-fab/mdc-fab.scss
@@ -31,7 +31,7 @@
 .mdc-fab--plain {
   @include mdc-fab-container-color(white);
   @include mdc-fab-ink-color(text-primary-on-light);
-  @include mdc-fab-ripple(()); //default dark ripple
+  @include mdc-fab-ripple(()); // default dark ripple
 }
 
 .mdc-fab--mini {


### PR DESCRIPTION
There's no good explanation for what `config` was other than 'a collection of background, foreground, and ripple colors. From an API perspective, there is no reason to group the three properties together. The logic has no dependency on each other, as you can see in the old `mdc-fab-theme` implementation.

Andy mentioned that `config`... 'gives clients the ability to create extensible themes that can be "inherited" by other themes (similar to Android)'. But when I talked to designers, it was difficult to see a use case where `config` would be used by any other component. If a client is already customizing the color of FABs container, ink, and ripple, they will also probably customize the color of a Menu's container, ink, and ripple with _slightly different_ colors.

I also updated the names, a.k.a. background -> container and foreground -> ink, after talking to the designers. This matches the spec better.