### PR TITLE
demo(text-field): Move script into head

### DIFF
--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -58,6 +58,7 @@
       }
 
     </style>
+    <script src="/assets/material-components-web.js"></script>
   </head>
   <body>
     <header class="mdc-toolbar mdc-toolbar--fixed">
@@ -361,7 +362,6 @@
         </div>
       </section>
     </main>
-    <script src="/assets/material-components-web.js"></script>
     <script>
       (function() {
         var tfs = document.querySelectorAll(


### PR DESCRIPTION
This removes the console error message caused by scripts trying to use the global variable `mdc`  before it was created:
`text-field.html:184 Uncaught ReferenceError: mdc is not defined`