### PR TITLE
Override default browser background-color <select> & <option> for 'CSS only' dark theme

### DIFF
--- a/demos/select.html
+++ b/demos/select.html
@@ -143,13 +143,13 @@
       <section class="example">
         <h2 class="mdc-typography--title">CSS Only</h2>
         <select class="mdc-select">
-          <option value="" selected>Pick a food group</option>
-          <option value="grains">Bread, Cereal, Rice, and Pasta</option>
-          <option value="vegetables" disabled>Vegetables</option>
-          <option value="fruit">Fruit</option>
-          <option value="dairy">Milk, Yogurt, and Cheese</option>
-          <option value="meat">Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts</option>
-          <option value="fats">Fats, Oils, and Sweets</option>
+          <option class="mdc-list-item" value="" selected>Pick a food group</option>
+          <option class="mdc-list-item" value="grains">Bread, Cereal, Rice, and Pasta</option>
+          <option class="mdc-list-item" value="vegetables" disabled>Vegetables</option>
+          <option class="mdc-list-item" value="fruit">Fruit</option>
+          <option class="mdc-list-item" value="dairy">Milk, Yogurt, and Cheese</option>
+          <option class="mdc-list-item" value="meat">Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts</option>
+          <option class="mdc-list-item" value="fats">Fats, Oils, and Sweets</option>
         </select>
       </section>
 

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -97,7 +97,7 @@
     overflow: hidden;
   }
 
-  option.mdc-list-item{
+  option.mdc-list-item {
     @include mdc-theme-dark {
       background-color: #424242;
     }

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -42,7 +42,8 @@
     mdc-animation-exit-temporary(background-color, 150ms);
   border: none;
   border-bottom: 1px solid rgba(black, .12);
-  border-radius: 0;
+  border-radius: 0;  
+  background-color: transparent;
   background-repeat: no-repeat;
   background-position: right center;
   font-family: Roboto, sans-serif;
@@ -94,6 +95,12 @@
       mdc-animation-exit-temporary(transform, 125ms);
     white-space: nowrap;
     overflow: hidden;
+  }
+
+  option.mdc-list-item{
+    @include mdc-theme-dark {
+      background-color: #424242;
+    }
   }
 }
 

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -42,7 +42,7 @@
     mdc-animation-exit-temporary(background-color, 150ms);
   border: none;
   border-bottom: 1px solid rgba(black, .12);
-  border-radius: 0;  
+  border-radius: 0;
   background-color: transparent;
   background-repeat: no-repeat;
   background-position: right center;


### PR DESCRIPTION
Override default browser background-color ```<select>``` & ```<option>``` for 'CSS only' dark theme:

```
.mdc-select {
  [...]
  background-color: transparent; 
  [...]

  option.mdc-list-item{
    @include mdc-theme-dark {
      background-color: #424242;
    }
  }
}
```
  
(And add .mdc-list-item in <option>'s in demo)