### PR TITLE
Fix Edge CSS variable glitches in specific cases

### DIFF
--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -136,3 +136,10 @@ Mixin | Description
 `mdc-button-ripple` | Sets the ripple to the given [ripple configuration](https://github.com/material-components/material-components-web/blob/master/packages/mdc-ripple/README.md)
 `mdc-button-corner-radius` | Sets the corner radius to the given number (defaults to 2px)
 `mdc-button-stroke-width` | Sets the stroke width to the given number (defaults to 2px)
+
+#### Caveat: Edge and CSS Variables
+
+In browsers that fully support CSS variables, the above mixins will hook up styles using CSS variables if a theme property is passed.
+However, due to Edge's buggy CSS variable support, `mdc-button-container-fill-color` will not honor CSS variables in Edge.
+This means you will need to override button container styles manually for Edge if you are altering the affected CSS variables for theme properties
+(raised and unelevated buttons use primary by default for the container fill color).

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -39,7 +39,7 @@
   // :not(:disabled) is used to support link styled as button
   // as link does not support :enabled style
   &:not(:disabled) {
-    @include mdc-theme-prop(background-color, $color);
+    @include mdc-theme-prop(background-color, $color, $edgeOptOut: true);
   }
 }
 

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -255,4 +255,11 @@ not return an object.
 
 ## Theming
 
-> TK once mdc-theming lands.
+MDC Checkboxes use the theme's primary color by default for checked and indeterminate states, and are completely dark theme
+aware.
+
+### Caveat: Edge and CSS Variables
+
+In browsers that fully support CSS variables, MDC Checkbox references CSS variables wherever theme properties are used.
+However, due to Edge's buggy CSS variable support, the `background-color` for `.mdc-checkbox__background::before` will not honor CSS variables in Edge.
+This means you will need to override this style manually for Edge if you alter the CSS variable for the primary color.

--- a/packages/mdc-checkbox/mdc-checkbox.scss
+++ b/packages/mdc-checkbox/mdc-checkbox.scss
@@ -98,7 +98,7 @@
     // The frame's ::before element is used as a focus indicator for the checkbox
     &::before {
       @include mdc-checkbox-cover-element;
-      @include mdc-theme-prop(background, primary);
+      @include mdc-theme-prop(background, primary, $edgeOptOut: true);
 
       width: 100%;
       height: 100%;

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -138,3 +138,9 @@ Mixin | Description
 `mdc-fab-ripple($ripple-config)` | Sets the ripple to the given [ripple configuration][ripple-readme]
 
 [ripple-readme]: https://github.com/material-components/material-components-web/blob/master/packages/mdc-ripple/README.md
+
+#### Caveat: Edge and CSS Variables
+
+In browsers that fully support CSS variables, the above mixins will hook up styles using CSS variables if a theme property is passed.
+However, due to Edge's buggy CSS variable support, `mdc-fab-container-color` will not honor CSS variables in Edge.
+This means you will need to override FAB container styles manually for Edge if you are altering the affected CSS variables for theme properties (FAB uses secondary by default for the container fill color).

--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -35,7 +35,7 @@
 }
 
 @mixin mdc-fab-container-color($color) {
-  @include mdc-theme-prop(background-color, $color);
+  @include mdc-theme-prop(background-color, $color, $edgeOptOut: true);
 }
 
 @mixin mdc-fab-ink-color($color) {

--- a/packages/mdc-radio/README.md
+++ b/packages/mdc-radio/README.md
@@ -201,3 +201,9 @@ not return an object.
 
 MDC Radios use the theme's primary color by default for on states, and are completely dark theme
 aware.
+
+### Caveat: Edge and CSS Variables
+
+In browsers that fully support CSS variables, MDC Radio references CSS variables wherever theme properties are used.
+However, due to Edge's buggy CSS variable support, the `background-color` for `.mdc-radio__background::before` will not honor CSS variables in Edge.
+This means you will need to override this style manually for Edge if you alter the CSS variable for the primary color.

--- a/packages/mdc-radio/mdc-radio.scss
+++ b/packages/mdc-radio/mdc-radio.scss
@@ -73,7 +73,7 @@ $mdc-radio-transition-duration: 120ms;
     height: $mdc-radio-ui-pct;
 
     &::before {
-      @include mdc-theme-prop(background-color, primary);
+      @include mdc-theme-prop(background-color, primary, $edgeOptOut: true);
 
       position: absolute;
       top: 0;

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -140,7 +140,7 @@ CSS Class | Description
 
 Mixin | Description
 --- | ---
-`mdc-theme-prop($property, $style, $important)` | Applies a theme color or a custom color to a CSS property
+`mdc-theme-prop($property, $style, $important, $edgeOptOut)` | Applies a theme color or a custom color to a CSS property, optionally with `!important`. If `$edgeOptOut` is `true` and a theme color is passed, the style will be wrapped in a `@supports` clause to exclude the style in Edge to avoid issues with its buggy CSS variable support.
 `mdc-theme-dark($root-selector, $compound)` | Creates a rule that is applied when the current selector is within an Dark Theme context
 
 #### `mdc-theme-dark($root-selector, $compound)`

--- a/packages/mdc-theme/_mixins.scss
+++ b/packages/mdc-theme/_mixins.scss
@@ -19,7 +19,9 @@
 // Applies the correct theme color style to the specified property.
 // $property is typically color or background-color, but can be any CSS property that accepts color values.
 // $style should be one of the map keys in $mdc-theme-property-values (_variables.scss), or a literal color value.
-@mixin mdc-theme-prop($property, $style, $important: false) {
+// $edgeOptOut controls whether to feature-detect around Edge to avoid emitting CSS variables for it,
+// intended for use in cases where interactions with pseudo-element styles cause problems due to Edge bugs.
+@mixin mdc-theme-prop($property, $style, $important: false, $edgeOptOut: false) {
   @if type-of($style) == "color" {
     @if $important {
       #{$property}: $style !important;
@@ -36,11 +38,31 @@
     @if $important {
       /* @alternate */
       #{$property}: $value !important;
-      #{$property}: var(--mdc-theme-#{$style}, $value) !important;
+      @if $edgeOptOut {
+        @at-root {
+          @supports not (-ms-ime-align:auto) {
+            & {
+              #{$property}: var(--mdc-theme-#{$style}, $value) !important;
+            }
+          }
+        }
+      } @else {
+        #{$property}: var(--mdc-theme-#{$style}, $value) !important;
+      }
     } @else {
       /* @alternate */
       #{$property}: $value;
-      #{$property}: var(--mdc-theme-#{$style}, $value);
+      @if $edgeOptOut {
+        @at-root {
+          @supports not (-ms-ime-align:auto) {
+            & {
+              #{$property}: var(--mdc-theme-#{$style}, $value);
+            }
+          }
+        }
+      } @else {
+        #{$property}: var(--mdc-theme-#{$style}, $value);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR has multiple commits across packages, which I intend to merge *without* squashing for the sake of changelog and versioning.

This PR adds support to `mdc-theme-prop` for a new optional parameter which will emit `@supports` clauses around its rules to exclude Edge.  The rest of the Sass updates in this PR use that parameter in specific places that singularly cause display glitches in Edge in those components. I mention this in the READMEs so that hopefully users aren't surprised if they change CSS variables and it takes effect everywhere except a few places.

Fixes #1102
Fixes #1212

FYI, #664 will be addressed separately by #998, after which its problematic selector will no longer exist.