### PR TITLE
chore: Preserve comments when replacing imports for goog.module format

### DIFF
--- a/packages/mdc-animation/index.js
+++ b/packages/mdc-animation/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-base/component.js
+++ b/packages/mdc-base/component.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-base/foundation.js
+++ b/packages/mdc-base/foundation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-base/index.js
+++ b/packages/mdc-base/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-checkbox/adapter.js
+++ b/packages/mdc-checkbox/adapter.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-checkbox/constants.js
+++ b/packages/mdc-checkbox/constants.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-checkbox/foundation.js
+++ b/packages/mdc-checkbox/foundation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-checkbox/index.js
+++ b/packages/mdc-checkbox/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-form-field/adapter.js
+++ b/packages/mdc-form-field/adapter.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-form-field/constants.js
+++ b/packages/mdc-form-field/constants.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-form-field/foundation.js
+++ b/packages/mdc-form-field/foundation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-form-field/index.js
+++ b/packages/mdc-form-field/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-icon-toggle/adapter.js
+++ b/packages/mdc-icon-toggle/adapter.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-icon-toggle/constants.js
+++ b/packages/mdc-icon-toggle/constants.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-icon-toggle/foundation.js
+++ b/packages/mdc-icon-toggle/foundation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-icon-toggle/index.js
+++ b/packages/mdc-icon-toggle/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-menu/index.js
+++ b/packages/mdc-menu/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-menu/simple/adapter.js
+++ b/packages/mdc-menu/simple/adapter.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-menu/simple/constants.js
+++ b/packages/mdc-menu/simple/constants.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-menu/simple/foundation.js
+++ b/packages/mdc-menu/simple/foundation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-menu/simple/index.js
+++ b/packages/mdc-menu/simple/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-radio/adapter.js
+++ b/packages/mdc-radio/adapter.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-radio/constants.js
+++ b/packages/mdc-radio/constants.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-radio/foundation.js
+++ b/packages/mdc-radio/foundation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-radio/index.js
+++ b/packages/mdc-radio/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-ripple/adapter.js
+++ b/packages/mdc-ripple/adapter.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-ripple/constants.js
+++ b/packages/mdc-ripple/constants.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-ripple/index.js
+++ b/packages/mdc-ripple/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-ripple/util.js
+++ b/packages/mdc-ripple/util.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/mdc-selection-control/index.js
+++ b/packages/mdc-selection-control/index.js
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -138,7 +138,13 @@ function transform(srcFile, rootDir) {
       }
 
       const variableDeclarator = t.variableDeclarator(variableDeclaratorId, callExpression);
-      path.replaceWith(t.variableDeclaration('const', [variableDeclarator]));
+      const variableDeclaration = t.variableDeclaration('const', [variableDeclarator]);
+      if (path.node.comments && path.node.comments.length > 0) {
+        const commentValue = path.node.comments[0].value;
+        variableDeclaration.comments = variableDeclaration.comments || [];
+        variableDeclaration.comments.push({type: 'CommentBlock', value: commentValue});
+      }
+      path.replaceWith(variableDeclaration);
     },
   });
 
@@ -156,7 +162,7 @@ function transform(srcFile, rootDir) {
   const packageParts = relativePath.replace('mdc-', '').replace('.js', '').split('/');
   const packageStr = 'mdc.' + packageParts.join('.').replace('.index', '');
 
-  outputCode = 'goog.module(\'' + packageStr + '\')\n' + outputCode;
+  outputCode = 'goog.module(\'' + packageStr + '\');\n' + outputCode;
   fs.writeFileSync(srcFile, outputCode, 'utf8');
   console.log(`[rewrite] ${srcFile}`);
 }

--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -139,6 +139,7 @@ function transform(srcFile, rootDir) {
 
       const variableDeclarator = t.variableDeclarator(variableDeclaratorId, callExpression);
       const variableDeclaration = t.variableDeclaration('const', [variableDeclarator]);
+      // Preserve comments above import statements, since this is most likely the license comment.
       if (path.node.comments && path.node.comments.length > 0) {
         const commentValue = path.node.comments[0].value;
         variableDeclaration.comments = variableDeclaration.comments || [];


### PR DESCRIPTION
Also adding @license to the comment blocks, which is required by our internal infrastructure.

Resolves #1368

(Includes a commit from #1369, just to get the linter to pass)