### PR TITLE
fix(textfield): activate focus on inputs with 'autofocus'

### DIFF
--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -323,21 +323,21 @@ complicated.
 
 | Method Signature | Description |
 | --- | --- |
-| addClass(className: string) => void | Adds a class to the root element |
-| removeClass(className: string) => void | Removes a class from the root element |
-| addClassToLabel(className: string) => void | Adds a class to the label element. We recommend you add a conditional check here, and in `removeClassFromLabel` for whether or not the label is present so that the JS component could be used with text fields that don't require a label, such as the full-width text field. |
-| removeClassFromLabel(className: string) => void | Removes a class from the label element |
-| eventTargetHasClass(target: HTMLElement, className: string) => boolean | Returns true if classname exists for a given target element |
-| registerTextFieldInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event handler on the root element for a given event |
-| deregisterTextFieldInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event handler on the root element for a given event |
-| notifyIconAction() => void | Emits a custom event "MDCTextField:icon" denoting a user has clicked the icon |
-| registerInputInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the native input element for a given event |
-| deregisterInputInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the native input element for a given event |
-| registerBottomLineEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the bottom line element for a given event |
-| deregisterBottomLineEventHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the bottom line element for a given event |
-| getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}? | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully. |
-| getBottomLineFoundation() => MDCTextFieldBottomLineFoundation | Returns the instance of the bottom line element's foundation |
-| getHelperTextFoundation() => MDCTextFieldHelperTextFoundation | Returns the instance of the helper text element's foundation |
+| `addClass(className: string) => void` | Adds a class to the root element |
+| `removeClass(className: string) => void` | Removes a class from the root element |
+| `addClassToLabel(className: string) => void` | Adds a class to the label element. We recommend you add a conditional check here, and in `removeClassFromLabel` for whether or not the label is present so that the JS component could be used with text fields that don't require a label, such as the full-width text field. |
+| `removeClassFromLabel(className: string) => void` | Removes a class from the label element |
+| `eventTargetHasClass(target: HTMLElement, className: string) => boolean` | Returns true if classname exists for a given target element |
+| `registerTextFieldInteractionHandler(evtType: string, handler: EventListener) => void` | Registers an event handler on the root element for a given event |
+| `deregisterTextFieldInteractionHandler(evtType: string, handler: EventListener) => void` | Deregisters an event handler on the root element for a given event |
+| `notifyIconAction() => void` | Emits a custom event "MDCTextField:icon" denoting a user has clicked the icon |
+| `registerInputEventHandler(evtType: string, handler: EventListener) => void` | Registers an event listener on the input element for a given event |
+| `deregisterInputEventHandler(evtType: string, handler: EventListener) => void` | Deregisters an event listener on the input element for a given event |
+| `registerBottomLineEventHandler(evtType: string, handler: EventListener) => void` | Registers an event listener on the bottom line element for a given event |
+| `deregisterBottomLineEventHandler(evtType: string, handler: EventListener) => void` | Deregisters an event listener on the bottom line element for a given event |
+| `getBottomLineFoundation() => MDCTextFieldBottomLineFoundation` | Returns the instance of the bottom line element's foundation |
+| `getHelperTextFoundation() => MDCTextFieldHelperTextFoundation` | Returns the instance of the helper text element's foundation |
+| `getInputFoundation() => MDCTextFieldInputFoundation` | Returns the instance of the input element's foundation |
 
 #### The full foundation API
 

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -18,18 +18,9 @@
 /* eslint-disable no-unused-vars */
 import MDCTextFieldBottomLineFoundation from './bottom-line/foundation';
 import MDCTextFieldHelperTextFoundation from './helper-text/foundation';
+import MDCTextFieldInputFoundation from './input/foundation';
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
-
-/**
- * @typedef {{
- *   value: string,
- *   disabled: boolean,
- *   badInput: boolean,
- *   checkValidity: (function(): boolean)
- * }}
- */
-let NativeInputType;
 
 /**
  * Adapter for MDC Text Field.
@@ -104,18 +95,20 @@ class MDCTextFieldAdapter {
   notifyIconAction() {}
 
   /**
-   * Registers an event listener on the native input element for a given event.
-   * @param {string} evtType
-   * @param {function(!Event): undefined} handler
-   */
-  registerInputInteractionHandler(evtType, handler) {}
 
   /**
-   * Deregisters an event listener on the native input element for a given event.
+   * Registers an event listener on the input element for a given event.
    * @param {string} evtType
    * @param {function(!Event): undefined} handler
    */
-  deregisterInputInteractionHandler(evtType, handler) {}
+  registerInputEventHandler(evtType, handler) {}
+
+  /**
+   * Deregisters an event listener on the input element for a given event.
+   * @param {string} evtType
+   * @param {function(!Event): undefined} handler
+   */
+  deregisterInputEventHandler(evtType, handler) {}
 
   /**
    * Registers an event listener on the bottom line element for a given event.
@@ -132,18 +125,6 @@ class MDCTextFieldAdapter {
   deregisterBottomLineEventHandler(evtType, handler) {}
 
   /**
-   * Returns an object representing the native text input element, with a
-   * similar API shape. The object returned should include the value, disabled
-   * and badInput properties, as well as the checkValidity() function. We never
-   * alter the value within our code, however we do update the disabled
-   * property, so if you choose to duck-type the return value for this method
-   * in your implementation it's important to keep this in mind. Also note that
-   * this method can return null, which the foundation will handle gracefully.
-   * @return {?Element|?NativeInputType}
-   */
-  getNativeInput() {}
-
-  /**
    * Returns the foundation for the bottom line element. Returns undefined if
    * there is no bottom line element.
    * @return {?MDCTextFieldBottomLineFoundation}
@@ -156,6 +137,12 @@ class MDCTextFieldAdapter {
    * @return {?MDCTextFieldHelperTextFoundation}
    */
   getHelperTextFoundation() {}
+
+  /**
+   * Returns the foundation for the input element.
+   * @return {!MDCTextFieldInputFoundation}
+   */
+  getInputFoundation() {}
 }
 
-export {MDCTextFieldAdapter, NativeInputType};
+export {MDCTextFieldAdapter};

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -23,6 +23,8 @@ import {MDCTextFieldAdapter} from './adapter';
 import MDCTextFieldFoundation from './foundation';
 import {MDCTextFieldBottomLine} from './bottom-line';
 import {MDCTextFieldHelperText} from './helper-text';
+import {MDCTextFieldInput} from './input';
+
 
 /**
  * @extends {MDCComponent<!MDCTextFieldFoundation>}
@@ -34,7 +36,7 @@ class MDCTextField extends MDCComponent {
    */
   constructor(...args) {
     super(...args);
-    /** @private {?Element} */
+    /** @private {!MDCTextFieldInput} */
     this.input_;
     /** @private {?Element} */
     this.label_;
@@ -61,11 +63,15 @@ class MDCTextField extends MDCComponent {
    * creates a new MDCRipple.
    * @param {(function(!Element): !MDCTextFieldBottomLine)=} bottomLineFactory A function which
    * creates a new MDCTextFieldBottomLine.
+   * @param {(function(!Element): !MDCTextFieldInput)=} inputFactory A function which
+   * creates a new MDCTextFieldInput.
    */
   initialize(
     rippleFactory = (el) => new MDCRipple(el),
-    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el)) {
-    this.input_ = this.root_.querySelector(strings.INPUT_SELECTOR);
+    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el),
+    inputFactory = (el) => new MDCTextFieldInput(el)) {
+    const inputElement = this.root_.querySelector(strings.INPUT_SELECTOR);
+    this.input_ = inputFactory(inputElement);
     this.label_ = this.root_.querySelector(strings.LABEL_SELECTOR);
     this.ripple = null;
     if (this.root_.classList.contains(cssClasses.BOX)) {
@@ -77,8 +83,8 @@ class MDCTextField extends MDCComponent {
         this.bottomLine_ = bottomLineFactory(bottomLineElement);
       }
     };
-    if (this.input_.hasAttribute(strings.ARIA_CONTROLS)) {
-      const helperTextElement = document.getElementById(this.input_.getAttribute(strings.ARIA_CONTROLS));
+    if (inputElement.hasAttribute(strings.ARIA_CONTROLS)) {
+      const helperTextElement = document.getElementById(inputElement.getAttribute(strings.ARIA_CONTROLS));
       if (helperTextElement) {
         this.helperText_ = new MDCTextFieldHelperText(helperTextElement);
       }
@@ -98,15 +104,8 @@ class MDCTextField extends MDCComponent {
     if (this.helperText_) {
       this.helperText_.destroy();
     }
+    this.input_.destroy();
     super.destroy();
-  }
-
-  /**
-   * Initiliazes the Text Field's internal state based on the environment's
-   * state.
-   */
-  initialSyncWithDom() {
-    this.disabled = this.input_.disabled;
   }
 
   /**
@@ -161,6 +160,8 @@ class MDCTextField extends MDCComponent {
       registerTextFieldInteractionHandler: (evtType, handler) => this.root_.addEventListener(evtType, handler),
       deregisterTextFieldInteractionHandler: (evtType, handler) => this.root_.removeEventListener(evtType, handler),
       notifyIconAction: () => this.emit(MDCTextFieldFoundation.strings.ICON_EVENT, {}),
+      registerInputEventHandler: (evtType, handler) => this.input_.listen(evtType, handler),
+      deregisterInputEventHandler: (evtType, handler) => this.input_.unlisten(evtType, handler),
       registerBottomLineEventHandler: (evtType, handler) => {
         if (this.bottomLine_) {
           this.bottomLine_.listen(evtType, handler);
@@ -183,8 +184,10 @@ class MDCTextField extends MDCComponent {
         }
         return undefined;
       },
+      getInputFoundation: () => {
+        return this.input_.foundation;
+      },
     },
-    this.getInputAdapterMethods_(),
     this.getIconAdapterMethods_())));
   }
 
@@ -200,21 +203,6 @@ class MDCTextField extends MDCComponent {
           this.icon_.setAttribute(name, value);
         }
       },
-    };
-  }
-
-  /**
-   * @return {!{
-   *   registerInputInteractionHandler: function(string, function()): undefined,
-   *   deregisterInputInteractionHandler: function(string, function()): undefined,
-   *   getNativeInput: function(): ?Element,
-   * }}
-   */
-  getInputAdapterMethods_() {
-    return {
-      registerInputInteractionHandler: (evtType, handler) => this.input_.addEventListener(evtType, handler),
-      deregisterInputInteractionHandler: (evtType, handler) => this.input_.removeEventListener(evtType, handler),
-      getNativeInput: () => this.input_,
     };
   }
 }

--- a/packages/mdc-textfield/input/README.md
+++ b/packages/mdc-textfield/input/README.md
@@ -1,0 +1,66 @@
+<!--docs:
+title: "Text Field Input"
+layout: detail
+section: components
+excerpt: "The input element is where the user enters text"
+iconId: input
+path: /catalog/input-controls/text-fields/input/
+-->
+
+# Text Field Input
+
+The input element is where the user enters text.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/text-fields.html#text-fields-field-types">Material Design guidelines: Text Field Types</a>
+  </li>
+</ul>
+
+
+## Usage
+
+#### MDCTextFieldInput API
+
+##### MDCTextFieldInput.foundation
+
+MDCTextFieldInputFoundation. This allows the parent MDCTextField component to access the public methods on the MDCTextFieldInputFoundation class.
+
+### Using the foundation class
+
+Method Signature | Description
+--- | ---
+`registerEventHandler(evtType: string, handler: EventListener) => void` | Registers an event listener on the input element for a given event
+`deregisterEventHandler(evtType: string, handler: EventListener) => void` | Deregisters an event listener on the input element for a given event
+`getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}?` | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully.
+`notifyFocusAction() => void` | Emits a custom event "MDCTextFieldInput:focus" denoting the input is focused
+`notifyBlurAction() => void` | Emits a custom event "MDCTextFieldInput:blur" denoting the input is blurred
+`notifyPressedAction() => void` | Emits a custom event "MDCTextFieldInput:pressed" denoting the input is pressed
+
+#### The full foundation API
+
+##### MDCTextFieldInputFoundation.isBadInput() => boolean
+
+True if the input fails validity checks.
+
+##### MDCTextFieldInputFoundation.getValue() => string
+
+Returns the value in the input.
+
+##### MDCTextFieldInputFoundation.checkValidity() => boolean
+
+Returns the result of the checkValidity() call in the native input.
+
+##### MDCTextFieldInputFoundation.isDisabled() => boolean
+
+True if the input is disabled.
+
+##### MDCTextFieldInputFoundation.setDisabled(disabled)
+
+Sets the input disabled or enabled.
+
+##### MDCTextFieldInputFoundation.handleTextFieldInteraction()
+
+Handles text field interaction.

--- a/packages/mdc-textfield/input/adapter.js
+++ b/packages/mdc-textfield/input/adapter.js
@@ -78,6 +78,12 @@ class MDCTextFieldInputAdapter {
    * Emits a custom event "MDCTextFieldInput:pressed" denoting a user has pressed the input.
    */
   notifyPressedAction() {}
+
+  /**
+   * Returns whether the input is focused.
+   * @return {boolean}
+   */
+  isFocused() {}
 }
 
 export {MDCTextFieldInputAdapter, NativeInputType};

--- a/packages/mdc-textfield/input/adapter.js
+++ b/packages/mdc-textfield/input/adapter.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint no-unused-vars: [2, {"args": "none"}] */
+
+/**
+ * @typedef {{
+ *   value: string,
+ *   disabled: boolean,
+ *   badInput: boolean,
+ *   checkValidity: (function(): boolean)
+ * }}
+ */
+let NativeInputType;
+
+/**
+ * Adapter for MDC Text Field Input.
+ *
+ * Defines the shape of the adapter expected by the foundation. Implement this
+ * adapter to integrate the TextField input into your framework. See
+ * https://github.com/material-components/material-components-web/blob/master/docs/authoring-components.md
+ * for more information.
+ *
+ * @record
+ */
+class MDCTextFieldInputAdapter {
+  /**
+   * Registers an event listener on the native input element for a given event.
+   * @param {string} evtType
+   * @param {function(!Event): undefined} handler
+   */
+  registerEventHandler(evtType, handler) {}
+
+  /**
+   * Deregisters an event listener on the native input element for a given event.
+   * @param {string} evtType
+   * @param {function(!Event): undefined} handler
+   */
+  deregisterEventHandler(evtType, handler) {}
+
+  /**
+   * Returns an object representing the native text input element, with a
+   * similar API shape. The object returned should include the value, disabled
+   * and badInput properties, as well as the checkValidity() function. We never
+   * alter the value within our code, however we do update the disabled
+   * property, so if you choose to duck-type the return value for this method
+   * in your implementation it's important to keep this in mind. Also note that
+   * this method can return null, which the foundation will handle gracefully.
+   * @return {?Element|?NativeInputType}
+   */
+  getNativeInput() {}
+
+  /**
+   * Emits a custom event "MDCTextFieldInput:focus" denoting a user has focused the input.
+   */
+  notifyFocusAction() {}
+
+  /**
+   * Emits a custom event "MDCTextFieldInput:blur" denoting a user has blurred the input.
+   */
+  notifyBlurAction() {}
+
+  /**
+   * Emits a custom event "MDCTextFieldInput:pressed" denoting a user has pressed the input.
+   */
+  notifyPressedAction() {}
+}
+
+export {MDCTextFieldInputAdapter, NativeInputType};

--- a/packages/mdc-textfield/input/constants.js
+++ b/packages/mdc-textfield/input/constants.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @enum {string} */
+const strings = {
+  FOCUS_EVENT: 'MDCTextFieldInput:focus',
+  BLUR_EVENT: 'MDCTextFieldInput:blur',
+  PRESSED_EVENT: 'MDCTextFieldInput:pressed',
+};
+
+export {strings};

--- a/packages/mdc-textfield/input/foundation.js
+++ b/packages/mdc-textfield/input/foundation.js
@@ -43,6 +43,7 @@ class MDCTextFieldInputFoundation extends MDCFoundation {
       notifyFocusAction: () => {},
       notifyBlurAction: () => {},
       notifyPressedAction: () => {},
+      isFocused: () => false,
     });
   }
 
@@ -71,6 +72,10 @@ class MDCTextFieldInputFoundation extends MDCFoundation {
     ['mousedown', 'touchstart'].forEach((evtType) => {
       this.adapter_.registerEventHandler(evtType, this.inputPressedHandler_);
     });
+
+    if (this.adapter_.isFocused()) {
+      this.autoCompleteFocus_();
+    }
   }
 
   destroy() {

--- a/packages/mdc-textfield/input/foundation.js
+++ b/packages/mdc-textfield/input/foundation.js
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from '@material/base/foundation';
+import {MDCTextFieldInputAdapter, NativeInputType} from './adapter';
+import {strings} from './constants';
+
+
+/**
+ * @extends {MDCFoundation<!MDCTextFieldInputAdapter>}
+ * @final
+ */
+class MDCTextFieldInputFoundation extends MDCFoundation {
+  /** @return enum {string} */
+  static get strings() {
+    return strings;
+  }
+
+  /**
+   * {@see MDCTextFieldInputAdapter} for typing information on parameters and return
+   * types.
+   * @return {!MDCTextFieldInputAdapter}
+   */
+  static get defaultAdapter() {
+    return /** @type {!MDCTextFieldInputAdapter} */ ({
+      registerEventHandler: () => {},
+      deregisterEventHandler: () => {},
+      getNativeInput: () => {},
+      notifyFocusAction: () => {},
+      notifyBlurAction: () => {},
+      notifyPressedAction: () => {},
+    });
+  }
+
+  /**
+   * @param {!MDCTextFieldInputAdapter=} adapter
+   */
+  constructor(adapter = /** @type {!MDCTextFieldInputAdapter} */ ({})) {
+    super(Object.assign(MDCTextFieldInputFoundation.defaultAdapter, adapter));
+
+    /** @private {boolean} */
+    this.receivedUserInput_ = false;
+    /** @private {function(): undefined} */
+    this.inputFocusHandler_ = () => this.activateFocus_();
+    /** @private {function(): undefined} */
+    this.inputBlurHandler_ = () => this.deactivateFocus_();
+    /** @private {function(): undefined} */
+    this.inputInputHandler_ = () => this.autoCompleteFocus_();
+    /** @private {function(): undefined} */
+    this.inputPressedHandler_ = () => this.notifyPressedAction_();
+  }
+
+  init() {
+    this.adapter_.registerEventHandler('focus', this.inputFocusHandler_);
+    this.adapter_.registerEventHandler('blur', this.inputBlurHandler_);
+    this.adapter_.registerEventHandler('input', this.inputInputHandler_);
+    ['mousedown', 'touchstart'].forEach((evtType) => {
+      this.adapter_.registerEventHandler(evtType, this.inputPressedHandler_);
+    });
+  }
+
+  destroy() {
+    this.adapter_.deregisterEventHandler('focus', this.inputFocusHandler_);
+    this.adapter_.deregisterEventHandler('blur', this.inputBlurHandler_);
+    this.adapter_.deregisterEventHandler('input', this.inputInputHandler_);
+    ['mousedown', 'touchstart'].forEach((evtType) => {
+      this.adapter_.deregisterEventHandler(evtType, this.inputPressedHandler_);
+    });
+  }
+
+  /**
+   * Activates the input's focus state.
+   * @private
+   */
+  activateFocus_() {
+    this.adapter_.notifyFocusAction();
+  }
+
+  /**
+   * Activates the input's focus state in cases when the input value
+   * changes without user input (e.g. programatically).
+   * @private
+   */
+  autoCompleteFocus_() {
+    if (!this.receivedUserInput_) {
+      this.activateFocus_();
+    }
+  }
+
+  /**
+   * Deactives the input's focus state.
+   * @private
+   */
+  deactivateFocus_() {
+    const input = this.getNativeInput_();
+
+    if (!input.value && !this.isBadInput()) {
+      this.receivedUserInput_ = false;
+    }
+
+    this.adapter_.notifyBlurAction();
+  }
+
+  notifyPressedAction_() {
+    this.adapter_.notifyPressedAction();
+  }
+
+  /**
+   * @return {boolean} True if the input fails validity checks.
+   */
+  isBadInput() {
+    const input = this.getNativeInput_();
+    return input.validity ? input.validity.badInput : input.badInput;
+  }
+
+  /**
+   * @return {string} Returns the value in the input.
+   */
+  getValue() {
+    return this.getNativeInput_().value;
+  }
+
+  /**
+   * @return {boolean} Returns the result of the checkValidity() call in the native input.
+   */
+  checkValidity() {
+    return this.getNativeInput_().checkValidity();
+  }
+
+  /**
+   * @return {boolean} True if the input is disabled.
+   */
+  isDisabled() {
+    return this.getNativeInput_().disabled;
+  }
+
+  /**
+   * @param {boolean} disabled Sets the input disabled or enabled.
+   */
+  setDisabled(disabled) {
+    this.getNativeInput_().disabled = disabled;
+  }
+
+  /**
+   * Handles text field interaction.
+   */
+  handleTextFieldInteraction() {
+    this.receivedUserInput_ = true;
+  }
+
+  /**
+   * @return {!Element|!NativeInputType} The native text input from the
+   * host environment, or a dummy if none exists.
+   * @private
+   */
+  getNativeInput_() {
+    return this.adapter_.getNativeInput() ||
+    /** @type {!NativeInputType} */ ({
+      checkValidity: () => true,
+      value: '',
+      disabled: false,
+      badInput: false,
+    });
+  }
+}
+
+export default MDCTextFieldInputFoundation;

--- a/packages/mdc-textfield/input/index.js
+++ b/packages/mdc-textfield/input/index.js
@@ -51,6 +51,7 @@ class MDCTextFieldInput extends MDCComponent {
       notifyFocusAction: () => this.emit(MDCTextFieldInputFoundation.strings.FOCUS_EVENT, {}),
       notifyBlurAction: () => this.emit(MDCTextFieldInputFoundation.strings.BLUR_EVENT, {}),
       notifyPressedAction: () => this.emit(MDCTextFieldInputFoundation.strings.PRESSED_EVENT, {}),
+      isFocused: () => document.activeElement === this.root_,
     })));
   }
 }

--- a/packages/mdc-textfield/input/index.js
+++ b/packages/mdc-textfield/input/index.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from '@material/base/component';
+
+import {MDCTextFieldInputAdapter} from './adapter';
+import MDCTextFieldInputFoundation from './foundation';
+
+/**
+ * @extends {MDCComponent<!MDCTextFieldInputFoundation>}
+ * @final
+ */
+class MDCTextFieldInput extends MDCComponent {
+  /**
+   * @param {!Element} root
+   * @return {!MDCTextFieldInput}
+   */
+  static attachTo(root) {
+    return new MDCTextFieldInput(root);
+  }
+
+  /**
+   * @return {!MDCTextFieldInputFoundation}
+   */
+  get foundation() {
+    return this.foundation_;
+  }
+
+  /**
+   * @return {!MDCTextFieldInputFoundation}
+   */
+  getDefaultFoundation() {
+    return new MDCTextFieldInputFoundation(/** @type {!MDCTextFieldInputAdapter} */ (Object.assign({
+      registerEventHandler: (evtType, handler) => this.root_.addEventListener(evtType, handler),
+      deregisterEventHandler: (evtType, handler) => this.root_.removeEventListener(evtType, handler),
+      getNativeInput: () => this.root_,
+      notifyFocusAction: () => this.emit(MDCTextFieldInputFoundation.strings.FOCUS_EVENT, {}),
+      notifyBlurAction: () => this.emit(MDCTextFieldInputFoundation.strings.BLUR_EVENT, {}),
+      notifyPressedAction: () => this.emit(MDCTextFieldInputFoundation.strings.PRESSED_EVENT, {}),
+    })));
+  }
+}
+
+export {MDCTextFieldInput, MDCTextFieldInputFoundation};

--- a/packages/mdc-textfield/input/mdc-text-field-input.scss
+++ b/packages/mdc-textfield/input/mdc-text-field-input.scss
@@ -1,0 +1,138 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@import "../functions";
+@import "../variables";
+@import "@material/theme/variables";
+@import "@material/theme/mixins";
+@import "@material/typography/mixins";
+@import "@material/typography/variables";
+
+// postcss-bem-linter: define textfield
+.mdc-text-field {
+
+  &__input {
+    @include mdc-theme-prop(color, text-primary-on-light);
+    @include mdc-typography-base;
+    // We use only a subset of the MDC typography values here as changing things such as line-height
+    // affects how the labels are transformed.
+    // TODO: Re-add setting the font-size from mdc-typography-styles (currently
+    // setting it here has no effect because it is overriden by the font-size
+    // given below).
+    @each $prop in (letter-spacing) {
+      #{$prop}: map-get(map-get($mdc-typography-styles, subheading2), $prop);
+    }
+
+    width: 100%;
+    padding: 0 0 8px;
+    transition: mdc-text-field-transition(opacity);
+    border: none;
+    border-bottom: 1px solid $mdc-text-field-underline-on-light-idle;
+    background: none;
+    font-size: inherit;
+    appearance: none;
+
+    &::placeholder {
+      @include mdc-theme-prop(color, text-hint-on-light);
+
+      transition: mdc-text-field-transition(color);
+      opacity: 1;
+    }
+
+    &:hover {
+      border-color: $mdc-text-field-underline-on-light;
+    }
+
+    &:focus {
+      outline: none;
+
+      &::placeholder {
+        @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
+      }
+    }
+
+    // Remove red outline on firefox
+    &:invalid {
+      box-shadow: none;
+    }
+
+    @include mdc-theme-dark {
+      @include mdc-theme-prop(color, text-primary-on-dark);
+
+      border-bottom: 1px solid $mdc-text-field-underline-on-dark-idle;
+
+      &:hover {
+        border-bottom: 1px solid $mdc-text-field-underline-on-dark;
+      }
+
+      &::placeholder {
+        @include mdc-theme-prop(color, text-hint-on-dark);
+      }
+
+      &:focus::placeholder {
+        @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
+      }
+    }
+  }
+}
+
+// Graceful degredation for css-only inputs
+
+.mdc-text-field {
+  &:not(.mdc-text-field--upgraded):not(.mdc-text-field--textarea) .mdc-text-field__input {
+    transition: mdc-text-field-transition(border-bottom-color);
+    border-bottom: 1px solid $mdc-text-field-divider-on-light;
+  }
+
+  &:not(.mdc-text-field--upgraded) .mdc-text-field__input {
+    &:focus {
+      @include mdc-theme-prop(border-color, primary);
+    }
+
+    &:disabled {
+      @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
+
+      border-bottom-style: dotted;
+    }
+
+    // stylelint-disable selector-max-specificity
+    &:invalid:not(:focus) {
+      border-color: $mdc-text-field-error-on-light;
+    }
+    // stylelint-enable selector-max-specificity
+  }
+
+  @include mdc-theme-dark {
+    &:not(.mdc-text-field--upgraded) .mdc-text-field__input {
+      &:not(:focus) {
+        border-color: rgba(white, .12);
+      }
+
+      &:disabled {
+        @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
+
+        border-color: $mdc-text-field-disabled-border-on-dark;
+        background-color: $mdc-textarea-disabled-background-on-dark;
+      }
+
+      // stylelint-disable selector-max-specificity
+      &:invalid:not(:focus) {
+        border-color: $mdc-text-field-error-on-dark;
+      }
+      // stylelint-enable selector-max-specificity
+    }
+  }
+}

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -26,6 +26,7 @@
 @import "@material/typography/variables";
 @import "./bottom-line/mdc-text-field-bottom-line";
 @import "./helper-text/mdc-text-field-helper-text";
+@import "./input/mdc-text-field-input";
 @include mdc-text-field-invalid-label-shake_keyframes_(standard, 100%);
 @include mdc-text-field-invalid-label-shake_keyframes_(box, 50%);
 
@@ -36,70 +37,6 @@
   position: relative;
   margin-bottom: 8px;
   will-change: opacity, transform, color;
-
-  &__input {
-    @include mdc-theme-prop(color, text-primary-on-light);
-    @include mdc-typography-base;
-    // We use only a subset of the MDC typography values here as changing things such as line-height
-    // affects how the labels are transformed.
-    // TODO: Re-add setting the font-size from mdc-typography-styles (currently
-    // setting it here has no effect because it is overriden by the font-size
-    // given below).
-    @each $prop in (letter-spacing) {
-      #{$prop}: map-get(map-get($mdc-typography-styles, subheading2), $prop);
-    }
-
-    width: 100%;
-    padding: 0 0 8px;
-    transition: mdc-text-field-transition(opacity);
-    border: none;
-    border-bottom: 1px solid $mdc-text-field-underline-on-light-idle;
-    background: none;
-    font-size: inherit;
-    appearance: none;
-
-    &::placeholder {
-      @include mdc-theme-prop(color, text-hint-on-light);
-
-      transition: mdc-text-field-transition(color);
-      opacity: 1;
-    }
-
-    &:hover {
-      border-color: $mdc-text-field-underline-on-light;
-    }
-
-    &:focus {
-      outline: none;
-
-      &::placeholder {
-        @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
-      }
-    }
-
-    // Remove red outline on firefox
-    &:invalid {
-      box-shadow: none;
-    }
-
-    @include mdc-theme-dark {
-      @include mdc-theme-prop(color, text-primary-on-dark);
-
-      border-bottom: 1px solid $mdc-text-field-underline-on-dark-idle;
-
-      &:hover {
-        border-bottom: 1px solid $mdc-text-field-underline-on-dark;
-      }
-
-      &::placeholder {
-        @include mdc-theme-prop(color, text-hint-on-dark);
-      }
-
-      &:focus::placeholder {
-        @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
-      }
-    }
-  }
 
   &__label {
     position: absolute;
@@ -551,54 +488,6 @@
   }
 
   // stylelint-enable plugin/selector-bem-pattern
-}
-
-// Graceful degredation for css-only inputs
-
-.mdc-text-field {
-  &:not(.mdc-text-field--upgraded):not(.mdc-text-field--textarea) .mdc-text-field__input {
-    transition: mdc-text-field-transition(border-bottom-color);
-    border-bottom: 1px solid $mdc-text-field-divider-on-light;
-  }
-
-  &:not(.mdc-text-field--upgraded) .mdc-text-field__input {
-    &:focus {
-      @include mdc-theme-prop(border-color, primary);
-    }
-
-    &:disabled {
-      @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
-
-      border-bottom-style: dotted;
-    }
-
-    // stylelint-disable selector-max-specificity
-    &:invalid:not(:focus) {
-      border-color: $mdc-text-field-error-on-light;
-    }
-    // stylelint-enable selector-max-specificity
-  }
-
-  @include mdc-theme-dark {
-    &:not(.mdc-text-field--upgraded) .mdc-text-field__input {
-      &:not(:focus) {
-        border-color: rgba(white, .12);
-      }
-
-      &:disabled {
-        @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
-
-        border-color: $mdc-text-field-disabled-border-on-dark;
-        background-color: $mdc-textarea-disabled-background-on-dark;
-      }
-
-      // stylelint-disable selector-max-specificity
-      &:invalid:not(:focus) {
-        border-color: $mdc-text-field-error-on-dark;
-      }
-      // stylelint-enable selector-max-specificity
-    }
-  }
 }
 
 .mdc-text-field--box:not(.mdc-text-field--upgraded) {

--- a/test/unit/mdc-textfield/mdc-text-field-input-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-input-foundation.test.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from 'chai';
+import td from 'testdouble';
+
+import {verifyDefaultAdapter} from '../helpers/foundation';
+import {setupFoundationTest} from '../helpers/setup';
+import MDCTextFieldInputFoundation from '../../../packages/mdc-textfield/input/foundation';
+
+suite('MDCTextFieldInputFoundation');
+
+test('exports strings', () => {
+  assert.isOk('strings' in MDCTextFieldInputFoundation);
+});
+
+test('defaultAdapter returns a complete adapter implementation', () => {
+  verifyDefaultAdapter(MDCTextFieldInputFoundation, [
+    'registerEventHandler', 'deregisterEventHandler', 'getNativeInput',
+    'notifyFocusAction', 'notifyBlurAction', 'notifyPressedAction',
+  ]);
+});
+
+const setupTest = () => setupFoundationTest(MDCTextFieldInputFoundation);
+
+test('#init adds event listeners', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.init();
+
+  td.verify(mockAdapter.registerEventHandler('focus', td.matchers.isA(Function)));
+  td.verify(mockAdapter.registerEventHandler('blur', td.matchers.isA(Function)));
+  td.verify(mockAdapter.registerEventHandler('input', td.matchers.isA(Function)));
+  td.verify(mockAdapter.registerEventHandler('mousedown', td.matchers.isA(Function)));
+  td.verify(mockAdapter.registerEventHandler('touchstart', td.matchers.isA(Function)));
+});
+
+test('#destroy removes event listeners', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.destroy();
+
+  td.verify(mockAdapter.deregisterEventHandler('focus', td.matchers.isA(Function)));
+  td.verify(mockAdapter.deregisterEventHandler('blur', td.matchers.isA(Function)));
+  td.verify(mockAdapter.deregisterEventHandler('input', td.matchers.isA(Function)));
+  td.verify(mockAdapter.deregisterEventHandler('mousedown', td.matchers.isA(Function)));
+  td.verify(mockAdapter.deregisterEventHandler('touchstart', td.matchers.isA(Function)));
+});
+
+test('#constructor sets disabled to false', () => {
+  const {foundation} = setupTest();
+  assert.isNotOk(foundation.isDisabled());
+});
+
+test('#setDisabled set the disabled property on the native input when there is one', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const nativeInput = {disabled: false};
+  td.when(mockAdapter.getNativeInput()).thenReturn(nativeInput);
+  foundation.setDisabled(true);
+  assert.isOk(nativeInput.disabled);
+});
+
+test('#setDisabled handles no native input being returned gracefully', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeInput()).thenReturn(null);
+  assert.doesNotThrow(() => foundation.setDisabled(true));
+});
+
+test('on input, notifies focus action if this.receivedUserInput_ is false', () => {
+  const {foundation, mockAdapter} = setupTest();
+  let input;
+
+  td.when(mockAdapter.registerEventHandler('input', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      input = handler;
+    });
+  foundation.init();
+  input();
+  td.verify(mockAdapter.notifyFocusAction());
+});
+
+test('on input, does nothing if this.receivedUserInput_ is true', () => {
+  const {foundation, mockAdapter} = setupTest();
+  let input;
+
+  td.when(mockAdapter.registerEventHandler('input', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      input = handler;
+    });
+  foundation.init();
+  foundation.handleTextFieldInteraction();
+  input();
+  td.verify(mockAdapter.notifyFocusAction(), {times: 0});
+});
+
+test('on focus, notifies focus action', () => {
+  const {foundation, mockAdapter} = setupTest();
+  let focus;
+
+  td.when(mockAdapter.registerEventHandler('focus', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      focus = handler;
+    });
+  foundation.init();
+  focus();
+  td.verify(mockAdapter.notifyFocusAction());
+});
+
+test('on blur, notifies blur action', () => {
+  const {foundation, mockAdapter} = setupTest();
+  let blur;
+
+  td.when(mockAdapter.registerEventHandler('blur', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      blur = handler;
+    });
+  foundation.init();
+  blur();
+  td.verify(mockAdapter.notifyBlurAction());
+});
+
+test('on mousedown, notifies pressed action', () => {
+  const {foundation, mockAdapter} = setupTest();
+  let pressed;
+
+  td.when(mockAdapter.registerEventHandler('mousedown', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      pressed = handler;
+    });
+  foundation.init();
+  pressed();
+  td.verify(mockAdapter.notifyPressedAction());
+});
+
+test('on touchstart, notifies pressed action', () => {
+  const {foundation, mockAdapter} = setupTest();
+  let pressed;
+
+  td.when(mockAdapter.registerEventHandler('touchstart', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      pressed = handler;
+    });
+  foundation.init();
+  pressed();
+  td.verify(mockAdapter.notifyPressedAction());
+});

--- a/test/unit/mdc-textfield/mdc-text-field-input-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-input-foundation.test.js
@@ -31,6 +31,7 @@ test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTextFieldInputFoundation, [
     'registerEventHandler', 'deregisterEventHandler', 'getNativeInput',
     'notifyFocusAction', 'notifyBlurAction', 'notifyPressedAction',
+    'isFocused',
   ]);
 });
 

--- a/test/unit/mdc-textfield/mdc-text-field-input.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-input.test.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import bel from 'bel';
+import {assert} from 'chai';
+import td from 'testdouble';
+import domEvents from 'dom-events';
+
+import {MDCTextFieldInput, MDCTextFieldInputFoundation} from '../../../packages/mdc-textfield/input';
+
+const getFixture = () => bel`
+  <div class="mdc-textfield__input"></div>
+`;
+
+suite('MDCTextFieldInput');
+
+test('attachTo returns an MDCTextFieldInput instance', () => {
+  assert.isOk(MDCTextFieldInput.attachTo(getFixture()) instanceof MDCTextFieldInput);
+});
+
+function setupTest() {
+  const root = getFixture();
+  const component = new MDCTextFieldInput(root);
+  return {root, component};
+}
+
+test('#adapter.getNativeInput returns the component input element', () => {
+  const {root, component} = setupTest();
+  assert.equal(component.getDefaultFoundation().adapter_.getNativeInput(), root);
+});
+
+test('#adapter.registerEventHandler adds event listener for a given event to the input element', () => {
+  const {root, component} = setupTest();
+  const handler = td.func('handler');
+  component.getDefaultFoundation().adapter_.registerEventHandler('focus', handler);
+  domEvents.emit(root, 'focus');
+
+  td.verify(handler(td.matchers.anything()));
+});
+
+test('#adapter.deregisterEventHandler removes event listener for a given event from the input element', () => {
+  const {root, component} = setupTest();
+  const handler = td.func('handler');
+  root.addEventListener('focus', handler);
+  component.getDefaultFoundation().adapter_.deregisterEventHandler('focus', handler);
+  domEvents.emit(root, 'focus');
+
+  td.verify(handler(td.matchers.anything()), {times: 0});
+});
+
+test('#adapter.notifyFocusAction emits ' +
+  `${MDCTextFieldInputFoundation.strings.FOCUS_EVENT}`, () => {
+  const {component} = setupTest();
+  const handler = td.func('handler');
+  component.listen(
+    MDCTextFieldInputFoundation.strings.FOCUS_EVENT, handler);
+  component.getDefaultFoundation().adapter_.notifyFocusAction();
+
+  td.verify(handler(td.matchers.anything()));
+});
+
+test('#adapter.notifyBlurAction emits ' +
+  `${MDCTextFieldInputFoundation.strings.BLUR_EVENT}`, () => {
+  const {component} = setupTest();
+  const handler = td.func('handler');
+  component.listen(
+    MDCTextFieldInputFoundation.strings.BLUR_EVENT, handler);
+  component.getDefaultFoundation().adapter_.notifyBlurAction();
+
+  td.verify(handler(td.matchers.anything()));
+});
+
+test('#adapter.notifyPressedAction emits ' +
+  `${MDCTextFieldInputFoundation.strings.PRESSED_EVENT}`, () => {
+  const {component} = setupTest();
+  const handler = td.func('handler');
+  component.listen(
+    MDCTextFieldInputFoundation.strings.PRESSED_EVENT, handler);
+  component.getDefaultFoundation().adapter_.notifyPressedAction();
+
+  td.verify(handler(td.matchers.anything()));
+});

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -55,6 +55,19 @@ class FakeBottomLine {
   }
 }
 
+class FakeInput {
+  constructor() {
+    this.foundation = td.object({
+      getValue: () => {},
+      isDisabled: () => {},
+      setDisabled: () => {},
+      handleTextFieldInteraction: () => {},
+    });
+    this.listen = td.func('input.listen');
+    this.unlisten = td.func('input.unlisten');
+  }
+}
+
 test('#constructor when given a `mdc-text-field--box` element instantiates a ripple on the root element', () => {
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
@@ -73,6 +86,18 @@ test('#constructor when given a `mdc-text-field--box` element, initializes a def
   root.classList.add(cssClasses.BOX);
   const component = new MDCTextField(root);
   assert.instanceOf(component.ripple, MDCRipple);
+});
+
+test('#constructor throws error when there is no `mdc-text-field__input` element', () => {
+  const root = bel`
+    <div class="mdc-text-field">
+      <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
+      <input type="text" id="my-text-field">
+      <label class="mdc-text-field__label" for="my-text-field">My Label</label>
+      <div class="mdc-text-field__bottom-line"></div>
+    </div>
+  `;
+  assert.throws(() => new MDCTextField(root));
 });
 
 const getHelperTextElement = () => bel`<p id="helper-text">helper text</p>`;
@@ -105,24 +130,10 @@ function setupTest() {
   const root = getFixture();
   const icon = root.querySelector('.mdc-text-field__icon');
   const bottomLine = new FakeBottomLine();
-  const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el), () => bottomLine);
-  return {root, bottomLine, icon, component};
+  const input = new FakeInput();
+  const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el), () => bottomLine, () => input);
+  return {root, bottomLine, input, icon, component};
 }
-
-test('#initialSyncWithDom sets disabled if input element is not disabled', () => {
-  const {component} = setupTest();
-  component.initialSyncWithDom();
-  assert.isNotOk(component.disabled);
-});
-
-test('get/set disabled updates the input element', () => {
-  const {root, component} = setupTest();
-  const input = root.querySelector('.mdc-text-field__input');
-  component.disabled = true;
-  assert.isOk(input.disabled);
-  component.disabled = false;
-  assert.isNotOk(input.disabled);
-});
 
 test('get/set disabled updates the component styles', () => {
   const {root, component} = setupTest();
@@ -163,6 +174,20 @@ test('#adapter.setIconAttr sets a given attribute to a given value to the icon e
 
   component.getDefaultFoundation().adapter_.setIconAttr('tabindex', '-1');
   assert.equal(icon.getAttribute('tabindex'), '-1');
+});
+
+test('#adapter.registerInputEventHandler adds event listener to input', () => {
+  const {component, input} = setupTest();
+  const handler = () => {};
+  component.getDefaultFoundation().adapter_.registerInputEventHandler('evt', handler);
+  td.verify(input.listen('evt', handler));
+});
+
+test('#adapter.deregisterInputEventHandler removes event listener from input', () => {
+  const {component, input} = setupTest();
+  const handler = () => {};
+  component.getDefaultFoundation().adapter_.deregisterInputEventHandler('evt', handler);
+  td.verify(input.unlisten('evt', handler));
 });
 
 test('#adapter.registerBottomLineEventHandler adds event listener to bottom line', () => {
@@ -218,26 +243,6 @@ test('#adapter.removeClassFromLabel does nothing if no label element present', (
   assert.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeClassFromLabel('foo'));
 });
 
-test('#adapter.registerInputInteractionHandler adds a handler to the input element for a given event', () => {
-  const {root, component} = setupTest();
-  const input = root.querySelector('.mdc-text-field__input');
-  const handler = td.func('eventHandler');
-  component.getDefaultFoundation().adapter_.registerInputInteractionHandler('click', handler);
-  domEvents.emit(input, 'click');
-  td.verify(handler(td.matchers.anything()));
-});
-
-test('#adapter.deregisterInputInteractionHandler removes a handler from the input element for a given event', () => {
-  const {root, component} = setupTest();
-  const input = root.querySelector('.mdc-text-field__input');
-  const handler = td.func('eventHandler');
-
-  input.addEventListener('click', handler);
-  component.getDefaultFoundation().adapter_.deregisterInputInteractionHandler('click', handler);
-  domEvents.emit(input, 'click');
-  td.verify(handler(td.matchers.anything()), {times: 0});
-});
-
 test('#adapter.registerTextFieldInteractionHandler adds an event handler for a given event on the root', () => {
   const {root, component} = setupTest();
   const handler = td.func('TextFieldInteractionHandler');
@@ -253,14 +258,6 @@ test('#adapter.deregisterTextFieldInteractionHandler removes an event handler fo
   component.getDefaultFoundation().adapter_.registerTextFieldInteractionHandler('click', handler);
   domEvents.emit(root, 'click');
   td.verify(handler(td.matchers.anything()));
-});
-
-test('#adapter.getNativeInput returns the component input element', () => {
-  const {root, component} = setupTest();
-  assert.equal(
-    component.getDefaultFoundation().adapter_.getNativeInput(),
-    root.querySelector('.mdc-text-field__input')
-  );
 });
 
 test(`#adapter.notifyIconAction emits ${strings.ICON_EVENT}`, () => {


### PR DESCRIPTION
Checks whether the text field's input is the active element on the document when the component is initialized and triggers the activateFocus() method on the foundation when it is.

Fixes #1529 