### PR TITLE
docs: Fix typos of "Components"

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -17,7 +17,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Button - Material Compoonents Catalog</title>
+    <title>Button - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <script src="/assets/demo-styles.css.js"></script>

--- a/demos/card.html
+++ b/demos/card.html
@@ -17,7 +17,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Card - Material Compoonents Catalog</title>
+    <title>Card - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <script src="/assets/demo-styles.css.js"></script>

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -17,7 +17,7 @@
 <html class="mdc-typography">
   <head>
     <meta charset="utf-8">
-    <title>Checkbox - Material Compoonents Catalog</title>
+    <title>Checkbox - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <script src="/assets/demo-styles.css.js"></script>

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -17,7 +17,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Linear Progress - Material Compoonents Catalog</title>
+    <title>Linear Progress - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <script src="/assets/demo-styles.css.js"></script>

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -17,7 +17,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Toolbar - Material Compoonents Catalog</title>
+    <title>Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <script src="/assets/demo-styles.css.js"></script>


### PR DESCRIPTION
I randomly noticed we had a few demo pages that had an extra 'o' in Components in the title. Good for a laugh but let's fix it 😂 