### PR TITLE
refactor(ripple): Combine base-color and theme-style into `color`

### DIFF
--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -114,7 +114,7 @@ argument, with which you can specify the following parameters:
 | --- | --- | --- |
 | `pseudo` | The name of the pseudo-element you want to use to style the ripple. Using pseudo-elements to style ripples obviates the need for any extra DOM and is recommended. However, if given `null` it will style the element directly, rather than attaching styles to the pseudo element. | `null` |
 | `radius` | For _bounded_ ripples, specifies radii of the ripple circles. Can be any valid numeric CSS unit. | `100%` |
-| `color` | A raw color value (e.g., `blue`, `#33cc00`) or a theme property name from `$mdc-theme-property-values` (e.g., `primary`, `secondary-dark`) to provide color for the ripple. Note that there are some current limitations here. See [below](#caveat-theme-custom-variables) | `null` |
+| `color` | A raw color value (e.g., `blue`, `#33cc00`) or a theme property name from `$mdc-theme-property-values` (e.g., `primary`, `secondary-dark`) to provide color for the ripple. Note that there are some current limitations here. See [below](#caveat-theme-custom-variables) | `black` |
 | `opacity` | A unitless number from `0-1` specifying the opacity that either the `base-color` or the `theme-style` color will take on. | `.06` |
 
 #### Adding the ripple JS
@@ -410,7 +410,7 @@ build that can handle our usage of CSS variables.
 > [CSS 4 color-mod functions](https://drafts.csswg.org/css-color/).
 
 The way that [mdc-theme works](../mdc-theme#mdc-theme-prop-mixin) is that it emits two properties: one with the hard-coded sass variable, and another for a
-CSS variable that can be interpolated. The problem is that ripple backgrounds need to have an opacity, and currently there's no way to opacity a pre-existing color defined by a CSS variable.
+CSS variable that can be interpolated. The problem is that ripple backgrounds need to have an opacity, and currently there's no way to opacify a pre-existing color defined by a CSS variable.
 There is an editor's draft for a `color-mod` function (see link in TL;DR) that _can_ do this:
 
 ```css

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -114,8 +114,7 @@ argument, with which you can specify the following parameters:
 | --- | --- | --- |
 | `pseudo` | The name of the pseudo-element you want to use to style the ripple. Using pseudo-elements to style ripples obviates the need for any extra DOM and is recommended. However, if given `null` it will style the element directly, rather than attaching styles to the pseudo element. | `null` |
 | `radius` | For _bounded_ ripples, specifies radii of the ripple circles. Can be any valid numeric CSS unit. | `100%` |
-| `theme-style` | When provided, will use a style specified by `mdc-theme` to provide colors to the ripple. For example, passing `(theme-style: primary)` would make the ripples the color of the theme's primary color. Note that there are some current limitations here. See [below](#caveat-theme-custom-variables) | `null` |
-| `base-color` | The RGB color (_without_ an alpha component) of the ripple. This will only be used if `theme-style` isn't specified. | `black` |
+| `color` | A raw color value (e.g., `blue`, `#33cc00`) or a theme property name from `$mdc-theme-property-values` (e.g., `primary`, `secondary-dark`) to provide color for the ripple. Note that there are some current limitations here. See [below](#caveat-theme-custom-variables) | `null` |
 | `opacity` | A unitless number from `0-1` specifying the opacity that either the `base-color` or the `theme-style` color will take on. | `.06` |
 
 #### Adding the ripple JS
@@ -411,11 +410,11 @@ build that can handle our usage of CSS variables.
 > [CSS 4 color-mod functions](https://drafts.csswg.org/css-color/).
 
 The way that [mdc-theme works](../mdc-theme#mdc-theme-prop-mixin) is that it emits two properties: one with the hard-coded sass variable, and another for a
-CSS variable that can be interpolated. The problem is that ripple backgrounds need to have an opacity, and currently there's no way to opacify a pre-existing color defined by a CSS variable.
+CSS variable that can be interpolated. The problem is that ripple backgrounds need to have an opacity, and currently there's no way to opacity a pre-existing color defined by a CSS variable.
 There is an editor's draft for a `color-mod` function (see link in TL;DR) that _can_ do this:
 
 ```css
-background: color(var(--mdc-theme-primary) a(6%));
+background: color-mod(var(--mdc-theme-primary) a(6%));
 ```
 
 But as far as we know, no browsers yet support it. We have added a `@supports` clause into our code

--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -22,9 +22,8 @@
   @return (
     pseudo: null,
     radius: 100%,
-    base-color: black,
-    opacity: .06,
-    theme-style: null
+    color: black,
+    opacity: .06
   );
 }
 
@@ -52,31 +51,53 @@
 }
 
 @mixin mdc-ripple-color_($config) {
-  $base-color: map-get($config, base-color);
+  $color: map-get($config, color);
   $opacity: map-get($config, opacity);
+
+  // These two properties are deprecated; they exist for backward compatibility only
+  $base-color: map-get($config, base-color);
   $theme-style: map-get($config, theme-style);
 
-  // stylelint-disable at-rule-empty-line-before, block-closing-brace-newline-after
-  @if ($theme-style) {
-    $theme-value: map-get($mdc-theme-property-values, $theme-style);
+  $theme-prop: null;
+  $color-value: null;
 
-    /* @alternate */
-    $css-var: $theme-value;
-    $css-var: var(--mdc-theme-#{$theme-style}, $theme-value);
+  // stylelint-disable scss/at-if-closing-brace-newline-after, scss/at-if-closing-brace-space-after, scss/at-else-closing-brace-newline-after, scss/at-else-closing-brace-space-after
+  @if map-has-key($mdc-theme-property-values, $theme-style) {
+    $theme-prop: $theme-style;
+    $color-value: map-get($mdc-theme-property-values, $theme-style);
+  }
+  @else if map-has-key($mdc-theme-property-values, $base-color) {
+    $theme-prop: $base-color;
+    $color-value: map-get($mdc-theme-property-values, $base-color);
+  }
+  @else if map-has-key($mdc-theme-property-values, $color) {
+    $theme-prop: $color;
+    $color-value: map-get($mdc-theme-property-values, $color);
+  }
 
-    background-color: rgba($theme-value, $opacity);
+  @if not $color-value {
+    @if $theme-style {
+      $color-value: $theme-style;
+    }
+    @else if $base-color {
+      $color-value: $base-color;
+    }
+    @else if $color {
+      $color-value: $color;
+    }
+  }
+  // stylelint-enable scss/at-if-closing-brace-newline-after, scss/at-if-closing-brace-space-after, scss/at-else-closing-brace-newline-after, scss/at-else-closing-brace-space-after
 
+  background-color: rgba($color-value, $opacity);
+
+  @if $theme-prop {
     // See: https://drafts.csswg.org/css-color/#modifying-colors
     // While this is currently unsupported as of now, it will begin to work by default as browsers
     // begin to implement the CSS 4 color spec.
-    @supports (background-color: color(green a(10%))) {
-      background-color: color(#{$css-var} a(#{percentage($opacity)}));
+    @supports (background-color: color-mod(green a(10%))) {
+      background-color: color-mod(var(--mdc-theme-#{$theme-prop}, $color-value) a(#{percentage($opacity)}));
     }
-  } @else {
-    background-color: rgba($base-color, $opacity);
   }
-
-  // stylelint-enable at-rule-empty-line-before, block-closing-brace-newline-after
 }
 
 @mixin mdc-ripple-bg-base_($config) {
@@ -101,7 +122,7 @@
   $radius: map-get($config, radius);
 
   // stylelint-disable at-rule-empty-line-before, block-closing-brace-newline-after
-  @if ($pseudo) {
+  @if $pseudo {
     &#{$pseudo} {
       @include mdc-ripple-bg-base_($config);
 
@@ -177,7 +198,7 @@
   $radius: map-get($config, radius);
 
   // stylelint-disable at-rule-empty-line-before, block-closing-brace-newline-after
-  @if ($pseudo) {
+  @if $pseudo {
     &#{$pseudo} {
       @include mdc-ripple-fg-base_($config);
 


### PR DESCRIPTION
- Similar to the `mdc-theme-prop` mixin, this change makes it simpler for callers to use a single property for all theme/color values
- Update CSS 4 color function name from `color` to `color-mod` per [spec](https://drafts.csswg.org/css-color/#modifying-colors)
- Backward compatible with existing usages