### PR TITLE
docs: Update README.md with MDC-WP framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Material Components for the web is the successor to [Material Design Lite](https
   - [Preact Material Components](https://github.com/prateekbh/preact-material-components)
   - [RMWC: React Material Web Components](https://github.com/jamesmfriedman/rmwc)
   - [Blox Material](https://blox.src.zone/material): Angular Integration Library.
+  - [MDC-WP: Material Design Components WordPress](https://github.com/touficbatache/material-components-web-wordpress)
   - More coming soon! Feel free to submit a pull request adding your library to this list, so long as you meet our [criteria](docs/integrating-into-frameworks.md).
 
 MDC-Web strives to seamlessly incorporate into a wider range of usage contexts, from simple static websites to complex, JavaScript-heavy applications to hybrid client/server rendering systems. In short, whether you're already heavily invested in another framework or not, it should be easy to incorporate Material Components into your site in a lightweight, idiomatic fashion.


### PR DESCRIPTION
Add [MDC-WP](https://github.com/touficbatache/material-components-web-wordpress) to recommended frameworks.