### PR TITLE
docs: Recommend yarn as the package manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,11 +29,11 @@ We strive to make developing Material Components Web as frictionless as possible
 
 You'll need a recent version of [nodejs](https://nodejs.org/en/) to work on MDC-Web. We [test our builds](https://travis-ci.org/material-components/material-components-web) using both the latest and LTS node versions, so use of one of those is recommended. You can use [nvm](https://github.com/creationix/nvm) to easily install and manage different versions of node on your system.
 
-Once node is installed, simply clone our repo (or your fork of it) and run `npm install`
+Once node is installed, simply clone our repo (or your fork of it) and run `yarn`
 
 ```
 git clone git@github.com:material-components/material-components-web.git  # or a path to your fork
-cd material-components-web && npm i
+cd material-components-web && yarn
 ```
 
 ### Building Components
@@ -51,34 +51,34 @@ You can find much more information with respect to building components within ou
 ### Running the development server
 
 ```
-npm run dev
+yarn run dev
 open http://localhost:8080
 ```
 
-`npm run dev` runs a [webpack-dev-server](https://webpack.github.io/docs/webpack-dev-server.html) instance that uses `demos/` as its content base. This should aid you in initial development of a component. It's served on port 8080.
+`yarn run dev` runs a [webpack-dev-server](https://webpack.github.io/docs/webpack-dev-server.html) instance that uses `demos/` as its content base. This should aid you in initial development of a component. It's served on port 8080.
 
 ### Building MDC-Web
 
 ```
-npm run build # Builds an unminified version of MDC-Web within build/
-npm run build:min # Same as above, but enables minification
-npm run dist # Cleans out build/ and runs both of the above commands sequentially
+yarn run build # Builds an unminified version of MDC-Web within build/
+yarn run build:min # Same as above, but enables minification
+yarn run dist # Cleans out build/ and runs both of the above commands sequentially
 ```
 
 ### Linting / Testing / Coverage Enforcement
 
 ```
-npm run lint:js # Lints javascript using eslint
-npm run lint:css # Lints (S)CSS using stylelint
-npm run lint # Runs both of the above commands in parallel
+yarn run lint:js # Lints javascript using eslint
+yarn run lint:css # Lints (S)CSS using stylelint
+yarn run lint # Runs both of the above commands in parallel
 
-npm run fix:js # Runs eslint with the --fix option enabled
-npm run fix:css # Runs stylefmt, which helps fix simple stylelint errors
-npm run fix # Runs both of the above commands in parallel
+yarn run fix:js # Runs eslint with the --fix option enabled
+yarn run fix:css # Runs stylefmt, which helps fix simple stylelint errors
+yarn run fix # Runs both of the above commands in parallel
 
-npm run test:watch # Runs karma on Chrome, re-running when source files change
+yarn run test:watch # Runs karma on Chrome, re-running when source files change
 
-npm test # Lints all files, runs karma, and then runs coverage enforcement checks.
+yarn run test # Lints all files, runs karma, and then runs coverage enforcement checks.
 ```
 
 #### Running Tests across browsers
@@ -90,11 +90,11 @@ If you're making big changes or developing new components, we encourage you to b
 3. Navigate to your dashboard, scroll down to where it says "Access Key", and click "Show"
 4. Enter your password when prompted
 5. Copy your access key
-6. Run `SAUCE_USERNAME=<your-saucelabs-username> SAUCE_ACCESS_KEY=<your-saucelabs-access-key> npm test`
+6. Run `SAUCE_USERNAME=<your-saucelabs-username> SAUCE_ACCESS_KEY=<your-saucelabs-access-key> yarn run test`
 
 This will have karma run our unit tests across all browsers we support, and ensure your changes will not introduce regressions.
 
-Alternatively, you can run `npm run test:watch` and manually open browsers / use VMs / use emulators to test your changes.
+Alternatively, you can run `yarn run test:watch` and manually open browsers / use VMs / use emulators to test your changes.
 
 ### Coding Style
 
@@ -118,7 +118,7 @@ Finally, it helps to make sure that your branch/fork is up to date with what's c
 
 To release MDC-Web, you should perform the following steps.
 
-1. Run `./scripts/pre-release.sh`. This will run `npm test`, build MDC-Web, copy the built assets over
+1. Run `./scripts/pre-release.sh`. This will run `yarn run test`, build MDC-Web, copy the built assets over
    to each module's `dist/` folder, and then print out a summary of all of the new versions that
    should be used for changed components. The summary is printed out to both the console, as well
    as a `.new-versions.log` file in the repo root. This information should be used within the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Material Components for the web is the successor to [Material Design Lite](https
 Install the library
 
 ```
-npm install --save material-components-web
+yarn add material-components-web
 ```
 
 Then simply include the correct files, write some HTML, and call `mdc.autoInit()` within a closing
@@ -50,7 +50,7 @@ MDC-Web is modular by design. Each component lives within its own packages under
 [@material npm scope](https://www.npmjs.com/~material).
 
 ```
-npm install --save @material/button @material/card @material/textfield @material/typography
+yarn add @material/button @material/card @material/textfield @material/typography
 ```
 
 All our components can be found in the [packages](./packages) directory. Each component has a
@@ -122,14 +122,14 @@ Setup the repo:
 
 ```
 git clone https://github.com/material-components/material-components-web.git && cd material-components-web
-npm i
+yarn
 ```
 
 Run the development server (served out of `demos/`):
 
 ```
 cd /path/to/material-components-web
-npm run dev
+yarn run dev
 open http://localhost:8080
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ components we have to offer.
 
 ### Setting up the project
 
-Before setting up the project, you will need to have a recent version of [NodeJS](https://nodejs.org/). Install it with the [NodeJS installer](https://nodejs.org/en/download/) or through [nvm](https://github.com/creationix/nvm). The [npm](https://www.npmjs.com/) command should made be available on your `$PATH`.
+Before setting up the project, you will need to have a recent version of [NodeJS](https://nodejs.org/). Install it with the [NodeJS installer](https://nodejs.org/en/download/) or through [nvm](https://github.com/creationix/nvm). You'll also need a package manager like [`npm`](https://www.npmjs.com/) or [`yarn`](https://yarnpkg.com/en/).  This example uses `yarn`.
 
 Let's begin creating the project by first creating the directory for the app and add MDC-Web.
 This will install MDC-Web into the `node_modules` folder inside of the `greeting-app` directory.
@@ -27,22 +27,26 @@ This will install MDC-Web into the `node_modules` folder inside of the `greeting
 ```
 mkdir greeting-app
 cd greeting-app
-npm init -y  # adds a package.json file into the directory
-npm install --save material-components-web
+yarn init -y  # adds a package.json file into the directory
+yarn add material-components-web
 ```
 
 We recommend installing and using [live-server](http://tapiov.net/live-server/) as the local
-development server that will automatically reload when changes are made.
+development server, which will automatically reload when changes are made.
+
+Run this command:
 
 ```
-npm install --global live-server
+yarn add live-server
 ```
 
-> NOTE: You may need to use `sudo` to install npm packages globally, depending on how your node
-installation is configured.
+and then add this chunk to your `package.json`:
 
-The `--global` flag tells npm to install the package globally, so that the `live-server` program
-will be available on your `$PATH`.
+```json
+  "scripts": {
+    "start": "live-server"
+  },
+```
 
 ### Creating the skeleton index.html file
 
@@ -67,13 +71,13 @@ the assets needed for MDC-Web. Put the following within `index.html` in the `gre
 </html>
 ```
 
-View this page by running `live-server` within the `greeting-app` directory. This will open up your
-browser to the URL which is serving our `index.html` file. You can leave `live-server` running for
-the duration of this guide.
+View this page by running `yarn run start` within the `greeting-app` directory. This will open up
+your browser to the URL which is serving our `index.html` file. You can leave `live-server` running
+for the duration of this guide.
 
 ```
 cd greeting-app
-live-server
+yarn run start
 ```
 
 Let's take a look at a few aspects of the above HTML.

--- a/framework-examples/angular2/README.md
+++ b/framework-examples/angular2/README.md
@@ -6,8 +6,8 @@ It is based off of [angular2-seed](https://github.com/angular/angular2-seed)
 
 ## Setup
 
-1. Run `npm install` within this folder
-2. Run `npm start` to start the demo server
+1. Run `yarn` within this folder
+2. Run `yarn run start` to start the demo server
 3. Navigate to http://localhost:3000 to view the demo.
 
 ## Notes

--- a/framework-examples/aurelia/README.md
+++ b/framework-examples/aurelia/README.md
@@ -5,8 +5,8 @@
 To run the app execute the following command:
 
 ```shell
-npm install
-npm start
+yarn
+yarn run start
 ```
 
 This command starts the webpack development server that serves the build bundles.

--- a/framework-examples/react/README.md
+++ b/framework-examples/react/README.md
@@ -6,8 +6,8 @@ It is based off of [react-hot-boilerplate](https://github.com/gaearon/react-hot-
 
 ## Setup
 
-1. Run `npm install` within this folder
-2. Run `npm start` to start the demo server
+1. Run `yarn` within this folder
+2. Run `yarn run start` to start the demo server
 3. Navigate to http://localhost:3000 to view the demo.
 
 ## Notes

--- a/framework-examples/vue/README.md
+++ b/framework-examples/vue/README.md
@@ -5,6 +5,6 @@ This folder contains an example of using mdc-checkbox within Vue v2.0+. Huge tha
 
 ## Setup
 
-1. Run `npm install` within this folder
-2. Run `npm start` to start the demo server
+1. Run `yarn` within this folder
+2. Run `yarn run start` to start the demo server
 3. Navigate to http://localhost:8080 to view the demo.

--- a/packages/material-components-web/README.md
+++ b/packages/material-components-web/README.md
@@ -6,7 +6,7 @@ sibling packages up into one comprehensive library for convenience.
 ## Installation
 
 ```
-npm install --save material-components-web
+yarn add material-components-web
 ```
 
 ## Usage

--- a/packages/mdc-animation/README.md
+++ b/packages/mdc-animation/README.md
@@ -5,7 +5,7 @@ mdc-animation is a sass / css library which provides variables, mixins, and clas
 ## Installation
 
 ```
-npm install --save @material/animation
+yarn add @material/animation
 ```
 
 ## Usage

--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -9,7 +9,7 @@ Most of the time, you shouldn't need to depend on `mdc-base` directly. It is use
 First install the module:
 
 ```
-npm install --save @material/base
+yarn add @material/base
 ```
 
 Then include it in your code in one of the following ways:

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -8,7 +8,7 @@ The MDC Button component is a spec-aligned button component adhering to the
 ## Installation
 
 ```
-npm install --save @material/button
+yarn add @material/button
 ```
 
 ## Usage

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -7,7 +7,7 @@ developers as a set of CSS classes.
 ## Installation
 
 ```
-npm install --save @material/card
+yarn add @material/card
 ```
 
 ## Usage

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -7,7 +7,7 @@ It works without JavaScript with basic functionality for all states. If you use 
 ## Installation
 
 ```
-npm install --save @material/checkbox
+yarn add @material/checkbox
 ```
 
 ## Usage
@@ -100,7 +100,7 @@ const MDCCheckboxFoundation = mdc.checkbox.MDCCheckboxFoundation;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the checkbox, simply call `attachTo()`
-and pass it a DOM element.  
+and pass it a DOM element.
 
 ```javascript
 mdc.checkbox.MDCCheckbox.attachTo(document.querySelector('.mdc-checkbox'));

--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -8,7 +8,7 @@ temporary drawers require JavaScript to function, in order to respond to user in
 ## Installation
 
 ```
-npm install --save @material/drawer
+yarn add @material/drawer
 ```
 
 ## Permanent drawer usage
@@ -207,7 +207,7 @@ const MDCTemporaryDrawerFoundation = mdc.drawer.MDCTemporaryDrawerFoundation;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the temporary drawer, simply call `attachTo()`
-and pass it a DOM element.  
+and pass it a DOM element.
 
 ```javascript
 mdc.drawer.MDCTemporaryDrawer.attachTo(document.querySelector('.mdc-temporary-drawer'));

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -18,7 +18,7 @@ which was created in collaboration with the designers on the Material Design tea
 ## Installation
 
 ```
-npm install --save @material/elevation
+yarn add @material/elevation
 ```
 
 ## Usage

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -8,7 +8,7 @@ If you initiate the JavaScript object for a button, then it will be enhanced wit
 ## Installation
 
 ```
-npm install --save @material/fab
+yarn add @material/fab
 ```
 
 ## Usage

--- a/packages/mdc-form-field/README.md
+++ b/packages/mdc-form-field/README.md
@@ -6,7 +6,7 @@ form field + label combos.
 ## Installation
 
 ```
-npm install --save @material/form-field
+yarn add @material/form-field
 ```
 
 ## Usage

--- a/packages/mdc-icon-toggle/README.md
+++ b/packages/mdc-icon-toggle/README.md
@@ -6,7 +6,7 @@ designed to work with any icon set.
 ## Installation
 
 ```
-npm install --save @material/icon-toggle
+yarn add @material/icon-toggle
 ```
 
 ## Usage

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -7,7 +7,7 @@ Lists are design to be accessible and RTL aware.
 ## Installation
 
 ```
-npm install --save @material/list
+yarn add @material/list
 ```
 
 ## Usage

--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -8,7 +8,7 @@ first render.
 ## Installation
 
 ```
-npm install --save @material/menu
+yarn add @material/menu
 ```
 
 ## Simple menu usage
@@ -180,7 +180,7 @@ const MDCSimpleMenuFoundation = mdc.Menu.MDCSimpleMenuFoundation;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the simple menu, simply call `attachTo()` and pass it a
-DOM element.  
+DOM element.
 
 ```javascript
 mdc.MDCSimpleMenu.attachTo(document.querySelector('.mdc-simple-menu'));

--- a/packages/mdc-radio/README.md
+++ b/packages/mdc-radio/README.md
@@ -7,7 +7,7 @@ interaction UX as well as a component-level API for state modification.
 ## Installation
 
 ```
-npm install --save @material/radio
+yarn add @material/radio
 ```
 
 ## Usage
@@ -90,7 +90,7 @@ const MDCRadioFoundation = mdc.radio.MDCRadioFoundation;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the radio, simply call `attachTo()`
-and pass it a DOM element.  
+and pass it a DOM element.
 
 ```javascript
 mdc.radio.MDCRadio.attachTo(document.querySelector('.mdc-radio'));

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -45,7 +45,7 @@ Given this, it is important that you _provide gracefully degraded interaction st
 ## Installation
 
 ```
-npm install --save @material/ripple
+yarn add @material/ripple
 ```
 
 ## Usage

--- a/packages/mdc-rtl/README.md
+++ b/packages/mdc-rtl/README.md
@@ -7,7 +7,7 @@ that any MDC-Web component that needs RTL support leverage this package.
 ## Installation
 
 ```
-npm install --save @material/rtl
+yarn add @material/rtl
 ```
 
 ## Usage

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -13,7 +13,7 @@ in conjunction with the browser's native element. Both are fully accessible, and
 ## Installation
 
 ```
-npm install --save @material/select
+yarn add @material/select
 ```
 
 ## Usage

--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -7,7 +7,7 @@ It requires JavaScript the trigger the display and hide of the snackbar.
 ## Installation
 
 ```
-npm install --save @material/snackbar
+yarn add @material/snackbar
 ```
 
 ## Usage
@@ -66,7 +66,7 @@ const MDCSnackbarFoundation = mdc.snackbar.MDCSnackbarFoundation;
 #### Automatic Instantiation
 
 If you do not care about retaining the component instance for the snackbar, simply call `attachTo()`
-and pass it a DOM element.  
+and pass it a DOM element.
 
 ```javascript
 mdc.snackbar.MDCSnackbar.attachTo(document.querySelector('.mdc-snackbar'));

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -7,7 +7,7 @@ not require any javascript.
 ## Installation
 
 ```
-npm install --save @material/textfield
+yarn add @material/textfield
 ```
 
 ## Usage

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -25,7 +25,7 @@ The text contrast colors are automatically calculated at the Sass level and expo
 ## Installation
 
 ```
-npm install --save @material/theme
+yarn add @material/theme
 ```
 
 ## Usage


### PR DESCRIPTION
Yarn has many advantages over NPM.  It's fast (using a shared local cache), but more importantly, it's deterministic.  With Yarn, you'll never check out a project and find that `yarn install` no longer works because a transitive dependency had a breaking change.  Unfortunately, it does happen with `npm install`.

I haven't made any changes to your lerna config to introduce yarn there; that can be a separate change.  However, `yarn` is a best practice, and the docs should reflect that.