### PR TITLE
fix(dialog): fixed dark-theme dialog copy color

### DIFF
--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -108,7 +108,7 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     margin-top: 20px;
     padding: 0 24px 24px;
 
-    @include mdc-theme-dark(".mdc-dialog", true) {
+    @include mdc-theme-dark(".mdc-dialog") {
       @include mdc-theme-prop(color, text-secondary-on-dark);
     }
 


### PR DESCRIPTION
Round 2 (with proper commit authoring this time!)

Fixes #1032 where the body copy color of the `.mdc-dialog--dark-theme` was not the appropriate color