### PR TITLE
docs: Remove redundant paragraph

### DIFF
--- a/docs/code/architecture.md
+++ b/docs/code/architecture.md
@@ -29,13 +29,6 @@ Foundation and Adapter. This lets us reuse Foundation code across multiple web
 platforms, e.g. Wiz and Angular, by re-implementing only the Adapter. For now
 we've only implemented a vanilla JavaScript version of the Adapter.
 
-### Foundation / Adapter
-
-MDC Web has split each dynamic component's JavaScript into two pieces:
-Foundation and Adapter. This lets us reuse Foundation code across multiple web
-platforms, e.g. Wiz and Angular, by re-implementing only the Adapter. For now
-we've only implemented a vanilla JavaScript version of the Adapter
-
 ### Foundation
 
 The Foundation contains the business logic that best represents Material Design,


### PR DESCRIPTION
Removes a paragraph that is exactly the same as the one before it minus a period.