### PR TITLE
chore: Transpile our JS to use goog.module format

### DIFF
--- a/docs/closure-compiler.md
+++ b/docs/closure-compiler.md
@@ -116,6 +116,22 @@ import MDCFoundation from '@material/base/foundation';
 
 This is an unfortunate side-effect of how [closure's module naming mechanism works](https://github.com/google/closure-compiler/issues/2257).
 
+#### All `export` statements must be consolidated into one line at the end of the file.
+
+```js
+// BAD
+export function getFoo() {
+...
+export function getBar() {
+// GOOD
+function getFoo() {
+...
+function getBar() {
+...
+export {getFoo, getBar};
+```
+
+
 #### Standard foundation constants must be defined as `@enum` types
 
 - `cssClasses` should be defined as `/** @enum {string} */`

--- a/packages/mdc-animation/index.js
+++ b/packages/mdc-animation/index.js
@@ -118,14 +118,14 @@ function getAnimationName(windowObj, eventType) {
 // Public functions to access getAnimationName() for JavaScript events or CSS
 // property names.
 
-export const transformStyleProperties = ['transform', 'WebkitTransform', 'MozTransform', 'OTransform', 'MSTransform'];
+const transformStyleProperties = ['transform', 'WebkitTransform', 'MozTransform', 'OTransform', 'MSTransform'];
 
 /**
  * @param {!Object} windowObj
  * @param {string} eventType
  * @return {string}
  */
-export function getCorrectEventName(windowObj, eventType) {
+function getCorrectEventName(windowObj, eventType) {
   return getAnimationName(windowObj, eventType);
 }
 
@@ -134,6 +134,8 @@ export function getCorrectEventName(windowObj, eventType) {
  * @param {string} eventType
  * @return {string}
  */
-export function getCorrectPropertyName(windowObj, eventType) {
+function getCorrectPropertyName(windowObj, eventType) {
   return getAnimationName(windowObj, eventType);
 }
+
+export {transformStyleProperties, getCorrectEventName, getCorrectPropertyName};

--- a/packages/mdc-base/component.js
+++ b/packages/mdc-base/component.js
@@ -19,7 +19,7 @@ import MDCFoundation from './foundation';
 /**
  * @template F
  */
-export default class MDCComponent {
+class MDCComponent {
   /**
    * @param {!Element} root
    * @return {!MDCComponent}
@@ -120,3 +120,5 @@ export default class MDCComponent {
     this.root_.dispatchEvent(evt);
   }
 }
+
+export default MDCComponent;

--- a/packages/mdc-base/foundation.js
+++ b/packages/mdc-base/foundation.js
@@ -17,7 +17,7 @@
 /**
  * @template A
  */
-export default class MDCFoundation {
+class MDCFoundation {
   /** @return enum{cssClasses} */
   static get cssClasses() {
     // Classes extending MDCFoundation should implement this method to return an object which exports every
@@ -63,3 +63,5 @@ export default class MDCFoundation {
     // Subclasses should override this method to perform de-initialization routines (de-registering events, etc.)
   }
 }
+
+export default MDCFoundation;

--- a/packages/mdc-checkbox/adapter.js
+++ b/packages/mdc-checkbox/adapter.js
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-unused-vars */
-import {MDCSelectionControlState} from '@material/selection-control';
+import * as selectionControl from '@material/selection-control';
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
@@ -35,7 +35,7 @@ import {MDCSelectionControlState} from '@material/selection-control';
  *
  * @record
  */
-export default class MDCCheckboxAdapter {
+class MDCCheckboxAdapter {
   /** @param {string} className */
   addClass(className) {}
 
@@ -54,7 +54,7 @@ export default class MDCCheckboxAdapter {
   /** @param {!EventListener} handler */
   deregisterChangeHandler(handler) {}
 
-  /** @return {!MDCSelectionControlState} */
+  /** @return {!selectionControl.MDCSelectionControlState} */
   getNativeControl() {}
 
   forceLayout() {}
@@ -62,3 +62,5 @@ export default class MDCCheckboxAdapter {
   /** @return {boolean} */
   isAttachedToDOM() {}
 }
+
+export default MDCCheckboxAdapter;

--- a/packages/mdc-checkbox/adapter.js
+++ b/packages/mdc-checkbox/adapter.js
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-unused-vars */
-import * as selectionControl from '@material/selection-control';
+import {MDCSelectionControlState} from '@material/selection-control';
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
@@ -54,7 +54,7 @@ class MDCCheckboxAdapter {
   /** @param {!EventListener} handler */
   deregisterChangeHandler(handler) {}
 
-  /** @return {!selectionControl.MDCSelectionControlState} */
+  /** @return {!MDCSelectionControlState} */
   getNativeControl() {}
 
   forceLayout() {}

--- a/packages/mdc-checkbox/constants.js
+++ b/packages/mdc-checkbox/constants.js
@@ -18,7 +18,7 @@
 const ROOT = 'mdc-checkbox';
 
 /** @enum {string} */
-export const cssClasses = {
+const cssClasses = {
   UPGRADED: 'mdc-checkbox--upgraded',
   CHECKED: 'mdc-checkbox--checked',
   INDETERMINATE: 'mdc-checkbox--indeterminate',
@@ -32,7 +32,7 @@ export const cssClasses = {
 };
 
 /** @enum {string} */
-export const strings = {
+const strings = {
   NATIVE_CONTROL_SELECTOR: `.${ROOT}__native-control`,
   TRANSITION_STATE_INIT: 'init',
   TRANSITION_STATE_CHECKED: 'checked',
@@ -41,6 +41,8 @@ export const strings = {
 };
 
 /** @enum {number} */
-export const numbers = {
+const numbers = {
   ANIM_END_LATCH_MS: 100,
 };
+
+export {cssClasses, strings, numbers};

--- a/packages/mdc-checkbox/foundation.js
+++ b/packages/mdc-checkbox/foundation.js
@@ -16,7 +16,7 @@
 
 import MDCFoundation from '@material/base/foundation';
 /* eslint-disable no-unused-vars */
-import {MDCSelectionControlState} from '@material/selection-control';
+import * as selectionControl from '@material/selection-control';
 import MDCCheckboxAdapter from './adapter';
 /* eslint-enable no-unused-vars */
 import {cssClasses, strings, numbers} from './constants';
@@ -27,7 +27,7 @@ const CB_PROTO_PROPS = ['checked', 'indeterminate'];
 /**
  * @extends {MDCFoundation<!MDCCheckboxAdapter>}
  */
-export default class MDCCheckboxFoundation extends MDCFoundation {
+class MDCCheckboxFoundation extends MDCFoundation {
   /** @return enum {cssClasses} */
   static get cssClasses() {
     return cssClasses;
@@ -52,7 +52,7 @@ export default class MDCCheckboxFoundation extends MDCFoundation {
       deregisterAnimationEndHandler: (/* handler: EventListener */) => {},
       registerChangeHandler: (/* handler: EventListener */) => {},
       deregisterChangeHandler: (/* handler: EventListener */) => {},
-      getNativeControl: () => /* !MDCSelectionControlState */ {},
+      getNativeControl: () => /* !selectionControl.MDCSelectionControlState */ {},
       forceLayout: () => {},
       isAttachedToDOM: () => /* boolean */ {},
     });
@@ -208,7 +208,7 @@ export default class MDCCheckboxFoundation extends MDCFoundation {
   }
 
   /**
-   * @param {!MDCSelectionControlState} nativeCb
+   * @param {!selectionControl.MDCSelectionControlState} nativeCb
    * @return {string}
    * @private
    */
@@ -264,7 +264,7 @@ export default class MDCCheckboxFoundation extends MDCFoundation {
   }
 
   /**
-   * @return {!MDCSelectionControlState}
+   * @return {!selectionControl.MDCSelectionControlState}
    * @private
    */
   getNativeControl_() {
@@ -284,3 +284,5 @@ export default class MDCCheckboxFoundation extends MDCFoundation {
 function validDescriptor(inputPropDesc) {
   return !!inputPropDesc && typeof inputPropDesc.set === 'function';
 }
+
+export default MDCCheckboxFoundation;

--- a/packages/mdc-checkbox/foundation.js
+++ b/packages/mdc-checkbox/foundation.js
@@ -16,7 +16,7 @@
 
 import MDCFoundation from '@material/base/foundation';
 /* eslint-disable no-unused-vars */
-import * as selectionControl from '@material/selection-control';
+import {MDCSelectionControlState} from '@material/selection-control';
 import MDCCheckboxAdapter from './adapter';
 /* eslint-enable no-unused-vars */
 import {cssClasses, strings, numbers} from './constants';
@@ -52,7 +52,7 @@ class MDCCheckboxFoundation extends MDCFoundation {
       deregisterAnimationEndHandler: (/* handler: EventListener */) => {},
       registerChangeHandler: (/* handler: EventListener */) => {},
       deregisterChangeHandler: (/* handler: EventListener */) => {},
-      getNativeControl: () => /* !selectionControl.MDCSelectionControlState */ {},
+      getNativeControl: () => /* !MDCSelectionControlState */ {},
       forceLayout: () => {},
       isAttachedToDOM: () => /* boolean */ {},
     });
@@ -208,7 +208,7 @@ class MDCCheckboxFoundation extends MDCFoundation {
   }
 
   /**
-   * @param {!selectionControl.MDCSelectionControlState} nativeCb
+   * @param {!MDCSelectionControlState} nativeCb
    * @return {string}
    * @private
    */
@@ -264,7 +264,7 @@ class MDCCheckboxFoundation extends MDCFoundation {
   }
 
   /**
-   * @return {!selectionControl.MDCSelectionControlState}
+   * @return {!MDCSelectionControlState}
    * @private
    */
   getNativeControl_() {

--- a/packages/mdc-checkbox/index.js
+++ b/packages/mdc-checkbox/index.js
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-import {getCorrectEventName} from '@material/animation';
+import * as animation from '@material/animation';
 import MDCComponent from '@material/base/component';
 /* eslint-disable no-unused-vars */
 import {MDCSelectionControlState, MDCSelectionControl} from '@material/selection-control';
 /* eslint-enable no-unused-vars */
 import MDCCheckboxFoundation from './foundation';
 import {MDCRipple, MDCRippleFoundation} from '@material/ripple';
-import {getMatchesProperty} from '@material/ripple/util';
-
-export {MDCCheckboxFoundation};
+import * as util from '@material/ripple/util';
 
 /**
  * @extends MDCComponent<!MDCCheckboxFoundation>
  * @implements {MDCSelectionControl}
  */
-export class MDCCheckbox extends MDCComponent {
+class MDCCheckbox extends MDCComponent {
   static attachTo(root) {
     return new MDCCheckbox(root);
   }
@@ -58,7 +56,7 @@ export class MDCCheckbox extends MDCComponent {
    * @private
    */
   initRipple_() {
-    const MATCHES = getMatchesProperty(HTMLElement.prototype);
+    const MATCHES = util.getMatchesProperty(HTMLElement.prototype);
     const adapter = Object.assign(MDCRipple.createAdapter(this), {
       isUnbounded: () => true,
       isSurfaceActive: () => this.nativeCb_[MATCHES](':active'),
@@ -87,9 +85,9 @@ export class MDCCheckbox extends MDCComponent {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
       registerAnimationEndHandler:
-        (handler) => this.root_.addEventListener(getCorrectEventName(window, 'animationend'), handler),
+        (handler) => this.root_.addEventListener(animation.getCorrectEventName(window, 'animationend'), handler),
       deregisterAnimationEndHandler:
-        (handler) => this.root_.removeEventListener(getCorrectEventName(window, 'animationend'), handler),
+        (handler) => this.root_.removeEventListener(animation.getCorrectEventName(window, 'animationend'), handler),
       registerChangeHandler: (handler) => this.nativeCb_.addEventListener('change', handler),
       deregisterChangeHandler: (handler) => this.nativeCb_.removeEventListener('change', handler),
       getNativeControl: () => this.nativeCb_,
@@ -148,3 +146,5 @@ export class MDCCheckbox extends MDCComponent {
     super.destroy();
   }
 }
+
+export {MDCCheckboxFoundation, MDCCheckbox};

--- a/packages/mdc-checkbox/index.js
+++ b/packages/mdc-checkbox/index.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as animation from '@material/animation';
+import {getCorrectEventName} from '@material/animation';
 import MDCComponent from '@material/base/component';
 /* eslint-disable no-unused-vars */
 import {MDCSelectionControlState, MDCSelectionControl} from '@material/selection-control';
 /* eslint-enable no-unused-vars */
 import MDCCheckboxFoundation from './foundation';
 import {MDCRipple, MDCRippleFoundation} from '@material/ripple';
-import * as util from '@material/ripple/util';
+import {getMatchesProperty} from '@material/ripple/util';
 
 /**
  * @extends MDCComponent<!MDCCheckboxFoundation>
@@ -56,7 +56,7 @@ class MDCCheckbox extends MDCComponent {
    * @private
    */
   initRipple_() {
-    const MATCHES = util.getMatchesProperty(HTMLElement.prototype);
+    const MATCHES = getMatchesProperty(HTMLElement.prototype);
     const adapter = Object.assign(MDCRipple.createAdapter(this), {
       isUnbounded: () => true,
       isSurfaceActive: () => this.nativeCb_[MATCHES](':active'),
@@ -85,9 +85,9 @@ class MDCCheckbox extends MDCComponent {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
       registerAnimationEndHandler:
-        (handler) => this.root_.addEventListener(animation.getCorrectEventName(window, 'animationend'), handler),
+        (handler) => this.root_.addEventListener(getCorrectEventName(window, 'animationend'), handler),
       deregisterAnimationEndHandler:
-        (handler) => this.root_.removeEventListener(animation.getCorrectEventName(window, 'animationend'), handler),
+        (handler) => this.root_.removeEventListener(getCorrectEventName(window, 'animationend'), handler),
       registerChangeHandler: (handler) => this.nativeCb_.addEventListener('change', handler),
       deregisterChangeHandler: (handler) => this.nativeCb_.removeEventListener('change', handler),
       getNativeControl: () => this.nativeCb_,

--- a/packages/mdc-form-field/adapter.js
+++ b/packages/mdc-form-field/adapter.js
@@ -31,7 +31,7 @@
  *
  * @record
  */
-export default class MDCFormFieldAdapter {
+class MDCFormFieldAdapter {
   /**
    * @param {string} type
    * @param {!EventListener} handler
@@ -48,3 +48,5 @@ export default class MDCFormFieldAdapter {
 
   deactivateInputRipple() {}
 }
+
+export default MDCFormFieldAdapter;

--- a/packages/mdc-form-field/constants.js
+++ b/packages/mdc-form-field/constants.js
@@ -15,11 +15,13 @@
  */
 
 /** @enum {string} */
-export const cssClasses = {
+const cssClasses = {
   ROOT: 'mdc-form-field',
 };
 
 /** @enum {string} */
-export const strings = {
+const strings = {
   LABEL_SELECTOR: '.mdc-form-field > label',
 };
+
+export {cssClasses, strings};

--- a/packages/mdc-form-field/foundation.js
+++ b/packages/mdc-form-field/foundation.js
@@ -15,13 +15,13 @@
  */
 
 import MDCFoundation from '@material/base/foundation';
-import {MDCFormFieldAdapter} from './adapter';
+import MDCFormFieldAdapter from './adapter';
 import {cssClasses, strings} from './constants';
 
 /**
  * @extends {MDCFoundation<!MDCFormFieldAdapter>}
  */
-export default class MDCFormFieldFoundation extends MDCFoundation {
+class MDCFormFieldFoundation extends MDCFoundation {
   /** @return enum {cssClasses} */
   static get cssClasses() {
     return cssClasses;
@@ -64,3 +64,5 @@ export default class MDCFormFieldFoundation extends MDCFoundation {
     requestAnimationFrame(() => this.adapter_.deactivateInputRipple());
   }
 }
+
+export default MDCFormFieldFoundation;

--- a/packages/mdc-form-field/index.js
+++ b/packages/mdc-form-field/index.js
@@ -17,7 +17,7 @@
 import MDCComponent from '@material/base/component';
 import MDCFormFieldFoundation from './foundation';
 /* eslint-disable no-unused-vars */
-import * as selectionControl from '@material/selection-control';
+import {MDCSelectionControl} from '@material/selection-control';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -28,12 +28,12 @@ class MDCFormField extends MDCComponent {
     return new MDCFormField(root);
   }
 
-  /** @param {?selectionControl.MDCSelectionControl} input */
+  /** @param {?MDCSelectionControl} input */
   set input(input) {
     this.input_ = input;
   }
 
-  /** @return {?selectionControl.MDCSelectionControl} */
+  /** @return {?MDCSelectionControl} */
   get input() {
     return this.input_;
   }
@@ -41,7 +41,7 @@ class MDCFormField extends MDCComponent {
   constructor(...args) {
     super(...args);
 
-    /** @private {?selectionControl.MDCSelectionControl} */
+    /** @private {?MDCSelectionControl} */
     this.input_;
   }
 

--- a/packages/mdc-form-field/index.js
+++ b/packages/mdc-form-field/index.js
@@ -17,25 +17,23 @@
 import MDCComponent from '@material/base/component';
 import MDCFormFieldFoundation from './foundation';
 /* eslint-disable no-unused-vars */
-import {MDCSelectionControl} from '@material/selection-control';
+import * as selectionControl from '@material/selection-control';
 /* eslint-enable no-unused-vars */
-
-export {MDCFormFieldFoundation};
 
 /**
  * @extends MDCComponent<!MDCFormFieldFoundation>
  */
-export class MDCFormField extends MDCComponent {
+class MDCFormField extends MDCComponent {
   static attachTo(root) {
     return new MDCFormField(root);
   }
 
-  /** @param {?MDCSelectionControl} input */
+  /** @param {?selectionControl.MDCSelectionControl} input */
   set input(input) {
     this.input_ = input;
   }
 
-  /** @return {?MDCSelectionControl} */
+  /** @return {?selectionControl.MDCSelectionControl} */
   get input() {
     return this.input_;
   }
@@ -43,7 +41,7 @@ export class MDCFormField extends MDCComponent {
   constructor(...args) {
     super(...args);
 
-    /** @private {?MDCSelectionControl} */
+    /** @private {?selectionControl.MDCSelectionControl} */
     this.input_;
   }
 
@@ -74,3 +72,5 @@ export class MDCFormField extends MDCComponent {
     });
   }
 }
+
+export {MDCFormField, MDCFormFieldFoundation};

--- a/packages/mdc-icon-toggle/adapter.js
+++ b/packages/mdc-icon-toggle/adapter.js
@@ -34,7 +34,8 @@
  *
  * @record
  */
-export class MDCIconToggleAdapter {
+
+class MDCIconToggleAdapter {
   /** @param {string} className */
   addClass(className) {}
 
@@ -86,4 +87,6 @@ export class MDCIconToggleAdapter {
  *   isOn: boolean,
  * }}
  */
-export let IconToggleEvent;
+let IconToggleEvent;
+
+export {MDCIconToggleAdapter, IconToggleEvent};

--- a/packages/mdc-icon-toggle/constants.js
+++ b/packages/mdc-icon-toggle/constants.js
@@ -15,13 +15,13 @@
  */
 
 /** @enum {string} */
-export const cssClasses = {
+const cssClasses = {
   ROOT: 'mdc-icon-toggle',
   DISABLED: 'mdc-icon-toggle--disabled',
 };
 
 /** @enum {string} */
-export const strings = {
+const strings = {
   DATA_TOGGLE_ON: 'data-toggle-on',
   DATA_TOGGLE_OFF: 'data-toggle-off',
   ARIA_PRESSED: 'aria-pressed',
@@ -29,3 +29,5 @@ export const strings = {
   ARIA_LABEL: 'aria-label',
   CHANGE_EVENT: 'MDCIconToggle:change',
 };
+
+export {cssClasses, strings};

--- a/packages/mdc-icon-toggle/foundation.js
+++ b/packages/mdc-icon-toggle/foundation.js
@@ -22,7 +22,7 @@ import {cssClasses, strings} from './constants';
 /**
  * @extends {MDCFoundation<!MDCIconToggleAdapter>}
  */
-export default class MDCIconToggleFoundation extends MDCFoundation {
+class MDCIconToggleFoundation extends MDCFoundation {
   static get cssClasses() {
     return cssClasses;
   }
@@ -228,3 +228,5 @@ IconToggleState.prototype.content;
  * @export {string|undefined}
  */
 IconToggleState.prototype.cssClass;
+
+export default MDCIconToggleFoundation;

--- a/packages/mdc-icon-toggle/index.js
+++ b/packages/mdc-icon-toggle/index.js
@@ -18,12 +18,10 @@ import MDCComponent from '@material/base/component';
 import MDCIconToggleFoundation from './foundation';
 import {MDCRipple, MDCRippleFoundation} from '@material/ripple';
 
-export {MDCIconToggleFoundation};
-
 /**
  * @extends {MDCComponent<!MDCIconToggleFoundation>}
  */
-export class MDCIconToggle extends MDCComponent {
+class MDCIconToggle extends MDCComponent {
   static attachTo(root) {
     return new MDCIconToggle(root);
   }
@@ -118,3 +116,5 @@ export class MDCIconToggle extends MDCComponent {
     this.foundation_.refreshToggleData();
   }
 }
+
+export {MDCIconToggle, MDCIconToggleFoundation};

--- a/packages/mdc-menu/index.js
+++ b/packages/mdc-menu/index.js
@@ -15,5 +15,5 @@
  */
 
 import * as util from './util';
-export {MDCSimpleMenu, MDCSimpleMenuFoundation} from './simple';
-export {util};
+import {MDCSimpleMenu, MDCSimpleMenuFoundation} from './simple';
+export {MDCSimpleMenu, MDCSimpleMenuFoundation, util};

--- a/packages/mdc-menu/simple/adapter.js
+++ b/packages/mdc-menu/simple/adapter.js
@@ -35,7 +35,7 @@
  *
  * @record
  */
-export default class MDCSimpleMenuAdapter {
+class MDCSimpleMenuAdapter {
   /** @param {string} className */
   addClass(className) {}
 
@@ -158,3 +158,5 @@ export default class MDCSimpleMenuAdapter {
   /** @return {number} */
   getAccurateTime() {}
 }
+
+export default MDCSimpleMenuAdapter;

--- a/packages/mdc-menu/simple/constants.js
+++ b/packages/mdc-menu/simple/constants.js
@@ -15,7 +15,7 @@
  */
 
 /** @enum {string} */
-export const cssClasses = {
+const cssClasses = {
   ROOT: 'mdc-simple-menu',
   OPEN: 'mdc-simple-menu--open',
   ANIMATING: 'mdc-simple-menu--animating',
@@ -25,7 +25,7 @@ export const cssClasses = {
 };
 
 /** @enum {string} */
-export const strings = {
+const strings = {
   ITEMS_SELECTOR: '.mdc-simple-menu__items',
   SELECTED_EVENT: 'MDCSimpleMenu:selected',
   CANCEL_EVENT: 'MDCSimpleMenu:cancel',
@@ -33,7 +33,7 @@ export const strings = {
 };
 
 /** @enum {number} */
-export const numbers = {
+const numbers = {
   // Amount of time to wait before triggering a selected event on the menu. Note that this time
   // will most likely be bumped up once interactive lists are supported to allow for the ripple to
   // animate before closing the menu
@@ -50,3 +50,5 @@ export const numbers = {
   TRANSITION_X2: 0.2,
   TRANSITION_Y2: 1,
 };
+
+export {cssClasses, strings, numbers};

--- a/packages/mdc-menu/simple/foundation.js
+++ b/packages/mdc-menu/simple/foundation.js
@@ -22,7 +22,7 @@ import {clamp, bezierProgress} from '../util';
 /**
  * @extends {MDCFoundation<!MDCSimpleMenuAdapter>}
  */
-export default class MDCSimpleMenuFoundation extends MDCFoundation {
+class MDCSimpleMenuFoundation extends MDCFoundation {
   /** @return enum{cssClasses} */
   static get cssClasses() {
     return cssClasses;
@@ -477,3 +477,5 @@ export default class MDCSimpleMenuFoundation extends MDCFoundation {
     return this.isOpen_;
   }
 }
+
+export default MDCSimpleMenuFoundation;

--- a/packages/mdc-menu/simple/index.js
+++ b/packages/mdc-menu/simple/index.js
@@ -16,14 +16,12 @@
 
 import MDCComponent from '@material/base/component';
 import MDCSimpleMenuFoundation from './foundation';
-import {getTransformPropertyName} from '../util';
-
-export {MDCSimpleMenuFoundation};
+import * as util from '../util';
 
 /**
  * @extends MDCComponent<!MDCSimpleMenuFoundation>
  */
-export class MDCSimpleMenu extends MDCComponent {
+class MDCSimpleMenu extends MDCComponent {
   /** @param {...?} args */
   constructor(...args) {
     super(...args);
@@ -99,10 +97,10 @@ export class MDCSimpleMenu extends MDCComponent {
         return {width: window.innerWidth, height: window.innerHeight};
       },
       setScale: (x, y) => {
-        this.root_.style[getTransformPropertyName(window)] = `scale(${x}, ${y})`;
+        this.root_.style[util.getTransformPropertyName(window)] = `scale(${x}, ${y})`;
       },
       setInnerScale: (x, y) => {
-        this.itemsContainer_.style[getTransformPropertyName(window)] = `scale(${x}, ${y})`;
+        this.itemsContainer_.style[util.getTransformPropertyName(window)] = `scale(${x}, ${y})`;
       },
       getNumberOfItems: () => this.items.length,
       registerInteractionHandler: (type, handler) => this.root_.addEventListener(type, handler),
@@ -135,7 +133,7 @@ export class MDCSimpleMenu extends MDCComponent {
       focusItemAtIndex: (index) => this.items[index].focus(),
       isRtl: () => getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
       setTransformOrigin: (origin) => {
-        this.root_.style[`${getTransformPropertyName(window)}-origin`] = origin;
+        this.root_.style[`${util.getTransformPropertyName(window)}-origin`] = origin;
       },
       setPosition: (position) => {
         this.root_.style.left = 'left' in position ? position.left : null;
@@ -147,3 +145,5 @@ export class MDCSimpleMenu extends MDCComponent {
     });
   }
 }
+
+export {MDCSimpleMenuFoundation, MDCSimpleMenu};

--- a/packages/mdc-menu/simple/index.js
+++ b/packages/mdc-menu/simple/index.js
@@ -16,7 +16,7 @@
 
 import MDCComponent from '@material/base/component';
 import MDCSimpleMenuFoundation from './foundation';
-import * as util from '../util';
+import {getTransformPropertyName} from '../util';
 
 /**
  * @extends MDCComponent<!MDCSimpleMenuFoundation>
@@ -97,10 +97,10 @@ class MDCSimpleMenu extends MDCComponent {
         return {width: window.innerWidth, height: window.innerHeight};
       },
       setScale: (x, y) => {
-        this.root_.style[util.getTransformPropertyName(window)] = `scale(${x}, ${y})`;
+        this.root_.style[getTransformPropertyName(window)] = `scale(${x}, ${y})`;
       },
       setInnerScale: (x, y) => {
-        this.itemsContainer_.style[util.getTransformPropertyName(window)] = `scale(${x}, ${y})`;
+        this.itemsContainer_.style[getTransformPropertyName(window)] = `scale(${x}, ${y})`;
       },
       getNumberOfItems: () => this.items.length,
       registerInteractionHandler: (type, handler) => this.root_.addEventListener(type, handler),
@@ -133,7 +133,7 @@ class MDCSimpleMenu extends MDCComponent {
       focusItemAtIndex: (index) => this.items[index].focus(),
       isRtl: () => getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
       setTransformOrigin: (origin) => {
-        this.root_.style[`${util.getTransformPropertyName(window)}-origin`] = origin;
+        this.root_.style[`${getTransformPropertyName(window)}-origin`] = origin;
       },
       setPosition: (position) => {
         this.root_.style.left = 'left' in position ? position.left : null;

--- a/packages/mdc-menu/util.js
+++ b/packages/mdc-menu/util.js
@@ -23,7 +23,7 @@ let storedTransformPropertyName_;
  * @param {boolean=} forceRefresh
  * @return {string}
  */
-export function getTransformPropertyName(globalObj, forceRefresh = false) {
+function getTransformPropertyName(globalObj, forceRefresh = false) {
   if (storedTransformPropertyName_ === undefined || forceRefresh) {
     const el = globalObj.document.createElement('div');
     const transformPropertyName = ('transform' in el.style ? 'transform' : 'webkitTransform');
@@ -40,7 +40,7 @@ export function getTransformPropertyName(globalObj, forceRefresh = false) {
  * @param {number} max
  * @return {number}
  */
-export function clamp(value, min = 0, max = 1) {
+function clamp(value, min = 0, max = 1) {
   return Math.min(max, Math.max(min, value));
 }
 
@@ -61,7 +61,7 @@ export function clamp(value, min = 0, max = 1) {
  * @param {number} y2
  * @return {number}
  */
-export function bezierProgress(time, x1, y1, x2, y2) {
+function bezierProgress(time, x1, y1, x2, y2) {
   return getBezierCoordinate_(solvePositionFromXValue_(time, x1, x2), y1, y2);
 }
 
@@ -151,3 +151,5 @@ function solvePositionFromXValue_(xVal, x1, x2) {
   }
   return t;
 }
+
+export {getTransformPropertyName, clamp, bezierProgress};

--- a/packages/mdc-radio/adapter.js
+++ b/packages/mdc-radio/adapter.js
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-unused-vars */
-import {MDCSelectionControlState} from '@material/selection-control';
+import * as selectionControl from '@material/selection-control';
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
@@ -34,13 +34,15 @@ import {MDCSelectionControlState} from '@material/selection-control';
  *
  * @record
  */
-export default class MDCRadioAdapter {
+class MDCRadioAdapter {
   /** @param {string} className */
   addClass(className) {}
 
   /** @param {string} className */
   removeClass(className) {}
 
-  /** @return {!MDCSelectionControlState} */
+  /** @return {!selectionControl.MDCSelectionControlState} */
   getNativeControl() {}
 }
+
+export default MDCRadioAdapter;

--- a/packages/mdc-radio/adapter.js
+++ b/packages/mdc-radio/adapter.js
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-unused-vars */
-import * as selectionControl from '@material/selection-control';
+import {MDCSelectionControlState} from '@material/selection-control';
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
@@ -41,7 +41,7 @@ class MDCRadioAdapter {
   /** @param {string} className */
   removeClass(className) {}
 
-  /** @return {!selectionControl.MDCSelectionControlState} */
+  /** @return {!MDCSelectionControlState} */
   getNativeControl() {}
 }
 

--- a/packages/mdc-radio/constants.js
+++ b/packages/mdc-radio/constants.js
@@ -15,12 +15,14 @@
  */
 
 /** @enum {string} */
-export const strings = {
+const strings = {
   NATIVE_CONTROL_SELECTOR: '.mdc-radio__native-control',
 };
 
 /** @enum {string} */
-export const cssClasses = {
+const cssClasses = {
   ROOT: 'mdc-radio',
   DISABLED: 'mdc-radio--disabled',
 };
+
+export {strings, cssClasses};

--- a/packages/mdc-radio/foundation.js
+++ b/packages/mdc-radio/foundation.js
@@ -16,7 +16,7 @@
 
 import MDCFoundation from '@material/base/foundation';
 /* eslint-disable no-unused-vars */
-import {MDCSelectionControlState} from '@material/selection-control';
+import * as selectionControl from '@material/selection-control';
 import MDCRadioAdapter from './adapter';
 /* eslint-enable no-unused-vars */
 import {cssClasses, strings} from './constants';
@@ -24,7 +24,7 @@ import {cssClasses, strings} from './constants';
 /**
  * @extends {MDCFoundation<!MDCRadioAdapter>}
  */
-export default class MDCRadioFoundation extends MDCFoundation {
+class MDCRadioFoundation extends MDCFoundation {
   /** @return enum {cssClasses} */
   static get cssClasses() {
     return cssClasses;
@@ -40,7 +40,7 @@ export default class MDCRadioFoundation extends MDCFoundation {
     return /** @type {!MDCRadioAdapter} */ ({
       addClass: (/* className: string */) => {},
       removeClass: (/* className: string */) => {},
-      getNativeControl: () => /* !MDCSelectionControlState */ {},
+      getNativeControl: () => /* !selectionControl.MDCSelectionControlState */ {},
     });
   }
 
@@ -81,7 +81,7 @@ export default class MDCRadioFoundation extends MDCFoundation {
   }
 
   /**
-   * @return {!MDCSelectionControlState}
+   * @return {!selectionControl.MDCSelectionControlState}
    * @private
    */
   getNativeControl_() {
@@ -92,3 +92,5 @@ export default class MDCRadioFoundation extends MDCFoundation {
     };
   }
 }
+
+export default MDCRadioFoundation;

--- a/packages/mdc-radio/foundation.js
+++ b/packages/mdc-radio/foundation.js
@@ -16,7 +16,7 @@
 
 import MDCFoundation from '@material/base/foundation';
 /* eslint-disable no-unused-vars */
-import * as selectionControl from '@material/selection-control';
+import {MDCSelectionControlState} from '@material/selection-control';
 import MDCRadioAdapter from './adapter';
 /* eslint-enable no-unused-vars */
 import {cssClasses, strings} from './constants';
@@ -40,7 +40,7 @@ class MDCRadioFoundation extends MDCFoundation {
     return /** @type {!MDCRadioAdapter} */ ({
       addClass: (/* className: string */) => {},
       removeClass: (/* className: string */) => {},
-      getNativeControl: () => /* !selectionControl.MDCSelectionControlState */ {},
+      getNativeControl: () => /* !MDCSelectionControlState */ {},
     });
   }
 
@@ -81,7 +81,7 @@ class MDCRadioFoundation extends MDCFoundation {
   }
 
   /**
-   * @return {!selectionControl.MDCSelectionControlState}
+   * @return {!MDCSelectionControlState}
    * @private
    */
   getNativeControl_() {

--- a/packages/mdc-radio/index.js
+++ b/packages/mdc-radio/index.js
@@ -21,13 +21,11 @@ import {MDCSelectionControlState, MDCSelectionControl} from '@material/selection
 import MDCRadioFoundation from './foundation';
 import {MDCRipple, MDCRippleFoundation} from '@material/ripple';
 
-export {MDCRadioFoundation};
-
 /**
  * @extends MDCComponent<!MDCRadioFoundation>
  * @implements {MDCSelectionControl}
  */
-export class MDCRadio extends MDCComponent {
+class MDCRadio extends MDCComponent {
   static attachTo(root) {
     return new MDCRadio(root);
   }
@@ -129,3 +127,6 @@ export class MDCRadio extends MDCComponent {
     });
   }
 }
+
+
+export {MDCRadio, MDCRadioFoundation};

--- a/packages/mdc-ripple/adapter.js
+++ b/packages/mdc-ripple/adapter.js
@@ -37,7 +37,7 @@
  *
  * @record
  */
-export default class MDCRippleAdapter {
+class MDCRippleAdapter {
   /** @return {boolean} */
   browserSupportsCssVars() {}
 
@@ -90,3 +90,5 @@ export default class MDCRippleAdapter {
   /** @return {{x: number, y: number}} */
   getWindowPageOffset() {}
 }
+
+export default MDCRippleAdapter;

--- a/packages/mdc-ripple/constants.js
+++ b/packages/mdc-ripple/constants.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const cssClasses = {
+const cssClasses = {
   // Ripple is a special case where the "root" component is really a "mixin" of sorts,
   // given that it's an 'upgrade' to an existing component. That being said it is the root
   // CSS class that all other CSS classes derive from.
@@ -26,7 +26,7 @@ export const cssClasses = {
   FG_DEACTIVATION: 'mdc-ripple-upgraded--foreground-deactivation',
 };
 
-export const strings = {
+const strings = {
   VAR_SURFACE_WIDTH: '--mdc-ripple-surface-width',
   VAR_SURFACE_HEIGHT: '--mdc-ripple-surface-height',
   VAR_FG_SIZE: '--mdc-ripple-fg-size',
@@ -37,9 +37,11 @@ export const strings = {
   VAR_FG_TRANSLATE_END: '--mdc-ripple-fg-translate-end',
 };
 
-export const numbers = {
+const numbers = {
   PADDING: 10,
   INITIAL_ORIGIN_SCALE: 0.6,
   DEACTIVATION_TIMEOUT_MS: 300,
   FG_DEACTIVATION_MS: 83,
 };
+
+export {cssClasses, strings, numbers};

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -17,7 +17,7 @@
 import MDCFoundation from '@material/base/foundation';
 import MDCRippleAdapter from './adapter';
 import {cssClasses, strings, numbers} from './constants';
-import {getNormalizedEventCoords} from './util';
+import * as util from './util';
 
 /**
  * @typedef {!{
@@ -74,7 +74,7 @@ const DEACTIVATION_ACTIVATION_PAIRS = {
 /**
  * @extends {MDCFoundation<!MDCRippleAdapter>}
  */
-export default class MDCRippleFoundation extends MDCFoundation {
+class MDCRippleFoundation extends MDCFoundation {
   static get cssClasses() {
     return cssClasses;
   }
@@ -313,7 +313,7 @@ export default class MDCRippleFoundation extends MDCFoundation {
 
     let startPoint;
     if (wasActivatedByPointer) {
-      startPoint = getNormalizedEventCoords(
+      startPoint = util.getNormalizedEventCoords(
         /** @type {!Event} */ (activationEvent),
         this.adapter_.getWindowPageOffset(), this.adapter_.computeBoundingRect()
       );
@@ -506,3 +506,5 @@ export default class MDCRippleFoundation extends MDCFoundation {
     }
   }
 }
+
+export default MDCRippleFoundation;

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -17,7 +17,7 @@
 import MDCFoundation from '@material/base/foundation';
 import MDCRippleAdapter from './adapter';
 import {cssClasses, strings, numbers} from './constants';
-import * as util from './util';
+import {getNormalizedEventCoords} from './util';
 
 /**
  * @typedef {!{
@@ -313,7 +313,7 @@ class MDCRippleFoundation extends MDCFoundation {
 
     let startPoint;
     if (wasActivatedByPointer) {
-      startPoint = util.getNormalizedEventCoords(
+      startPoint = getNormalizedEventCoords(
         /** @type {!Event} */ (activationEvent),
         this.adapter_.getWindowPageOffset(), this.adapter_.computeBoundingRect()
       );

--- a/packages/mdc-ripple/index.js
+++ b/packages/mdc-ripple/index.js
@@ -19,13 +19,10 @@ import MDCRippleAdapter from './adapter';
 import MDCRippleFoundation from './foundation';
 import * as util from './util';
 
-export {MDCRippleFoundation};
-export {util};
-
 /**
  * @extends MDCComponent<!MDCRippleFoundation>
  */
-export class MDCRipple extends MDCComponent {
+class MDCRipple extends MDCComponent {
   /** @param {...?} args */
   constructor(...args) {
     super(...args);
@@ -136,3 +133,5 @@ RippleCapableSurface.prototype.unbounded;
  * @type {boolean|undefined}
  */
 RippleCapableSurface.prototype.disabled;
+
+export {MDCRipple, MDCRippleFoundation, util};

--- a/packages/mdc-ripple/util.js
+++ b/packages/mdc-ripple/util.js
@@ -53,7 +53,8 @@ function detectEdgePseudoVarBug(windowObj) {
  * @param {boolean=} forceRefresh
  * @return {boolean|undefined}
  */
-export function supportsCssVariables(windowObj, forceRefresh = false) {
+
+function supportsCssVariables(windowObj, forceRefresh = false) {
   if (typeof supportsCssVariables_ === 'boolean' && !forceRefresh) {
     return supportsCssVariables_;
   }
@@ -86,7 +87,7 @@ export function supportsCssVariables(windowObj, forceRefresh = false) {
  * @param {boolean=} forceRefresh
  * @return {boolean|{passive: boolean}}
  */
-export function applyPassive(globalObj = window, forceRefresh = false) {
+function applyPassive(globalObj = window, forceRefresh = false) {
   if (supportsPassive_ === undefined || forceRefresh) {
     let isSupported = false;
     try {
@@ -105,7 +106,7 @@ export function applyPassive(globalObj = window, forceRefresh = false) {
  * @param {!Object} HTMLElementPrototype
  * @return {!Array<string>}
  */
-export function getMatchesProperty(HTMLElementPrototype) {
+function getMatchesProperty(HTMLElementPrototype) {
   return [
     'webkitMatchesSelector', 'msMatchesSelector', 'matches',
   ].filter((p) => p in HTMLElementPrototype).pop();
@@ -117,7 +118,7 @@ export function getMatchesProperty(HTMLElementPrototype) {
  * @param {!ClientRect} clientRect
  * @return {!{x: number, y: number}}
  */
-export function getNormalizedEventCoords(ev, pageOffset, clientRect) {
+function getNormalizedEventCoords(ev, pageOffset, clientRect) {
   const {x, y} = pageOffset;
   const documentX = x + clientRect.left;
   const documentY = y + clientRect.top;
@@ -135,3 +136,5 @@ export function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 
   return {x: normalizedX, y: normalizedY};
 }
+
+export {supportsCssVariables, applyPassive, getMatchesProperty, getNormalizedEventCoords};

--- a/packages/mdc-selection-control/index.js
+++ b/packages/mdc-selection-control/index.js
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-unused-vars */
-import * as ripple from '@material/ripple';
+import {MDCRipple} from '@material/ripple';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -32,7 +32,7 @@ let MDCSelectionControlState;
  * @record
  */
 class MDCSelectionControl {
-  /** @return {?ripple.MDCRipple} */
+  /** @return {?MDCRipple} */
   get ripple() {}
 }
 

--- a/packages/mdc-selection-control/index.js
+++ b/packages/mdc-selection-control/index.js
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-unused-vars */
-import {MDCRipple} from '@material/ripple';
+import * as ripple from '@material/ripple';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -26,12 +26,14 @@ import {MDCRipple} from '@material/ripple';
  *   value: ?string
  * }}
  */
-export let MDCSelectionControlState;
+let MDCSelectionControlState;
 
 /**
  * @record
  */
-export class MDCSelectionControl {
-  /** @return {?MDCRipple} */
+class MDCSelectionControl {
+  /** @return {?ripple.MDCRipple} */
   get ripple() {}
 }
+
+export {MDCSelectionControlState, MDCSelectionControl};

--- a/scripts/closure-test.sh
+++ b/scripts/closure-test.sh
@@ -48,6 +48,7 @@ echo ''
 
 set +e
 for pkg in $CLOSURIZED_PKGS; do
+  entry_point="goog:mdc.${pkg/mdc-/}"
   # Note that the jscomp_error flags turn all default warnings into errors, so that
   # closure exits with a non-zero status if any of them are caught.
   # Also note that we disable accessControls checks due to
@@ -60,7 +61,7 @@ for pkg in $CLOSURIZED_PKGS; do
   --dependency_mode STRICT \
   --module_resolution LEGACY \
   --js_module_root $CLOSURE_PKGDIR \
-  --entry_point $CLOSURE_PKGDIR/$pkg/index \
+  --entry_point $entry_point \
   --checks_only \
   --jscomp_error checkTypes \
   --jscomp_error conformanceViolations \

--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -19,8 +19,8 @@
  *  * Add goog.module to the top of the source code
  *  * Rewrite export {foo, bar} to exports = {foo, bar}
  *  * Rewrite export default Foo, to exports = Foo
- *  * Rewrite import Foo from ‘./foo’ to const Foo = goog.require(‘mdc.foo’)
- *  * Rewrite import {foo, bar} from ‘./util’ to const {foo, bar} = goog.require(‘mdc.util)
+ *  * Rewrite import Foo from './foo' to const Foo = goog.require('mdc.foo')
+ *  * Rewrite import {foo, bar} from './util' to const {foo, bar} = goog.require('mdc.util')
  *
  *  
  * This script rewrites import statements such that:

--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -15,17 +15,24 @@
  */
 
 /**
- * @fileoverview Rewrites import statements such that:
+ * @fileoverview Rewrites JS to match a goog.module format. That means
+ *  * Add goog.module to the top of the source code
+ *  * Rewrite export {foo, bar} to exports = {foo, bar}
+ *  * Rewrite export default Foo, to exports = Foo
+ *  * Rewrite import Foo from ‘./foo’ to const Foo = goog.require(‘mdc.foo’)
+ *  * Rewrite import {foo, bar} from ‘./util’ to const {foo, bar} = goog.require(‘mdc.util)
+ *
+ *  
+ * This script rewrites import statements such that:
  *
  * ```js
  * import [<SPECIFIERS> from] '@material/$PKG[/files...]';
  * ```
  * becomes
  * ```js
- * import [<SPECIFIERS> from] 'mdc-$PKG/<RESOLVED_FILE_PATH>';
+ * const [<SPECIFIERS>] = goog.require('mdc.$PKG.<RESOLVED_FILE_NAMESPACE>');
  * ```
- * The RESOLVED_FILE_PATH is the file that node's module resolution algorithm would have resolved the import
- * source to.
+ * The RESOLVED_FILE_NAMESPACE is a namespace matching the directory structure.
  *
  * This script also handles third-party dependencies, e.g.
  *
@@ -36,7 +43,7 @@
  * becomes
  *
  * ```js
- * import {thing1, thing2} from 'goog:mdc.thirdparty.thirdPartyLib';
+ * const {thing1, thing2} = goog.require('goog:mdc.thirdparty.thirdPartyLib');
  * ```
  *
  * and
@@ -48,7 +55,7 @@
  * becomes
  *
  * ```js
- * import {default as someDefaultExport} from 'goog:mdc.thirdparty.thirdPartyLib'
+ * const {someDefaultExport} = goog.require('goog:mdc.thirdparty.thirdPartyLib')
  * ```
  *
  * This is so closure is able to properly build and check our files without breaking when it encounters

--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -120,7 +120,7 @@ function transform(srcFile, rootDir) {
       const callExpression = t.callExpression(callee, [t.stringLiteral(packageStr)]);
 
       let variableDeclaratorId;
-      if (path.node.specifiers.length > 1) {
+      if (path.node.specifiers.length > 1 || (src.substr(path.node.specifiers[0].start - 1, 1) === '{')) {
         const properties = [];
         path.node.specifiers.forEach((specifier) => {
           properties.push(t.objectProperty(specifier.local, specifier.local, false, true, []));


### PR DESCRIPTION
First we will have to rewrite some of the source code to be more transpile-friendly
- Move all ‘export’ expressions to the end of the file. Otherwise replacing that expression with a new expression drops the leading closure comment.
- Instead of `import {foo} from './util'`, use `import * as util from './util'`. This is only necessary if there is only ONE object within the curly brackets. Unfortunately the AST parser does see the difference between `import {foo}` and `import foo`. However, `import {foo, bar}` is okay.

Both of these source code changes are nitpicky, but it makes the transpiling script easier to maintain.

The actual transpiling scripting does the following
- Added goog.module to the top
- ExportNamedDeclaration, aka export {foo, bar}, becomes exports = {foo, bar}
- ExportDefaultDeclaration, aka export default Foo, becomes exports = Foo
- ImportDeclaration
  - import Foo from ‘./foo’, becomes const Foo = goog.require(‘mdc.foo’)
  - import {foo, bar} from ‘./util’, becomes const {foo, bar} = goog.require(‘mdc.util)
  - import Foo from ‘@material/foo’, becomes const Foo = goog.require(‘mdc.foo’)

Resolves #1337 