### PR TITLE
feat(theme): Allow users to override -theme-text-colors

### DIFF
--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -68,7 +68,7 @@ $mdc-theme-text-colors: (
     disabled: rgba(white, .5),
     icon: rgba(white, .5)
   )
-);
+) !default;
 
 //
 // Primary text colors for each of the theme colors.


### PR DESCRIPTION
Hey, in my attempt to extend this project by importing sass files and building my own bundle, I found that it is not possible to change the default themes color scheme using sass variables. It is possible to do this using css custom properties, but I think it would make this project better to be able to do it using the base sass variables for better browser support.

