### PR TITLE
chore(demos): Remove z-index from dialog on new theme demo page

### DIFF
--- a/demos/theme/index.scss
+++ b/demos/theme/index.scss
@@ -181,6 +181,7 @@ $demo-section-margin: 48px;
 .demo-dialog {
   position: relative;
   justify-content: unset;
+  z-index: unset;
 }
 
 //


### PR DESCRIPTION
Previously, the dialog was displayed on top of open drawers, which is not what we want.