### PR TITLE
style(textfield): Focused color of textfield (#1435), added caret-color for supported browsers to conform to spec

### DIFF
--- a/packages/mdc-textfield/mdc-textfield.scss
+++ b/packages/mdc-textfield/mdc-textfield.scss
@@ -40,6 +40,7 @@
 
   &__input {
     @include mdc-theme-prop(color, text-primary-on-light);
+    @include mdc-theme-prop(caret-color, primary);
     @include mdc-typography-base;
     // We use only a subset of the MDC typography values here as changing things such as line-height
     // affects how the labels are transformed.
@@ -223,7 +224,6 @@
     position: absolute;
     bottom: 20px;
     width: calc(100% - #{$mdc-textfield-icon-padding});
-    color: $mdc-textfield-box-secondary-text;
     text-overflow: ellipsis;
     white-space: nowrap;
     pointer-events: none;
@@ -231,10 +231,6 @@
     // Force the label into its own layer to prevent to prevent visible layer promotion adjustments
     // when the ripple is activated behind it.
     will-change: transform;
-
-    @include mdc-theme-dark(".mdc-textfield") {
-      @include mdc-theme-prop(color, text-secondary-on-dark);
-    }
 
     &--float-above {
       transform: translateY(-50%) scale(.75, .75);
@@ -400,6 +396,10 @@
   .mdc-textfield__label {
     pointer-events: none;
   }
+}
+
+.mdc-textfield--focused .mdc-textfield__label {
+  @include mdc-theme-prop(color, primary);
 }
 
 .mdc-textfield--invalid {


### PR DESCRIPTION
I used https://material.io/guidelines/components/text-fields.html#text-fields-text-field-boxes as a guide to fix issue #1435 . 

I noticed that textfield and textfield-box were both affected. I simplified the CSS by removing the specific declarations from `.mdc-textfield--box .mdc-textfield--box` because as far as I can tell the inherited default is correct. Then we don't have to try to override the specificity for the textfield box case and a generic textfield focus declaration works for both.

I also made sure that error states override the primary color, as defined by the guidelines.

As a bonus I noticed that the guidelines specify a `caret-color`. This is not supported by IE, Edge, or safari but it seems like an enhancement for browsers with support.

<img width="419" alt="screen shot 2017-10-24 at 9 38 55 am" src="https://user-images.githubusercontent.com/967026/31957067-5a7c568e-b8a2-11e7-9561-e672ddd571ec.png">
<img width="203" alt="screen shot 2017-10-24 at 9 38 29 am" src="https://user-images.githubusercontent.com/967026/31957070-5cddeffa-b8a2-11e7-9ff6-82cff7d4b8a8.png">
<img width="222" alt="screen shot 2017-10-24 at 9 39 11 am" src="https://user-images.githubusercontent.com/967026/31957076-5e9c6d44-b8a2-11e7-9143-4be4cde68988.png">



---------------------------

@lynnjepsen it was great talking to you yesterday, this is my bugfix. 😜 