### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Material Components for the web
 
-Material Components for the web (MDC-Web) help developers execute [Material Design](https://www.material.io).
+Material Components for the web (MDC-Web) helps developers execute [Material Design](https://www.material.io).
 Developed by a core team of engineers and UX designers at Google, these components enable a reliable development workflow to build beautiful and functional web projects.
 
 Material Components for the web is the successor to [Material Design Lite](https://getmdl.io/), and has 3 high-level goals:


### PR DESCRIPTION
I think it should be "Material Components for the web (MDC-Web) helps" and not ". . . help". This is because Material Components for the web (MDC-Web) is the name of a collection and therefore, is a collective singular noun even though it appears to be plural.  As an example, you wouldn't say "The Chinese Association of Monks help people in their community." You'd rather say "The Chinese Association of Monks helps people in their community."