### PR TITLE
docs(toolbar): Fix Toolbar with Menu demo's icon padding

### DIFF
--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -52,17 +52,17 @@
         <section class="mdc-toolbar__section mdc-toolbar__section--align-end" role="toolbar">
           <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Download" alt="Download">file_download</a>
           <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Print this page" alt="Print this page">print</a>
-          <div class="mdc-menu-anchor">
           <a href="#" class="material-icons mdc-toolbar__icon toggle" aria-label="Bookmark this page" alt="Bookmark this page">more_vert</a>
-          <div class="mdc-simple-menu" tabindex="-1" id="demo-menu">
-            <ul class="mdc-simple-menu__items mdc-list" role="menu" aria-hidden="true" style="transform: scale(1, 1);">
-              <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.069s;">Back</li>
-              <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.124s;">Forward</li>
-              <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.179s;">Reload</li>
-              <li class="mdc-list-divider" role="separator"></li>
-              <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.236s;">Save As...</li>
-            </ul>
-          </div>
+          <div class="mdc-menu-anchor">
+            <div class="mdc-simple-menu" tabindex="-1" id="demo-menu">
+              <ul class="mdc-simple-menu__items mdc-list" role="menu" aria-hidden="true" style="transform: scale(1, 1);">
+                <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.069s;">Back</li>
+                <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.124s;">Forward</li>
+                <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.179s;">Reload</li>
+                <li class="mdc-list-divider" role="separator"></li>
+                <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.236s;">Save As...</li>
+              </ul>
+            </div>
           </div>
         </section>
       </div>

--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -52,7 +52,7 @@
         <section class="mdc-toolbar__section mdc-toolbar__section--align-end" role="toolbar">
           <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Download" alt="Download">file_download</a>
           <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Print this page" alt="Print this page">print</a>
-          <a href="#" class="material-icons mdc-toolbar__icon toggle" aria-label="Bookmark this page" alt="Bookmark this page">more_vert</a>
+          <a href="#" class="material-icons mdc-toolbar__icon toggle" aria-label="More" alt="More">more_vert</a>
           <div class="mdc-menu-anchor">
             <div class="mdc-simple-menu" tabindex="-1" id="demo-menu">
               <ul class="mdc-simple-menu__items mdc-list" role="menu" aria-hidden="true" style="transform: scale(1, 1);">


### PR DESCRIPTION
Fix a small regression introduced by #1068 

Before
<img width="373" alt="screen shot 2017-09-14 at 14 48 11" src="https://user-images.githubusercontent.com/1894234/30448187-0a55bfa2-995c-11e7-8d2d-38ab9ce320f1.png">

After
<img width="359" alt="screen shot 2017-09-14 at 14 48 49" src="https://user-images.githubusercontent.com/1894234/30448196-1106d0e8-995c-11e7-9e0f-1e5e3e8f52b6.png">
