### PR TITLE
chore(text-field): Split out helper text as a subelement

### DIFF
--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -100,91 +100,6 @@ since it won't be added until that JS runs, adding it manually will prevent an i
 </div>
 ```
 
-### Using helper text
-
-MDC Text Fields can include helper text that is useful for providing supplemental
-information to users, as well for validation messages (covered below).
-
-```html
-<div class="mdc-text-field">
-  <input type="text" id="username" class="mdc-text-field__input" aria-controls="username-helper-text">
-  <label for="username" class="mdc-text-field__label">Username</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-<p id="username-helper-text" class="mdc-text-field-helper-text" aria-hidden="true">
-  This will be displayed on your public profile
-</p>
-```
-
-Helper text appears on input field focus and disappears on input field blur by default when using
-the text-field JS component.
-
-#### Persistent helper text
-
-If you'd like the helper text to always be visible, add the
-`mdc-text-field-helper-text--persistent` modifier class to the element.
-
-```html
-<div class="mdc-text-field">
-  <input type="email" id="email" class="mdc-text-field__input">
-  <label for="email" class="mdc-text-field__label">Email address</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-<p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent">
-  We will <em>never</em> share your email address with third parties
-</p>
-```
-
-#### Helper text and accessibility
-
-Note that in every example where the helper text is dependent on the state of the input element, we
-assign an id to the `mdc-text-field-helper-text` element and set that id to the value of the
-`aria-controls` attribute on the input element. We recommend doing this as well as it will help
-indicate to assistive devices that the display of the helper text is dependent on the interaction with
-the input element.
-
-When using our vanilla JS component, if it sees that the input element has an `aria-controls`
-attribute, it will look for an element with the id specified and treat it as the text field's help
-text element, taking care of adding/removing `aria-hidden` and other a11y attributes. This can also
-be done programmatically, which is described below.
-
-### Validation
-
-MDC TextField provides validity styling by using the `:invalid` and `:required` attributes provided
-by HTML5's form validation API.
-
-```html
-<div class="mdc-text-field">
-  <input type="password" id="pw" class="mdc-text-field__input" required minlength=8>
-  <label for="pw" class="mdc-text-field__label">Password</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-```
-
-By default an input's validity is checked via `checkValidity()` on blur, and the styles are updated
-accordingly. Set the MDCTextField.valid variable to set the input's validity explicitly. MDC TextField
-automatically appends an asterisk to the label text if the required attribute is set.
-
-Helper text can be used to provide additional validation messages. Use
-`mdc-text-field-helper-text--validation-msg` to provide styles for using the helper text as a validation
-message. This can be easily combined with `mdc-text-field-helper-text--persistent` to provide a robust
-UX for client-side form field validation.
-
-```html
-<div class="mdc-text-field">
-  <input required minlength=8 type="password" class="mdc-text-field__input" id="pw"
-         aria-controls="pw-validation-msg">
-  <label for="pw" class="mdc-text-field__label">Choose password</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-<p class="mdc-text-field-helper-text
-          mdc-text-field-helper-text--persistent
-          mdc-text-field-helper-text--validation-msg"
-   id="pw-validation-msg">
-  Must be at least 8 characters long
-</p>
-```
-
 ### Leading and Trailing Icons
 Leading and trailing icons can be added to MDC Text Fields as visual indicators
 as well as interaction targets. To do so, add the relevant classes
@@ -415,6 +330,7 @@ complicated.
 | removeHelperTextAttr(name: string) => void | Removes an attribute from the helper text element |
 | getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}? | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully. |
 | getBottomLineFoundation() => MDCTextFieldBottomLineFoundation | Returns the instance of the bottom line element's foundation |
+| getHelperTextFoundation() => MDCTextFieldHelperTextFoundation | Returns the instance of the helper text element's foundation |
 
 #### The full foundation API
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -373,6 +373,10 @@ event with clientX/clientY properties.
 Handles the end of the bottom line animation, performing actions that must wait for animations to
 finish. Expects a transition-end event.
 
+##### MDCTextField.helperTextContent
+
+Sets the content of the helper text, if it exists.
+
 ### Theming
 
 MDC TextField components use the configured theme's primary color for its underline and label text

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -100,6 +100,23 @@ since it won't be added until that JS runs, adding it manually will prevent an i
 </div>
 ```
 
+### Validation
+
+MDC TextField provides validity styling by using the `:invalid` and `:required` attributes provided
+by HTML5's form validation API.
+
+```html
+<div class="mdc-text-field">
+  <input type="password" id="pw" class="mdc-text-field__input" required minlength=8>
+  <label for="pw" class="mdc-text-field__label">Password</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
+
+By default an input's validity is checked via `checkValidity()` on blur, and the styles are updated
+accordingly. Set the MDCTextField.valid field to set the input's validity explicitly. MDC TextField
+automatically appends an asterisk to the label text if the required attribute is set.
+
 ### Leading and Trailing Icons
 Leading and trailing icons can be added to MDC Text Fields as visual indicators
 as well as interaction targets. To do so, add the relevant classes

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -182,7 +182,7 @@ behave normally.
 </div>
 ```
 
-Note that Text field boxes support all of the same features as normal text-fields, including help
+Note that Text field boxes support all of the same features as normal text-fields, including helper
 text, validation, and dense UI.
 
 #### CSS-only text field boxes
@@ -281,13 +281,6 @@ By default the ripple factory simply calls `new MDCRipple(el)` and returns the r
 Similar to regular DOM elements, the `MDCTextField` functionality is exposed through accessor
 methods.
 
-##### MDCTextField.helperTextElement
-
-HTMLLabelElement. This is a normal property (non-accessor) that holds a reference to the element
-being used as the text field's "helper text". It defaults to `null`. If the text field's input element
-contains an `aria-controls` attribute on instantiation of the component, it will look for an element
-with the corresponding id within the document and automatically assign it to this property.
-
 ##### MDCTextField.disabled
 
 Boolean. Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set
@@ -319,15 +312,10 @@ complicated.
 | notifyIconAction() => void | Emits a custom event "MDCTextField:icon" denoting a user has clicked the icon |
 | addClassToBottomLine(className: string) => void | Adds a class to the bottom line element |
 | removeClassFromBottomLine(className: string) => void | Removes a class from the bottom line element |
-| addClassToHelperText(className: string) => void | Adds a class to the helper text element. Note that in our code we check for whether or not we have a helper text element and if we don't, we simply return. |
-| removeClassFromHelperText(className: string) => void | Removes a class from the helper text element. |
-| helperTextHasClass(className: string) => boolean | Returns whether or not the helper text element contains the current class |
 | registerInputInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the native input element for a given event |
 | deregisterInputInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the native input element for a given event |
 | registerBottomLineEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the bottom line element for a given event |
 | deregisterBottomLineEventHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the bottom line element for a given event |
-| setHelperTextAttr(name: string, value: string) => void | Sets an attribute with a given value on the helper text element |
-| removeHelperTextAttr(name: string) => void | Removes an attribute from the helper text element |
 | getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}? | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully. |
 | getBottomLineFoundation() => MDCTextFieldBottomLineFoundation | Returns the instance of the bottom line element's foundation |
 | getHelperTextFoundation() => MDCTextFieldHelperTextFoundation | Returns the instance of the helper text element's foundation |

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -17,6 +17,7 @@
 
 /* eslint-disable no-unused-vars */
 import MDCTextFieldBottomLineFoundation from './bottom-line/foundation';
+import MDCTextFieldHelperTextFoundation from './helper-text/foundation';
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
@@ -182,6 +183,13 @@ class MDCTextFieldAdapter {
    * @return {?MDCTextFieldBottomLineFoundation}
    */
   getBottomLineFoundation() {}
+
+  /**
+   * Returns the foundation for the helper text element. Returns undefined if
+   * there is no helper text element.
+   * @return {?MDCTextFieldHelperTextFoundation}
+   */
+  getHelperTextFoundation() {}
 }
 
 export {MDCTextFieldAdapter, NativeInputType};

--- a/packages/mdc-textfield/constants.js
+++ b/packages/mdc-textfield/constants.js
@@ -17,8 +17,7 @@
 
 /** @enum {string} */
 const strings = {
-  ARIA_HIDDEN: 'aria-hidden',
-  ROLE: 'role',
+  ARIA_CONTROLS: 'aria-controls',
   INPUT_SELECTOR: '.mdc-text-field__input',
   LABEL_SELECTOR: '.mdc-text-field__label',
   ICON_SELECTOR: '.mdc-text-field__icon',
@@ -33,8 +32,6 @@ const cssClasses = {
   DISABLED: 'mdc-text-field--disabled',
   FOCUSED: 'mdc-text-field--focused',
   INVALID: 'mdc-text-field--invalid',
-  HELPER_TEXT_PERSISTENT: 'mdc-text-field-helper-text--persistent',
-  HELPER_TEXT_VALIDATION_MSG: 'mdc-text-field-helper-text--validation-msg',
   LABEL_FLOAT_ABOVE: 'mdc-text-field__label--float-above',
   LABEL_SHAKE: 'mdc-text-field__label--shake',
   BOX: 'mdc-text-field--box',

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -272,10 +272,13 @@ class MDCTextFieldFoundation extends MDCFoundation {
   }
 
   /**
-   * @param {string} content Sets the content of the helper text field
+   * @param {string} content Sets the content of the helper text.
    */
   setHelperTextContent(content) {
-    this.adapter_.setHelperTextContent(content);
+    const helperText = this.adapter_.getHelperTextFoundation();
+    if (helperText) {
+      helperText.setContent(content);
+    }
   }
 
   /**

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -58,7 +58,7 @@ class MDCTextFieldFoundation extends MDCFoundation {
       deregisterBottomLineEventHandler: () => {},
       getNativeInput: () => {},
       getBottomLineFoundation: () => {},
-      getHelperTextFoundation: () => {}
+      getHelperTextFoundation: () => {},
     });
   }
 

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -52,17 +52,13 @@ class MDCTextFieldFoundation extends MDCFoundation {
       registerTextFieldInteractionHandler: () => {},
       deregisterTextFieldInteractionHandler: () => {},
       notifyIconAction: () => {},
-      addClassToHelperText: () => {},
-      removeClassFromHelperText: () => {},
-      helperTextHasClass: () => false,
       registerInputInteractionHandler: () => {},
       deregisterInputInteractionHandler: () => {},
       registerBottomLineEventHandler: () => {},
       deregisterBottomLineEventHandler: () => {},
-      setHelperTextAttr: () => {},
-      removeHelperTextAttr: () => {},
       getNativeInput: () => {},
       getBottomLineFoundation: () => {},
+      getHelperTextFoundation: () => {}
     });
   }
 
@@ -160,7 +156,10 @@ class MDCTextFieldFoundation extends MDCFoundation {
     }
     this.adapter_.addClassToLabel(LABEL_FLOAT_ABOVE);
     this.adapter_.removeClassFromLabel(LABEL_SHAKE);
-    this.showHelperText_();
+    const helperText = this.adapter_.getHelperTextFoundation();
+    if (helperText) {
+      helperText.show();
+    }
     this.isFocused_ = true;
   }
 
@@ -184,15 +183,6 @@ class MDCTextFieldFoundation extends MDCFoundation {
     if (!this.receivedUserInput_) {
       this.activateFocus();
     }
-  }
-
-  /**
-   * Makes the helper text visible to screen readers.
-   * @private
-   */
-  showHelperText_() {
-    const {ARIA_HIDDEN} = MDCTextFieldFoundation.strings;
-    this.adapter_.removeHelperTextAttr(ARIA_HIDDEN);
   }
 
   /**
@@ -243,40 +233,10 @@ class MDCTextFieldFoundation extends MDCFoundation {
       this.adapter_.addClassToLabel(LABEL_SHAKE);
       this.adapter_.addClass(INVALID);
     }
-    this.updateHelperText_(isValid);
-  }
-
-  /**
-   * Updates the state of the Text Field's helper text based on validity and
-   * the Text Field's options.
-   * @param {boolean} isValid
-   */
-  updateHelperText_(isValid) {
-    const {HELPER_TEXT_PERSISTENT, HELPER_TEXT_VALIDATION_MSG} = MDCTextFieldFoundation.cssClasses;
-    const {ROLE} = MDCTextFieldFoundation.strings;
-    const helperTextIsPersistent = this.adapter_.helperTextHasClass(HELPER_TEXT_PERSISTENT);
-    const helperTextIsValidationMsg = this.adapter_.helperTextHasClass(HELPER_TEXT_VALIDATION_MSG);
-    const validationMsgNeedsDisplay = helperTextIsValidationMsg && !isValid;
-
-    if (validationMsgNeedsDisplay) {
-      this.adapter_.setHelperTextAttr(ROLE, 'alert');
-    } else {
-      this.adapter_.removeHelperTextAttr(ROLE);
+    const helperText = this.adapter_.getHelperTextFoundation();
+    if (helperText) {
+      helperText.update(isValid);
     }
-
-    if (helperTextIsPersistent || validationMsgNeedsDisplay) {
-      return;
-    }
-    this.hideHelperText_();
-  }
-
-  /**
-   * Hides the helper text from screen readers.
-   * @private
-   */
-  hideHelperText_() {
-    const {ARIA_HIDDEN} = MDCTextFieldFoundation.strings;
-    this.adapter_.setHelperTextAttr(ARIA_HIDDEN, 'true');
   }
 
   /**

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -158,7 +158,7 @@ class MDCTextFieldFoundation extends MDCFoundation {
     this.adapter_.removeClassFromLabel(LABEL_SHAKE);
     const helperText = this.adapter_.getHelperTextFoundation();
     if (helperText) {
-      helperText.show();
+      helperText.showToScreenReader();
     }
     this.isFocused_ = true;
   }
@@ -235,7 +235,7 @@ class MDCTextFieldFoundation extends MDCFoundation {
     }
     const helperText = this.adapter_.getHelperTextFoundation();
     if (helperText) {
-      helperText.update(isValid);
+      helperText.setValidity(isValid);
     }
   }
 

--- a/packages/mdc-textfield/helper-text/README.md
+++ b/packages/mdc-textfield/helper-text/README.md
@@ -116,9 +116,14 @@ addClass(className: string) => void | Adds a class to the helper text element
 removeClass(className: string) => void | Removes a class from the helper text element
 hasClass(className: string) => boolean | Returns true if classname exists for the helper text element
 setAttr(attr: string, value: string) => void | Sets an attribute with a given value on the helper text element
-removeAttr(attr: string) => void | Removes an attribute on the helper text element |
+removeAttr(attr: string) => void | Removes an attribute on the helper text element
+setContent(attr: string) => void | Sets the text content for the helper text element
 
 #### The full foundation API
+
+##### MDCTextFieldHelperTextFoundation.setContent()
+
+Sets the content of the helper text.
 
 ##### MDCTextFieldHelperTextFoundation.showToScreenReader()
 

--- a/packages/mdc-textfield/helper-text/README.md
+++ b/packages/mdc-textfield/helper-text/README.md
@@ -28,11 +28,11 @@ MDC Text Fields can include helper text that is useful for providing supplementa
 
 ```html
 <div class="mdc-text-field">
-  <input type="text" id="username" class="mdc-text-field__input" aria-controls="username-helper-text">
+  <input type="text" id="username" class="mdc-text-field__input">
   <label for="username" class="mdc-text-field__label">Username</label>
   <div class="mdc-text-field__bottom-line"></div>
 </div>
-<p id="username-helper-text" class="mdc-text-field-helper-text" aria-hidden="true">
+<p class="mdc-text-field-helper-text" aria-hidden="true">
   This will be displayed on your public profile
 </p>
 ```

--- a/packages/mdc-textfield/helper-text/README.md
+++ b/packages/mdc-textfield/helper-text/README.md
@@ -128,6 +128,6 @@ removeAttr(attr: string) => void | Removes an attribute on the helper text eleme
 
 Makes the helper text visible to screen readers.
 
-##### MDCTextFieldHelperTextFoundation.update()
+##### MDCTextFieldHelperTextFoundation.update(inputIsValid)
 
-Updates the state of the helper text based on validity.
+Updates the state of the helper text based on input validity.

--- a/packages/mdc-textfield/helper-text/README.md
+++ b/packages/mdc-textfield/helper-text/README.md
@@ -1,0 +1,133 @@
+<!--docs:
+title: "Text Field Helper Text"
+layout: detail
+section: components
+excerpt: "The helper text provides supplemental information and/or validation messages to users"
+iconId: text_field
+path: /catalog/input-controls/text-fields/helper-text/
+-->
+
+# Text Field Helper Text
+
+The helper text provides supplemental information and/or validation messages to users. It appears and disappears on input field focus and blur respectively by default when using the TextField JS component. If you’d like the helper text to always be visible, add the `mdc-text-field-helptext--persistent` modifier class to the element.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/text-fields.html#text-fields-layout">Material Design guidelines: Text Fields Layout</a>
+  </li>
+</ul>
+
+
+## Usage
+
+### Using helper text
+
+MDC Text Fields can include helper text that is useful for providing supplemental
+information to users, as well for validation messages (covered below).
+
+```html
+<div class="mdc-text-field">
+  <input type="text" id="username" class="mdc-text-field__input" aria-controls="username-helper-text">
+  <label for="username" class="mdc-text-field__label">Username</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+<p id="username-helper-text" class="mdc-text-field-helper-text" aria-hidden="true">
+  This will be displayed on your public profile
+</p>
+```
+
+Helper text appears on input field focus and disappears on input field blur by default when using
+the Text Field JS component.
+
+#### Persistent helper text
+
+If you'd like the helper text to always be visible, add the `mdc-text-field-helper-text--persistent` modifier class to the element.
+
+```html
+<div class="mdc-text-field">
+  <input type="email" id="email" class="mdc-text-field__input">
+  <label for="email" class="mdc-text-field__label">Email address</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+<p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent">
+  We will <em>never</em> share your email address with third parties
+</p>
+```
+
+#### Helper text and accessibility
+
+Note that in every example where the helper text is dependent on the state of the input element, we
+assign an id to the `mdc-text-field-helper-text` element and set that id to the value of the
+`aria-controls` attribute on the input element. We recommend doing this as well as it will help
+indicate to assistive devices that the display of the helper text is dependent on the interaction with
+the input element.
+
+When using our vanilla JS component, if it sees that the input element has an `aria-controls`
+attribute, it will look for an element with the id specified and treat it as the text field's help
+text element, taking care of adding/removing `aria-hidden` and other a11y attributes. This can also
+be done programmatically, which is described below.
+
+### Validation
+
+MDC TextField provides validity styling by using the `:invalid` and `:required` attributes provided
+by HTML5's form validation API.
+
+```html
+<div class="mdc-text-field">
+  <input type="password" id="pw" class="mdc-text-field__input" required minlength=8>
+  <label for="pw" class="mdc-text-field__label">Password</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
+
+By default an input's validity is checked via `checkValidity()` on blur, and the styles are updated
+accordingly. Set the MDCTextField.valid variable to set the input's validity explicitly. MDC TextField
+automatically appends an asterisk to the label text if the required attribute is set.
+
+Helper text can be used to provide additional validation messages. Use
+`mdc-text-field-helper-text--validation-msg` to provide styles for using the helper text as a validation
+message. This can be easily combined with `mdc-text-field-helper-text--persistent` to provide a robust
+UX for client-side form field validation.
+
+```html
+<div class="mdc-text-field">
+  <input required minlength=8 type="password" class="mdc-text-field__input" id="pw"
+         aria-controls="pw-validation-msg">
+  <label for="pw" class="mdc-text-field__label">Choose password</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+<p class="mdc-text-field-helper-text
+          mdc-text-field-helper-text--persistent
+          mdc-text-field-helper-text--validation-msg"
+   id="pw-validation-msg">
+  Must be at least 8 characters long
+</p>
+```
+
+#### MDCTextFieldHelperText API
+
+##### MDCTextFieldHelperText.foundation
+
+MDCTextFieldHelperTextFoundation. This allows the parent MDCTextField component to access the public methods on the MDCTextFieldHelperTextFoundation class.
+
+### Using the foundation class
+
+Method Signature | Description
+--- | ---
+addClass(className: string) => void | Adds a class to the helper text element
+removeClass(className: string) => void | Removes a class from the helper text element
+hasClass(className: string) => boolean | Returns true if classname exists for the helper text element
+setAttr(attr: string, value: string) => void | Sets an attribute with a given value on the helper text element
+removeAttr(attr: string) => void | Removes an attribute on the helper text element |
+
+#### The full foundation API
+
+##### MDCTextFieldHelperTextFoundation.show()
+
+Makes the helper text visible to screen readers.
+
+##### MDCTextFieldHelperTextFoundation.update()
+
+Updates the state of the helper text based on validity.

--- a/packages/mdc-textfield/helper-text/README.md
+++ b/packages/mdc-textfield/helper-text/README.md
@@ -9,7 +9,7 @@ path: /catalog/input-controls/text-fields/helper-text/
 
 # Text Field Helper Text
 
-The helper text provides supplemental information and/or validation messages to users. It appears and disappears on input field focus and blur respectively by default when using the TextField JS component. If you’d like the helper text to always be visible, add the `mdc-text-field-helptext--persistent` modifier class to the element.
+The helper text provides supplemental information and/or validation messages to users. It appears on input field focus and disappears on input field blur by default, or it can be persistent.
 
 ## Design & API Documentation
 

--- a/packages/mdc-textfield/helper-text/README.md
+++ b/packages/mdc-textfield/helper-text/README.md
@@ -24,8 +24,7 @@ The helper text provides supplemental information and/or validation messages to 
 
 ### Using helper text
 
-MDC Text Fields can include helper text that is useful for providing supplemental
-information to users, as well for validation messages (covered below).
+MDC Text Fields can include helper text that is useful for providing supplemental information to users.
 
 ```html
 <div class="mdc-text-field">
@@ -64,32 +63,29 @@ assign an id to the `mdc-text-field-helper-text` element and set that id to the 
 indicate to assistive devices that the display of the helper text is dependent on the interaction with
 the input element.
 
-When using our vanilla JS component, if it sees that the input element has an `aria-controls`
-attribute, it will look for an element with the id specified and treat it as the text field's help
-text element, taking care of adding/removing `aria-hidden` and other a11y attributes. This can also
-be done programmatically, which is described below.
+```html
+<div class="mdc-text-field">
+  <input type="text" id="username" class="mdc-text-field__input" aria-controls="username-helper-text">
+  <label for="username" class="mdc-text-field__label">Username</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+<p id="username-helper-text" class="mdc-text-field-helper-text" aria-hidden="true">
+  This will be displayed on your public profile
+</p>
+```
+
+When using our vanilla JS component, if the browser sees that the input element has an `aria-controls`
+attribute, it will look for an element with the id specified and treat it as the text field's helper
+text element, taking care of adding/removing `aria-hidden` and other accessibility attributes. Adding
+and removing classes and attributes to the helper text element can also be done using the
+MDCTextFieldHelperText API, which is described below.
 
 ### Validation
 
-MDC TextField provides validity styling by using the `:invalid` and `:required` attributes provided
-by HTML5's form validation API.
-
-```html
-<div class="mdc-text-field">
-  <input type="password" id="pw" class="mdc-text-field__input" required minlength=8>
-  <label for="pw" class="mdc-text-field__label">Password</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-```
-
-By default an input's validity is checked via `checkValidity()` on blur, and the styles are updated
-accordingly. Set the MDCTextField.valid variable to set the input's validity explicitly. MDC TextField
-automatically appends an asterisk to the label text if the required attribute is set.
-
-Helper text can be used to provide additional validation messages. Use
-`mdc-text-field-helper-text--validation-msg` to provide styles for using the helper text as a validation
-message. This can be easily combined with `mdc-text-field-helper-text--persistent` to provide a robust
-UX for client-side form field validation.
+Helper text can be used to provide validation messages in addition to the validity styling provided by
+MDC TextField. Use `mdc-text-field-helper-text--validation-msg` to provide styles for using the helper
+text as a validation message. This can be combined with `mdc-text-field-helper-text--persistent` to
+provide a robust UX for client-side form field validation.
 
 ```html
 <div class="mdc-text-field">
@@ -124,10 +120,10 @@ removeAttr(attr: string) => void | Removes an attribute on the helper text eleme
 
 #### The full foundation API
 
-##### MDCTextFieldHelperTextFoundation.show()
+##### MDCTextFieldHelperTextFoundation.showToScreenReader()
 
-Makes the helper text visible to screen readers.
+Makes the helper text visible to the screen reader.
 
-##### MDCTextFieldHelperTextFoundation.update(inputIsValid)
+##### MDCTextFieldHelperTextFoundation.setValidity(inputIsValid)
 
-Updates the state of the helper text based on input validity.
+Sets the validity of the helper text based on the input validity.

--- a/packages/mdc-textfield/helper-text/adapter.js
+++ b/packages/mdc-textfield/helper-text/adapter.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint no-unused-vars: [2, {"args": "none"}] */
+
+/**
+ * Adapter for MDC Text Field Helper Text.
+ *
+ * Defines the shape of the adapter expected by the foundation. Implement this
+ * adapter to integrate the TextField helper text into your framework. See
+ * https://github.com/material-components/material-components-web/blob/master/docs/authoring-components.md
+ * for more information.
+ *
+ * @record
+ */
+class MDCTextFieldHelperTextAdapter {
+  /**
+   * Adds a class to the helper text element.
+   * @param {string} className
+   */
+  addClass(className) {}
+
+  /**
+   * Removes a class from the helper text element.
+   * @param {string} className
+   */
+  removeClass(className) {}
+
+  /**
+   * Returns whether or not the helper text element contains the given class.
+   * @param {string} className
+   * @return {boolean}
+   */
+  hasClass(className) {}
+
+  /**
+   * Sets an attribute with a given value on the helper text element.
+   * @param {string} attr
+   * @param {string} value
+   */
+  setAttr(attr, value) {}
+
+  /**
+   * Removes an attribute from the helper text element.
+   * @param {string} attr
+   */
+  removeAttr(attr) {}
+}
+
+export default MDCTextFieldHelperTextAdapter;

--- a/packages/mdc-textfield/helper-text/adapter.js
+++ b/packages/mdc-textfield/helper-text/adapter.js
@@ -59,6 +59,12 @@ class MDCTextFieldHelperTextAdapter {
    * @param {string} attr
    */
   removeAttr(attr) {}
+
+  /**
+   * Sets the text content for the helper text element.
+   * @param {string} content
+   */
+  setContent(content) {}
 }
 
 export default MDCTextFieldHelperTextAdapter;

--- a/packages/mdc-textfield/helper-text/constants.js
+++ b/packages/mdc-textfield/helper-text/constants.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @enum {string} */
+const strings = {
+  ARIA_HIDDEN: 'aria-hidden',
+  ROLE: 'role',
+};
+
+/** @enum {string} */
+const cssClasses = {
+  HELPER_TEXT_PERSISTENT: 'mdc-text-field-helper-text--persistent',
+  HELPER_TEXT_VALIDATION_MSG: 'mdc-text-field-helper-text--validation-msg',
+};
+
+export {strings, cssClasses};

--- a/packages/mdc-textfield/helper-text/foundation.js
+++ b/packages/mdc-textfield/helper-text/foundation.js
@@ -47,6 +47,7 @@ class MDCTextFieldHelperTextFoundation extends MDCFoundation {
       hasClass: () => {},
       setAttr: () => {},
       removeAttr: () => {},
+      setContent: () => {},
     });
   }
 
@@ -55,6 +56,14 @@ class MDCTextFieldHelperTextFoundation extends MDCFoundation {
    */
   constructor(adapter = /** @type {!MDCTextFieldHelperTextAdapter} */ ({})) {
     super(Object.assign(MDCTextFieldHelperTextFoundation.defaultAdapter, adapter));
+  }
+
+  /**
+   * Sets the content of the helper text field.
+   * @param {string} content
+   */
+  setContent(content) {
+    this.adapter_.setContent(content);
   }
 
   /** Makes the helper text visible to the screen reader. */

--- a/packages/mdc-textfield/helper-text/foundation.js
+++ b/packages/mdc-textfield/helper-text/foundation.js
@@ -57,16 +57,16 @@ class MDCTextFieldHelperTextFoundation extends MDCFoundation {
     super(Object.assign(MDCTextFieldHelperTextFoundation.defaultAdapter, adapter));
   }
 
-  /** Makes the helper text visible to screen readers. */
-  show() {
+  /** Makes the helper text visible to the screen reader. */
+  showToScreenReader() {
     this.adapter_.removeAttr(strings.ARIA_HIDDEN);
   }
 
   /**
-   * Updates the state of the helper text based on the input validity.
+   * Sets the validity of the helper text based on the input validity.
    * @param {boolean} inputIsValid
    */
-  update(inputIsValid) {
+  setValidity(inputIsValid) {
     const helperTextIsPersistent = this.adapter_.hasClass(cssClasses.HELPER_TEXT_PERSISTENT);
     const helperTextIsValidationMsg = this.adapter_.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG);
     const validationMsgNeedsDisplay = helperTextIsValidationMsg && !inputIsValid;
@@ -77,10 +77,9 @@ class MDCTextFieldHelperTextFoundation extends MDCFoundation {
       this.adapter_.removeAttr(strings.ROLE);
     }
 
-    if (helperTextIsPersistent || validationMsgNeedsDisplay) {
-      return;
+    if (!helperTextIsPersistent && !validationMsgNeedsDisplay) {
+      this.hide_();
     }
-    this.hide_();
   }
 
   /**

--- a/packages/mdc-textfield/helper-text/foundation.js
+++ b/packages/mdc-textfield/helper-text/foundation.js
@@ -63,13 +63,13 @@ class MDCTextFieldHelperTextFoundation extends MDCFoundation {
   }
 
   /**
-   * Updates the state of the helper text based on validity.
-   * @param {boolean} isValid
+   * Updates the state of the helper text based on the input validity.
+   * @param {boolean} inputIsValid
    */
-  update(isValid) {
+  update(inputIsValid) {
     const helperTextIsPersistent = this.adapter_.hasClass(cssClasses.HELPER_TEXT_PERSISTENT);
     const helperTextIsValidationMsg = this.adapter_.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG);
-    const validationMsgNeedsDisplay = helperTextIsValidationMsg && !isValid;
+    const validationMsgNeedsDisplay = helperTextIsValidationMsg && !inputIsValid;
 
     if (validationMsgNeedsDisplay) {
       this.adapter_.setAttr(strings.ROLE, 'alert');

--- a/packages/mdc-textfield/helper-text/foundation.js
+++ b/packages/mdc-textfield/helper-text/foundation.js
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from '@material/base/foundation';
+import MDCTextFieldHelperTextAdapter from './adapter';
+import {cssClasses, strings} from './constants';
+
+
+/**
+ * @extends {MDCFoundation<!MDCTextFieldHelperTextAdapter>}
+ * @final
+ */
+class MDCTextFieldHelperTextFoundation extends MDCFoundation {
+  /** @return enum {string} */
+  static get cssClasses() {
+    return cssClasses;
+  }
+
+  /** @return enum {string} */
+  static get strings() {
+    return strings;
+  }
+
+  /**
+   * {@see MDCTextFieldHelperTextAdapter} for typing information on parameters and return
+   * types.
+   * @return {!MDCTextFieldHelperTextAdapter}
+   */
+  static get defaultAdapter() {
+    return /** @type {!MDCTextFieldHelperTextAdapter} */ ({
+      addClass: () => {},
+      removeClass: () => {},
+      hasClass: () => {},
+      setAttr: () => {},
+      removeAttr: () => {},
+    });
+  }
+
+  /**
+   * @param {!MDCTextFieldHelperTextAdapter=} adapter
+   */
+  constructor(adapter = /** @type {!MDCTextFieldHelperTextAdapter} */ ({})) {
+    super(Object.assign(MDCTextFieldHelperTextFoundation.defaultAdapter, adapter));
+  }
+
+  /** Makes the helper text visible to screen readers. */
+  show() {
+    this.adapter_.removeAttr(strings.ARIA_HIDDEN);
+  }
+
+  /**
+   * Updates the state of the helper text based on validity.
+   * @param {boolean} isValid
+   */
+  update(isValid) {
+    const helperTextIsPersistent = this.adapter_.hasClass(cssClasses.HELPER_TEXT_PERSISTENT);
+    const helperTextIsValidationMsg = this.adapter_.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG);
+    const validationMsgNeedsDisplay = helperTextIsValidationMsg && !isValid;
+
+    if (validationMsgNeedsDisplay) {
+      this.adapter_.setAttr(strings.ROLE, 'alert');
+    } else {
+      this.adapter_.removeAttr(strings.ROLE);
+    }
+
+    if (helperTextIsPersistent || validationMsgNeedsDisplay) {
+      return;
+    }
+    this.hide_();
+  }
+
+  /**
+   * Hides the help text from screen readers.
+   * @private
+   */
+  hide_() {
+    this.adapter_.setAttr(strings.ARIA_HIDDEN, 'true');
+  }
+}
+
+export default MDCTextFieldHelperTextFoundation;

--- a/packages/mdc-textfield/helper-text/index.js
+++ b/packages/mdc-textfield/helper-text/index.js
@@ -49,7 +49,7 @@ class MDCTextFieldHelperText extends MDCComponent {
       removeClass: (className) => this.root_.classList.remove(className),
       hasClass: (className) => this.root_.classList.contains(className),
       setAttr: (attr, value) => this.root_.setAttribute(attr, value),
-      removeAttr: (attr, value) => this.root_.removeAttribute(attr, value)
+      removeAttr: (attr) => this.root_.removeAttribute(attr),
     })));
   }
 }

--- a/packages/mdc-textfield/helper-text/index.js
+++ b/packages/mdc-textfield/helper-text/index.js
@@ -50,6 +50,9 @@ class MDCTextFieldHelperText extends MDCComponent {
       hasClass: (className) => this.root_.classList.contains(className),
       setAttr: (attr, value) => this.root_.setAttribute(attr, value),
       removeAttr: (attr) => this.root_.removeAttribute(attr),
+      setContent: (content) => {
+        this.root_.textContent = content;
+      },
     })));
   }
 }

--- a/packages/mdc-textfield/helper-text/index.js
+++ b/packages/mdc-textfield/helper-text/index.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from '@material/base/component';
+
+import MDCTextFieldHelperTextAdapter from './adapter';
+import MDCTextFieldHelperTextFoundation from './foundation';
+
+/**
+ * @extends {MDCComponent<!MDCTextFieldHelperTextFoundation>}
+ * @final
+ */
+class MDCTextFieldHelperText extends MDCComponent {
+  /**
+   * @param {!Element} root
+   * @return {!MDCTextFieldHelperText}
+   */
+  static attachTo(root) {
+    return new MDCTextFieldHelperText(root);
+  }
+
+  /**
+   * @return {MDCTextFieldHelperTextFoundation}
+   */
+  get foundation() {
+    return this.foundation_;
+  }
+
+  /**
+   * @return {!MDCTextFieldHelperTextFoundation}
+   */
+  getDefaultFoundation() {
+    return new MDCTextFieldHelperTextFoundation(/** @type {!MDCTextFieldHelperTextAdapter} */ (Object.assign({
+      addClass: (className) => this.root_.classList.add(className),
+      removeClass: (className) => this.root_.classList.remove(className),
+      hasClass: (className) => this.root_.classList.contains(className),
+      setAttr: (attr, value) => this.root_.setAttribute(attr, value),
+      removeAttr: (attr, value) => this.root_.removeAttribute(attr, value)
+    })));
+  }
+}
+
+export {MDCTextFieldHelperText, MDCTextFieldHelperTextFoundation};

--- a/packages/mdc-textfield/helper-text/mdc-text-field-helper-text.scss
+++ b/packages/mdc-textfield/helper-text/mdc-text-field-helper-text.scss
@@ -1,0 +1,49 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@import "../functions";
+@import "@material/theme/mixins";
+
+// postcss-bem-linter: define text-field-helper-text
+
+.mdc-text-field-helper-text {
+  @include mdc-theme-prop(color, text-hint-on-light);
+
+  margin: 0;
+  transition: mdc-text-field-transition(opacity);
+  opacity: 0;
+  font-size: .75rem;
+  will-change: opacity;
+
+  @include mdc-theme-dark {
+    @include mdc-theme-prop(color, text-hint-on-dark);
+  }
+
+  // stylelint-disable plugin/selector-bem-pattern
+  .mdc-text-field + & {
+    margin-bottom: 8px;
+  }
+
+  // stylelint-enable plugin/selector-bem-pattern
+}
+
+.mdc-text-field-helper-text--persistent {
+  transition: none;
+  opacity: 1;
+  will-change: initial;
+}
+
+// postcss-bem-linter: end

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -22,6 +22,7 @@ import {cssClasses, strings} from './constants';
 import {MDCTextFieldAdapter} from './adapter';
 import MDCTextFieldFoundation from './foundation';
 import {MDCTextFieldBottomLine} from './bottom-line';
+import {MDCTextFieldHelperText} from './helper-text';
 
 /**
  * @extends {MDCComponent<!MDCTextFieldFoundation>}
@@ -37,12 +38,12 @@ class MDCTextField extends MDCComponent {
     this.input_;
     /** @private {?Element} */
     this.label_;
-    /** @type {?Element} */
-    this.helperTextElement;
     /** @type {?MDCRipple} */
     this.ripple;
     /** @private {?MDCTextFieldBottomLine} */
     this.bottomLine_;
+    /** @private {?MDCTextFieldHelperText} */
+    this.helperText_;
     /** @private {?Element} */
     this.icon_;
   }
@@ -63,13 +64,16 @@ class MDCTextField extends MDCComponent {
    */
   initialize(
     rippleFactory = (el) => new MDCRipple(el),
-    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el)) {
+    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el),
+    helperTextFactory = (el) => new MDCTextFieldHelperText(el)) {
     this.input_ = this.root_.querySelector(strings.INPUT_SELECTOR);
     this.label_ = this.root_.querySelector(strings.LABEL_SELECTOR);
-    this.helperTextElement = null;
     this.ripple = null;
     if (this.input_.hasAttribute('aria-controls')) {
-      this.helperTextElement = document.getElementById(this.input_.getAttribute('aria-controls'));
+      const helperTextElement = document.getElementById(this.input_.getAttribute(strings.ARIA_CONTROLS));
+      if (helperTextElement) {
+        this.helperText_ = helperTextFactory(helperTextElement);
+      }
     }
     if (this.root_.classList.contains(cssClasses.BOX)) {
       this.ripple = rippleFactory(this.root_);
@@ -91,6 +95,9 @@ class MDCTextField extends MDCComponent {
     }
     if (this.bottomLine_) {
       this.bottomLine_.destroy();
+    }
+    if (this.helperText_) {
+      this.helperText_.destroy();
     }
     super.destroy();
   }
@@ -163,6 +170,12 @@ class MDCTextField extends MDCComponent {
         }
         return undefined;
       },
+      getHelperTextFoundation: () => {
+        if (this.helperText_) {
+          return this.helperText_.foundation;
+        }
+        return undefined;
+      }
     },
     this.getInputAdapterMethods_(),
     this.getHelperTextAdapterMethods_(),

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -61,6 +61,8 @@ class MDCTextField extends MDCComponent {
    * creates a new MDCRipple.
    * @param {(function(!Element): !MDCTextFieldBottomLine)=} bottomLineFactory A function which
    * creates a new MDCTextFieldBottomLine.
+   * @param {(function(!Element): !MDCTextFieldHelperText)=} helperTextFactory A function which
+   * creates a new MDCTextFieldHelperText.
    */
   initialize(
     rippleFactory = (el) => new MDCRipple(el),
@@ -69,12 +71,6 @@ class MDCTextField extends MDCComponent {
     this.input_ = this.root_.querySelector(strings.INPUT_SELECTOR);
     this.label_ = this.root_.querySelector(strings.LABEL_SELECTOR);
     this.ripple = null;
-    if (this.input_.hasAttribute(strings.ARIA_CONTROLS)) {
-      const helperTextElement = document.getElementById(this.input_.getAttribute(strings.ARIA_CONTROLS));
-      if (helperTextElement) {
-        this.helperText_ = helperTextFactory(helperTextElement);
-      }
-    }
     if (this.root_.classList.contains(cssClasses.BOX)) {
       this.ripple = rippleFactory(this.root_);
     };
@@ -84,6 +80,12 @@ class MDCTextField extends MDCComponent {
         this.bottomLine_ = bottomLineFactory(bottomLineElement);
       }
     };
+    if (this.input_.hasAttribute(strings.ARIA_CONTROLS)) {
+      const helperTextElement = document.getElementById(this.input_.getAttribute(strings.ARIA_CONTROLS));
+      if (helperTextElement) {
+        this.helperText_ = helperTextFactory(helperTextElement);
+      }
+    }
     if (!this.root_.classList.contains(cssClasses.TEXT_FIELD_ICON)) {
       this.icon_ = this.root_.querySelector(strings.ICON_SELECTOR);
     };

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -175,10 +175,9 @@ class MDCTextField extends MDCComponent {
           return this.helperText_.foundation;
         }
         return undefined;
-      }
+      },
     },
     this.getInputAdapterMethods_(),
-    this.getHelperTextAdapterMethods_(),
     this.getIconAdapterMethods_())));
   }
 
@@ -209,46 +208,6 @@ class MDCTextField extends MDCComponent {
       registerInputInteractionHandler: (evtType, handler) => this.input_.addEventListener(evtType, handler),
       deregisterInputInteractionHandler: (evtType, handler) => this.input_.removeEventListener(evtType, handler),
       getNativeInput: () => this.input_,
-    };
-  }
-
-  /**
-   * @return {!{
-   *   addClassToHelperText: function(string): undefined,
-   *   removeClassFromHelperText: function(string): undefined,
-   *   helperTextHasClass: function(string): boolean,
-   *   setHelperTextAttr: function(string, string): undefined,
-   *   removeHelperTextAttr: function(string): undefined,
-   * }}
-   */
-  getHelperTextAdapterMethods_() {
-    return {
-      addClassToHelperText: (className) => {
-        if (this.helperTextElement) {
-          this.helperTextElement.classList.add(className);
-        }
-      },
-      removeClassFromHelperText: (className) => {
-        if (this.helperTextElement) {
-          this.helperTextElement.classList.remove(className);
-        }
-      },
-      helperTextHasClass: (className) => {
-        if (!this.helperTextElement) {
-          return false;
-        }
-        return this.helperTextElement.classList.contains(className);
-      },
-      setHelperTextAttr: (name, value) => {
-        if (this.helperTextElement) {
-          this.helperTextElement.setAttribute(name, value);
-        }
-      },
-      removeHelperTextAttr: (name) => {
-        if (this.helperTextElement) {
-          this.helperTextElement.removeAttribute(name);
-        }
-      },
     };
   }
 }

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -61,13 +61,10 @@ class MDCTextField extends MDCComponent {
    * creates a new MDCRipple.
    * @param {(function(!Element): !MDCTextFieldBottomLine)=} bottomLineFactory A function which
    * creates a new MDCTextFieldBottomLine.
-   * @param {(function(!Element): !MDCTextFieldHelperText)=} helperTextFactory A function which
-   * creates a new MDCTextFieldHelperText.
    */
   initialize(
     rippleFactory = (el) => new MDCRipple(el),
-    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el),
-    helperTextFactory = (el) => new MDCTextFieldHelperText(el)) {
+    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el)) {
     this.input_ = this.root_.querySelector(strings.INPUT_SELECTOR);
     this.label_ = this.root_.querySelector(strings.LABEL_SELECTOR);
     this.ripple = null;
@@ -83,7 +80,7 @@ class MDCTextField extends MDCComponent {
     if (this.input_.hasAttribute(strings.ARIA_CONTROLS)) {
       const helperTextElement = document.getElementById(this.input_.getAttribute(strings.ARIA_CONTROLS));
       if (helperTextElement) {
-        this.helperText_ = helperTextFactory(helperTextElement);
+        this.helperText_ = new MDCTextFieldHelperText(helperTextElement);
       }
     }
     if (!this.root_.classList.contains(cssClasses.TEXT_FIELD_ICON)) {

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -69,7 +69,7 @@ class MDCTextField extends MDCComponent {
     this.input_ = this.root_.querySelector(strings.INPUT_SELECTOR);
     this.label_ = this.root_.querySelector(strings.LABEL_SELECTOR);
     this.ripple = null;
-    if (this.input_.hasAttribute('aria-controls')) {
+    if (this.input_.hasAttribute(strings.ARIA_CONTROLS)) {
       const helperTextElement = document.getElementById(this.input_.getAttribute(strings.ARIA_CONTROLS));
       if (helperTextElement) {
         this.helperText_ = helperTextFactory(helperTextElement);

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -131,7 +131,8 @@ class MDCTextField extends MDCComponent {
   }
 
   /**
-   * @param {string} content Sets the Helper Text element textContent.
+   * Sets the helper text element content.
+   * @param {string} content
    */
   set helperTextContent(content) {
     this.foundation_.setHelperTextContent(content);

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -26,11 +26,11 @@
 @import "@material/typography/variables";
 @import "./bottom-line/mdc-text-field-bottom-line";
 @import "./helper-text/mdc-text-field-helper-text";
-
 @include mdc-text-field-invalid-label-shake_keyframes_(standard, 100%);
 @include mdc-text-field-invalid-label-shake_keyframes_(box, 50%);
 
 // postcss-bem-linter: define text-field
+
 .mdc-text-field {
   display: inline-block;
   position: relative;
@@ -619,6 +619,7 @@
 // postcss-bem-linter: define text-field-helper-text
 
 .mdc-text-field-helper-text {
+  // stylelint-disable plugin/selector-bem-pattern
   .mdc-text-field--dense + & {
     margin-bottom: 4px;
   }

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -25,6 +25,8 @@
 @import "@material/typography/mixins";
 @import "@material/typography/variables";
 @import "./bottom-line/mdc-text-field-bottom-line";
+@import "./helper-text/mdc-text-field-helper-text";
+
 @include mdc-text-field-invalid-label-shake_keyframes_(standard, 100%);
 @include mdc-text-field-invalid-label-shake_keyframes_(box, 50%);
 
@@ -617,23 +619,6 @@
 // postcss-bem-linter: define text-field-helper-text
 
 .mdc-text-field-helper-text {
-  @include mdc-theme-prop(color, text-hint-on-light);
-
-  margin: 0;
-  transition: mdc-text-field-transition(opacity);
-  opacity: 0;
-  font-size: .75rem;
-  will-change: opacity;
-
-  @include mdc-theme-dark {
-    @include mdc-theme-prop(color, text-hint-on-dark);
-  }
-
-  // stylelint-disable plugin/selector-bem-pattern
-  .mdc-text-field + & {
-    margin-bottom: 8px;
-  }
-
   .mdc-text-field--dense + & {
     margin-bottom: 4px;
   }
@@ -648,12 +633,6 @@
   }
 
   // stylelint-enable plugin/selector-bem-pattern
-}
-
-.mdc-text-field-helper-text--persistent {
-  transition: none;
-  opacity: 1;
-  will-change: initial;
 }
 
 // postcss-bem-linter: end

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -244,10 +244,10 @@ test('on focus adds mdc-text-field__label--float-above class', () => {
   td.verify(mockAdapter.addClassToLabel(cssClasses.LABEL_FLOAT_ABOVE));
 });
 
-test('on focus shows helperText', () => {
+test('on focus makes helper text visible to the screen reader', () => {
   const {foundation, mockAdapter} = setupTest();
   const helperText = td.object({
-    show: () => {},
+    showToScreenReader: () => {},
   });
   td.when(mockAdapter.getHelperTextFoundation()).thenReturn(helperText);
   let focus;
@@ -257,7 +257,7 @@ test('on focus shows helperText', () => {
     });
   foundation.init();
   focus();
-  td.verify(helperText.show());
+  td.verify(helperText.showToScreenReader());
 });
 
 const setupBlurTest = () => {
@@ -327,17 +327,17 @@ test('on blur does not add mdc-textfied--invalid if custom validity is true and'
   td.verify(mockAdapter.addClass(cssClasses.INVALID), {times: 0});
 });
 
-test('on blur updates helper text', () => {
+test('on blur set validity of helper text', () => {
   const {mockAdapter, blur, nativeInput} = setupBlurTest();
   const helperText = td.object({
-    update: () => {},
+    setValidity: () => {},
     hasClass: () => {},
   });
   td.when(mockAdapter.getHelperTextFoundation()).thenReturn(helperText);
   nativeInput.checkValidity = () => false;
   td.when(helperText.hasClass('mdc-text-field-helper-text--validation-msg')).thenReturn(true);
   blur();
-  td.verify(helperText.update(false));
+  td.verify(helperText.setValidity(false));
 });
 
 test('on blur handles getNativeInput() not returning anything gracefully', () => {

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -182,8 +182,12 @@ test('#init does not add mdc-text-field__label--float-above class if the input d
 
 test('#setHelperTextContent sets the content of the helper text element', () => {
   const {foundation, mockAdapter} = setupTest();
+  const helperText = td.object({
+    setContent: () => {},
+  });
+  td.when(mockAdapter.getHelperTextFoundation()).thenReturn(helperText);
   foundation.setHelperTextContent('foo');
-  td.verify(mockAdapter.setHelperTextContent('foo'));
+  td.verify(mockAdapter.getHelperTextFoundation().setContent('foo'));
 });
 
 test('on input focuses if input event occurs without any other events', () => {

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -39,10 +39,9 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'addClass', 'removeClass', 'addClassToLabel', 'removeClassFromLabel',
     'setIconAttr', 'eventTargetHasClass', 'registerTextFieldInteractionHandler',
     'deregisterTextFieldInteractionHandler', 'notifyIconAction',
-    'addClassToHelperText', 'removeClassFromHelperText', 'helperTextHasClass',
     'registerInputInteractionHandler', 'deregisterInputInteractionHandler',
     'registerBottomLineEventHandler', 'deregisterBottomLineEventHandler',
-    'setHelperTextAttr', 'removeHelperTextAttr', 'getNativeInput', 'getBottomLineFoundation',
+    'getNativeInput', 'getBottomLineFoundation', 'getHelperTextFoundation',
   ]);
 });
 
@@ -245,8 +244,12 @@ test('on focus adds mdc-text-field__label--float-above class', () => {
   td.verify(mockAdapter.addClassToLabel(cssClasses.LABEL_FLOAT_ABOVE));
 });
 
-test('on focus removes aria-hidden from helperText', () => {
+test('on focus shows helperText', () => {
   const {foundation, mockAdapter} = setupTest();
+  const helperText = td.object({
+    show: () => {},
+  });
+  td.when(mockAdapter.getHelperTextFoundation()).thenReturn(helperText);
   let focus;
   td.when(mockAdapter.registerInputInteractionHandler('focus', td.matchers.isA(Function)))
     .thenDo((evtType, handler) => {
@@ -254,7 +257,7 @@ test('on focus removes aria-hidden from helperText', () => {
     });
   foundation.init();
   focus();
-  td.verify(mockAdapter.removeHelperTextAttr('aria-hidden'));
+  td.verify(helperText.show());
 });
 
 const setupBlurTest = () => {
@@ -324,47 +327,17 @@ test('on blur does not add mdc-textfied--invalid if custom validity is true and'
   td.verify(mockAdapter.addClass(cssClasses.INVALID), {times: 0});
 });
 
-test('on blur adds role="alert" to helper text if input is invalid and helper text is being used ' +
-     'as a validation message', () => {
+test('on blur updates helper text', () => {
   const {mockAdapter, blur, nativeInput} = setupBlurTest();
+  const helperText = td.object({
+    update: () => {},
+    hasClass: () => {},
+  });
+  td.when(mockAdapter.getHelperTextFoundation()).thenReturn(helperText);
   nativeInput.checkValidity = () => false;
-  td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+  td.when(helperText.hasClass('mdc-text-field-helper-text--validation-msg')).thenReturn(true);
   blur();
-  td.verify(mockAdapter.setHelperTextAttr('role', 'alert'));
-});
-
-test('on blur remove role="alert" if input is valid', () => {
-  const {mockAdapter, blur} = setupBlurTest();
-  blur();
-  td.verify(mockAdapter.removeHelperTextAttr('role'));
-});
-
-test('on blur sets aria-hidden="true" on helper text by default', () => {
-  const {mockAdapter, blur} = setupBlurTest();
-  blur();
-  td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'));
-});
-
-test('on blur does not set aria-hidden on helper text when it is persistent', () => {
-  const {mockAdapter, blur} = setupBlurTest();
-  td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(true);
-  blur();
-  td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'), {times: 0});
-});
-
-test('on blur does not set aria-hidden if input is invalid and helper text is validation message', () => {
-  const {mockAdapter, blur, nativeInput} = setupBlurTest();
-  td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-  nativeInput.checkValidity = () => false;
-  blur();
-  td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'), {times: 0});
-});
-
-test('on blur sets aria-hidden=true if input is valid and helper text is validation message', () => {
-  const {mockAdapter, blur} = setupBlurTest();
-  td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-  blur();
-  td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'));
+  td.verify(helperText.update(false));
 });
 
 test('on blur handles getNativeInput() not returning anything gracefully', () => {

--- a/test/unit/mdc-textfield/mdc-text-field-bottom-line-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-bottom-line-foundation.test.js
@@ -53,7 +53,6 @@ test('#init adds event listeners', () => {
 test('#destroy removes event listeners', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.destroy();
-
   td.verify(mockAdapter.deregisterEventHandler('transitionend', td.matchers.isA(Function)));
 });
 

--- a/test/unit/mdc-textfield/mdc-text-field-bottom-line-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-bottom-line-foundation.test.js
@@ -53,6 +53,7 @@ test('#init adds event listeners', () => {
 test('#destroy removes event listeners', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.destroy();
+
   td.verify(mockAdapter.deregisterEventHandler('transitionend', td.matchers.isA(Function)));
 });
 

--- a/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
@@ -1,0 +1,54 @@
+// test('on focus removes aria-hidden from helperText', () => {
+//   const {foundation, mockAdapter} = setupTest();
+//   let focus;
+//   td.when(mockAdapter.registerInputInteractionHandler('focus', td.matchers.isA(Function)))
+//     .thenDo((evtType, handler) => {
+//       focus = handler;
+//     });
+//   foundation.init();
+//   focus();
+//   td.verify(mockAdapter.removeHelperTextAttr('aria-hidden'));
+// });
+
+// test('on blur adds role="alert" to helper text if input is invalid and helper text is being used ' +
+//      'as a validation message', () => {
+//   const {mockAdapter, blur, nativeInput} = setupBlurTest();
+//   nativeInput.checkValidity = () => false;
+//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+//   blur();
+//   td.verify(mockAdapter.setHelperTextAttr('role', 'alert'));
+// });
+
+// test('on blur remove role="alert" if input is valid', () => {
+//   const {mockAdapter, blur} = setupBlurTest();
+//   blur();
+//   td.verify(mockAdapter.removeHelperTextAttr('role'));
+// });
+
+// test('on blur sets aria-hidden="true" on helper text by default', () => {
+//   const {mockAdapter, blur} = setupBlurTest();
+//   blur();
+//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'));
+// });
+
+// test('on blur does not set aria-hidden on helper text when it is persistent', () => {
+//   const {mockAdapter, blur} = setupBlurTest();
+//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(true);
+//   blur();
+//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'), {times: 0});
+// });
+
+// test('on blur does not set aria-hidden if input is invalid and helper text is validation message', () => {
+//   const {mockAdapter, blur, nativeInput} = setupBlurTest();
+//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+//   nativeInput.checkValidity = () => false;
+//   blur();
+//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'), {times: 0});
+// });
+
+// test('on blur sets aria-hidden=true if input is valid and helper text is validation message', () => {
+//   const {mockAdapter, blur} = setupBlurTest();
+//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+//   blur();
+//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'));
+// });

--- a/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
@@ -1,54 +1,103 @@
-// test('on focus removes aria-hidden from helperText', () => {
-//   const {foundation, mockAdapter} = setupTest();
-//   let focus;
-//   td.when(mockAdapter.registerInputInteractionHandler('focus', td.matchers.isA(Function)))
-//     .thenDo((evtType, handler) => {
-//       focus = handler;
-//     });
-//   foundation.init();
-//   focus();
-//   td.verify(mockAdapter.removeHelperTextAttr('aria-hidden'));
-// });
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-// test('on blur adds role="alert" to helper text if input is invalid and helper text is being used ' +
-//      'as a validation message', () => {
-//   const {mockAdapter, blur, nativeInput} = setupBlurTest();
-//   nativeInput.checkValidity = () => false;
-//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-//   blur();
-//   td.verify(mockAdapter.setHelperTextAttr('role', 'alert'));
-// });
+import {assert} from 'chai';
+import td from 'testdouble';
 
-// test('on blur remove role="alert" if input is valid', () => {
-//   const {mockAdapter, blur} = setupBlurTest();
-//   blur();
-//   td.verify(mockAdapter.removeHelperTextAttr('role'));
-// });
+import {verifyDefaultAdapter} from '../helpers/foundation';
+import {setupFoundationTest} from '../helpers/setup';
+import MDCTextFieldHelperTextFoundation from '../../../packages/mdc-textfield/helper-text/foundation';
 
-// test('on blur sets aria-hidden="true" on helper text by default', () => {
-//   const {mockAdapter, blur} = setupBlurTest();
-//   blur();
-//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'));
-// });
+const {cssClasses} = MDCTextFieldHelperTextFoundation;
 
-// test('on blur does not set aria-hidden on helper text when it is persistent', () => {
-//   const {mockAdapter, blur} = setupBlurTest();
-//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(true);
-//   blur();
-//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'), {times: 0});
-// });
+suite('MDCTextFieldHelperTextFoundation');
 
-// test('on blur does not set aria-hidden if input is invalid and helper text is validation message', () => {
-//   const {mockAdapter, blur, nativeInput} = setupBlurTest();
-//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-//   nativeInput.checkValidity = () => false;
-//   blur();
-//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'), {times: 0});
-// });
+test('exports cssClasses', () => {
+  assert.isOk('cssClasses' in MDCTextFieldHelperTextFoundation);
+});
 
-// test('on blur sets aria-hidden=true if input is valid and helper text is validation message', () => {
-//   const {mockAdapter, blur} = setupBlurTest();
-//   td.when(mockAdapter.helperTextHasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-//   blur();
-//   td.verify(mockAdapter.setHelperTextAttr('aria-hidden', 'true'));
-// });
+test('exports strings', () => {
+  assert.isOk('strings' in MDCTextFieldHelperTextFoundation);
+});
+
+test('defaultAdapter returns a complete adapter implementation', () => {
+  verifyDefaultAdapter(MDCTextFieldHelperTextFoundation, [
+    'addClass', 'removeClass', 'hasClass', 'setAttr', 'removeAttr',
+  ]);
+});
+
+const setupTest = () => setupFoundationTest(MDCTextFieldHelperTextFoundation);
+
+test('#show removes aria-hidden from helperText', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.show();
+  td.verify(mockAdapter.removeAttr('aria-hidden'));
+});
+
+test('#update adds role="alert" to helper text if input is invalid and helper text is being used ' +
+     'as a validation message', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const inputIsValid = false;
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+  foundation.update(inputIsValid);
+  td.verify(mockAdapter.setAttr('role', 'alert'));
+});
+
+test('#update removes role="alert" if input is valid', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const inputIsValid = true;
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+  foundation.update(inputIsValid);
+  td.verify(mockAdapter.removeAttr('role'));
+});
+
+test('#update sets aria-hidden="true" on helper text by default', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const inputIsValid = true;
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(false);
+  foundation.update(inputIsValid);
+  td.verify(mockAdapter.setAttr('aria-hidden', 'true'));
+});
+
+test('#update does not set aria-hidden on helper text when it is persistent', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const inputIsValid = true;
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(true);
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(false);
+  foundation.update(inputIsValid);
+  td.verify(mockAdapter.setAttr('aria-hidden', 'true'), {times: 0});
+});
+
+test('#update does not set aria-hidden if input is invalid and helper text is validation message', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const inputIsValid = false;
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+  foundation.update(inputIsValid);
+  td.verify(mockAdapter.setAttr('aria-hidden', 'true'), {times: 0});
+});
+
+test('#update sets aria-hidden=true if input is valid and helper text is validation message', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const inputIsValid = true;
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
+  td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
+  foundation.update(inputIsValid);
+  td.verify(mockAdapter.setAttr('aria-hidden', 'true'));
+});

--- a/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
@@ -41,63 +41,63 @@ test('defaultAdapter returns a complete adapter implementation', () => {
 
 const setupTest = () => setupFoundationTest(MDCTextFieldHelperTextFoundation);
 
-test('#show removes aria-hidden from helperText', () => {
+test('#showToScreenReader removes aria-hidden from helperText', () => {
   const {foundation, mockAdapter} = setupTest();
-  foundation.show();
+  foundation.showToScreenReader();
   td.verify(mockAdapter.removeAttr('aria-hidden'));
 });
 
-test('#update adds role="alert" to helper text if input is invalid and helper text is being used ' +
+test('#setValidity adds role="alert" to helper text if input is invalid and helper text is being used ' +
      'as a validation message', () => {
   const {foundation, mockAdapter} = setupTest();
   const inputIsValid = false;
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-  foundation.update(inputIsValid);
+  foundation.setValidity(inputIsValid);
   td.verify(mockAdapter.setAttr('role', 'alert'));
 });
 
-test('#update removes role="alert" if input is valid', () => {
+test('#setValidity removes role="alert" if input is valid', () => {
   const {foundation, mockAdapter} = setupTest();
   const inputIsValid = true;
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-  foundation.update(inputIsValid);
+  foundation.setValidity(inputIsValid);
   td.verify(mockAdapter.removeAttr('role'));
 });
 
-test('#update sets aria-hidden="true" on helper text by default', () => {
+test('#setValidity sets aria-hidden="true" on helper text by default', () => {
   const {foundation, mockAdapter} = setupTest();
   const inputIsValid = true;
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(false);
-  foundation.update(inputIsValid);
+  foundation.setValidity(inputIsValid);
   td.verify(mockAdapter.setAttr('aria-hidden', 'true'));
 });
 
-test('#update does not set aria-hidden on helper text when it is persistent', () => {
+test('#setValidity does not set aria-hidden on helper text when it is persistent', () => {
   const {foundation, mockAdapter} = setupTest();
   const inputIsValid = true;
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(true);
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(false);
-  foundation.update(inputIsValid);
+  foundation.setValidity(inputIsValid);
   td.verify(mockAdapter.setAttr('aria-hidden', 'true'), {times: 0});
 });
 
-test('#update does not set aria-hidden if input is invalid and helper text is validation message', () => {
+test('#setValidity does not set aria-hidden if input is invalid and helper text is validation message', () => {
   const {foundation, mockAdapter} = setupTest();
   const inputIsValid = false;
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-  foundation.update(inputIsValid);
+  foundation.setValidity(inputIsValid);
   td.verify(mockAdapter.setAttr('aria-hidden', 'true'), {times: 0});
 });
 
-test('#update sets aria-hidden=true if input is valid and helper text is validation message', () => {
+test('#setValidity sets aria-hidden=true if input is valid and helper text is validation message', () => {
   const {foundation, mockAdapter} = setupTest();
   const inputIsValid = true;
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_PERSISTENT)).thenReturn(false);
   td.when(mockAdapter.hasClass(cssClasses.HELPER_TEXT_VALIDATION_MSG)).thenReturn(true);
-  foundation.update(inputIsValid);
+  foundation.setValidity(inputIsValid);
   td.verify(mockAdapter.setAttr('aria-hidden', 'true'));
 });

--- a/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-helper-text-foundation.test.js
@@ -35,11 +35,17 @@ test('exports strings', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTextFieldHelperTextFoundation, [
-    'addClass', 'removeClass', 'hasClass', 'setAttr', 'removeAttr',
+    'addClass', 'removeClass', 'hasClass', 'setAttr', 'removeAttr', 'setContent',
   ]);
 });
 
 const setupTest = () => setupFoundationTest(MDCTextFieldHelperTextFoundation);
+
+test('#setContent sets the content of the helper text element', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setContent('foo');
+  td.verify(mockAdapter.setContent('foo'));
+});
 
 test('#showToScreenReader removes aria-hidden from helperText', () => {
   const {foundation, mockAdapter} = setupTest();

--- a/test/unit/mdc-textfield/mdc-text-field-helper-text.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-helper-text.test.js
@@ -68,3 +68,9 @@ test('#adapter.removeAttr removes a given attribute from the element', () => {
   component.getDefaultFoundation().adapter_.removeAttr('aria-label', 'foo');
   assert.isNotOk(root.hasAttribute('aria-label'));
 });
+
+test('#adapter.setContent sets the text content of the element', () => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setContent('foo');
+  assert.equal(root.textContent, 'foo');
+});

--- a/test/unit/mdc-textfield/mdc-text-field-helper-text.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-helper-text.test.js
@@ -1,0 +1,69 @@
+
+
+// test('#adapter.addClassToHelperText does nothing if no helper text element present', () => {
+//   const {component} = setupTest();
+//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.addClassToHelperText('foo'));
+// });
+
+// test('#adapter.addClassToHelperText adds a class to the helper text element when present', () => {
+//   const {component} = setupTest();
+//   component.helperTextElement = getHelperText();
+//   component.getDefaultFoundation().adapter_.addClassToHelperText('foo');
+//   assert.isOk(component.helperTextElement.classList.contains('foo'));
+// });
+
+// test('#adapter.removeClassFromHelperText does nothing if no helper text element present', () => {
+//   const {component} = setupTest();
+//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeClassFromHelperText('foo'));
+// });
+
+// test('#adapter.removeClassFromHelperText removes a class from the helper text element when present', () => {
+//   const {component} = setupTest();
+//   const helperText = getHelperText();
+//   component.helperTextElement = helperText;
+//   helperText.classList.add('foo');
+//   component.getDefaultFoundation().adapter_.removeClassFromHelperText('foo');
+//   assert.isNotOk(helperText.classList.contains('foo'));
+// });
+
+// test('#adapter.helperTextHasClass does nothing if no helper text element present', () => {
+//   const {component} = setupTest();
+//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
+// });
+
+// test('#adapter.helperTextHasClass returns whether or not the helper text contains a certain class', () => {
+//   const {component} = setupTest();
+//   const helperText = getHelperText();
+//   component.helperTextElement = helperText;
+//   helperText.classList.add('foo');
+//   assert.isOk(component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
+//   helperText.classList.remove('foo');
+//   assert.isNotOk(component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
+// });
+
+// test('#adapter.setHelperTextAttr does nothing if no helper text element present', () => {
+//   const {component} = setupTest();
+//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
+// });
+
+// test('#adapter.setHelperTextAttr sets an attribute to a certain value on the helper text element', () => {
+//   const {component} = setupTest();
+//   const helperText = getHelperText();
+//   component.helperTextElement = helperText;
+//   component.getDefaultFoundation().adapter_.setHelperTextAttr('aria-label', 'foo');
+//   assert.equal(helperText.getAttribute('aria-label'), 'foo');
+// });
+
+// test('#adapter.removeHelperTextAttr does nothing if no helper text element present', () => {
+//   const {component} = setupTest();
+//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeHelperTextAttr('aria-label'));
+// });
+
+// test('#adapter.removeHelperTextAttr removes an attribute on the helper text element', () => {
+//   const {component} = setupTest();
+//   const helperText = getHelperText();
+//   helperText.setAttribute('aria-label', 'foo');
+//   component.helperTextElement = helperText;
+//   component.getDefaultFoundation().adapter_.removeHelperTextAttr('aria-label');
+//   assert.isNotOk(helperText.hasAttribute('aria-label'));
+// });

--- a/test/unit/mdc-textfield/mdc-text-field-helper-text.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-helper-text.test.js
@@ -1,69 +1,70 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+import bel from 'bel';
+import {assert} from 'chai';
 
-// test('#adapter.addClassToHelperText does nothing if no helper text element present', () => {
-//   const {component} = setupTest();
-//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.addClassToHelperText('foo'));
-// });
+import {MDCTextFieldHelperText} from '../../../packages/mdc-textfield/helper-text';
 
-// test('#adapter.addClassToHelperText adds a class to the helper text element when present', () => {
-//   const {component} = setupTest();
-//   component.helperTextElement = getHelperText();
-//   component.getDefaultFoundation().adapter_.addClassToHelperText('foo');
-//   assert.isOk(component.helperTextElement.classList.contains('foo'));
-// });
+const getFixture = () => bel`
+  <div class="mdc-textfield__helper-text"></div>
+`;
 
-// test('#adapter.removeClassFromHelperText does nothing if no helper text element present', () => {
-//   const {component} = setupTest();
-//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeClassFromHelperText('foo'));
-// });
+suite('MDCTextFieldHelperText');
 
-// test('#adapter.removeClassFromHelperText removes a class from the helper text element when present', () => {
-//   const {component} = setupTest();
-//   const helperText = getHelperText();
-//   component.helperTextElement = helperText;
-//   helperText.classList.add('foo');
-//   component.getDefaultFoundation().adapter_.removeClassFromHelperText('foo');
-//   assert.isNotOk(helperText.classList.contains('foo'));
-// });
+test('attachTo returns an MDCTextFieldHelperText instance', () => {
+  assert.isOk(MDCTextFieldHelperText.attachTo(getFixture()) instanceof MDCTextFieldHelperText);
+});
 
-// test('#adapter.helperTextHasClass does nothing if no helper text element present', () => {
-//   const {component} = setupTest();
-//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-// });
+function setupTest() {
+  const root = getFixture();
+  const component = new MDCTextFieldHelperText(root);
+  return {root, component};
+}
 
-// test('#adapter.helperTextHasClass returns whether or not the helper text contains a certain class', () => {
-//   const {component} = setupTest();
-//   const helperText = getHelperText();
-//   component.helperTextElement = helperText;
-//   helperText.classList.add('foo');
-//   assert.isOk(component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-//   helperText.classList.remove('foo');
-//   assert.isNotOk(component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-// });
+test('#adapter.addClass adds a class to the element', () => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.addClass('foo');
+  assert.isTrue(root.classList.contains('foo'));
+});
 
-// test('#adapter.setHelperTextAttr does nothing if no helper text element present', () => {
-//   const {component} = setupTest();
-//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-// });
+test('#adapter.removeClass removes a class from the element', () => {
+  const {root, component} = setupTest();
+  root.classList.add('foo');
+  component.getDefaultFoundation().adapter_.removeClass('foo');
+  assert.isFalse(root.classList.contains('foo'));
+});
 
-// test('#adapter.setHelperTextAttr sets an attribute to a certain value on the helper text element', () => {
-//   const {component} = setupTest();
-//   const helperText = getHelperText();
-//   component.helperTextElement = helperText;
-//   component.getDefaultFoundation().adapter_.setHelperTextAttr('aria-label', 'foo');
-//   assert.equal(helperText.getAttribute('aria-label'), 'foo');
-// });
+test('#adapter.hasClass returns whether or not the element contains a certain class', () => {
+  const {root, component} = setupTest();
+  root.classList.add('foo');
+  assert.isOk(component.getDefaultFoundation().adapter_.hasClass('foo'));
+  root.classList.remove('foo');
+  assert.isNotOk(component.getDefaultFoundation().adapter_.hasClass('foo'));
+});
 
-// test('#adapter.removeHelperTextAttr does nothing if no helper text element present', () => {
-//   const {component} = setupTest();
-//   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeHelperTextAttr('aria-label'));
-// });
+test('#adapter.setAttr adds a given attribute to the element', () => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setAttr('aria-label', 'foo');
+  assert.equal(root.getAttribute('aria-label'), 'foo');
+});
 
-// test('#adapter.removeHelperTextAttr removes an attribute on the helper text element', () => {
-//   const {component} = setupTest();
-//   const helperText = getHelperText();
-//   helperText.setAttribute('aria-label', 'foo');
-//   component.helperTextElement = helperText;
-//   component.getDefaultFoundation().adapter_.removeHelperTextAttr('aria-label');
-//   assert.isNotOk(helperText.hasAttribute('aria-label'));
-// });
+test('#adapter.removeAttr removes a given attribute from the element', () => {
+  const {root, component} = setupTest();
+  root.setAttribute('aria-label', 'foo');
+  component.getDefaultFoundation().adapter_.removeAttr('aria-label', 'foo');
+  assert.isNotOk(root.hasAttribute('aria-label'));
+});

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -55,12 +55,6 @@ class FakeBottomLine {
   }
 }
 
-class FakeHelperText {
-  constructor(root) {
-    this.root = root;
-  }
-}
-
 test('#constructor when given a `mdc-text-field--box` element instantiates a ripple on the root element', () => {
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
@@ -89,17 +83,6 @@ test('#constructor instantiates a helper text on the element with id specified i
   root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
   const helperText = getHelperTextElement();
   document.body.appendChild(helperText);
-  const component = new MDCTextField(root, undefined, undefined, undefined, (el) => new FakeHelperText(el));
-  assert.equal(component.helperText_.root, helperText);
-  document.body.removeChild(helperText);
-});
-
-test('#constructor input aria-controls specified initializes a default helper text when no helper text' +
-     'factory given', () => {
-  const root = getFixture();
-  root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
-  const helperText = getHelperTextElement();
-  document.body.appendChild(helperText);
   const component = new MDCTextField(root);
   assert.instanceOf(component.helperText_, MDCTextFieldHelperText);
   document.body.removeChild(helperText);
@@ -122,9 +105,8 @@ function setupTest() {
   const root = getFixture();
   const icon = root.querySelector('.mdc-text-field__icon');
   const bottomLine = new FakeBottomLine();
-  const helperText = new FakeHelperText();
-  const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el), () => bottomLine, () => helperText);
-  return {root, bottomLine, helperText, icon, component};
+  const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el), () => bottomLine);
+  return {root, bottomLine, icon, component};
 }
 
 test('#initialSyncWithDom sets disabled if input element is not disabled', () => {

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -141,18 +141,21 @@ test('set valid updates the component styles', () => {
 });
 
 test('set helperTextContent updates the helper text element content', () => {
-  const {component} = setupTest();
-  const helptext = getHelperText();
-  component.helperTextElement = helptext;
+  const root = getFixture();
+  root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
+  const helperText = getHelperTextElement();
+  document.body.appendChild(helperText);
+  const component = new MDCTextField(root);
   component.helperTextContent = 'foo';
-  assert.equal(helptext.textContent, 'foo');
+  assert.equal(helperText.textContent, 'foo');
+  document.body.removeChild(helperText);
 });
 
 test('set helperTextContent has no effect when no helper text element is present', () => {
   const {component} = setupTest();
-  assert.isNull(component.helperTextElement);
-  component.helperTextContent = 'foo';
-  assert.isNull(component.helperTextElement);
+  assert.doesNotThrow(() => {
+    component.helperTextContent = 'foo';
+  });
 });
 
 test('#adapter.setIconAttr sets a given attribute to a given value to the icon element', () => {

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -21,6 +21,7 @@ import {assert} from 'chai';
 
 import {MDCRipple} from '../../../packages/mdc-ripple';
 import {MDCTextField, MDCTextFieldFoundation} from '../../../packages/mdc-textfield';
+import {MDCTextFieldHelperText} from '../../../packages/mdc-textfield/helper-text/index';
 
 const {cssClasses, strings} = MDCTextFieldFoundation;
 
@@ -55,9 +56,8 @@ class FakeBottomLine {
 }
 
 class FakeHelperText {
-  constructor() {
-    this.listen = td.func('helperText.listen');
-    this.unlisten = td.func('helperText.unlisten');
+  constructor(root) {
+    this.root = root;
   }
 }
 
@@ -81,17 +81,29 @@ test('#constructor when given a `mdc-text-field--box` element, initializes a def
   assert.instanceOf(component.ripple, MDCRipple);
 });
 
-// const getHelperTextElement = () => bel`<p id="helper-text">helper text</p>`;
+const getHelperTextElement = () => bel`<p id="helper-text">helper text</p>`;
 
-// test('#constructor assigns helperTextElement to the id specified in the input aria-controls if present', () => {
-//   const root = getFixture();
-//   root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
-//   const helperText = getHelperTextElement();
-//   document.body.appendChild(helperText);
-//   const component = new MDCTextField(root);
-//   assert.equal(component.helperTextElement, helperText);
-//   document.body.removeChild(helperText);
-// });
+test('#constructor instantiates a helper text on the element with id specified in the input aria-controls' +
+     'if present', () => {
+  const root = getFixture();
+  root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
+  const helperText = getHelperTextElement();
+  document.body.appendChild(helperText);
+  const component = new MDCTextField(root, undefined, undefined, undefined, (el) => new FakeHelperText(el));
+  assert.equal(component.helperText_.root, helperText);
+  document.body.removeChild(helperText);
+});
+
+test('#constructor input aria-controls specified initializes a default helper text when no helper text' +
+     'factory given', () => {
+  const root = getFixture();
+  root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
+  const helperText = getHelperTextElement();
+  document.body.appendChild(helperText);
+  const component = new MDCTextField(root);
+  assert.instanceOf(component.helperText_, MDCTextFieldHelperText);
+  document.body.removeChild(helperText);
+});
 
 test('#destroy cleans up the ripple if present', () => {
   const root = getFixture();

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -39,18 +39,6 @@ test('attachTo returns an MDCTextField instance', () => {
   assert.isOk(MDCTextField.attachTo(getFixture()) instanceof MDCTextField);
 });
 
-const getHelperText = () => bel`<p id="helper-text">helper text</p>`;
-
-test('#constructor assigns helperTextElement to the id specified in the input aria-controls if present', () => {
-  const root = getFixture();
-  root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
-  const helperText = getHelperText();
-  document.body.appendChild(helperText);
-  const component = new MDCTextField(root);
-  assert.equal(component.helperTextElement, helperText);
-  document.body.removeChild(helperText);
-});
-
 class FakeRipple {
   constructor(root) {
     this.root = root;
@@ -63,6 +51,13 @@ class FakeBottomLine {
   constructor() {
     this.listen = td.func('bottomLine.listen');
     this.unlisten = td.func('bottomLine.unlisten');
+  }
+}
+
+class FakeHelperText {
+  constructor() {
+    this.listen = td.func('helperText.listen');
+    this.unlisten = td.func('helperText.unlisten');
   }
 }
 
@@ -86,6 +81,18 @@ test('#constructor when given a `mdc-text-field--box` element, initializes a def
   assert.instanceOf(component.ripple, MDCRipple);
 });
 
+// const getHelperTextElement = () => bel`<p id="helper-text">helper text</p>`;
+
+// test('#constructor assigns helperTextElement to the id specified in the input aria-controls if present', () => {
+//   const root = getFixture();
+//   root.querySelector('.mdc-text-field__input').setAttribute('aria-controls', 'helper-text');
+//   const helperText = getHelperTextElement();
+//   document.body.appendChild(helperText);
+//   const component = new MDCTextField(root);
+//   assert.equal(component.helperTextElement, helperText);
+//   document.body.removeChild(helperText);
+// });
+
 test('#destroy cleans up the ripple if present', () => {
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
@@ -103,8 +110,9 @@ function setupTest() {
   const root = getFixture();
   const icon = root.querySelector('.mdc-text-field__icon');
   const bottomLine = new FakeBottomLine();
-  const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el), () => bottomLine);
-  return {root, bottomLine, icon, component};
+  const helperText = new FakeHelperText();
+  const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el), () => bottomLine, () => helperText);
+  return {root, bottomLine, helperText, icon, component};
 }
 
 test('#initialSyncWithDom sets disabled if input element is not disabled', () => {
@@ -241,74 +249,6 @@ test('#adapter.getNativeInput returns the component input element', () => {
     component.getDefaultFoundation().adapter_.getNativeInput(),
     root.querySelector('.mdc-text-field__input')
   );
-});
-
-test('#adapter.addClassToHelperText does nothing if no helper text element present', () => {
-  const {component} = setupTest();
-  assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.addClassToHelperText('foo'));
-});
-
-test('#adapter.addClassToHelperText adds a class to the helper text element when present', () => {
-  const {component} = setupTest();
-  component.helperTextElement = getHelperText();
-  component.getDefaultFoundation().adapter_.addClassToHelperText('foo');
-  assert.isOk(component.helperTextElement.classList.contains('foo'));
-});
-
-test('#adapter.removeClassFromHelperText does nothing if no helper text element present', () => {
-  const {component} = setupTest();
-  assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeClassFromHelperText('foo'));
-});
-
-test('#adapter.removeClassFromHelperText removes a class from the helper text element when present', () => {
-  const {component} = setupTest();
-  const helperText = getHelperText();
-  component.helperTextElement = helperText;
-  helperText.classList.add('foo');
-  component.getDefaultFoundation().adapter_.removeClassFromHelperText('foo');
-  assert.isNotOk(helperText.classList.contains('foo'));
-});
-
-test('#adapter.helperTextHasClass does nothing if no helper text element present', () => {
-  const {component} = setupTest();
-  assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-});
-
-test('#adapter.helperTextHasClass returns whether or not the helper text contains a certain class', () => {
-  const {component} = setupTest();
-  const helperText = getHelperText();
-  component.helperTextElement = helperText;
-  helperText.classList.add('foo');
-  assert.isOk(component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-  helperText.classList.remove('foo');
-  assert.isNotOk(component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-});
-
-test('#adapter.setHelperTextAttr does nothing if no helper text element present', () => {
-  const {component} = setupTest();
-  assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.helperTextHasClass('foo'));
-});
-
-test('#adapter.setHelperTextAttr sets an attribute to a certain value on the helper text element', () => {
-  const {component} = setupTest();
-  const helperText = getHelperText();
-  component.helperTextElement = helperText;
-  component.getDefaultFoundation().adapter_.setHelperTextAttr('aria-label', 'foo');
-  assert.equal(helperText.getAttribute('aria-label'), 'foo');
-});
-
-test('#adapter.removeHelperTextAttr does nothing if no helper text element present', () => {
-  const {component} = setupTest();
-  assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeHelperTextAttr('aria-label'));
-});
-
-test('#adapter.removeHelperTextAttr removes an attribute on the helper text element', () => {
-  const {component} = setupTest();
-  const helperText = getHelperText();
-  helperText.setAttribute('aria-label', 'foo');
-  component.helperTextElement = helperText;
-  component.getDefaultFoundation().adapter_.removeHelperTextAttr('aria-label');
-  assert.isNotOk(helperText.hasAttribute('aria-label'));
 });
 
 test(`#adapter.notifyIconAction emits ${strings.ICON_EVENT}`, () => {


### PR DESCRIPTION
This PR splits out helper text logic into another subdirectory, similar to PR#1585 for bottom line. The goal is to increase readability and reduce merge conflicts.