### PR TITLE
chore(dialog): Remove height property from scroll-lock class

### DIFF
--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -188,6 +188,5 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
 // postcss-bem-linter: end
 
 .mdc-dialog-scroll-lock {
-  height: 100vh;
   overflow: hidden;
 }


### PR DESCRIPTION
This property seems unnecessary after testing on our demo pages