### PR TITLE
chore(demos): Use `var` instead of `const`

### DIFF
--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -269,8 +269,8 @@
     <script>
       (function() {
         mdc.dialog.MDCDialog.attachTo(document.querySelector('.mdc-dialog'));
-        const demoWrapper = document.querySelector('.demo-body');
-        const hero = document.querySelector('.hero');
+        var demoWrapper = document.querySelector('.demo-body');
+        var hero = document.querySelector('.hero');
         document.getElementById('toggle-rtl').addEventListener('change', function() {
           if (this.checked) {
             demoWrapper.setAttribute('dir', 'rtl');

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -182,7 +182,7 @@
     <script>
       var determinates = document.querySelectorAll('.mdc-linear-progress');
       for (var i = 0, determinate; determinate = determinates[i]; i++) {
-        const linearProgress = mdc.linearProgress.MDCLinearProgress.attachTo(determinate);
+        var linearProgress = mdc.linearProgress.MDCLinearProgress.attachTo(determinate);
         linearProgress.progress = 0.5;
         if (determinate.dataset.buffer) {
           linearProgress.buffer = 0.75;

--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -195,7 +195,7 @@
 
       var lastSelected = document.getElementById('last-selected');
       menuEl.addEventListener('MDCSimpleMenu:selected', function(evt) {
-        const detail = evt.detail;
+        var detail = evt.detail;
         lastSelected.textContent = '"' + detail.item.textContent.trim() +
           '" at index ' + detail.index;
       });


### PR DESCRIPTION
All other demo pages use `var`. Additionally, older browsers (notably IE < 11) don't support `const`, and we don't currently transpile our demo JS to ES5.