### PR TITLE
feat(theme): Support currentColor in mdc-theme-prop*

### DIFF
--- a/packages/mdc-theme/_mixins.scss
+++ b/packages/mdc-theme/_mixins.scss
@@ -22,7 +22,7 @@
 // $edgeOptOut controls whether to feature-detect around Edge to avoid emitting CSS variables for it,
 // intended for use in cases where interactions with pseudo-element styles cause problems due to Edge bugs.
 @mixin mdc-theme-prop($property, $style, $important: false, $edgeOptOut: false) {
-  @if type-of($style) == "color" {
+  @if type-of($style) == "color" or $style == "currentColor" {
     @if $important {
       #{$property}: $style !important;
     } @else {

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -154,7 +154,7 @@ $mdc-theme-property-values: (
 //
 // NOTE: This function must be defined in _variables.scss instead of _functions.scss to avoid circular imports.
 @function mdc-theme-prop-value($property) {
-  @if type-of($property) == color {
+  @if type-of($property) == "color" or $property == "currentColor" {
     @return $property;
   }
 


### PR DESCRIPTION
The `mdc-theme-prop` mixin and `mdc-theme-prop-value` function now treat `currentColor` as if it were a color and emit/return it directly.