### PR TITLE
feat(icon-toggle): Add public API for MDCRipple in icon-toggle (#1171)

### DIFF
--- a/packages/mdc-icon-toggle/index.js
+++ b/packages/mdc-icon-toggle/index.js
@@ -93,6 +93,11 @@ class MDCIconToggle extends MDCComponent {
     this.disabled = this.root_.getAttribute(MDCIconToggleFoundation.strings.ARIA_DISABLED) === 'true';
   }
 
+  /** @return {!MDCRipple} */
+  get ripple() {
+    return this.ripple_;
+  }
+
   /** @return {boolean} */
   get on() {
     return this.foundation_.isOn();

--- a/test/unit/mdc-icon-toggle/mdc-icon-toggle.test.js
+++ b/test/unit/mdc-icon-toggle/mdc-icon-toggle.test.js
@@ -22,6 +22,7 @@ import {assert} from 'chai';
 import {supportsCssVariables} from '../../../packages/mdc-ripple/util';
 import {createMockRaf} from '../helpers/raf';
 import {MDCIconToggle, MDCIconToggleFoundation} from '../../../packages/mdc-icon-toggle';
+import {MDCRipple} from '../../../packages/mdc-ripple';
 import {cssClasses} from '../../../packages/mdc-ripple/constants';
 
 function setupTest({useInnerIconElement = false} = {}) {
@@ -105,6 +106,11 @@ test('intially set to disabled if root has aria-disabled=true', () => {
   const root = bel`<i class="mdc-icon-toggle" aria-disabled="true"></i>`;
   const component = new MDCIconToggle(root);
   assert.isOk(component.disabled);
+});
+
+test('get ripple returns a MDCRipple instance', () => {
+  const {component} = setupTest();
+  assert.isOk(component.ripple instanceof MDCRipple);
 });
 
 test('#adapter.addClass adds a class to the root element', () => {


### PR DESCRIPTION
Add a getter for MDCRipple in icon toggle so it can be used through a public API

#1171