### PR TITLE
chore(demos): Fix CSS specificity of Material Icons in theme demo

### DIFF
--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -20,10 +20,10 @@
     <title>Color Theming - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/theme/index.css.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/assets/theme/index.css.js"></script>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed">


### PR DESCRIPTION
Previously, the Material Icons CSS had a higher specificity because it was imported after the theme page CSS. As a result, icons were sometimes displayed incorrectly.