### PR TITLE
fix(list): Make bottom padding match top for dense lists

### DIFF
--- a/packages/mdc-list/mdc-list.scss
+++ b/packages/mdc-list/mdc-list.scss
@@ -59,6 +59,7 @@ $mdc-list-side-padding: 16px;
 
 .mdc-list--dense {
   padding-top: 4px;
+  padding-bottom: 4px;
   font-size: .812rem;
 }
 


### PR DESCRIPTION
#1523 made the bottom padding match the top padding in lists, but dense lists already had an override for top padding only. This adds an override for bottom padding to match.