### PR TITLE
chore(drawer): Remove height property from scroll-lock class

### DIFF
--- a/packages/mdc-drawer/temporary/mdc-temporary-drawer.scss
+++ b/packages/mdc-drawer/temporary/mdc-temporary-drawer.scss
@@ -137,6 +137,5 @@
 }
 
 .mdc-drawer-scroll-lock {
-  height: 100vh;
   overflow: hidden;
 }


### PR DESCRIPTION
This property seems unnecessary after testing on our demo pages