### PR TITLE
docs(button): Make call in stylesheet button.html to create primary and secondary example

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -141,9 +141,6 @@
             <button class="mdc-button mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button primary-text-button">
-              Primary
-            </button>
             <button class="mdc-button secondary-text-button">
               Secondary
             </button>
@@ -164,9 +161,6 @@
             </button>
             <button class="mdc-button mdc-button--raised mdc-button--dense">
               Dense
-            </button>
-            <button class="mdc-button mdc-button--raised primary-filled-button">
-              Primary
             </button>
             <button class="mdc-button mdc-button--raised secondary-filled-button">
               Secondary
@@ -189,9 +183,6 @@
             <button class="mdc-button mdc-button--unelevated mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button mdc-button--unelevated primary-filled-button">
-              Primary
-            </button>
             <button class="mdc-button mdc-button--unelevated secondary-filled-button">
               Secondary
             </button>
@@ -212,9 +203,6 @@
             </button>
             <button class="mdc-button mdc-button--stroked mdc-button--dense">
               Dense
-            </button>
-            <button class="mdc-button mdc-button--stroked primary-stroked-button">
-              Primary
             </button>
             <button class="mdc-button mdc-button--stroked secondary-stroked-button">
               Secondary
@@ -238,9 +226,6 @@
             <button class="mdc-button mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button primary-text-button" data-demo-no-js>
-              Primary
-            </button>
             <button class="mdc-button secondary-text-button" data-demo-no-js>
               Secondary
             </button>
@@ -261,9 +246,6 @@
             </button>
             <button class="mdc-button mdc-button--raised mdc-button--dense" data-demo-no-js>
               Dense
-            </button>
-            <button class="mdc-button mdc-button--raised primary-filled-button" data-demo-no-js>
-              Primary
             </button>
             <button class="mdc-button mdc-button--raised secondary-filled-button" data-demo-no-js>
               Secondary
@@ -286,9 +268,6 @@
             <button class="mdc-button mdc-button--unelevated mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button mdc-button--unelevated primary-filled-button" data-demo-no-js>
-              Primary
-            </button>
             <button class="mdc-button mdc-button--unelevated secondary-filled-button" data-demo-no-js>
               Secondary
             </button>
@@ -309,9 +288,6 @@
             </button>
             <button class="mdc-button mdc-button--stroked mdc-button--dense" data-demo-no-js>
               Dense
-            </button>
-            <button class="mdc-button mdc-button--stroked primary-stroked-button" data-demo-no-js>
-              Primary
             </button>
             <button class="mdc-button mdc-button--stroked secondary-stroked-button" data-demo-no-js>
               Secondary

--- a/demos/button.html
+++ b/demos/button.html
@@ -141,10 +141,10 @@
             <button class="mdc-button mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button mdc-button--primary">
+            <button class="mdc-button primary-text-button">
               Primary
             </button>
-            <button class="mdc-button mdc-button--accent">
+            <button class="mdc-button secondary-text-button">
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button">
@@ -165,10 +165,10 @@
             <button class="mdc-button mdc-button--raised mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button mdc-button--raised mdc-button--primary">
+            <button class="mdc-button mdc-button--raised primary-filled-button">
               Primary
             </button>
-            <button class="mdc-button mdc-button--raised mdc-button--accent">
+            <button class="mdc-button mdc-button--raised secondary-filled-button">
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button mdc-button--raised">
@@ -189,10 +189,10 @@
             <button class="mdc-button mdc-button--unelevated mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button mdc-button--unelevated mdc-button--primary">
+            <button class="mdc-button mdc-button--unelevated primary-filled-button">
               Primary
             </button>
-            <button class="mdc-button mdc-button--unelevated mdc-button--accent">
+            <button class="mdc-button mdc-button--unelevated secondary-filled-button">
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button mdc-button--unelevated">
@@ -213,10 +213,10 @@
             <button class="mdc-button mdc-button--stroked mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--primary">
+            <button class="mdc-button mdc-button--stroked primary-stroked-button">
               Primary
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--accent">
+            <button class="mdc-button mdc-button--stroked secondary-stroked-button">
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button mdc-button--stroked">
@@ -238,10 +238,10 @@
             <button class="mdc-button mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button mdc-button--primary" data-demo-no-js>
+            <button class="mdc-button primary-text-button" data-demo-no-js>
               Primary
             </button>
-            <button class="mdc-button mdc-button--accent" data-demo-no-js>
+            <button class="mdc-button secondary-text-button" data-demo-no-js>
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button" data-demo-no-js>
@@ -262,10 +262,10 @@
             <button class="mdc-button mdc-button--raised mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button mdc-button--raised mdc-button--primary" data-demo-no-js>
+            <button class="mdc-button mdc-button--raised primary-filled-button" data-demo-no-js>
               Primary
             </button>
-            <button class="mdc-button mdc-button--raised mdc-button--accent" data-demo-no-js>
+            <button class="mdc-button mdc-button--raised secondary-filled-button" data-demo-no-js>
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button mdc-button--raised" data-demo-no-js>
@@ -286,10 +286,10 @@
             <button class="mdc-button mdc-button--unelevated mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button mdc-button--unelevated mdc-button--primary" data-demo-no-js>
+            <button class="mdc-button mdc-button--unelevated primary-filled-button" data-demo-no-js>
               Primary
             </button>
-            <button class="mdc-button mdc-button--unelevated mdc-button--accent" data-demo-no-js>
+            <button class="mdc-button mdc-button--unelevated secondary-filled-button" data-demo-no-js>
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button mdc-button--unelevated" data-demo-no-js>
@@ -310,10 +310,10 @@
             <button class="mdc-button mdc-button--stroked mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--primary" data-demo-no-js>
+            <button class="mdc-button mdc-button--stroked primary-stroked-button" data-demo-no-js>
               Primary
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--accent" data-demo-no-js>
+            <button class="mdc-button mdc-button--stroked secondary-stroked-button" data-demo-no-js>
               Secondary
             </button>
             <a href="javascript:void(0)" class="mdc-button mdc-button--stroked" data-demo-no-js>

--- a/demos/demos.scss
+++ b/demos/demos.scss
@@ -24,10 +24,77 @@ $mdc-theme-primary: #212121 !default; // Grey 900
 $mdc-theme-secondary: #64dd17 !default; // Light Green A700
 
 @import "../packages/mdc-theme/color_palette";
+@import "../packages/mdc-button/mixins";
 @import "../packages/mdc-fab/mixins";
 
 .mdc-fab.lightGreen800Fab {
   @include mdc-fab-accessible($material-color-light-green-800);
+}
+
+.mdc-button.primary-text-button {
+  $primary-color: map-get($mdc-theme-property-values, primary);
+  @include mdc-button-ink-color($primary-color);
+  @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-ink-color($primary-color);
+    @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
+  }
+}
+
+.mdc-button.secondary-text-button {
+  $secondary-color: map-get($mdc-theme-property-values, secondary);
+  @include mdc-button-ink-color($secondary-color);
+  @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-ink-color($secondary-color);
+    @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
+  }
+}
+
+.mdc-button.primary-filled-button {
+  $primary-color: map-get($mdc-theme-property-values, primary);
+  @include mdc-button-filled-accessible($primary-color);
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-filled-accessible($primary-color);
+  }
+}
+
+.mdc-button.secondary-filled-button {
+  $secondary-color: map-get($mdc-theme-property-values, secondary);
+  @include mdc-button-filled-accessible($secondary-color);
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-filled-accessible($secondary-color);
+  }
+}
+
+.mdc-button.primary-stroked-button {
+  $primary-color: map-get($mdc-theme-property-values, primary);
+  @include mdc-button-ink-color($primary-color);
+  @include mdc-button-stroke-color($primary-color);
+  @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-ink-color($primary-color);
+    @include mdc-button-stroke-color($primary-color);
+    @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
+  }
+}
+
+.mdc-button.secondary-stroked-button {
+  $secondary-color: map-get($mdc-theme-property-values, secondary);
+  @include mdc-button-ink-color($secondary-color);
+  @include mdc-button-stroke-color($secondary-color);
+  @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
+
+  @include mdc-theme-dark(".mdc-button") {
+    @include mdc-button-ink-color($secondary-color);
+    @include mdc-button-stroke-color($secondary-color);
+    @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
+  }
 }
 
 @import "../packages/material-components-web/material-components-web";

--- a/demos/demos.scss
+++ b/demos/demos.scss
@@ -31,69 +31,33 @@ $mdc-theme-secondary: #64dd17 !default; // Light Green A700
   @include mdc-fab-accessible($material-color-light-green-800);
 }
 
-.mdc-button.primary-text-button {
-  $primary-color: map-get($mdc-theme-property-values, primary);
-  @include mdc-button-ink-color($primary-color);
-  @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
-
-  @include mdc-theme-dark(".mdc-button") {
-    @include mdc-button-ink-color($primary-color);
-    @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
-  }
-}
-
 .mdc-button.secondary-text-button {
-  $secondary-color: map-get($mdc-theme-property-values, secondary);
-  @include mdc-button-ink-color($secondary-color);
-  @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
+  @include mdc-button-ink-color($mdc-theme-secondary);
+  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
 
   @include mdc-theme-dark(".mdc-button") {
-    @include mdc-button-ink-color($secondary-color);
-    @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
-  }
-}
-
-.mdc-button.primary-filled-button {
-  $primary-color: map-get($mdc-theme-property-values, primary);
-  @include mdc-button-filled-accessible($primary-color);
-
-  @include mdc-theme-dark(".mdc-button") {
-    @include mdc-button-filled-accessible($primary-color);
+    @include mdc-button-ink-color($mdc-theme-secondary);
+    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
   }
 }
 
 .mdc-button.secondary-filled-button {
-  $secondary-color: map-get($mdc-theme-property-values, secondary);
-  @include mdc-button-filled-accessible($secondary-color);
+  @include mdc-button-filled-accessible($mdc-theme-secondary);
 
   @include mdc-theme-dark(".mdc-button") {
-    @include mdc-button-filled-accessible($secondary-color);
-  }
-}
-
-.mdc-button.primary-stroked-button {
-  $primary-color: map-get($mdc-theme-property-values, primary);
-  @include mdc-button-ink-color($primary-color);
-  @include mdc-button-stroke-color($primary-color);
-  @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
-
-  @include mdc-theme-dark(".mdc-button") {
-    @include mdc-button-ink-color($primary-color);
-    @include mdc-button-stroke-color($primary-color);
-    @include mdc-button-ripple((base-color: $primary-color, opacity: .16));
+    @include mdc-button-filled-accessible($mdc-theme-secondary);
   }
 }
 
 .mdc-button.secondary-stroked-button {
-  $secondary-color: map-get($mdc-theme-property-values, secondary);
-  @include mdc-button-ink-color($secondary-color);
-  @include mdc-button-stroke-color($secondary-color);
-  @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
+  @include mdc-button-ink-color($mdc-theme-secondary);
+  @include mdc-button-stroke-color($mdc-theme-secondary);
+  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
 
   @include mdc-theme-dark(".mdc-button") {
-    @include mdc-button-ink-color($secondary-color);
-    @include mdc-button-stroke-color($secondary-color);
-    @include mdc-button-ripple((base-color: $secondary-color, opacity: .16));
+    @include mdc-button-ink-color($mdc-theme-secondary);
+    @include mdc-button-stroke-color($mdc-theme-secondary);
+    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
   }
 }
 


### PR DESCRIPTION
I renamed `accent` to correctly using `secondary` in the new class selector.
In the next PR, I will remove the stale modifier.

I split `stroked` and `text` button in order to show how to completely customize the style of each button type, if that makes sense.