### PR TITLE
chore(demos): Remove white gap from simple-menu demo in dark mode

### DIFF
--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -40,7 +40,7 @@
       .demo-content {
         position: relative;
         flex: 1;
-        margin-top: 16px;
+        padding: 16px;
       }
 
       .demo-controls-container {


### PR DESCRIPTION
This was supposed to be part of PR #1659, but I was dumb and forgot to `git push` before merging the PR into master. D'oh!