### PR TITLE
fix(fab): Add hover/focus elevation

### DIFF
--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -74,6 +74,11 @@ $mdc-fab-icon-enter-duration_: 180ms;
   -webkit-appearance: none;
   overflow: hidden;
 
+  &:hover,
+  &:focus {
+    @include mdc-elevation(8);
+  }
+
   &:active {
     @include mdc-elevation(12);
   }


### PR DESCRIPTION
This makes FABs more consistent with Buttons which already have a hover/focus elevation.

The guideline does not explicitly call out hover/focus elevation but we have discussed the topic with designers, and it will definitely be called out more specifically in the future.