### PR TITLE
refactor(button): Make ripple configure using variables

### DIFF
--- a/demos/button.scss
+++ b/demos/button.scss
@@ -17,17 +17,18 @@
 @import "./common";
 @import "../packages/mdc-button/mdc-button";
 @import "../packages/mdc-button/mixins";
+@import "../packages/mdc-button/variables";
 @import "../packages/mdc-checkbox/mdc-checkbox";
 @import "../packages/mdc-form-field/mdc-form-field";
 @import "../packages/mdc-typography/mdc-typography";
 
 .mdc-button.secondary-text-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
-  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
+  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
 
   @include mdc-theme-dark(".mdc-button") {
     @include mdc-button-ink-color($mdc-theme-secondary);
-    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
+    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
   }
 }
 
@@ -42,12 +43,12 @@
 .mdc-button.secondary-stroked-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
   @include mdc-button-stroke-color($mdc-theme-secondary);
-  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
+  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
 
   @include mdc-theme-dark(".mdc-button") {
     @include mdc-button-ink-color($mdc-theme-secondary);
     @include mdc-button-stroke-color($mdc-theme-secondary);
-    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
+    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
   }
 }
 

--- a/demos/button.scss
+++ b/demos/button.scss
@@ -24,11 +24,12 @@
 
 .mdc-button.secondary-text-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
-  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
+  @include mdc-button-ripple((theme-style: secondary, opacity: $mdc-unfilled-button-ripple-opacity));
 
   @include mdc-theme-dark(".mdc-button") {
+    // TODO(yiranm): Revisit ripple initialization after ripple refactoring
     @include mdc-button-ink-color($mdc-theme-secondary);
-    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
+    @include mdc-button-ripple((theme-style: secondary, opacity: $mdc-unfilled-button-ripple-opacity));
   }
 }
 
@@ -43,12 +44,12 @@
 .mdc-button.secondary-stroked-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
   @include mdc-button-stroke-color($mdc-theme-secondary);
-  @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
+  @include mdc-button-ripple((theme-style: secondary, opacity: $mdc-unfilled-button-ripple-opacity));
 
   @include mdc-theme-dark(".mdc-button") {
     @include mdc-button-ink-color($mdc-theme-secondary);
     @include mdc-button-stroke-color($mdc-theme-secondary);
-    @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: $mdc-unfilled-button-ripple-opacity));
+    @include mdc-button-ripple((theme-style: secondary, opacity: $mdc-unfilled-button-ripple-opacity));
   }
 }
 

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -28,10 +28,10 @@
 
   @if ($light-or-dark == "light") {
     @include mdc-button-ink-color(text-primary-on-dark);
-    @include mdc-button-ripple((base-color: white, opacity: .32));
+    @include mdc-button-ripple((base-color: text-primary-on-dark, opacity: $mdc-filled-button-ripple-opacity));
   } @else {
     @include mdc-button-ink-color(text-primary-on-light);
-    @include mdc-button-ripple((base-color: black, opacity: .32));
+    @include mdc-button-ripple((base-color: text-primary-on-light, opacity: $mdc-filled-button-ripple-opacity));
   }
 }
 
@@ -57,6 +57,14 @@
 
 @mixin mdc-button-ripple($ripple-config) {
   &:not(:disabled) {
+    // TODO(yiranm): Move base-color and tap-highlight-color into ripple
+    $base-color: map-get($ripple-config, base-color);
+
+    @if type-of($base-color) != color {
+      $base-color-value: map-get($mdc-theme-property-values, $base-color);
+      $ripple-config: map-merge($ripple-config, (base-color: $base-color-value));
+    }
+
     @include mdc-ripple-base;
     @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
     @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -28,10 +28,10 @@
 
   @if ($light-or-dark == "light") {
     @include mdc-button-ink-color(text-primary-on-dark);
-    @include mdc-button-ripple((base-color: text-primary-on-dark, opacity: $mdc-filled-button-ripple-opacity));
+    @include mdc-button-ripple((theme-style: text-primary-on-dark, opacity: $mdc-filled-button-ripple-opacity));
   } @else {
     @include mdc-button-ink-color(text-primary-on-light);
-    @include mdc-button-ripple((base-color: text-primary-on-light, opacity: $mdc-filled-button-ripple-opacity));
+    @include mdc-button-ripple((theme-style: text-primary-on-light, opacity: $mdc-filled-button-ripple-opacity));
   }
 }
 
@@ -57,23 +57,9 @@
 
 @mixin mdc-button-ripple($ripple-config) {
   &:not(:disabled) {
-    // TODO(yiranm): Move base-color and tap-highlight-color into ripple
-    $base-color: map-get($ripple-config, base-color);
-
-    @if type-of($base-color) != color {
-      $base-color-value: map-get($mdc-theme-property-values, $base-color);
-      $ripple-config: map-merge($ripple-config, (base-color: $base-color-value));
-    }
-
     @include mdc-ripple-base;
     @include mdc-ripple-bg(map-merge((pseudo: "::before"), $ripple-config));
     @include mdc-ripple-fg(map-merge((pseudo: "::after"), $ripple-config));
-
-    &:not(.mdc-ripple-upgraded) {
-      $tap-highlight-color: rgba(map-get($ripple-config, base-color), map-get($ripple-config, opacity));
-
-      @include mdc-theme-prop(-webkit-tap-highlight-color, $tap-highlight-color);
-    }
   }
 }
 
@@ -108,6 +94,7 @@
   text-align: center;
   user-select: none;
   -webkit-appearance: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   overflow: hidden;
   vertical-align: middle;
 

--- a/packages/mdc-button/_variables.scss
+++ b/packages/mdc-button/_variables.scss
@@ -16,3 +16,6 @@
 
 $mdc-button-height: 36px;
 $mdc-dense-button-height: 32px;
+
+$mdc-unfilled-button-ripple-opacity: .16;
+$mdc-filled-button-ripple-opacity: .32;

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -16,6 +16,7 @@
 
 @import "@material/theme/mixins";
 @import "./mixins";
+@import "./variables";
 
 // postcss-bem-linter: define button
 .mdc-button {
@@ -23,11 +24,11 @@
   @include mdc-button-corner-radius(2px);
   @include mdc-button-container-fill-color(transparent);
   @include mdc-button-ink-color(text-primary-on-light);
-  @include mdc-button-ripple((base-color: black, opacity: .16));
+  @include mdc-button-ripple((base-color: text-primary-on-light, opacity: $mdc-unfilled-button-ripple-opacity));
 
   @include mdc-theme-dark(".mdc-button") {
     @include mdc-button-ink-color(text-primary-on-dark);
-    @include mdc-button-ripple((base-color: white, opacity: .16));
+    @include mdc-button-ripple((base-color: text-primary-on-dark, opacity: $mdc-unfilled-button-ripple-opacity));
   }
 }
 

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -24,11 +24,11 @@
   @include mdc-button-corner-radius(2px);
   @include mdc-button-container-fill-color(transparent);
   @include mdc-button-ink-color(text-primary-on-light);
-  @include mdc-button-ripple((base-color: text-primary-on-light, opacity: $mdc-unfilled-button-ripple-opacity));
+  @include mdc-button-ripple((theme-style: text-primary-on-light, opacity: $mdc-unfilled-button-ripple-opacity));
 
   @include mdc-theme-dark(".mdc-button") {
     @include mdc-button-ink-color(text-primary-on-dark);
-    @include mdc-button-ripple((base-color: text-primary-on-dark, opacity: $mdc-unfilled-button-ripple-opacity));
+    @include mdc-button-ripple((theme-style: text-primary-on-dark, opacity: $mdc-unfilled-button-ripple-opacity));
   }
 }
 


### PR DESCRIPTION
## Related to #991 

This PR is made to make customize button with mixins easier:
1. Expose `filled` and `unfilled` button ripple opacity value, so they could use those value if they only wish to adapt ripple color to custom ink color 
2. Allow theme-variable to be passed as `base-color` in `mdc-button-ripple`, so that `mdc-button-filled-accessible` will ensure ink color is always aligned with ripple color to prevent potential error.

*Note*: It worths considering move `tap-color` as well as `base-color` logic into ripple, but I suggest we do that separately when we refactor ripple. I added a todo here to indicate this is something that we should revisit. 