### PR TITLE
fix(demos): Remove z-index from non-modal dialogs

### DIFF
--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -44,6 +44,7 @@
       .catalog-dialog-demo {
         position: relative;
         width: 320px;
+        z-index: unset;
       }
 
       .dialog-container {

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -44,7 +44,7 @@
       .catalog-dialog-demo {
         position: relative;
         width: 320px;
-        z-index: unset;
+        z-index: auto;
       }
 
       .dialog-container {


### PR DESCRIPTION
Previously, clicking the "Show dialog" button would display a dialog behind the "Dark Theme" dialogs.