### PR TITLE
fix(drawer): Fix permanent drawer above toolbar layout on mobile

### DIFF
--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -39,6 +39,7 @@
         box-sizing: border-box;
         min-height: 100%;
         width: 100%;
+        min-width: 715px;
       }
 
       /* Stack toolbar and main on top of each other. */

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -38,6 +38,7 @@
         margin: 0;
         box-sizing: border-box;
         min-height: 100%;
+        min-width: 715px;
       }
 
       /* Place drawer and main next to each other. */


### PR DESCRIPTION
Add min-width to the .demo-body class for permanent drawer above and permanent drawer below toolbar.
Encourage using these only for desktop style layouts and something else for more mobile friendly
layouts.

Fixes #733