### PR TITLE
fix(slider): Don't hide focus ring on discrete sliders

### DIFF
--- a/packages/mdc-slider/mdc-slider.scss
+++ b/packages/mdc-slider/mdc-slider.scss
@@ -324,11 +324,6 @@ $mdc-slider-dark-theme-grey: #5c5c5c;
     .mdc-slider__thumb {
       animation: none;
     }
-
-    .mdc-slider__focus-ring {
-      transform: none;
-      opacity: 0;
-    }
   }
 
   &.mdc-slider--display-markers {


### PR DESCRIPTION
The old behavior is not in the M1 or M2 specs. Even if it was, it's terrible for accessibility and is inconsistent with the continuous slider behavior.

Resolves #1427