### PR TITLE
fix(drawer): Fix typo on `align-items` value

### DIFF
--- a/packages/mdc-drawer/_mixins.scss
+++ b/packages/mdc-drawer/_mixins.scss
@@ -25,7 +25,7 @@
     position: relative;
     flex-direction: row;
     flex-shrink: 0;
-    align-items: flex-center;
+    align-items: center;
     box-sizing: border-box;
     height: 56px;
     padding: 16px;


### PR DESCRIPTION
There is no `flex-center` value; only `flex-start`, `flex-end`, and `center`.

See the [MDN docs on `align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).