### PR TITLE
fix(slider): Change how step value is initialized (#1173)

### DIFF
--- a/packages/mdc-slider/foundation.js
+++ b/packages/mdc-slider/foundation.js
@@ -123,7 +123,7 @@ export default class MDCSliderFoundation extends MDCFoundation {
     this.layout();
     // At last step, provide a reasonable default value to discrete slider
     if (this.isDiscrete_ && this.getStep() == 0) {
-      this.setStep(1);
+      this.step_ = 1;
     }
   }
 


### PR DESCRIPTION
resolves #1173 

Micro-change, but the "setStep"-function actually triggers a "setValue" which sets aria-valuenow to null since the value is still uninitialized at this time.

(Sorry, had to recreate my previous pr)