### PR TITLE
fix(slider): Deregister correct handlers on destroy

### DIFF
--- a/packages/mdc-slider/foundation.js
+++ b/packages/mdc-slider/foundation.js
@@ -129,8 +129,8 @@ export default class MDCSliderFoundation extends MDCFoundation {
 
   destroy() {
     this.adapter_.deregisterInteractionHandler('mousedown', this.mousedownHandler_);
-    this.adapter_.deregisterInteractionHandler('pointerdown', this.mousedownHandler_);
-    this.adapter_.deregisterInteractionHandler('touchstart', this.mousedownHandler_);
+    this.adapter_.deregisterInteractionHandler('pointerdown', this.pointerdownHandler_);
+    this.adapter_.deregisterInteractionHandler('touchstart', this.touchstartHandler_);
     this.adapter_.deregisterInteractionHandler('keydown', this.keydownHandler_);
     this.adapter_.deregisterInteractionHandler('focus', this.focusHandler_);
     this.adapter_.deregisterInteractionHandler('blur', this.blurHandler_);


### PR DESCRIPTION
Fixes #1429.

Note that our init/destroy tests generally don't nit-pick _which_ function gets called, which is why this went unnoticed. Addressing tests across all packages to be able to spot this would be a larger undertaking...