### PR TITLE
fix(dialog): Fix $compound param in mdc-theme-dark

### DIFF
--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -29,7 +29,7 @@
   @include mdc-button-ink-color(text-primary-on-light);
   @include mdc-button-ripple((base-color: black, opacity: .16));
 
-  @include mdc-theme-dark(".mdc-button") {
+  @include mdc-theme-dark(".mdc-button", true /* compound */) {
     @include mdc-button-ink-color(text-primary-on-dark);
     @include mdc-button-ripple((base-color: white, opacity: .16));
   }
@@ -40,7 +40,7 @@
   @include mdc-button--filled_;
   @include mdc-button-filled-accessible(black);
 
-  @include mdc-theme-dark(".mdc-button") {
+  @include mdc-theme-dark(".mdc-button", true /* compound */) {
     @include mdc-button-filled-accessible(white);
   }
 }
@@ -55,7 +55,7 @@
   @include mdc-button-stroke-style(solid);
   @include mdc-button-stroke-color(text-primary-on-light);
 
-  @include mdc-theme-dark(".mdc-button") {
+  @include mdc-theme-dark(".mdc-button", true /* compound */) {
     @include mdc-button-stroke-color(text-primary-on-dark);
   }
 }

--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -108,7 +108,7 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     margin-top: 20px;
     padding: 0 24px 24px;
 
-    @include mdc-theme-dark(".mdc-dialog", true) {
+    @include mdc-theme-dark(".mdc-dialog") {
       @include mdc-theme-prop(color, text-secondary-on-dark);
     }
 


### PR DESCRIPTION
resolves #1031
resolves #1032

$compound param was set to true in dialog, when it should not have been. Conversely, it was not set in mdc-button, when it should have been. Fixing the first caused the second to show up as broken in the dialog demo, so I fixed both in one commit instead.