### PR TITLE
feat(tabs): tab bar foundation - publicize layoutIndicator method

### DIFF
--- a/packages/mdc-tabs/README.md
+++ b/packages/mdc-tabs/README.md
@@ -557,6 +557,10 @@ classes, an adapter object must be provided.
 
 Sets layout for the Tab Bar component.
 
+#### MDCTabBarFoundation.layoutIndicator() => void
+
+Sets layout and styles for the Tab Bar indicator based on active tab width and position.
+
 #### MDCTabBarFoundation.getActiveTabIndex() => number
 
 Returns index of currently active tab

--- a/packages/mdc-tabs/tab-bar/foundation.js
+++ b/packages/mdc-tabs/tab-bar/foundation.js
@@ -82,10 +82,10 @@ export default class MDCTabBarFoundation extends MDCFoundation {
   layoutInternal_() {
     this.forEachTabIndex_((index) => this.adapter_.measureTabAtIndex(index));
     this.computedWidth_ = this.adapter_.getOffsetWidth();
-    this.layoutIndicator_();
+    this.layoutIndicator();
   }
 
-  layoutIndicator_() {
+  layoutIndicator() {
     const isIndicatorFirstRender = !this.isIndicatorShown_;
 
     // Ensure that indicator appears in the right position immediately for correct first render.
@@ -157,7 +157,7 @@ export default class MDCTabBarFoundation extends MDCFoundation {
         this.adapter_.setTabActiveAtIndex(prevActiveTabIndex, false);
       }
       this.adapter_.setTabActiveAtIndex(this.activeTabIndex_, true);
-      this.layoutIndicator_();
+      this.layoutIndicator();
       if (shouldNotify) {
         this.adapter_.notifyChange({activeTabIndex: this.activeTabIndex_});
       }


### PR DESCRIPTION
This pull request removes the underscore from the method `layoutIndicator_()` on the `MDCTabBar` foundation so that the framework using it can call this method and force an update to the indicator's styles. Additional documentation has also been added to the README for MDC tabs.

**Example use case:**
The user visits a route containing a tab bar of tabs `[ A ][ B ][ C ]`, in which tab B is active. The state of the app changes (without the route changing), causing the tab bar to change to `[ D ][ E ][ F ]`. Simultaneously, tab E becomes active. However, since E has the same index as B, the `switchToTabAtIndex()` method thinks the tabs never changed, so the indicator is not updated. We need to communicate to the tab bar to update the indicator's width and position based on the newly active tab.