### PR TITLE
feat(drawer): use a backdrop element for temporary drawers

### DIFF
--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -48,6 +48,7 @@
     </div>
 
     <aside class="mdc-temporary-drawer">
+      <div class="mdc-temporary-drawer__backdrop"></div>
       <nav class="mdc-temporary-drawer__drawer">
         <header class="mdc-temporary-drawer__header">
           <div class="mdc-temporary-drawer__header-content mdc-theme--primary-bg mdc-theme--text-primary-on-primary">

--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -239,6 +239,7 @@ for any display size.
 
 ```html
 <aside class="mdc-temporary-drawer mdc-typography">
+  <div class="mdc-temporary-drawer__backdrop"></div>
   <nav class="mdc-temporary-drawer__drawer">
     <header class="mdc-temporary-drawer__header">
       <div class="mdc-temporary-drawer__header-content">
@@ -271,6 +272,7 @@ very useful for visual alignment and consistency. Note that you can place conten
 
 ```html
 <aside class="mdc-temporary-drawer mdc-typography">
+  <div class="mdc-temporary-drawer__backdrop"></div>
   <nav class="mdc-temporary-drawer__drawer">
 
     <div class="mdc-temporary-drawer__toolbar-spacer"></div>
@@ -294,6 +296,7 @@ for placing the actual content, which will be bottom-aligned.
 
 ```html
 <aside class="mdc-temporary-drawer mdc-typography">
+  <div class="mdc-temporary-drawer__backdrop"></div>
   <nav class="mdc-temporary-drawer__drawer">
 
     <header class="mdc-temporary-drawer__header">
@@ -319,6 +322,7 @@ CSS classes:
 | Class                                  | Description                                                                |
 | -------------------------------------- | -------------------------------------------------------------------------- |
 | `mdc-temporary-drawer`                 | Mandatory. Needs to be set on the root element of the component.           |
+| `mdc-temporary-drawer__backdrop`       | Mandatory. Needs to be set on the backdrop element of the component.       |
 | `mdc-temporary-drawer__drawer`         | Mandatory. Needs to be set on the container node for the drawer content.   |
 | `mdc-temporary-drawer__content`        | Optional. Should be set on the list of items inside the drawer.            |
 | `mdc-temporary-drawer__toolbar-spacer` | Optional. Add to node to provide the matching amount of space for toolbar. |
@@ -409,13 +413,15 @@ The adapter for temporary drawers must provide the following functions, with cor
 | `deregisterInteractionHandler(evt: string, handler: EventListener) => void` | Removes an event listener from the root element, for the specified event name. |
 | `registerDrawerInteractionHandler(evt: string, handler: EventListener) => void` | Adds an event listener to the drawer container sub-element, for the specified event name. |
 | `deregisterDrawerInteractionHandler(evt: string, handler: EventListener) => void` | Removes an event listener from drawer container sub-element, for the specified event name. |
+| `registerBackdropInteractionHandler(evt: string, handler: EventListener) => void` | Adds an event listener to the backdrop container sub-element, for the specified event name. |
+| `deregisterBackdropInteractionHandler(evt: string, handler: EventListener) => void` | Removes an event listener from backdrop container sub-element, for the specified event name. |
 | `registerTransitionEndHandler(handler: EventListener) => void` | Registers an event handler to be called when a `transitionend` event is triggered on the drawer container sub-element element. |
 | `deregisterTransitionEndHandler(handler: EventListener) => void` | Deregisters an event handler from a `transitionend` event listener. This will only be called with handlers that have previously been passed to `registerTransitionEndHandler` calls. |
 | `registerDocumentKeydownHandler(handler: EventListener) => void` | Registers an event handler on the `document` object for a `keydown` event. |
 | `deregisterDocumentKeydownHandler(handler: EventListener) => void` | Deregisters an event handler on the `document` object for a `keydown` event. |
 | `getDrawerWidth() => number` | Returns the current drawer width, in pixels. |
 | `setTranslateX(value: number) => void` | Sets the current position for the drawer, in pixels from the border. |
-| `updateCssVariable(value: string) => void` | Sets a CSS custom property, for controlling the current background opacity when manually dragging the drawer. |
+| `updateBackdropOpacity(value: number) => void` | Sets the current backdrop opacity when manually dragging the drawer. |
 | `getFocusableElements() => NodeList` | Returns the node list of focusable elements inside the drawer. |
 | `saveElementTabState(el: Element) => void` | Saves the current tab index for the element in a data property. |
 | `restoreElementTabState(el: Element) => void` | Restores the saved tab index (if any) for an element. |

--- a/packages/mdc-drawer/slidable/foundation.js
+++ b/packages/mdc-drawer/slidable/foundation.js
@@ -54,7 +54,6 @@ export class MDCSlidableDrawerFoundation extends MDCFoundation {
 
     this.inert_ = false;
 
-    this.drawerClickHandler_ = (evt) => evt.stopPropagation();
     this.componentTouchStartHandler_ = (evt) => this.handleTouchStart_(evt);
     this.componentTouchMoveHandler_ = (evt) => this.handleTouchMove_(evt);
     this.componentTouchEndHandler_ = (evt) => this.handleTouchEnd_(evt);
@@ -84,14 +83,12 @@ export class MDCSlidableDrawerFoundation extends MDCFoundation {
       this.isOpen_ = false;
     }
 
-    this.adapter_.registerDrawerInteractionHandler('click', this.drawerClickHandler_);
     this.adapter_.registerDrawerInteractionHandler('touchstart', this.componentTouchStartHandler_);
     this.adapter_.registerInteractionHandler('touchmove', this.componentTouchMoveHandler_);
     this.adapter_.registerInteractionHandler('touchend', this.componentTouchEndHandler_);
   }
 
   destroy() {
-    this.adapter_.deregisterDrawerInteractionHandler('click', this.drawerClickHandler_);
     this.adapter_.deregisterDrawerInteractionHandler('touchstart', this.componentTouchStartHandler_);
     this.adapter_.deregisterInteractionHandler('touchmove', this.componentTouchMoveHandler_);
     this.adapter_.deregisterInteractionHandler('touchend', this.componentTouchEndHandler_);

--- a/packages/mdc-drawer/temporary/constants.js
+++ b/packages/mdc-drawer/temporary/constants.js
@@ -25,6 +25,7 @@ export const cssClasses = {
 
 export const strings = {
   DRAWER_SELECTOR: '.mdc-temporary-drawer__drawer',
+  BACKDROP_SELECTOR: '.mdc-temporary-drawer__backdrop',
   OPACITY_VAR_NAME: '--mdc-temporary-drawer-opacity',
   FOCUSABLE_ELEMENTS,
   OPEN_EVENT: 'MDCTemporaryDrawer:open',

--- a/packages/mdc-drawer/temporary/foundation.js
+++ b/packages/mdc-drawer/temporary/foundation.js
@@ -31,7 +31,9 @@ export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFound
       addBodyClass: (/* className: string */) => {},
       removeBodyClass: (/* className: string */) => {},
       isDrawer: () => false,
-      updateCssVariable: (/* value: string */) => {},
+      updateBackdropOpacity: (/* value: string */) => {},
+      registerBackdropInteractionHandler: (/* evt: string, handler: EventListener */) => {},
+      deregisterBackdropInteractionHandler: (/* evt: string, handler: EventListener */) => {},
     });
   }
 
@@ -42,7 +44,7 @@ export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFound
       MDCTemporaryDrawerFoundation.cssClasses.ANIMATING,
       MDCTemporaryDrawerFoundation.cssClasses.OPEN);
 
-    this.componentClickHandler_ = () => this.close();
+    this.backdropClickHandler_ = () => this.close();
   }
 
   init() {
@@ -50,28 +52,28 @@ export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFound
 
     // Make browser aware of custom property being used in this element.
     // Workaround for certain types of hard-to-reproduce heisenbugs.
-    this.adapter_.updateCssVariable(0);
-    this.adapter_.registerInteractionHandler('click', this.componentClickHandler_);
+    this.adapter_.updateBackdropOpacity(0);
+    this.adapter_.registerBackdropInteractionHandler('click', this.backdropClickHandler_);
   }
 
   destroy() {
     super.destroy();
 
-    this.adapter_.deregisterInteractionHandler('click', this.componentClickHandler_);
+    this.adapter_.deregisterBackdropInteractionHandler('click', this.backdropClickHandler_);
     this.enableScroll_();
   }
 
   open() {
     this.disableScroll_();
     // Make sure custom property values are cleared before starting.
-    this.adapter_.updateCssVariable('');
+    this.adapter_.updateBackdropOpacity('');
 
     super.open();
   }
 
   close() {
     // Make sure custom property values are cleared before making any changes.
-    this.adapter_.updateCssVariable('');
+    this.adapter_.updateBackdropOpacity('');
 
     super.close();
   }
@@ -79,14 +81,14 @@ export default class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFound
   prepareForTouchEnd_() {
     super.prepareForTouchEnd_();
 
-    this.adapter_.updateCssVariable('');
+    this.adapter_.updateBackdropOpacity('');
   }
 
   updateDrawer_() {
     super.updateDrawer_();
 
     const newOpacity = Math.max(0, 1 + this.direction_ * (this.newPosition_ / this.drawerWidth_));
-    this.adapter_.updateCssVariable(newOpacity);
+    this.adapter_.updateBackdropOpacity(newOpacity);
   }
 
   isRootTransitioningEventTarget_(el) {

--- a/packages/mdc-drawer/temporary/index.js
+++ b/packages/mdc-drawer/temporary/index.js
@@ -26,6 +26,10 @@ export class MDCTemporaryDrawer extends MDCComponent {
     return new MDCTemporaryDrawer(root);
   }
 
+  initialize() {
+    this.backdrop_ = this.root_.querySelector(MDCTemporaryDrawerFoundation.strings.BACKDROP_SELECTOR);
+  }
+
   get open() {
     return this.foundation_.isOpen();
   }
@@ -44,7 +48,7 @@ export class MDCTemporaryDrawer extends MDCComponent {
   }
 
   getDefaultFoundation() {
-    const {FOCUSABLE_ELEMENTS, OPACITY_VAR_NAME} = MDCTemporaryDrawerFoundation.strings;
+    const {FOCUSABLE_ELEMENTS} = MDCTemporaryDrawerFoundation.strings;
 
     return new MDCTemporaryDrawerFoundation({
       addClass: (className) => this.root_.classList.add(className),
@@ -52,7 +56,7 @@ export class MDCTemporaryDrawer extends MDCComponent {
       hasClass: (className) => this.root_.classList.contains(className),
       addBodyClass: (className) => document.body.classList.add(className),
       removeBodyClass: (className) => document.body.classList.remove(className),
-      hasNecessaryDom: () => Boolean(this.drawer),
+      hasNecessaryDom: () => Boolean(this.drawer) && this.root_.contains(this.backdrop_),
       registerInteractionHandler: (evt, handler) =>
         this.root_.addEventListener(util.remapEvent(evt), handler, util.applyPassive()),
       deregisterInteractionHandler: (evt, handler) =>
@@ -61,6 +65,10 @@ export class MDCTemporaryDrawer extends MDCComponent {
         this.drawer.addEventListener(util.remapEvent(evt), handler),
       deregisterDrawerInteractionHandler: (evt, handler) =>
         this.drawer.removeEventListener(util.remapEvent(evt), handler),
+      registerBackdropInteractionHandler: (evt, handler) =>
+        this.backdrop_.addEventListener(util.remapEvent(evt), handler),
+      deregisterBackdropInteractionHandler: (evt, handler) =>
+        this.backdrop_.removeEventListener(util.remapEvent(evt), handler),
       registerTransitionEndHandler: (handler) => this.drawer.addEventListener('transitionend', handler),
       deregisterTransitionEndHandler: (handler) => this.drawer.removeEventListener('transitionend', handler),
       registerDocumentKeydownHandler: (handler) => document.addEventListener('keydown', handler),
@@ -68,11 +76,7 @@ export class MDCTemporaryDrawer extends MDCComponent {
       getDrawerWidth: () => this.drawer.offsetWidth,
       setTranslateX: (value) => this.drawer.style.setProperty(
         util.getTransformPropertyName(), value === null ? null : `translateX(${value}px)`),
-      updateCssVariable: (value) => {
-        if (util.supportsCssCustomProperties()) {
-          this.root_.style.setProperty(OPACITY_VAR_NAME, value);
-        }
-      },
+      updateBackdropOpacity: (value) => this.backdrop_.style.opacity = value,
       getFocusableElements: () => this.drawer.querySelectorAll(FOCUSABLE_ELEMENTS),
       saveElementTabState: (el) => util.saveElementTabState(el),
       restoreElementTabState: (el) => util.restoreElementTabState(el),

--- a/packages/mdc-drawer/temporary/mdc-temporary-drawer.scss
+++ b/packages/mdc-drawer/temporary/mdc-temporary-drawer.scss
@@ -37,7 +37,7 @@
   z-index: 5;
 
   /* Shaded background */
-  &::before {
+  &__backdrop {
     display: block;
     position: absolute;
     top: 0;
@@ -45,9 +45,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, .6);
-    content: "";
     opacity: 0;
-    opacity: var(--mdc-temporary-drawer-opacity, 0);
     will-change: opacity;
     box-sizing: border-box;
   }
@@ -102,7 +100,7 @@
   }
 
   &--animating {
-    &::before {
+    .mdc-temporary-drawer__backdrop {
       transition: mdc-animation-enter(opacity, .3s);
     }
 
@@ -118,9 +116,8 @@
   &--open {
     pointer-events: auto;
 
-    &::before {
+    .mdc-temporary-drawer__backdrop {
       opacity: 1;
-      opacity: var(--mdc-temporary-drawer-opacity, 1);
     }
 
     .mdc-temporary-drawer__drawer {

--- a/test/unit/mdc-drawer/mdc-temporary-drawer.test.js
+++ b/test/unit/mdc-drawer/mdc-temporary-drawer.test.js
@@ -337,3 +337,15 @@ test('adapter#removeBodyClass remove a class from the body', () => {
   component.getDefaultFoundation().adapter_.removeBodyClass('mdc-drawer--scroll-lock');
   assert.isNotOk(body.classList.contains('mdc-drawer--scroll-lock'));
 });
+
+test('propagation of click events is not stopped', () => {
+  const {root, component} = setupTest();
+  const handler = td.func('clickHandler');
+  const link = document.createElement('a');
+  link.href = '#foo';
+  component.drawer.appendChild(link);
+  document.body.appendChild(root);
+  document.body.addEventListener('click', handler);
+  link.click();
+  td.verify(handler(td.matchers.anything()));
+});

--- a/test/unit/mdc-drawer/mdc-temporary-drawer.test.js
+++ b/test/unit/mdc-drawer/mdc-temporary-drawer.test.js
@@ -21,13 +21,13 @@ import td from 'testdouble';
 
 import {MDCTemporaryDrawer} from '../../../packages/mdc-drawer/temporary';
 import {strings} from '../../../packages/mdc-drawer/temporary/constants';
-import {getTransformPropertyName, supportsCssCustomProperties} from '../../../packages/mdc-drawer/util';
+import {getTransformPropertyName} from '../../../packages/mdc-drawer/util';
 
 function getFixture() {
   return bel`
     <aside class="mdc-temporary-drawer">
-      <nav class="mdc-temporary-drawer__drawer">
-      </nav>
+      <div class="mdc-temporary-drawer__backdrop"></div>
+      <nav class="mdc-temporary-drawer__drawer"></nav>
     </aside>
   `;
 }
@@ -87,7 +87,7 @@ test('adapter#hasClass returns false if the root element does not have specified
   assert.isNotOk(component.getDefaultFoundation().adapter_.hasClass('foo'));
 });
 
-test('adapter#hasNecessaryDom returns true if the DOM includes a drawer', () => {
+test('adapter#hasNecessaryDom returns true if the DOM includes a drawer and a backdrop', () => {
   const {component} = setupTest();
   assert.isOk(component.getDefaultFoundation().adapter_.hasNecessaryDom());
 });
@@ -96,6 +96,13 @@ test('adapter#hasNecessaryDom returns false if the DOM does not include a drawer
   const {root, component} = setupTest();
   const drawer = root.querySelector(strings.DRAWER_SELECTOR);
   root.removeChild(drawer);
+  assert.isNotOk(component.getDefaultFoundation().adapter_.hasNecessaryDom());
+});
+
+test('adapter#hasNecessaryDom returns false if the DOM does not include a backdrop', () => {
+  const {root, component} = setupTest();
+  const backdrop = root.querySelector(strings.BACKDROP_SELECTOR);
+  root.removeChild(backdrop);
   assert.isNotOk(component.getDefaultFoundation().adapter_.hasNecessaryDom());
 });
 
@@ -139,6 +146,29 @@ test('adapter#deregisterDrawerInteractionHandler removes an event listener from 
 
   component.getDefaultFoundation().adapter_.deregisterDrawerInteractionHandler('click', handler);
   domEvents.emit(drawer, 'click');
+
+  td.verify(handler(td.matchers.anything()), {times: 0});
+});
+
+test('adapter#registerBackdropInteractionHandler adds an event listener to the backdrop element', () => {
+  const {root, component} = setupTest();
+  const backdrop = root.querySelector(strings.BACKDROP_SELECTOR);
+  const handler = td.func('eventHandler');
+
+  component.getDefaultFoundation().adapter_.registerBackdropInteractionHandler('click', handler);
+  domEvents.emit(backdrop, 'click');
+
+  td.verify(handler(td.matchers.anything()));
+});
+
+test('adapter#deregisterBackdropInteractionHandler removes an event listener from the backdrop element', () => {
+  const {root, component} = setupTest();
+  const backdrop = root.querySelector(strings.BACKDROP_SELECTOR);
+  const handler = td.func('eventHandler');
+  backdrop.addEventListener('click', handler);
+
+  component.getDefaultFoundation().adapter_.deregisterBackdropInteractionHandler('click', handler);
+  domEvents.emit(backdrop, 'click');
 
   td.verify(handler(td.matchers.anything()), {times: 0});
 });
@@ -189,17 +219,17 @@ test('adapter#setTranslateX sets translateX to null when given the null value', 
   );
 });
 
-test('adapter#updateCssVariable sets custom property on root', () => {
+test('adapter#updateBackdropOpacity sets backdrop opacity', () => {
   const {root, component} = setupTest();
-  component.getDefaultFoundation().adapter_.updateCssVariable('0');
-  if (supportsCssCustomProperties()) {
-    assert.equal(root.style.getPropertyValue(strings.OPACITY_VAR_NAME), '0');
-  }
+  const backdrop = root.querySelector(strings.BACKDROP_SELECTOR);
+  component.getDefaultFoundation().adapter_.updateBackdropOpacity(0.5);
+  assert.equal(backdrop.style.opacity, 0.5);
 });
 
 test('adapter#getFocusableElements returns all the focusable elements in the drawer', () => {
   const root = bel`
     <aside class="mdc-temporary-drawer">
+      <div class="mdc-temporary-drawer__backdrop"></div>
       <nav class="mdc-temporary-drawer__drawer">
         <div class="mdc-temporary-drawer__toolbar-spacer"></div>
         <button></button>
@@ -216,6 +246,7 @@ test('adapter#getFocusableElements returns all the focusable elements in the dra
 test('adapter#restoreElementTabState restores tabindex and removes data-mdc-tabindex', () => {
   const root = bel`
     <aside class="mdc-temporary-drawer">
+      <div class="mdc-temporary-drawer__backdrop"></div>
       <nav class="mdc-temporary-drawer__drawer">
         <div id="foo" tabindex="0"></div>
       </nav>
@@ -232,6 +263,7 @@ test('adapter#restoreElementTabState restores tabindex and removes data-mdc-tabi
 test('adapter#makeElementUntabbable sets a tab index of -1 on the element', () => {
   const root = bel`
     <aside class="mdc-temporary-drawer mdc-temporary-drawer--open">
+      <div class="mdc-temporary-drawer__backdrop"></div>
       <nav class="mdc-temporary-drawer__drawer">
         <a id="foo" href="foo"></a>
       </nav>
@@ -262,8 +294,8 @@ test(`adapter#notifyClose fires an ${strings.CLOSE_EVENT} custom event`, () => {
 test('adapter#isRtl returns true for RTL documents', () => {
   const root = bel`
     <aside dir="rtl" class="mdc-temporary-drawer">
-      <nav class="mdc-temporary-drawer__drawer">
-      </nav>
+      <div class="mdc-temporary-drawer__backdrop"></div>
+      <nav class="mdc-temporary-drawer__drawer"></nav>
     </aside>
   `;
   document.body.appendChild(root);
@@ -274,8 +306,8 @@ test('adapter#isRtl returns true for RTL documents', () => {
 test('adapter#isRtl returns false for explicit LTR documents', () => {
   const root = bel`
     <aside dir="ltr" class="mdc-temporary-drawer">
-      <nav class="mdc-temporary-drawer__drawer">
-      </nav>
+      <div class="mdc-temporary-drawer__backdrop"></div>
+      <nav class="mdc-temporary-drawer__drawer"></nav>
     </aside>
   `;
   document.body.appendChild(root);
@@ -286,8 +318,8 @@ test('adapter#isRtl returns false for explicit LTR documents', () => {
 test('adapter#isRtl returns false for implicit LTR documents', () => {
   const root = bel`
     <aside class="mdc-temporary-drawer">
-      <nav class="mdc-temporary-drawer__drawer">
-      </nav>
+      <div class="mdc-temporary-drawer__backdrop"></div>
+      <nav class="mdc-temporary-drawer__drawer"></nav>
     </aside>
   `;
   document.body.appendChild(root);

--- a/test/unit/mdc-drawer/persistent.foundation.test.js
+++ b/test/unit/mdc-drawer/persistent.foundation.test.js
@@ -55,7 +55,7 @@ test('#init is super.init', () => {
   const {isA} = td.matchers;
 
   foundation.init();
-  td.verify(mockAdapter.registerDrawerInteractionHandler('click', isA(Function)));
+  td.verify(mockAdapter.registerDrawerInteractionHandler('touchstart', isA(Function)));
 });
 
 test('#isRootTransitioningEventTarget_ returns true if the element is the drawer element', () => {

--- a/test/unit/mdc-drawer/slidable.foundation.test.js
+++ b/test/unit/mdc-drawer/slidable.foundation.test.js
@@ -78,7 +78,6 @@ test('#init calls component and drawer event registrations', () => {
   const {isA} = td.matchers;
 
   foundation.init();
-  td.verify(mockAdapter.registerDrawerInteractionHandler('click', isA(Function)));
   td.verify(mockAdapter.registerDrawerInteractionHandler('touchstart', isA(Function)));
   td.verify(mockAdapter.registerInteractionHandler('touchmove', isA(Function)));
   td.verify(mockAdapter.registerInteractionHandler('touchend', isA(Function)));
@@ -90,7 +89,6 @@ test('#destroy calls component and drawer event deregistrations', () => {
 
   foundation.init();
   foundation.destroy();
-  td.verify(mockAdapter.deregisterDrawerInteractionHandler('click', isA(Function)));
   td.verify(
     mockAdapter.deregisterDrawerInteractionHandler('touchstart', isA(Function))
   );

--- a/test/unit/mdc-drawer/temporary.foundation.test.js
+++ b/test/unit/mdc-drawer/temporary.foundation.test.js
@@ -45,29 +45,30 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'addClass', 'removeClass', 'hasClass', 'addBodyClass', 'removeBodyClass',
     'hasNecessaryDom', 'registerInteractionHandler',
     'deregisterInteractionHandler', 'registerDrawerInteractionHandler', 'deregisterDrawerInteractionHandler',
+    'registerBackdropInteractionHandler', 'deregisterBackdropInteractionHandler',
     'registerTransitionEndHandler', 'deregisterTransitionEndHandler', 'registerDocumentKeydownHandler',
     'deregisterDocumentKeydownHandler', 'setTranslateX', 'getFocusableElements',
     'saveElementTabState', 'restoreElementTabState', 'makeElementUntabbable',
     'notifyOpen', 'notifyClose', 'isRtl', 'getDrawerWidth', 'isDrawer',
-    'updateCssVariable',
+    'updateBackdropOpacity',
   ]);
 });
 
-test('#init calls component and drawer event registrations', () => {
+test('#init calls component and backdrop event registrations', () => {
   const {foundation, mockAdapter} = setupTest();
   const {isA} = td.matchers;
 
   foundation.init();
-  td.verify(mockAdapter.registerInteractionHandler('click', isA(Function)));
+  td.verify(mockAdapter.registerBackdropInteractionHandler('click', isA(Function)));
 });
 
-test('#destroy calls component and drawer event deregistrations', () => {
+test('#destroy calls component and backdrop event deregistrations', () => {
   const {foundation, mockAdapter} = setupTest();
   const {isA} = td.matchers;
 
   foundation.init();
   foundation.destroy();
-  td.verify(mockAdapter.deregisterInteractionHandler('click', isA(Function)));
+  td.verify(mockAdapter.deregisterBackdropInteractionHandler('click', isA(Function)));
 });
 
 test('on touch start updates the drawer to the touch target coordinates', () => {
@@ -82,7 +83,7 @@ test('on touch start updates the drawer to the touch target coordinates', () => 
     touches: [{pageX: 50}],
   });
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(1));
+  td.verify(mockAdapter.updateBackdropOpacity(1));
 
   raf.restore();
 });
@@ -99,7 +100,7 @@ test('on touch start does not update the drawer when drawer not open', () => {
     touches: [{pageX: 50}],
   });
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(1), {times: 0});
+  td.verify(mockAdapter.updateBackdropOpacity(1), {times: 0});
 
   raf.restore();
 });
@@ -117,7 +118,7 @@ test('on touch start works for pointer events', () => {
     pageX: 50,
   });
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(1));
+  td.verify(mockAdapter.updateBackdropOpacity(1));
 
   raf.restore();
 });
@@ -135,7 +136,7 @@ test('on touch start does not update the drawer when pointertype != touch', () =
     pageX: 50,
   });
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(1), {times: 0});
+  td.verify(mockAdapter.updateBackdropOpacity(1), {times: 0});
 
   raf.restore();
 });
@@ -160,7 +161,7 @@ test('on touch move updates currentX causing the drawer to update', () => {
   });
   raf.flush();
 
-  td.verify(mockAdapter.updateCssVariable(0.98));
+  td.verify(mockAdapter.updateBackdropOpacity(0.98));
 
   handlers.touchmove({
     touches: [{pageX: 495}],
@@ -168,7 +169,7 @@ test('on touch move updates currentX causing the drawer to update', () => {
   });
   raf.flush();
 
-  td.verify(mockAdapter.updateCssVariable(0.99));
+  td.verify(mockAdapter.updateBackdropOpacity(0.99));
   raf.restore();
 });
 
@@ -192,7 +193,7 @@ test('on touch move does not allow the drawer to move past its width', () => {
   });
   raf.flush();
 
-  td.verify(mockAdapter.updateCssVariable(1));
+  td.verify(mockAdapter.updateBackdropOpacity(1));
   raf.restore();
 });
 
@@ -217,7 +218,7 @@ test('on touch move does not allow the drawer to move past its width in RTL', ()
   });
   raf.flush();
 
-  td.verify(mockAdapter.updateCssVariable(1));
+  td.verify(mockAdapter.updateBackdropOpacity(1));
   raf.restore();
 });
 
@@ -242,7 +243,7 @@ test('on touch move works for pointer events', () => {
     preventDefault: () => {},
   });
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(0.98));
+  td.verify(mockAdapter.updateBackdropOpacity(0.98));
 
   raf.restore();
 });
@@ -267,7 +268,7 @@ test('on touch move does not update the drawer when pointertype != touch', () =>
     pageX: 490,
   });
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(0.98), {times: 0});
+  td.verify(mockAdapter.updateBackdropOpacity(0.98), {times: 0});
 
   raf.restore();
 });
@@ -287,7 +288,7 @@ test('on touch end resets touch update styles', () => {
   raf.flush();
 
   handlers.touchend({});
-  td.verify(mockAdapter.updateCssVariable(''));
+  td.verify(mockAdapter.updateBackdropOpacity(''));
   raf.restore();
 });
 
@@ -304,13 +305,23 @@ test('on touch end does not update drawer', () => {
     touches: [{pageX: 500}],
   });
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(1), {times: 1});
+  td.verify(mockAdapter.updateBackdropOpacity(1), {times: 1});
 
   handlers.touchend({});
   raf.flush();
-  td.verify(mockAdapter.updateCssVariable(1), {times: 1});
+  td.verify(mockAdapter.updateBackdropOpacity(1), {times: 1});
 
   raf.restore();
+});
+
+test('click on the backdrop closes the drawer', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const backdropHandlers = captureHandlers(mockAdapter, 'registerBackdropInteractionHandler');
+  td.when(mockAdapter.hasClass('mdc-temporary-drawer--open')).thenReturn(true);
+  foundation.init();
+
+  backdropHandlers.click({});
+  td.verify(mockAdapter.removeClass(cssClasses.OPEN));
 });
 
 test('#isRootTransitioningEventTarget_ returns true if the element is the drawer element', () => {


### PR DESCRIPTION
Using a real element as backdrop (instead of a pseudo-element) allows click events on the drawer to bubble properly. As a side-effect, the component doesn't require CSS custom properties support anymore.

Closes #579 
Closes #1004 