### PR TITLE
chore(demos): Make simple-menu demo less ugly

### DIFF
--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html>
+<html class="mdc-typography">
   <head>
     <meta charset="utf-8">
     <title>Simple Menu - Material Components Catalog</title>
@@ -60,6 +60,7 @@
 
       .mdc-theme--dark {
         background-color: #333;
+        color: #ddd;
       }
 
       .mdc-menu-anchor {
@@ -114,36 +115,24 @@
 
         <div class="demo-controls-container">
           <div class="demo-controls">
-            <p>
-              Button position:
-              <div class="">
-                <label><input type="radio" name="position" value="top left" checked>Top left</label>
-              </div>
-
-              <div class="">
-                <label><input type="radio" name="position" value="top right">Top right</label>
-              </div>
-
-              <div class="">
-              <label>
-                <input type="radio" name="position" value="bottom left">
-                Bottom left
-              </label>
+            <p>Button position:</p>
+            <div>
+              <label><input type="radio" name="position" value="top left" checked> Top left</label>
+            </div>
+            <div>
+              <label><input type="radio" name="position" value="top right"> Top right</label>
+            </div>
+            <div>
+              <label><input type="radio" name="position" value="bottom left"> Bottom left</label>
+            </div>
+            <div>
+              <label><input type="radio" name="position" value="bottom right"> Bottom right</label>
             </div>
 
-            <div class="">
-              <label>
-                <input type="radio" name="position" value="bottom right">
-                Bottom right
-              </label>
-            </div>
-            </p>
             <p>
-              <label>
-                <input type="checkbox" name="dark">
-                Dark mode
-              </label>
+              <label><input type="checkbox" name="dark"> Dark mode</label>
             </p>
+
             <div>
               <span>Last Selected item: <em id="last-selected">&lt;none selected&gt;</em></span>
             </div>

--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License
 -->
-<html class="mdc-typography">
+<html>
   <head>
     <meta charset="utf-8">
     <title>Simple Menu - Material Components Catalog</title>
@@ -68,7 +68,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">


### PR DESCRIPTION
- Use mdc-typography to make text look nicer
- Fix invalid markup
- Reformat markup
- Add a space between radio buttons and their label text
- Use light colored text in dark mode