### PR TITLE
docs: Fix typos in getting started and integrating frameworks docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,7 +148,7 @@ Replace the contents of the `<body>` tag in `index.html` with the following:
 ```
 
 Once the changes are made, return to your browser and you will see two very nicely styled form
-fields along with a Material Design styled button. The button shows an ink ripple effect when pressed. For now, the ripple is a fairly subtle that will be addressed shortly.
+fields along with a Material Design styled button. The button shows an ink ripple effect when pressed. For now, the ripple is a fairly subtle effect that will be addressed shortly.
 
 Two important points that are demonstrated in the code that was added:
 

--- a/docs/integrating-into-frameworks.md
+++ b/docs/integrating-into-frameworks.md
@@ -14,7 +14,7 @@ frameworks.
 
 ## Examples
 
-We maintain a list of component libraries, which wrap MDC Web for other frameworks, on our main [README](../README.md). Each library must:
+We maintain a list of component libraries, which wrap MDC Web for other frameworks, in our main [README](../README.md). Each library must:
 - Serve components in an à-la-carte delivery model
 - Have existed for longer than 6 weeks and show continued maintenance over time
 - Provide usage documentation per component


### PR DESCRIPTION
Fix a missing word in the getting started guide: "effect" in "a fairly subtle effect". Fix a typo in the integrating frameworks guide: "on our main README" to "in our main README".