### PR TITLE
chore(list): Rename CSS class to follow BEM

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -42,63 +42,63 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
             <a href="button.html" class="mdc-list-item__text">
               Button
-              <span class="mdc-list-item__text__secondary">Raised and flat buttons</span>
+              <span class="mdc-list-item__text-secondary">Raised and flat buttons</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
             <a href="card.html" class="mdc-list-item__text">
               Card
-              <span class="mdc-list-item__text__secondary">Various card layout styles</span>
+              <span class="mdc-list-item__text-secondary">Various card layout styles</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_selection_control_24px.svg" /></span>
             <a href="checkbox.html" class="mdc-list-item__text">
               Checkbox
-              <span class="mdc-list-item__text__secondary">Multi-selection controls</span>
+              <span class="mdc-list-item__text-secondary">Multi-selection controls</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_dialog_24px.svg" /></span>
             <a href="dialog.html" class="mdc-list-item__text">
               Dialog
-              <span class="mdc-list-item__text__secondary">Secondary text</span>
+              <span class="mdc-list-item__text-secondary">Secondary text</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/temporary-drawer.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text__secondary">Temporary</span>
+              <span class="mdc-list-item__text-secondary">Temporary</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/persistent-drawer.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text__secondary">Persistent</span>
+              <span class="mdc-list-item__text-secondary">Persistent</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/permanent-drawer-above-toolbar.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text__secondary">Permanent drawer above toolbar</span>
+              <span class="mdc-list-item__text-secondary">Permanent drawer above toolbar</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/permanent-drawer-below-toolbar.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text__secondary">Permanent drawer below toolbar</span>
+              <span class="mdc-list-item__text-secondary">Permanent drawer below toolbar</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_shadow_24px.svg" /></span>
             <a href="elevation.html" class="mdc-list-item__text">
               Elevation
-              <span class="mdc-list-item__text__secondary">Shadow for different elevations</span>
+              <span class="mdc-list-item__text-secondary">Shadow for different elevations</span>
             </a>
           </li>
 
@@ -106,7 +106,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
             <a href="fab.html" class="mdc-list-item__text">
               Floating action button
-              <span class="mdc-list-item__text__secondary">The primary action in an application</span>
+              <span class="mdc-list-item__text-secondary">The primary action in an application</span>
             </a>
           </li>
 
@@ -114,7 +114,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
             <a href="grid-list.html" class="mdc-list-item__text">
               Grid list
-              <span class="mdc-list-item__text__secondary">2D grid layouts</span>
+              <span class="mdc-list-item__text-secondary">2D grid layouts</span>
             </a>
           </li>
 
@@ -122,7 +122,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_component_24px.svg" /></span>
             <a href="icon-toggle.html" class="mdc-list-item__text">
               Icon toggle
-              <span class="mdc-list-item__text__secondary">Toggling icon states</span>
+              <span class="mdc-list-item__text-secondary">Toggling icon states</span>
             </a>
           </li>
 
@@ -130,7 +130,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
             <a href="layout-grid.html" class="mdc-list-item__text">
               Layout grid
-              <span class="mdc-list-item__text__secondary">Grid and gutter support</span>
+              <span class="mdc-list-item__text-secondary">Grid and gutter support</span>
             </a>
           </li>
 
@@ -138,7 +138,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_progress_activity.svg" /></span>
             <a href="linear-progress.html" class="mdc-list-item__text">
               Linear progress
-              <span class="mdc-list-item__text__secondary">Fills from 0% to 100%, represented by bars</span>
+              <span class="mdc-list-item__text-secondary">Fills from 0% to 100%, represented by bars</span>
             </a>
           </li>
 
@@ -146,7 +146,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_list_24px.svg" /></span>
             <a href="list.html" class="mdc-list-item__text">
               List
-              <span class="mdc-list-item__text__secondary">Item layouts in lists</span>
+              <span class="mdc-list-item__text-secondary">Item layouts in lists</span>
             </a>
           </li>
 
@@ -155,7 +155,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_radio_button_24px.svg" /></span>
             <a href="radio.html" class="mdc-list-item__text">
               Radio buttons
-              <span class="mdc-list-item__text__secondary">Single selection controls</span>
+              <span class="mdc-list-item__text-secondary">Single selection controls</span>
             </a>
           </li>
 
@@ -163,7 +163,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_ripple_24px.svg" /></span>
             <a href="ripple.html" class="mdc-list-item__text">
               Ripple
-              <span class="mdc-list-item__text__secondary">Touch ripple</span>
+              <span class="mdc-list-item__text-secondary">Touch ripple</span>
             </a>
           </li>
 
@@ -171,7 +171,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
             <a href="select.html" class="mdc-list-item__text">
               Select
-              <span class="mdc-list-item__text__secondary">Popover selection menus</span>
+              <span class="mdc-list-item__text-secondary">Popover selection menus</span>
             </a>
           </li>
 
@@ -179,7 +179,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
             <a href="simple-menu.html" class="mdc-list-item__text">
               Simple Menu
-              <span class="mdc-list-item__text__secondary">Pop over menus</span>
+              <span class="mdc-list-item__text-secondary">Pop over menus</span>
             </a>
           </li>
 
@@ -187,7 +187,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/slider.svg" /></span>
             <a href="slider.html" class="mdc-list-item__text">
               Slider
-              <span class="mdc-list-item__text__secondary">Range Controls</span>
+              <span class="mdc-list-item__text-secondary">Range Controls</span>
             </a>
           </li>
 
@@ -195,7 +195,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toast_24px.svg" /></span>
             <a href="snackbar.html" class="mdc-list-item__text">
               Snackbar
-              <span class="mdc-list-item__text__secondary">Transient messages</span>
+              <span class="mdc-list-item__text-secondary">Transient messages</span>
             </a>
           </li>
 
@@ -203,7 +203,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_switch_24px.svg" /></span>
             <a href="switch.html" class="mdc-list-item__text">
               Switch
-              <span class="mdc-list-item__text__secondary">On off switches</span>
+              <span class="mdc-list-item__text-secondary">On off switches</span>
             </a>
           </li>
 
@@ -211,7 +211,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_tabs_24px.svg" /></span>
             <a href="tabs.html" class="mdc-list-item__text">
               Tabs
-              <span class="mdc-list-item__text__secondary">Tabs with support for icon and text labels</span>
+              <span class="mdc-list-item__text-secondary">Tabs with support for icon and text labels</span>
             </a>
           </li>
 
@@ -219,7 +219,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_text_field_24px.svg" /></span>
             <a href="text-field.html" class="mdc-list-item__text">
               Text field
-              <span class="mdc-list-item__text__secondary">Single and multiline text fields</span>
+              <span class="mdc-list-item__text-secondary">Single and multiline text fields</span>
             </a>
           </li>
 
@@ -227,7 +227,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_theme_24px.svg" /></span>
             <a href="theme.html" class="mdc-list-item__text">
               Theme
-              <span class="mdc-list-item__text__secondary">Using primary and secondary colors</span>
+              <span class="mdc-list-item__text-secondary">Using primary and secondary colors</span>
             </a>
           </li>
 
@@ -235,7 +235,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toolbar_24px.svg" /></span>
             <a href="toolbar/index.html" class="mdc-list-item__text">
               Toolbar
-              <span class="mdc-list-item__text__secondary">Header and footers</span>
+              <span class="mdc-list-item__text-secondary">Header and footers</span>
             </a>
           </li>
 
@@ -243,7 +243,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_typography_24px.svg" /></span>
             <a href="typography.html" class="mdc-list-item__text">
               Typography
-              <span class="mdc-list-item__text__secondary">Type hierarchy</span>
+              <span class="mdc-list-item__text-secondary">Type hierarchy</span>
             </a>
           </li>
         </ul>

--- a/demos/index.html
+++ b/demos/index.html
@@ -42,63 +42,63 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
             <a href="button.html" class="mdc-list-item__text">
               Button
-              <span class="mdc-list-item__text-secondary">Raised and flat buttons</span>
+              <span class="mdc-list-item__secondary-text">Raised and flat buttons</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
             <a href="card.html" class="mdc-list-item__text">
               Card
-              <span class="mdc-list-item__text-secondary">Various card layout styles</span>
+              <span class="mdc-list-item__secondary-text">Various card layout styles</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_selection_control_24px.svg" /></span>
             <a href="checkbox.html" class="mdc-list-item__text">
               Checkbox
-              <span class="mdc-list-item__text-secondary">Multi-selection controls</span>
+              <span class="mdc-list-item__secondary-text">Multi-selection controls</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_dialog_24px.svg" /></span>
             <a href="dialog.html" class="mdc-list-item__text">
               Dialog
-              <span class="mdc-list-item__text-secondary">Secondary text</span>
+              <span class="mdc-list-item__secondary-text">Secondary text</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/temporary-drawer.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text-secondary">Temporary</span>
+              <span class="mdc-list-item__secondary-text">Temporary</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/persistent-drawer.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text-secondary">Persistent</span>
+              <span class="mdc-list-item__secondary-text">Persistent</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/permanent-drawer-above-toolbar.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text-secondary">Permanent drawer above toolbar</span>
+              <span class="mdc-list-item__secondary-text">Permanent drawer above toolbar</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_side_navigation_24px.svg" /></span>
             <a href="drawer/permanent-drawer-below-toolbar.html" class="mdc-list-item__text">
               Drawer
-              <span class="mdc-list-item__text-secondary">Permanent drawer below toolbar</span>
+              <span class="mdc-list-item__secondary-text">Permanent drawer below toolbar</span>
             </a>
           </li>
           <li class="mdc-list-item">
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_shadow_24px.svg" /></span>
             <a href="elevation.html" class="mdc-list-item__text">
               Elevation
-              <span class="mdc-list-item__text-secondary">Shadow for different elevations</span>
+              <span class="mdc-list-item__secondary-text">Shadow for different elevations</span>
             </a>
           </li>
 
@@ -106,7 +106,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_button_24px.svg" /></span>
             <a href="fab.html" class="mdc-list-item__text">
               Floating action button
-              <span class="mdc-list-item__text-secondary">The primary action in an application</span>
+              <span class="mdc-list-item__secondary-text">The primary action in an application</span>
             </a>
           </li>
 
@@ -114,7 +114,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
             <a href="grid-list.html" class="mdc-list-item__text">
               Grid list
-              <span class="mdc-list-item__text-secondary">2D grid layouts</span>
+              <span class="mdc-list-item__secondary-text">2D grid layouts</span>
             </a>
           </li>
 
@@ -122,7 +122,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_component_24px.svg" /></span>
             <a href="icon-toggle.html" class="mdc-list-item__text">
               Icon toggle
-              <span class="mdc-list-item__text-secondary">Toggling icon states</span>
+              <span class="mdc-list-item__secondary-text">Toggling icon states</span>
             </a>
           </li>
 
@@ -130,7 +130,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_card_24px.svg" /></span>
             <a href="layout-grid.html" class="mdc-list-item__text">
               Layout grid
-              <span class="mdc-list-item__text-secondary">Grid and gutter support</span>
+              <span class="mdc-list-item__secondary-text">Grid and gutter support</span>
             </a>
           </li>
 
@@ -138,7 +138,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_progress_activity.svg" /></span>
             <a href="linear-progress.html" class="mdc-list-item__text">
               Linear progress
-              <span class="mdc-list-item__text-secondary">Fills from 0% to 100%, represented by bars</span>
+              <span class="mdc-list-item__secondary-text">Fills from 0% to 100%, represented by bars</span>
             </a>
           </li>
 
@@ -146,7 +146,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_list_24px.svg" /></span>
             <a href="list.html" class="mdc-list-item__text">
               List
-              <span class="mdc-list-item__text-secondary">Item layouts in lists</span>
+              <span class="mdc-list-item__secondary-text">Item layouts in lists</span>
             </a>
           </li>
 
@@ -155,7 +155,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_radio_button_24px.svg" /></span>
             <a href="radio.html" class="mdc-list-item__text">
               Radio buttons
-              <span class="mdc-list-item__text-secondary">Single selection controls</span>
+              <span class="mdc-list-item__secondary-text">Single selection controls</span>
             </a>
           </li>
 
@@ -163,7 +163,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_ripple_24px.svg" /></span>
             <a href="ripple.html" class="mdc-list-item__text">
               Ripple
-              <span class="mdc-list-item__text-secondary">Touch ripple</span>
+              <span class="mdc-list-item__secondary-text">Touch ripple</span>
             </a>
           </li>
 
@@ -171,7 +171,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
             <a href="select.html" class="mdc-list-item__text">
               Select
-              <span class="mdc-list-item__text-secondary">Popover selection menus</span>
+              <span class="mdc-list-item__secondary-text">Popover selection menus</span>
             </a>
           </li>
 
@@ -179,7 +179,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_menu_24px.svg" /></span>
             <a href="simple-menu.html" class="mdc-list-item__text">
               Simple Menu
-              <span class="mdc-list-item__text-secondary">Pop over menus</span>
+              <span class="mdc-list-item__secondary-text">Pop over menus</span>
             </a>
           </li>
 
@@ -187,7 +187,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/slider.svg" /></span>
             <a href="slider.html" class="mdc-list-item__text">
               Slider
-              <span class="mdc-list-item__text-secondary">Range Controls</span>
+              <span class="mdc-list-item__secondary-text">Range Controls</span>
             </a>
           </li>
 
@@ -195,7 +195,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toast_24px.svg" /></span>
             <a href="snackbar.html" class="mdc-list-item__text">
               Snackbar
-              <span class="mdc-list-item__text-secondary">Transient messages</span>
+              <span class="mdc-list-item__secondary-text">Transient messages</span>
             </a>
           </li>
 
@@ -203,7 +203,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_switch_24px.svg" /></span>
             <a href="switch.html" class="mdc-list-item__text">
               Switch
-              <span class="mdc-list-item__text-secondary">On off switches</span>
+              <span class="mdc-list-item__secondary-text">On off switches</span>
             </a>
           </li>
 
@@ -211,7 +211,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_tabs_24px.svg" /></span>
             <a href="tabs.html" class="mdc-list-item__text">
               Tabs
-              <span class="mdc-list-item__text-secondary">Tabs with support for icon and text labels</span>
+              <span class="mdc-list-item__secondary-text">Tabs with support for icon and text labels</span>
             </a>
           </li>
 
@@ -219,7 +219,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_text_field_24px.svg" /></span>
             <a href="text-field.html" class="mdc-list-item__text">
               Text field
-              <span class="mdc-list-item__text-secondary">Single and multiline text fields</span>
+              <span class="mdc-list-item__secondary-text">Single and multiline text fields</span>
             </a>
           </li>
 
@@ -227,7 +227,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_theme_24px.svg" /></span>
             <a href="theme.html" class="mdc-list-item__text">
               Theme
-              <span class="mdc-list-item__text-secondary">Using primary and secondary colors</span>
+              <span class="mdc-list-item__secondary-text">Using primary and secondary colors</span>
             </a>
           </li>
 
@@ -235,7 +235,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_toolbar_24px.svg" /></span>
             <a href="toolbar/index.html" class="mdc-list-item__text">
               Toolbar
-              <span class="mdc-list-item__text-secondary">Header and footers</span>
+              <span class="mdc-list-item__secondary-text">Header and footers</span>
             </a>
           </li>
 
@@ -243,7 +243,7 @@
             <span class="catalog-list-icon mdc-list-item__start-detail"><img class="catalog-component-icon" src="/images/ic_typography_24px.svg" /></span>
             <a href="typography.html" class="mdc-list-item__text">
               Typography
-              <span class="mdc-list-item__text-secondary">Type hierarchy</span>
+              <span class="mdc-list-item__secondary-text">Type hierarchy</span>
             </a>
           </li>
         </ul>

--- a/demos/list.html
+++ b/demos/list.html
@@ -132,7 +132,7 @@
             </span>
             <span class="mdc-list-item__text">
               Photos
-              <span class="mdc-list-item__text__secondary">Jan 9, 2014</span>
+              <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
             </span>
             <a href="#" class="mdc-list-item__end-detail material-icons"
                aria-label="View more information" title="More info"
@@ -146,7 +146,7 @@
             </span>
             <span class="mdc-list-item__text">
               Recipes
-              <span class="mdc-list-item__text__secondary">Jan 17, 2014</span>
+              <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
             </span>
             <a href="#" class="mdc-list-item__end-detail material-icons"
                aria-label="View more information" title="More info"
@@ -160,7 +160,7 @@
             </span>
             <span class="mdc-list-item__text">
               Work
-              <span class="mdc-list-item__text__secondary">Jan 28, 2014</span>
+              <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
             </span>
             <a href="#" class="mdc-list-item__end-detail material-icons"
                aria-label="View more information" title="More info"
@@ -545,19 +545,19 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -568,19 +568,19 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -592,21 +592,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -618,21 +618,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -644,21 +644,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -670,21 +670,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -695,21 +695,21 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
@@ -721,21 +721,21 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text__secondary">Secondary text</span>
+                  <span class="mdc-list-item__text-secondary">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
@@ -750,7 +750,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Photos
-                  <span class="mdc-list-item__text__secondary">Jan 9, 2014</span>
+                  <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -764,7 +764,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Recipes
-                  <span class="mdc-list-item__text__secondary">Jan 17, 2014</span>
+                  <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -778,7 +778,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Work
-                  <span class="mdc-list-item__text__secondary">Jan 28, 2014</span>
+                  <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -797,7 +797,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Photos
-                  <span class="mdc-list-item__text__secondary">Jan 9, 2014</span>
+                  <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -811,7 +811,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Recipes
-                  <span class="mdc-list-item__text__secondary">Jan 17, 2014</span>
+                  <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -825,7 +825,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Work
-                  <span class="mdc-list-item__text__secondary">Jan 28, 2014</span>
+                  <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -907,7 +907,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Photos
-                    <span class="mdc-list-item__text__secondary">Jan 9, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -921,7 +921,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Recipes
-                    <span class="mdc-list-item__text__secondary">Jan 17, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -935,7 +935,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Work
-                    <span class="mdc-list-item__text__secondary">Jan 28, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -953,7 +953,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Vacation Itinerary
-                    <span class="mdc-list-item__text__secondary">Jan 10, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 10, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -967,7 +967,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Kitchen Remodel
-                    <span class="mdc-list-item__text__secondary">Jan 20, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 20, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -989,7 +989,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Photos
-                    <span class="mdc-list-item__text__secondary">Jan 9, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1003,7 +1003,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Recipes
-                    <span class="mdc-list-item__text__secondary">Jan 17, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1017,7 +1017,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Work
-                    <span class="mdc-list-item__text__secondary">Jan 28, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1035,7 +1035,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Vacation Itinerary
-                    <span class="mdc-list-item__text__secondary">Jan 10, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 10, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1049,7 +1049,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Kitchen Remodel
-                    <span class="mdc-list-item__text__secondary">Jan 20, 2014</span>
+                    <span class="mdc-list-item__text-secondary">Jan 20, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"

--- a/demos/list.html
+++ b/demos/list.html
@@ -132,7 +132,7 @@
             </span>
             <span class="mdc-list-item__text">
               Photos
-              <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
+              <span class="mdc-list-item__secondary-text">Jan 9, 2014</span>
             </span>
             <a href="#" class="mdc-list-item__end-detail material-icons"
                aria-label="View more information" title="More info"
@@ -146,7 +146,7 @@
             </span>
             <span class="mdc-list-item__text">
               Recipes
-              <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
+              <span class="mdc-list-item__secondary-text">Jan 17, 2014</span>
             </span>
             <a href="#" class="mdc-list-item__end-detail material-icons"
                aria-label="View more information" title="More info"
@@ -160,7 +160,7 @@
             </span>
             <span class="mdc-list-item__text">
               Work
-              <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
+              <span class="mdc-list-item__secondary-text">Jan 28, 2014</span>
             </span>
             <a href="#" class="mdc-list-item__end-detail material-icons"
                aria-label="View more information" title="More info"
@@ -545,19 +545,19 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -568,19 +568,19 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -592,21 +592,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -618,21 +618,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -644,21 +644,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -670,21 +670,21 @@
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__start-detail grey-bg"></span>
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
               </li>
             </ul>
@@ -695,21 +695,21 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
@@ -721,21 +721,21 @@
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
               <li class="mdc-list-item">
                 <span class="mdc-list-item__text">
                   Two-line item
-                  <span class="mdc-list-item__text-secondary">Secondary text</span>
+                  <span class="mdc-list-item__secondary-text">Secondary text</span>
                 </span>
                 <span class="mdc-list-item__end-detail grey-bg"></span>
               </li>
@@ -750,7 +750,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Photos
-                  <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
+                  <span class="mdc-list-item__secondary-text">Jan 9, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -764,7 +764,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Recipes
-                  <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
+                  <span class="mdc-list-item__secondary-text">Jan 17, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -778,7 +778,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Work
-                  <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
+                  <span class="mdc-list-item__secondary-text">Jan 28, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -797,7 +797,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Photos
-                  <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
+                  <span class="mdc-list-item__secondary-text">Jan 9, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -811,7 +811,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Recipes
-                  <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
+                  <span class="mdc-list-item__secondary-text">Jan 17, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -825,7 +825,7 @@
                 </span>
                 <span class="mdc-list-item__text">
                   Work
-                  <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
+                  <span class="mdc-list-item__secondary-text">Jan 28, 2014</span>
                 </span>
                 <a href="#" class="mdc-list-item__end-detail material-icons"
                    aria-label="View more information" title="More info"
@@ -907,7 +907,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Photos
-                    <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 9, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -921,7 +921,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Recipes
-                    <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 17, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -935,7 +935,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Work
-                    <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 28, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -953,7 +953,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Vacation Itinerary
-                    <span class="mdc-list-item__text-secondary">Jan 10, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 10, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -967,7 +967,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Kitchen Remodel
-                    <span class="mdc-list-item__text-secondary">Jan 20, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 20, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -989,7 +989,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Photos
-                    <span class="mdc-list-item__text-secondary">Jan 9, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 9, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1003,7 +1003,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Recipes
-                    <span class="mdc-list-item__text-secondary">Jan 17, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 17, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1017,7 +1017,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Work
-                    <span class="mdc-list-item__text-secondary">Jan 28, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 28, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1035,7 +1035,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Vacation Itinerary
-                    <span class="mdc-list-item__text-secondary">Jan 10, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 10, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"
@@ -1049,7 +1049,7 @@
                   </span>
                   <span class="mdc-list-item__text">
                     Kitchen Remodel
-                    <span class="mdc-list-item__text-secondary">Jan 20, 2014</span>
+                    <span class="mdc-list-item__secondary-text">Jan 20, 2014</span>
                   </span>
                   <a href="#" class="mdc-list-item__end-detail material-icons"
                      aria-label="View more information" title="More info"

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -99,7 +99,7 @@ While in theory you can add any number of "lines" to a list item, you can use th
   <li class="mdc-list-item">
     <span class="mdc-list-item__text">
       Two-line item
-      <span class="mdc-list-item__text__secondary">Secondary text</span>
+      <span class="mdc-list-item__text-secondary">Secondary text</span>
     </span>
   </li>
 </ul>
@@ -361,7 +361,7 @@ The html for this can be easily added
   <li class="mdc-list-item">
     <span class="mdc-list-item__text">
       Ali Connors
-      <span class="mdc-list-item__text__secondary">Lunch this afternoon? I was...</span>
+      <span class="mdc-list-item__text-secondary">Lunch this afternoon? I was...</span>
     </span>
 
     <span class="mdc-list-item__end-detail">

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -99,7 +99,7 @@ While in theory you can add any number of "lines" to a list item, you can use th
   <li class="mdc-list-item">
     <span class="mdc-list-item__text">
       Two-line item
-      <span class="mdc-list-item__text-secondary">Secondary text</span>
+      <span class="mdc-list-item__secondary-text">Secondary text</span>
     </span>
   </li>
 </ul>
@@ -361,7 +361,7 @@ The html for this can be easily added
   <li class="mdc-list-item">
     <span class="mdc-list-item__text">
       Ali Connors
-      <span class="mdc-list-item__text-secondary">Lunch this afternoon? I was...</span>
+      <span class="mdc-list-item__secondary-text">Lunch this afternoon? I was...</span>
     </span>
 
     <span class="mdc-list-item__end-detail">

--- a/packages/mdc-list/mdc-list.scss
+++ b/packages/mdc-list/mdc-list.scss
@@ -88,7 +88,7 @@ $mdc-list-side-padding: 16px;
     display: inline-flex;
     flex-direction: column;
 
-    &__secondary {
+    &-secondary {
       @include mdc-typography(body1);
       @include mdc-theme-prop(color, text-secondary-on-background);
 

--- a/packages/mdc-list/mdc-list.scss
+++ b/packages/mdc-list/mdc-list.scss
@@ -87,22 +87,22 @@ $mdc-list-side-padding: 16px;
   &__text {
     display: inline-flex;
     flex-direction: column;
+  }
 
-    &-secondary {
-      @include mdc-typography(body1);
-      @include mdc-theme-prop(color, text-secondary-on-background);
+  &__secondary-text {
+    @include mdc-typography(body1);
+    @include mdc-theme-prop(color, text-secondary-on-background);
 
-      @include mdc-theme-dark {
-        @include mdc-theme-prop(color, text-secondary-on-dark);
-      }
-
-      // Match the font size to the primary text when dense
-      // stylelint-disable plugin/selector-bem-pattern
-      .mdc-list--dense & {
-        font-size: inherit;
-      }
-      // stylelint-enable plugin/selector-bem-pattern
+    @include mdc-theme-dark {
+      @include mdc-theme-prop(color, text-secondary-on-dark);
     }
+
+    // Match the font size to the primary text when dense
+    // stylelint-disable plugin/selector-bem-pattern
+    .mdc-list--dense & {
+      font-size: inherit;
+    }
+    // stylelint-enable plugin/selector-bem-pattern
   }
 
   // stylelint-disable plugin/selector-bem-pattern


### PR DESCRIPTION
BREAKING CHANGE: The `mdc-list-item__text__secondary` class was renamed to `mdc-list-item__secondary-text` to adhere to BEM conventions.