### PR TITLE
refactor(switch): Reference animation timing function directly

### DIFF
--- a/packages/mdc-checkbox/_keyframes.scss
+++ b/packages/mdc-checkbox/_keyframes.scss
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+@import "@material/animation/variables";
 @import "@material/theme/mixins";
 @import "./variables";
 
@@ -74,7 +75,7 @@
   }
 
   50% {
-    @include mdc-animation-deceleration-curve;
+    animation-timing-function: $mdc-animation-deceleration-curve-timing-function;
   }
 
   100% {
@@ -99,8 +100,7 @@
 
 @keyframes mdc-checkbox-checked-unchecked-checkmark-path {
   from {
-    @include mdc-animation-acceleration-curve;
-
+    animation-timing-function: $mdc-animation-acceleration-curve-timing-function;
     opacity: 1;
     stroke-dashoffset: 0;
   }
@@ -113,10 +113,9 @@
 
 @keyframes mdc-checkbox-checked-indeterminate-checkmark {
   from {
+    animation-timing-function: $mdc-animation-deceleration-curve-timing-function;
     transform: rotate(0deg);
     opacity: 1;
-
-    @include mdc-animation-deceleration-curve;
   }
 
   to {
@@ -140,10 +139,9 @@
 
 @keyframes mdc-checkbox-checked-indeterminate-mixedmark {
   from {
+    animation-timing-function: mdc-animation-deceleration-curve-timing-function;
     transform: rotate(-45deg);
     opacity: 0;
-
-    @include mdc-animation-deceleration-curve;
   }
 
   to {

--- a/packages/mdc-checkbox/mdc-checkbox.scss
+++ b/packages/mdc-checkbox/mdc-checkbox.scss
@@ -15,7 +15,6 @@
 //
 
 @import "@material/animation/functions";
-@import "@material/animation/mixins";
 @import "@material/ripple/mixins";
 @import "@material/rtl/mixins";
 @import "./variables";


### PR DESCRIPTION
This is the only place where we actually use mdc-animation mixins. I think referencing the animation variable directly is more clear.