### PR TITLE
chore: Fix cssom module reference to work on case-sensitive filesystems

### DIFF
--- a/scripts/check-pkg-for-release.js
+++ b/scripts/check-pkg-for-release.js
@@ -28,7 +28,7 @@ const path = require('path');
 const {default: traverse} = require('babel-traverse');
 const babylon = require('babylon');
 const camelCase = require('camel-case');
-const cssom = require('CSSOM');
+const cssom = require('cssom');
 const recast = require('recast');
 
 const pkg = require(path.join(process.env.PWD, process.argv[process.argv.length - 1]));


### PR DESCRIPTION
Previously `npm run test:dependency` would not work on Linux.