### PR TITLE
fix(snackbar): ensure snackbar is hidden when off-screen (#1258) [FOR DISCUSSION]

### DIFF
--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -73,8 +73,7 @@
       <section class="hero">
         <div class="mdc-snackbar mdc-snackbar--active"
              aria-live="assertive"
-             aria-atomic="true"
-             aria-hidden="true">
+             aria-atomic="true">
           <div class="mdc-snackbar__text">Message sent</div>
           <div class="mdc-snackbar__action-wrapper">
             <button type="button" class="mdc-snackbar__action-button">Undo</button>

--- a/packages/mdc-snackbar/mdc-snackbar.scss
+++ b/packages/mdc-snackbar/mdc-snackbar.scss
@@ -36,6 +36,12 @@
   pointer-events: none;
   will-change: transform;
 
+  // to match both <div aria-hidden="true"> and <div aria-hidden>
+  // if client manually add the attribute to the markup
+  &[aria-hidden] {
+    visibility: hidden;
+  }
+
   @include mdc-theme-dark(".mdc-snackbar") {
     background-color: $mdc-snackbar-background-color-on-dark;
   }


### PR DESCRIPTION
Address: #1258. This is a simple fix (see long-term suggestion under "notes") and ensure enter/exit transitions still work.

**Concerns:**
- couple style behavior to accessibility behavior. It relies on `aria-hidden` attribute. Changing accessibility behavior (unlikely) would cause style behavior to break unexpectedly.
- does not work without Javascript. Although, the widget will still work (degrade to this issue), and I am not sure how a snackbar widget would be used in JS-disabled environments.

**Alternatives, variations:**
- [deap82's suggestion](https://github.com/material-components/material-components-web/issues/1258#issuecomment-334368890) also works well. It does require ensuring the delay duration and transition duration matches (which could be achieved by using variables). Also, I believe you can still "tab to" the button (the subtree is not visibility-hidden or displayed none) —can be addressed with `tabindex="-1"` but would be more complex to use.
- I looked into using transition + delay for visibility (since it's transition-able). With the snippet below. But the enter transition did not work (just appears without transition for transform—due to `visibility: hidden` when the transition kicks off) (exit transition works fine). Same issue can be observed in [the demo on CSS-Tricks](https://css-tricks.com/snippets/css/toggle-visibility-when-hiding-elements/).

```scss
.mdc-snackbar {
  transform: translate(-50%, 100%);
  visibility: hidden;
  transition:
    visibility 0 linear .25s,
    mdc-animation-exit-permanent(transform, .25s);
  
  &--active {
    transform: translate(0);
    visibility: visible;
    transition:
      visibility 0 linear 0,
      mdc-animation-enter(transform, .25s);
  }
}
```

**Note:** knowing two states for animation generally is not enough (show, hide). We generally want  to do some work (imperatively) right before/after animation and sometimes we want to know the direction of the animation (action) ([action driven animation vs state driven animation](http://tobiasahlin.com/blog/meaningful-motion-w-action-driven-animation/)).

An idea for a longer-term fix might be creating a Javascript module that handles animation of an item entering/exiting the DOM. For mounting (showing), we inject the widget to the DOM (to a target container) then trigger enter transition. For unmounting (hiding), we trigger exit transition, wait for `transitionend` event then remove the widget from the DOM.