### PR TITLE
Docs(button): Fix button corner radius and add demos

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -180,7 +180,7 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Unelevated Button</legend>
+          <legend class="mdc-typography--title">Unelevated Button (Experimental)</legend>
           <div>
             <button class="mdc-button mdc-button--unelevated">
               Baseline
@@ -205,7 +205,7 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Stroked Button</legend>
+          <legend class="mdc-typography--title">Stroked Button (Experimental)</legend>
           <div>
             <button class="mdc-button mdc-button--stroked">
               Baseline
@@ -226,6 +226,18 @@
             <a href="javascript:void(0)" class="mdc-button mdc-button--stroked">
               Link
             </a>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend class="mdc-typography--title">Custom button (Experimental)</legend>
+          <div>
+            <button class="mdc-button mdc-button--unelevated big-round-corner-button">
+              Corner Radius
+            </button>
+            <button class="mdc-button mdc-button--stroked thick-stroke-button">
+              Thick Stroke Width
+            </button>
           </div>
         </fieldset>
 
@@ -281,7 +293,7 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Unelevated Button</legend>
+          <legend class="mdc-typography--title">Unelevated Button (Experimental)</legend>
           <div>
             <button class="mdc-button mdc-button--unelevated" data-demo-no-js>
               Baseline
@@ -306,7 +318,7 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--title">Stroked Button</legend>
+          <legend class="mdc-typography--title">Stroked Button (Experimental)</legend>
           <div>
             <button class="mdc-button mdc-button--stroked" data-demo-no-js>
               Baseline
@@ -327,6 +339,18 @@
             <a href="javascript:void(0)" class="mdc-button mdc-button--stroked" data-demo-no-js>
               Link
             </a>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend class="mdc-typography--title">Custom button (Experimental)</legend>
+          <div>
+            <button class="mdc-button mdc-button--unelevated big-round-corner-button" data-demo-no-js>
+              Big Corner Radius
+            </button>
+            <button class="mdc-button mdc-button--stroked thick-stroke-button" data-demo-no-js>
+              Thick Stroke Width
+            </button>
           </div>
         </fieldset>
       </section>

--- a/demos/button.scss
+++ b/demos/button.scss
@@ -50,3 +50,11 @@
     @include mdc-button-ripple((base-color: $mdc-theme-secondary, opacity: .16));
   }
 }
+
+.mdc-button.big-round-corner-button {
+  @include mdc-button-corner-radius(8px);
+}
+
+.mdc-button.thick-stroke-button {
+  @include mdc-button-stroke-width(4px);
+}

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -116,5 +116,5 @@ Mixin | Description
 `mdc-button-ink-color` | Sets the ink color to the given color
 `mdc-button-stroke-color` | Sets the stroke color to the given color
 `mdc-button-ripple` | Sets the ripple to the given [ripple configuration](https://github.com/material-components/material-components-web/blob/master/packages/mdc-ripple/README.md)
-`mdc-button-corner-radius` | Sets the corner radius to the given number (defaults to 4px)
+`mdc-button-corner-radius` | Sets the corner radius to the given number (defaults to 2px)
 `mdc-button-stroke-width` | Sets the stroke width to the given number (defaults to 2px)

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -20,7 +20,7 @@
 // postcss-bem-linter: define button
 .mdc-button {
   @include mdc-button-base_;
-  @include mdc-button-corner-radius(4px);
+  @include mdc-button-corner-radius(2px);
   @include mdc-button-container-fill-color(transparent);
   @include mdc-button-ink-color(text-primary-on-light);
   @include mdc-button-ripple((base-color: black, opacity: .16));


### PR DESCRIPTION
Closes #1163 

## Related to #991 

This PR contains small things related to demos:
1. Fix baseline button corner radius from 4px to 2px, as required by guideline
2. Add demos how to customize stroke width and corn radius
3. Add `experimental` to `unelevated`, `stroke` and `custom` to specify their states

Deployed to https://1307-dot-mdc-web-dev.xxxx.com/