### PR TITLE
chore(text-field): Remove extra code and documentation from re-arch

### DIFF
--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -327,8 +327,6 @@ complicated.
 | registerTextFieldInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event handler on the root element for a given event |
 | deregisterTextFieldInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event handler on the root element for a given event |
 | notifyIconAction() => void | Emits a custom event "MDCTextField:icon" denoting a user has clicked the icon |
-| addClassToBottomLine(className: string) => void | Adds a class to the bottom line element |
-| removeClassFromBottomLine(className: string) => void | Removes a class from the bottom line element |
 | registerInputInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the native input element for a given event |
 | deregisterInputInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the native input element for a given event |
 | registerBottomLineEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the bottom line element for a given event |
@@ -363,17 +361,12 @@ Activates the focus state of the Text Field. Normally called in response to the 
 
 Deactivates the focus state of the Text Field. Normally called in response to the input blur event.
 
-##### MDCTextFieldFoundation.animateBottomLine(evt: Event)
-
-Animates the bottom line. The animation expands outward from the user's click or touch. Expects an
-event with clientX/clientY properties.
-
 ##### MDCTextFieldFoundation.handleBottomLineAnimationEnd(evt: Event)
 
 Handles the end of the bottom line animation, performing actions that must wait for animations to
 finish. Expects a transition-end event.
 
-##### MDCTextField.helperTextContent
+##### MDCTextField.setHelperTextContent(content)
 
 Sets the content of the helper text, if it exists.
 

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -104,27 +104,6 @@ class MDCTextFieldAdapter {
   notifyIconAction() {}
 
   /**
-   * Adds a class to the helper text element. Note that in our code we check for
-   * whether or not we have a helper text element and if we don't, we simply
-   * return.
-   * @param {string} className
-   */
-  addClassToHelperText(className) {}
-
-  /**
-   * Removes a class from the helper text element.
-   * @param {string} className
-   */
-  removeClassFromHelperText(className) {}
-
-  /**
-   * Returns whether or not the helper text element contains the given class.
-   * @param {string} className
-   * @return {boolean}
-   */
-  helperTextHasClass(className) {}
-
-  /**
    * Registers an event listener on the native input element for a given event.
    * @param {string} evtType
    * @param {function(!Event): undefined} handler
@@ -151,25 +130,6 @@ class MDCTextFieldAdapter {
    * @param {function(!Event): undefined} handler
    */
   deregisterBottomLineEventHandler(evtType, handler) {}
-
-  /**
-   * Sets an attribute with a given value on the helper text element.
-   * @param {string} name
-   * @param {string} value
-   */
-  setHelperTextAttr(name, value) {}
-
-  /**
-   * Removes an attribute from the helper text element.
-   * @param {string} name
-   */
-  removeHelperTextAttr(name) {}
-
-  /**
-   * Sets the text content for the help text element
-   * @param {string} content
-   */
-  setHelperTextContent(content) {}
 
   /**
    * Returns an object representing the native text input element, with a


### PR DESCRIPTION
Remove extra code/documentation lines from splitting out bottom-line and helper-text. 