### PR TITLE
fix(demos): Make unsupported ripple message visible and improve detection

### DIFF
--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -115,7 +115,7 @@
   <body>
     <aside id="unsupported-msg">
       It appears your browser does not support custom properties, or has a broken implementation.
-      Please try this in Desktop Chrome or Desktop Firefox.
+      Please try this in Chrome, Firefox, or Safari 10+.
     </aside>
     <header class="mdc-toolbar mdc-toolbar--fixed">
       <div class="mdc-toolbar__row">

--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -24,12 +24,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <script>
-      if (!window.CSS || !window.CSS.supports ||
-        !window.CSS.supports('--css-vars', 'yes') && !(window.CSS.supports('color', '#00000000'))) {
-        document.documentElement.classList.add('unsupported');
-      }
-    </script>
     <style>
       .demo-surface {
         display: flex;
@@ -77,6 +71,8 @@
         color: red;
         border-radius: 4px;
         display: none;
+        position: absolute;
+        z-index: 10;
       }
 
       .unsupported #unsupported-msg {
@@ -210,6 +206,10 @@
     <script src="/assets/material-components-web.js"></script>
     <script>
       (function(global) {
+        if (!mdc.ripple.util.supportsCssVariables(global)) {
+          document.documentElement.classList.add('unsupported');
+        }
+
         [].forEach.call(document.querySelectorAll('.mdc-ripple-surface:not([data-demo-no-js])'), function(surface) {
           mdc.ripple.MDCRipple.attachTo(surface);
         });


### PR DESCRIPTION
Message was previously:
- Hidden behind the toolbar
- Not displayed in Edge, even though Edge doesn't support ripple

Before:
![image](https://user-images.githubusercontent.com/409245/31406736-4c424d12-adb7-11e7-9ff0-dae05099196c.png)

After:
![image](https://user-images.githubusercontent.com/409245/31406749-524cc278-adb7-11e7-8a8e-05b868484153.png)
