### PR TITLE
feat(button): Move all button styles to mixins

### DIFF
--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -115,54 +115,6 @@
   @include mdc-button-theme_($config);
 }
 
-// @mixin mdc-button-filled-theme_($config) {
-//   $bg-color: map-get($config, bg-color);
-//   $fg-color: map-get($config, fg-color);
-//   $ripple-config: map-get($config, ripple-config);
-//   $tap-highlight-color: map-get($config, tap-highlight-color);
-
-//   @if $ripple-config {
-//     @include mdc-ripple-base;
-//     @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
-//     @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));
-//   }
-
-//   @if $tap-highlight-color {
-//     @if $ripple-config {
-//       &:not(.mdc-ripple-upgraded) {
-//         @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
-//       }
-//     }
-
-//     @else {
-//       @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
-//     }
-//   }
-
-//   @if $bg-color {
-//     @include mdc-theme-prop(background-color, $bg-color);
-//   }
-
-//   @if $fg-color {
-//     @include mdc-theme-prop(color, $fg-color);
-//   }
-
-//   // Is dark theme taken care by theme?
-
-//   // @include mdc-theme-dark(".mdc-button") {
-//   //   @include mdc-ripple-base;
-//   //   @include mdc-ripple-bg((pseudo: "::before", base-color: black, opacity: .32));
-//   //   @include mdc-ripple-fg((pseudo: "::after", base-color: black, opacity: .32));
-//   //   @include mdc-theme-prop(color, text-primary-on-light);
-
-//   //   background-color: white;
-
-//   //   &:not(.mdc-ripple-upgraded) {
-//   //     -webkit-tap-highlight-color: rgba(black, .18);
-//   //   }
-//   // }
-// }
-
 @mixin mdc-button-theme_($config) {
   $bg-color: map-get($config, bg-color);
   $fg-color: map-get($config, fg-color);
@@ -216,16 +168,4 @@
   @if $stroke-style {
     border-style: $stroke-style;
   }
-
-  // @include mdc-theme-dark(".mdc-button") {
-  //   @include mdc-ripple-base;
-  //   @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .16));
-  //   @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .16));
-  //   @include mdc-theme-prop(color, text-primary-on-dark);
-  //   @include mdc-theme-prop(border-color, text-primary-on-dark);
-
-  //   &:not(.mdc-ripple-upgraded) {
-  //     -webkit-tap-highlight-color: rgba(white, .18);
-  //   }
-  // }
 }

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -17,25 +17,215 @@
 @import "@material/ripple/mixins";
 @import "@material/theme/mixins";
 @import "@material/theme/variables";
+@import "./variables";
 
-@mixin mdc-button-filled_() {
-  @include mdc-ripple-base;
-  @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .32));
-  @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .32));
-  @include mdc-theme-prop(color, text-primary-on-dark);
+@mixin mdc-button-base_() {
+  @include mdc-typography(button);
 
-  background-color: black;
+  display: inline-block;
+  position: relative;
+  min-width: 88px;
+  height: $mdc-button-height;
+  padding: 0 16px;
+  border: none;
+  border-radius: 4px;
+  box-sizing: border-box;
+  outline: none;
+  background: transparent;
+  text-align: center;
+  overflow: hidden;
+  vertical-align: middle;
+  user-select: none;
+  -webkit-appearance: none;
 
-  @include mdc-theme-dark(".mdc-button") {
+  // postcss-bem-linter: ignore
+  &:active {
+    outline: none;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &::-moz-focus-inner {
+    padding: 0;
+    border: 0;
+  }
+
+  fieldset:disabled &,
+  &:disabled {
+    cursor: default;
+    pointer-events: none;
+  }
+}
+
+@mixin mdc-button--raised_() {
+  @include mdc-elevation(2);
+  @include mdc-elevation-transition;
+
+  &:hover,
+  &:focus {
+    @include mdc-elevation(4);
+  }
+
+  &:active {
+    @include mdc-elevation(8);
+  }
+
+  fieldset:disabled &,
+  &:disabled {
+    @include mdc-elevation(0);
+  }
+}
+
+@mixin mdc-button--compact_() {
+  padding: 0 8px;
+}
+
+@mixin mdc-button--dense_() {
+  height: $mdc-dense-button-height;
+  font-size: .8125rem; // 13sp
+  line-height: $mdc-dense-button-height;
+}
+
+@mixin mdc-button-text-theme($config) {
+  // Filter valid key
+  // which for simplicity I removed the invalid key here
+  @if (map-has-key($config, "stroke-color")) {
+    $config: map-remove($config, "stroke-color")
+  }
+  @if (map-has-key($config, "stroke-width")) {
+    $config: map-remove($config, "stroke-width")
+  }
+  @if (map-has-key($config, "stroke-style")) {
+    $config: map-remove($config, "stroke-style")
+  }
+  @include mdc-button-theme_($config);
+}
+
+@mixin mdc-button-stroked-theme($config) {
+  @include mdc-button-theme_($config);
+}
+
+@mixin mdc-button-raised-theme($config) {
+  @include mdc-button-theme_($config);
+}
+
+@mixin mdc-button-unelevated-theme($config) {
+  @include mdc-button-theme_($config);
+}
+
+// @mixin mdc-button-filled-theme_($config) {
+//   $bg-color: map-get($config, bg-color);
+//   $fg-color: map-get($config, fg-color);
+//   $ripple-config: map-get($config, ripple-config);
+//   $tap-highlight-color: map-get($config, tap-highlight-color);
+
+//   @if $ripple-config {
+//     @include mdc-ripple-base;
+//     @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
+//     @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));
+//   }
+
+//   @if $tap-highlight-color {
+//     @if $ripple-config {
+//       &:not(.mdc-ripple-upgraded) {
+//         @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
+//       }
+//     }
+
+//     @else {
+//       @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
+//     }
+//   }
+
+//   @if $bg-color {
+//     @include mdc-theme-prop(background-color, $bg-color);
+//   }
+
+//   @if $fg-color {
+//     @include mdc-theme-prop(color, $fg-color);
+//   }
+
+//   // Is dark theme taken care by theme?
+
+//   // @include mdc-theme-dark(".mdc-button") {
+//   //   @include mdc-ripple-base;
+//   //   @include mdc-ripple-bg((pseudo: "::before", base-color: black, opacity: .32));
+//   //   @include mdc-ripple-fg((pseudo: "::after", base-color: black, opacity: .32));
+//   //   @include mdc-theme-prop(color, text-primary-on-light);
+
+//   //   background-color: white;
+
+//   //   &:not(.mdc-ripple-upgraded) {
+//   //     -webkit-tap-highlight-color: rgba(black, .18);
+//   //   }
+//   // }
+// }
+
+@mixin mdc-button-theme_($config) {
+  $bg-color: map-get($config, bg-color);
+  $fg-color: map-get($config, fg-color);
+  $ripple-config: map-get($config, ripple-config);
+  $tap-highlight-color: map-get($config, tap-highlight-color);
+  $stroke-color: map-get($config, stroke-color);
+  $stroke-style: map-get($config, stroke-style);
+  $stroke-width: map-get($config, stroke-width);
+
+  @if $ripple-config {
     @include mdc-ripple-base;
-    @include mdc-ripple-bg((pseudo: "::before", base-color: black, opacity: .32));
-    @include mdc-ripple-fg((pseudo: "::after", base-color: black, opacity: .32));
-    @include mdc-theme-prop(color, text-primary-on-light);
+    @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
+    @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));
+  }
 
-    background-color: white;
+  @if $tap-highlight-color {
+    @if $ripple-config {
+      &:not(.mdc-ripple-upgraded) {
+        @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
+      }
+    }
 
-    &:not(.mdc-ripple-upgraded) {
-      -webkit-tap-highlight-color: rgba(black, .18);
+    @else {
+      @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
     }
   }
+
+  @if $bg-color {
+    @include mdc-theme-prop(background-color, $bg-color);
+  }
+
+  @if $fg-color {
+    @include mdc-theme-prop(color, $fg-color);
+  }
+
+  @if $stroke-color {
+    @include mdc-theme-prop(border-color, $stroke-color);
+  }
+
+  @if $stroke-width {
+    border-width: $stroke-width;
+    line-height: $mdc-button-height - $stroke-width * 2;
+
+    // postcss-bem-linter: ignore
+    &.mdc-button--dense {
+      // Minus extra 1 to accommodate odd font size of dense button
+      line-height: $mdc-dense-button-height - $stroke-width * 2 - 1;
+    }
+  }
+
+  @if $stroke-style {
+    border-style: $stroke-style;
+  }
+
+  // @include mdc-theme-dark(".mdc-button") {
+  //   @include mdc-ripple-base;
+  //   @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .16));
+  //   @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .16));
+  //   @include mdc-theme-prop(color, text-primary-on-dark);
+  //   @include mdc-theme-prop(border-color, text-primary-on-dark);
+
+  //   &:not(.mdc-ripple-upgraded) {
+  //     -webkit-tap-highlight-color: rgba(white, .18);
+  //   }
+  // }
 }

--- a/packages/mdc-button/_variables.scss
+++ b/packages/mdc-button/_variables.scss
@@ -1,0 +1,18 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+$mdc-button-height: 36px;
+$mdc-dense-button-height: 32px;

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -30,6 +30,13 @@
     ripple-config: (base-color: black, opacity: .16),
     tap-highlight-color: rgba(0, 0, 0, .16)
   ));
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-text-theme((
+      fg-color: text-primary-on-dark,
+      ripple-config: (base-color: white, opacity: .16),
+      tap-highlight-color: rgba(white, .16)
+    ));
+  }
 }
 
 .mdc-button--raised {
@@ -40,6 +47,14 @@
     ripple-config: (base-color: white, opacity: .32),
     tap-highlight-color: rgba(255, 255, 255, .32)
   ));
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-raised-theme((
+      bg-color: white,
+      fg-color: text-primary-on-light,
+      ripple-config: (base-color: black, opacity: .32),
+      tap-highlight-color: rgba(black, .32)
+    ));
+  }
 }
 
 .mdc-button--unelevated {
@@ -49,6 +64,14 @@
     ripple-config: (base-color: white, opacity: .32),
     tap-highlight-color: rgba(255, 255, 255, .32)
   ));
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-unelevated-theme((
+      bg-color: white,
+      fg-color: text-primary-on-light,
+      ripple-config: (base-color: black, opacity: .32),
+      tap-highlight-color: rgba(black, .32)
+    ));
+  }
 }
 
 .mdc-button--stroked {
@@ -57,6 +80,11 @@
     stroke-style: solid,
     stroke-color: text-primary-on-light
   ));
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-stroked-theme((
+      stroke-color: text-primary-on-dark
+    ));
+  }
 }
 
 .mdc-button--compact {
@@ -73,38 +101,54 @@
 
   // postcss-bem-linter: ignore
   .mdc-button--#{$modifier} {
-    $theme-value: map-get($mdc-theme-property-values, $theme-style);
+    $unfilled-text-value: map-get($mdc-theme-property-values, $theme-style);
+    $filled-text-value: map-get($mdc-theme-property-values, text-primary-on-#{$theme-style});
 
-    @include mdc-ripple-base;
-    @include mdc-ripple-bg((pseudo: "::before", base-color: $theme-value, opacity: .16));
-    @include mdc-ripple-fg((pseudo: "::after", base-color: $theme-value, opacity: .16));
-    @include mdc-theme-prop(color, $theme-style);
-
+    @include mdc-button-text-theme((
+      fg-color: $unfilled-text-value,
+      ripple-config: (base-color: $unfilled-text-value, opacity: .16),
+      tap-highlight-color: rgba($unfilled-text-value, .16)
+    ));
     @include mdc-theme-dark(".mdc-button") {
-      @include mdc-ripple-base;
-      @include mdc-ripple-bg((pseudo: "::before", base-color: $theme-value, opacity: .16));
-      @include mdc-ripple-fg((pseudo: "::after", base-color: $theme-value, opacity: .16));
-      @include mdc-theme-prop(color, $theme-style);
+      @include mdc-button-text-theme((
+        fg-color: $unfilled-text-value,
+        ripple-config: (base-color: $unfilled-text-value, opacity: .16),
+        tap-highlight-color: rgba($unfilled-text-value, .16)
+      ));
     }
-    // postcss-bem-linter: ignore
-    &.mdc-button--raised,
-    &.mdc-button--unelevated {
-      $theme-value: map-get($mdc-theme-property-values, text-primary-on-#{$theme-style});
 
-      @include mdc-ripple-base;
-      @include mdc-ripple-bg((pseudo: "::before", base-color: $theme-value, opacity: .32));
-      @include mdc-ripple-fg((pseudo: "::after", base-color: $theme-value, opacity: .32));
-      @include mdc-theme-prop(background-color, $theme-style);
-      @include mdc-theme-prop(color, text-primary-on-#{$theme-style});
-    }
     // postcss-bem-linter: ignore
     &.mdc-button--stroked {
-      @include mdc-theme-prop(border-color, $theme-style);
-
+      @include mdc-button-stroked-theme((
+        stroke-color: $unfilled-text-value
+      ));
       @include mdc-theme-dark(".mdc-button") {
-        @include mdc-theme-prop(border-color, $theme-style);
+        @include mdc-button-stroked-theme((
+          stroke-color: $unfilled-text-value
+        ));
       }
     }
+
+    // postcss-bem-linter: ignore
+    &.mdc-button--raised{
+      @include mdc-button-raised-theme((
+        bg-color: $theme-style,
+        fg-color: $filled-text-value,
+        ripple-config: (base-color: $filled-text-value, opacity: .32),
+        tap-highlight-color: rgba($filled-text-value, .32)
+      ));
+    }
+
+    // postcss-bem-linter: ignore
+    &.mdc-button--unelevated {
+      @include mdc-button-unelevated-theme((
+        bg-color: $theme-style,
+        fg-color: $filled-text-value,
+        ripple-config: (base-color: $filled-text-value, opacity: .32),
+        tap-highlight-color: rgba($filled-text-value, .32)
+      ));
+    }
+
   }
 }
 
@@ -114,8 +158,13 @@
   fieldset:disabled &,
   &:disabled {
     @include mdc-button-text-theme((
-      fg-color: rgba(0, 0, 0, .38)
+      fg-color: text-disabled-on-light
     ));
+    @include mdc-theme-dark(".mdc-button") {
+      @include mdc-button-text-theme((
+        fg-color: text-disabled-on-dark
+      ));
+    }
   }
 }
 
@@ -123,14 +172,15 @@
   fieldset:disabled &,
   &:disabled {
     @include mdc-button-raised-theme((
-      bg-color: rgba(black, .15),
+      bg-color: rgba(black, .38),
       fg-color: text-primary-on-dark
     ));
-    // @include mdc-theme-dark(".mdc-button") {
-    //   @include mdc-theme-prop(color, text-disabled-on-dark);
-
-    //   background-color: rgba(255, 255, 255, .15);
-    // }
+    @include mdc-theme-dark(".mdc-button") {
+      @include mdc-button-raised-theme((
+        bg-color: rgba(white, .38),
+        fg-color: text-disabled-on-dark
+      ));
+    }
   }
 }
 
@@ -138,14 +188,15 @@
   fieldset:disabled &,
   &:disabled {
     @include mdc-button-unelevated-theme((
-      bg-color: rgba(black, .15),
+      bg-color: rgba(black, .38),
       fg-color: text-primary-on-dark
     ));
-    // @include mdc-theme-dark(".mdc-button") {
-    //   @include mdc-theme-prop(color, text-disabled-on-dark);
-
-    //   background-color: rgba(255, 255, 255, .15);
-    // }
+    @include mdc-theme-dark(".mdc-button") {
+      @include mdc-button-unelevated-theme((
+        bg-color: rgba(white, .38),
+        fg-color: text-disabled-on-dark
+      ));
+    }
   }
 }
 
@@ -153,11 +204,13 @@
   fieldset:disabled &,
   &:disabled {
     @include mdc-button-stroked-theme((
-      stroke-color: rgba(0, 0, 0, .38)
+      stroke-color: text-disabled-on-light
     ));
-    // @include mdc-theme-dark(".mdc-button") {
-    //   @include mdc-theme-prop(border-color, text-disabled-on-dark);
-    // }
+    @include mdc-theme-dark(".mdc-button") {
+      @include mdc-button-stroked-theme((
+        stroke-color: text-disabled-on-dark
+      ));
+    }
   }
 }
 // postcss-bem-linter: end

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -23,102 +23,48 @@
 
 // postcss-bem-linter: define button
 .mdc-button {
-  @include mdc-ripple-base;
-  @include mdc-ripple-bg((pseudo: "::before"));
-  @include mdc-ripple-fg((pseudo: "::after"));
-  @include mdc-typography(button);
-  @include mdc-theme-prop(color, text-primary-on-light);
-
-  display: inline-block;
-  position: relative;
-  min-width: 88px;
-  height: 36px;
-  padding: 0 16px;
-  border: none;
-  border-radius: 4px;
-  box-sizing: border-box;
-  outline: none;
-  background: transparent;
-  text-align: center;
-  overflow: hidden;
-  vertical-align: middle;
-  user-select: none;
-  -webkit-appearance: none;
-
-  // postcss-bem-linter: ignore
-  &:active {
-    outline: none;
-  }
-
-  &:hover {
-    cursor: pointer;
-  }
-
-  &::-moz-focus-inner {
-    padding: 0;
-    border: 0;
-  }
-
-  &:not(.mdc-ripple-upgraded) {
-    -webkit-tap-highlight-color: rgba(black, .3);
-  }
-
-  @include mdc-theme-dark(".mdc-button") {
-    @include mdc-ripple-base;
-    @include mdc-ripple-bg((pseudo: "::before", base-color: white, opacity: .16));
-    @include mdc-ripple-fg((pseudo: "::after", base-color: white, opacity: .16));
-    @include mdc-theme-prop(color, text-primary-on-dark);
-
-    &:not(.mdc-ripple-upgraded) {
-      -webkit-tap-highlight-color: rgba(white, .18);
-    }
-  }
-}
-
-.mdc-button--raised,
-.mdc-button--unelevated {
-  @include mdc-button-filled_;
+  @include mdc-button-base_;
+  @include mdc-button-text-theme((
+    bg-color: transparent,
+    fg-color: text-primary-on-light,
+    ripple-config: (base-color: black, opacity: .16),
+    tap-highlight-color: rgba(0, 0, 0, .16)
+  ));
 }
 
 .mdc-button--raised {
-  @include mdc-elevation(2);
-  @include mdc-elevation-transition;
+  @include mdc-button--raised_;
+  @include mdc-button-raised-theme((
+    bg-color: black,
+    fg-color: text-primary-on-dark,
+    ripple-config: (base-color: white, opacity: .32),
+    tap-highlight-color: rgba(255, 255, 255, .32)
+  ));
+}
 
-  &:hover,
-  &:focus {
-    @include mdc-elevation(4);
-  }
-
-  &:active {
-    @include mdc-elevation(8);
-  }
+.mdc-button--unelevated {
+  @include mdc-button-unelevated-theme((
+    bg-color: black,
+    fg-color: text-primary-on-dark,
+    ripple-config: (base-color: white, opacity: .32),
+    tap-highlight-color: rgba(255, 255, 255, .32)
+  ));
 }
 
 .mdc-button--stroked {
-  @include mdc-theme-prop(border-color, text-primary-on-light);
-
-  border-width: 2px;
-  border-style: solid;
-  line-height: 32px;
-
-  @include mdc-theme-dark(".mdc-button") {
-    @include mdc-theme-prop(border-color, text-primary-on-dark);
-  }
-
-  // postcss-bem-linter: ignore
-  &.mdc-button--dense {
-    line-height: 27px;  // To accommodate odd font size of dense button
-  }
+  @include mdc-button-stroked-theme((
+    stroke-width: 2px,
+    stroke-style: solid,
+    stroke-color: text-primary-on-light
+  ));
 }
 
 .mdc-button--compact {
-  padding: 0 8px;
+  @include mdc-button--compact_;
 }
 
 .mdc-button--dense {
-  height: 32px;
-  font-size: .8125rem; // 13sp
-  line-height: 32px;
+  @include mdc-button--dense_;
 }
 
 @each $theme-style in (primary, secondary) {
@@ -167,41 +113,51 @@
 .mdc-button {
   fieldset:disabled &,
   &:disabled {
-    color: rgba(black, .38);
-    cursor: default;
-    pointer-events: none;
-
-    @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(color, text-disabled-on-dark);
-    }
+    @include mdc-button-text-theme((
+      fg-color: rgba(0, 0, 0, .38)
+    ));
   }
 }
 
-.mdc-button--raised,
+.mdc-button--raised {
+  fieldset:disabled &,
+  &:disabled {
+    @include mdc-button-raised-theme((
+      bg-color: rgba(black, .15),
+      fg-color: text-primary-on-dark
+    ));
+    // @include mdc-theme-dark(".mdc-button") {
+    //   @include mdc-theme-prop(color, text-disabled-on-dark);
+
+    //   background-color: rgba(255, 255, 255, .15);
+    // }
+  }
+}
+
 .mdc-button--unelevated {
   fieldset:disabled &,
   &:disabled {
-    @include mdc-elevation(0);
-    @include mdc-theme-prop(color, text-primary-on-dark);
+    @include mdc-button-unelevated-theme((
+      bg-color: rgba(black, .15),
+      fg-color: text-primary-on-dark
+    ));
+    // @include mdc-theme-dark(".mdc-button") {
+    //   @include mdc-theme-prop(color, text-disabled-on-dark);
 
-    background-color: rgba(black, .15);
-
-    @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(color, text-disabled-on-dark);
-
-      background-color: rgba(255, 255, 255, .15);
-    }
+    //   background-color: rgba(255, 255, 255, .15);
+    // }
   }
 }
 
 .mdc-button--stroked {
   fieldset:disabled &,
   &:disabled {
-    border-color: rgba(black, .38);
-
-    @include mdc-theme-dark(".mdc-button") {
-      @include mdc-theme-prop(border-color, text-disabled-on-dark);
-    }
+    @include mdc-button-stroked-theme((
+      stroke-color: rgba(0, 0, 0, .38)
+    ));
+    // @include mdc-theme-dark(".mdc-button") {
+    //   @include mdc-theme-prop(border-color, text-disabled-on-dark);
+    // }
   }
 }
 // postcss-bem-linter: end


### PR DESCRIPTION
# Background

This is for reference of parameterizing button.
The PR was created after #1194 as a proof of concept that the button could be parameterized in a similar way as #1166 .

In this PR, I created 4 public theme mixin
- `mdc-button-text-theme`
- `mdc-button-stroked-theme`
- `mdc-button-raised-theme`
- `mdc-button-unelevated-theme`

And under the hood, with a couple of private base style mixin and one private theme mixin.
Depends on requirement from design, we might consider split the one mixin into 2 as `unfilled` and `filled` in the future, but one theme seems to be enough for the moment.

@acdvorak I tested this setup works for our existing demo page (without dark-theme). Feel free to pull/fork this PR for the changes you needed.
