### PR TITLE
chore: Fix changelog generation step in release process

### DIFF
--- a/docs/open_source/release.md
+++ b/docs/open_source/release.md
@@ -35,18 +35,29 @@ This will pull the latest of `master` onto your git clone.
 
 `./scripts/pre-release.sh`
 
-This will ensure you can publish/tag, build all release files, ensure all tests
-pass, and update our CHANGELOG prior to releasing (lerna will update the tag
-for us in the next step).
-
-> Make sure that a CHANGELOG commit actually appears in your `git log`!
+This will ensure you can publish/tag, build all release files, and ensure all tests
+pass prior to releasing (lerna will update versions for us in the next step).
 
 ### Release
 
-`$(npm bin)/lerna publish -m "chore: Publish"`
+```
+$(npm bin)/lerna publish --skip-git
+git commit -am "chore: Publish"
+```
 
-When prompted for version, you should pick Minor for typical releases,
+When lerna prompts for version, you should pick Minor for typical releases,
 or Patch for hotfix releases with no breaking changes.
+
+> **Do not forget** `--skip-git` - we want to generate the changelog before
+> generating and pushing the new tag.
+
+### Post-Release
+
+`./scripts/post-release.sh`
+
+This will update our CHANGELOG.md and generate a vX.Y.Z semver tag.
+
+> Make sure that a CHANGELOG commit actually appears in your `git log`!
 
 ### Push
 

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+##
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+set -e
+
+function log() {
+  echo '\033[36m[post-release]\033[0m' "$@"
+}
+
+log "Generating and committing changelog"
+npm run changelog
+git add CHANGELOG.md
+git commit -m "docs: Update CHANGELOG.md"
+echo ""
+
+# Extract repo version from updated lerna.json
+REPO_VERSION=$(grep 'version' lerna.json | sed 's/ *"version": "//' | sed 's/",//')
+SEMVER_TAG="v$REPO_VERSION"
+log "Tagging repo using semver tag $SEMVER_TAG"
+git tag $SEMVER_TAG -m "Material Components for the web release $SEMVER_TAG"
+echo ""
+
+log "Done! You should now git push to master and git push --tags"

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -61,20 +61,6 @@ log "Moving built assets to package directories..."
 node scripts/cp-pkgs.js
 echo ""
 
-# Don't immediately exit without end message if changelog commit goes wrong
-set +e
-
-log "Generating and committing changelog" \
-  "(if this says no changes added to commit, something is probably wrong)"
-npm run changelog
-git add CHANGELOG.md
-git commit -m "docs: Update CHANGELOG.md"
-echo ""
-
-log "Pre-release steps done! First, please confirm that the changelog looks" \
-    "correct (git show should show the changelog commit),"
-log "and amend if necessary (edit CHANGELOG.md, git add CHANGELOG.md, and" \
-    "git commit --amend, assuming there _was_ a changelog commit). "
-log "Next, you should run:" \
-    "\$(npm bin)/lerna publish -m \"chore: Publish\""
+log "Pre-release steps done! Next, you should run:" \
+    "\$(npm bin)/lerna publish --skip-git"
 echo ""


### PR DESCRIPTION
This reinstates `scripts/post-release.sh` and moves changelog generation back to that, because standard-changelog operates based on the latest version it sees in package.json.

This also updates the command used to detect the latest version for tagging, since we're no longer using lerna in independent mode and so the old command we used no longer picks up the latest version.