### PR TITLE
chore: Switch lerna to fixed mode

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0-beta.36",
-  "version": "independent",
+  "version": "0.22.0",
   "commands": {
     "publish": {
       "ignore": [


### PR DESCRIPTION
Resolves #1134 (or at least, makes it so it should no longer happen).

After several discussions on the team (and several instances of #1134 happening), we've decided to simply switch to fixed mode to avoid risking further issues like this, at least during the duration of the 0.x line. We'll likely discuss release management again in the future for 1.x and beyond.

This commit updates the version string so that lerna will prompt appropriately based on the current version when we next release.