### PR TITLE
fix(fab): Import correct mdc-animation resource for functions

### DIFF
--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import "@material/animation/variables";
+@import "@material/animation/functions";
 @import "@material/elevation/mixins";
 @import "@material/elevation/variables";
 @import "@material/ripple/mixins";


### PR DESCRIPTION
Not sure how this was missed earlier, but FAB uses functions from mdc-animation, not variables. The missing functions didn't cause a Sass compile error - it just caused the function names to be left in verbatim, which caused browsers to toss out the transition rules entirely.