### PR TITLE
feat(text-field): Add outline subelement and demo for outlined text field

### DIFF
--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -134,6 +134,7 @@
           </label>
         </div>
       </section>
+
       <section class="example">
         <h2>Password field with validation</h2>
         <div class="mdc-text-field">
@@ -148,6 +149,54 @@
           Must be at least 8 characters long
         </p>
       </section>
+
+      <section class="example">
+        <h2>Outlined Text Field</h2>
+        <div id="demo-tf-outlined-wrapper">
+          <div id="tf-outlined-example" class="mdc-text-field mdc-text-field--outlined" data-demo-no-auto-js>
+            <input required pattern=".{8,}" type="text" id="tf-outlined-input" class="mdc-text-field__input"
+                   aria-controls="name-validation-message">
+            <label for="tf-outlined-input" class="mdc-text-field__label">Your Name</label>
+            <div class="mdc-text-field__outline">
+              <svg>
+                <path class="mdc-text-field__outline-path"/>
+              </svg>
+            </div>
+            <div class="mdc-text-field__idle-outline"></div>
+          </div>
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg"
+            id="name-validation-msg">
+            Must be at least 8 characters
+          </p>
+        </div>
+        <div>
+          <input id="outlined-disable" type="checkbox">
+          <label for="outlined-disable">Disabled</label>
+        </div>
+        <div>
+          <input id="outlined-rtl" type="checkbox">
+          <label for="outlined-rtl">RTL</label>
+        </div>
+        <script>
+          setTimeout(function() {
+            var tfEl = document.getElementById('tf-outlined-example');
+            var tf = new mdc.textField.MDCTextField(tfEl);
+            var wrapper = document.getElementById('demo-tf-outlined-wrapper');
+            document.getElementById('outlined-disable').addEventListener('change', function(evt) {
+              tf.disabled = evt.target.checked;
+            });
+            document.getElementById('outlined-rtl').addEventListener('change', function(evt) {
+              if (evt.target.checked) {
+                wrapper.setAttribute('dir', 'rtl');
+              } else {
+                wrapper.removeAttribute('dir');
+              }
+              tf.layout();
+            });
+          }, 0);
+        </script>
+      </section>
+
       <section class="example">
         <h2>Text Field box</h2>
         <div id="demo-tf-box-wrapper">
@@ -194,7 +243,7 @@
               } else {
                 wrapper.removeAttribute('dir');
               }
-              tf.ripple.layout();
+              tf.layout();
             });
 
             document.getElementById('box-dark-theme').addEventListener('change', function(evt) {
@@ -203,7 +252,7 @@
 
             document.getElementById('box-dense').addEventListener('change', function(evt) {
               tfEl.classList[evt.target.checked ? 'add' : 'remove']('mdc-text-field--dense');
-              tf.ripple.layout();
+              tf.layout();
             });
           }, 0);
         </script>
@@ -397,8 +446,8 @@
             wrapperLeading.removeAttribute('dir');
             wrapperTrailing.removeAttribute('dir');
           }
-          tfLeading.ripple.layout();
-          tfTrailing.ripple.layout();
+          tfLeading.layout();
+          tfTrailing.layout();
         });
 
         document.getElementById('box-dark-theme-leading-trailing').addEventListener('change', function(evt) {
@@ -408,9 +457,9 @@
 
         document.getElementById('box-dense-leading-trailing').addEventListener('change', function(evt) {
           tfLeadingEl.classList[evt.target.checked ? 'add' : 'remove']('mdc-text-field--dense');
-          tfLeading.ripple.layout();
+          tfLeading.layout();
           tfTrailingEl.classList[evt.target.checked ? 'add' : 'remove']('mdc-text-field--dense');
-          tfTrailing.ripple.layout();
+          tfTrailing.layout();
         });
 
         document.getElementById('box-unclickable-leading-trailing').addEventListener('change', function(evt) {

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -332,8 +332,6 @@ complicated.
 | registerBottomLineEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the bottom line element for a given event |
 | deregisterBottomLineEventHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the bottom line element for a given event |
 | getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}? | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully. |
-| getWidth() => number | Returns the width of the root element. |
-| getHeight() => number | Returns the height of the root element. |
 | getLabelWidth() => number | Returns the width of the label element. |
 | getIdleOutlineStyleValue(propertyName: string) => string | Returns the idle outline element's computed style value of the given css property `propertyName`. We achieve this via `getComputedStyle(...).getPropertyValue(propertyName)`.|
 | isRtl() => boolean | Returns whether the direction of the root element is set to RTL. |

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -196,7 +196,7 @@ See [here](outline/) for more information on using the outline sub-component.
 </div>
 ```
 
-Note that both Text Field Boxes and Outlined Text Fields support all of the same features as normal text-fields, including helper text, validation, and dense UI.
+Note that both Text Field Boxes and Outlined Text Fields support all of the same features as normal Text Fields, including helper text, validation, and dense UI.
 
 #### CSS-only text field boxes
 
@@ -338,7 +338,7 @@ complicated.
 | getIdleOutlineStyleValue(propertyName: string) => string | Returns the idle outline element's computed style value of the given css property `propertyName`. We achieve this via `getComputedStyle(...).getPropertyValue(propertyName)`.|
 | isRtl() => boolean | Returns whether the direction of the root element is set to RTL. |
 
-MDC Text Field has multiple optional sub-elements: bottom line, helper text and outline. The foundations of these sub-elements must be passed in as constructor arguments for the `MDCTextField` foundation. Since the `MDCTextField` component takes care of creating its foundation, we need to pass sub-element foundations through the `MDCTextField` component. This is typically done in the component's implementation of `getDefaultFoundation()`.
+MDC Text Field has multiple optional sub-elements: bottom line, helper text, and outline. The foundations of these sub-elements must be passed in as constructor arguments for the `MDCTextField` foundation. Since the `MDCTextField` component takes care of creating its foundation, we need to pass sub-element foundations through the `MDCTextField` component. This is typically done in the component's implementation of `getDefaultFoundation()`.
 
 #### The full foundation API
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -316,6 +316,10 @@ String setter. Proxies to the foundation's `setHelperTextContent` method when se
 `MDCRipple` instance. Set to the `MDCRipple` instance for the root element that `MDCTextField`
 initializes when given an `mdc-text-field--box` root element. Otherwise, the field is set to `null`.
 
+##### MDCTextField.layout()
+
+Recomputes the outline SVG path for the outline element, and recomputes all dimensions and positions for the ripple element.
+
 ### Using the foundation class
 
 Because MDC Text Field is a feature-rich and relatively complex component, its adapter is a bit more
@@ -334,8 +338,13 @@ complicated.
 | registerBottomLineEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the bottom line element for a given event |
 | deregisterBottomLineEventHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the bottom line element for a given event |
 | getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}? | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully. |
+| getWidth() => number | Returns the width of the root element. |
+| getHeight() => number | Returns the height of the root element. |
+| getLabelWidth() => number | Returns the width of the label element. |
+| getIdleOutlineStyleValue(propertyName: string) => string | Returns the idle outline element's computed style value of the given css property `propertyName`. We achieve this via `getComputedStyle(...).getPropertyValue(propertyName)`.|
+| isRtl() => boolean | Returns whether the direction of the root element is set to RTL. |
 
-MDC Text Field has multiple optional sub-elements: bottom line and helper text. The foundations of these sub-elements must be passed in as constructor arguments for the `MDCTextField` foundation. Since the `MDCTextField` component takes care of creating its foundation, we need to pass sub-element foundations through the `MDCTextField` component. This is typically done in the component's implementation of `getDefaultFoundation()`.
+MDC Text Field has multiple optional sub-elements: bottom line, helper text and outline. The foundations of these sub-elements must be passed in as constructor arguments for the `MDCTextField` foundation. Since the `MDCTextField` component takes care of creating its foundation, we need to pass sub-element foundations through the `MDCTextField` component. This is typically done in the component's implementation of `getDefaultFoundation()`.
 
 #### The full foundation API
 
@@ -371,6 +380,10 @@ finish. Expects a transition-end event.
 ##### MDCTextFieldFoundation.setHelperTextContent(content)
 
 Sets the content of the helper text, if it exists.
+
+##### MDCTextFieldFoundation.updateOutline()
+
+Updates the focus outline for outlined text fields.
 
 ### Theming
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -332,7 +332,6 @@ complicated.
 | registerBottomLineEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the bottom line element for a given event |
 | deregisterBottomLineEventHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the bottom line element for a given event |
 | getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}? | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully. |
-| getLabelWidth() => number | Returns the width of the label element. |
 | getIdleOutlineStyleValue(propertyName: string) => string | Returns the idle outline element's computed style value of the given css property `propertyName`. We achieve this via `getComputedStyle(...).getPropertyValue(propertyName)`.|
 | isRtl() => boolean | Returns whether the direction of the root element is set to RTL. |
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -189,6 +189,23 @@ Note that **full-width text fields do not support floating labels**. Labels shou
 included as part of the DOM structure for full-width text fields. Full-width textareas
 behave normally.
 
+### Outlined Text Fields
+
+```html
+<div class="mdc-text-field mdc-text-field--outlined">
+  <input type="text" id="tf-outlined" class="mdc-text-field__input">
+  <label for="tf-outlined" class="mdc-text-field__label">Your Name</label>
+  <div class="mdc-text-field__outline">
+    <svg>
+      <path class="mdc-text-field__outline-path"/>
+    </svg>
+  </div>
+  <div class="mdc-text-field__idle-outline"></div>
+</div>
+```
+
+See [here](outline/) for more information on using the outline sub-component.
+
 ### Text Field Boxes
 
 ```html
@@ -199,8 +216,7 @@ behave normally.
 </div>
 ```
 
-Note that Text field boxes support all of the same features as normal text-fields, including helper
-text, validation, and dense UI.
+Note that both Text Field Boxes and Outlined Text Fields support all of the same features as normal text-fields, including helper text, validation, and dense UI.
 
 #### CSS-only text field boxes
 

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -14,6 +14,10 @@
 // limitations under the License.
 //
 
+@mixin mdc-text-field-outlined-corner-radius($radius) {
+  border-radius: $radius $radius $radius $radius;
+}
+
 @mixin mdc-text-field-box-corner-radius($radius) {
   border-radius: $radius $radius 0 0;
 }
@@ -45,7 +49,7 @@
 
     33% {
       animation-timing-function: cubic-bezier(.5, 0, .701732, .495819);
-      transform: translateX(10px) translateY(-#{$positionY}) scale(.75, .75);
+      transform: translateX(5px) translateY(-#{$positionY}) scale(.75, .75);
     }
 
     66% {

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -15,7 +15,7 @@
 //
 
 @mixin mdc-text-field-outlined-corner-radius($radius) {
-  border-radius: $radius $radius $radius $radius;
+  border-radius: $radius;
 }
 
 @mixin mdc-text-field-box-corner-radius($radius) {

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -43,6 +43,10 @@ $mdc-text-field-box-disabled-background: rgba(black, .02);
 $mdc-text-field-box-disabled-background-dark: rgba(white, .05);
 $mdc-text-field-box-secondary-text: rgba(black, .6);
 
+$mdc-text-field-outlined-idle-border: rgba(black, .12);
+$mdc-text-field-outlined-disabled-border: rgba(black, .06);
+$mdc-text-field-outlined-hover-border: rgba(black, .87);
+
 $mdc-textarea-border-on-light: rgba(black, .73);
 $mdc-textarea-border-on-dark: rgba(white, 1);
 $mdc-textarea-light-background: rgba(white, 1);

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -163,6 +163,12 @@ class MDCTextFieldAdapter {
    * @return {string}
    */
   getIdleOutlineStyleValue(propertyName) {}
+
+  /**
+   * Returns true if the direction of the root element is set to RTL.
+   * @return {boolean}
+   */
+  isRtl() {}
 }
 
 export {MDCTextFieldAdapter, NativeInputType, FoundationMapType};

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -137,6 +137,32 @@ class MDCTextFieldAdapter {
    * @return {?Element|?NativeInputType}
    */
   getNativeInput() {}
+
+  /**
+   * Returns the width of the root element.
+   * @return {number}
+   */
+  getWidth() {}
+
+  /**
+   * Returns the height of the root element.
+   * @return {number}
+   */
+  getHeight() {}
+
+  /**
+   * Returns the width of the label element.
+   * @return {number}
+   */
+  getLabelWidth() {}
+
+  /**
+   * Returns the idle outline element's computed style value of the given css property `propertyName`.
+   * We achieve this via `getComputedStyle(...).getPropertyValue(propertyName)`.
+   * @param {string} propertyName
+   * @return {string}
+   */
+  getIdleOutlineStyleValue(propertyName) {}
 }
 
 export {MDCTextFieldAdapter, NativeInputType, FoundationMapType};

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -121,18 +121,6 @@ class MDCTextFieldAdapter {
   getNativeInput() {}
 
   /**
-   * Returns the width of the root element.
-   * @return {number}
-   */
-  getWidth() {}
-
-  /**
-   * Returns the height of the root element.
-   * @return {number}
-   */
-  getHeight() {}
-
-  /**
    * Returns the width of the label element.
    * @return {number}
    */

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -121,12 +121,6 @@ class MDCTextFieldAdapter {
   getNativeInput() {}
 
   /**
-   * Returns the width of the label element.
-   * @return {number}
-   */
-  getLabelWidth() {}
-
-  /**
    * Returns the idle outline element's computed style value of the given css property `propertyName`.
    * We achieve this via `getComputedStyle(...).getPropertyValue(propertyName)`.
    * @param {string} propertyName

--- a/packages/mdc-textfield/constants.js
+++ b/packages/mdc-textfield/constants.js
@@ -35,9 +35,7 @@ const cssClasses = {
   FOCUSED: 'mdc-text-field--focused',
   INVALID: 'mdc-text-field--invalid',
   BOX: 'mdc-text-field--box',
-  OUTLINED: 'mdc-text-field--outlined',
   TEXT_FIELD_ICON: 'mdc-text-field__icon',
-  TEXTAREA: 'mdc-text-field--textarea',
 };
 
 export {cssClasses, strings};

--- a/packages/mdc-textfield/constants.js
+++ b/packages/mdc-textfield/constants.js
@@ -22,6 +22,8 @@ const strings = {
   LABEL_SELECTOR: '.mdc-text-field__label',
   ICON_SELECTOR: '.mdc-text-field__icon',
   ICON_EVENT: 'MDCTextField:icon',
+  IDLE_OUTLINE_SELECTOR: '.mdc-text-field__idle-outline',
+  OUTLINE_SELECTOR: '.mdc-text-field__outline',
   BOTTOM_LINE_SELECTOR: '.mdc-text-field__bottom-line',
 };
 
@@ -33,6 +35,7 @@ const cssClasses = {
   FOCUSED: 'mdc-text-field--focused',
   INVALID: 'mdc-text-field--invalid',
   BOX: 'mdc-text-field--box',
+  OUTLINED: 'mdc-text-field--outlined',
   TEXT_FIELD_ICON: 'mdc-text-field__icon',
   TEXTAREA: 'mdc-text-field--textarea',
 };

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -58,9 +58,6 @@ class MDCTextFieldFoundation extends MDCFoundation {
       registerBottomLineEventHandler: () => {},
       deregisterBottomLineEventHandler: () => {},
       getNativeInput: () => {},
-      getWidth: () => {},
-      getHeight: () => {},
-      getLabelWidth: () => {},
       getIdleOutlineStyleValue: () => {},
       isRtl: () => {},
     });
@@ -154,13 +151,13 @@ class MDCTextFieldFoundation extends MDCFoundation {
    * Updates the focus outline for outlined text fields.
    */
   updateOutline() {
-    if (!this.outline_) {
+    if (!this.outline_ || !this.label_) {
       return;
     }
-    // The label is scaled 75% when it floats above the text field.
-    const labelWidth = this.adapter_.getLabelWidth() * 0.75;
+    const labelWidth = this.label_.getFloatingWidth();
+    // Fall back to reading a specific corner's style because Firefox doesn't report the style on border-radius.
     const radiusStyleValue = this.adapter_.getIdleOutlineStyleValue('border-radius') ||
-      /* Firefox requires specifying the corner. */ this.adapter_.getIdleOutlineStyleValue('border-top-left-radius');
+      this.adapter_.getIdleOutlineStyleValue('border-top-left-radius');
     const radius = parseFloat(radiusStyleValue);
     const isRtl = this.adapter_.isRtl();
     this.outline_.updateSvgPath(labelWidth, radius, isRtl);

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -162,7 +162,7 @@ class MDCTextFieldFoundation extends MDCFoundation {
     // The label is scaled 75% when it floats above the text field.
     const labelWidth = this.adapter_.getLabelWidth() * 0.75;
     const radiusStyleValue = this.adapter_.getIdleOutlineStyleValue('border-radius') ||
-      this.adapter_.getIdleOutlineStyleValue('border-top-left-radius') /* Firefox requires specifying the corner. */;
+      /* Firefox requires specifying the corner. */ this.adapter_.getIdleOutlineStyleValue('border-top-left-radius');
     const radius = parseFloat(radiusStyleValue);
     const isRtl = this.adapter_.isRtl();
     this.outline_.updateSvgPath(width, height, labelWidth, radius, isRtl);

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -172,7 +172,9 @@ class MDCTextFieldFoundation extends MDCFoundation {
     const height = this.adapter_.getHeight();
     // The label is scaled 75% when it floats above the text field.
     const labelWidth = this.adapter_.getLabelWidth() * 0.75;
-    const radius = parseFloat(this.adapter_.getIdleOutlineStyleValue('border-radius'));
+    const radiusStyleValue = this.adapter_.getIdleOutlineStyleValue('border-radius') ||
+      this.adapter_.getIdleOutlineStyleValue('border-top-left-radius') /* Firefox requires specifying the corner. */;
+    const radius = parseFloat(radiusStyleValue);
     const isRtl = this.adapter_.isRtl();
     this.outline_.updateSvgPath(width, height, labelWidth, radius, isRtl);
   }

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -21,6 +21,7 @@ import MDCTextFieldBottomLineFoundation from './bottom-line/foundation';
 /* eslint-disable no-unused-vars */
 import MDCTextFieldHelperTextFoundation from './helper-text/foundation';
 import MDCTextFieldLabelFoundation from './label/foundation';
+import MDCTextFieldOutlineFoundation from './outline/foundation';
 /* eslint-enable no-unused-vars */
 import {cssClasses, strings} from './constants';
 
@@ -76,6 +77,8 @@ class MDCTextFieldFoundation extends MDCFoundation {
     this.helperText_ = foundationMap.helperText;
     /** @type {!MDCTextFieldLabelFoundation|undefined} */
     this.label_ = foundationMap.label;
+    /** @type {!MDCTextFieldOutlineFoundation|undefined} */
+    this.outline_ = foundationMap.outline;
 
     /** @private {boolean} */
     this.isFocused_ = false;
@@ -154,6 +157,21 @@ class MDCTextFieldFoundation extends MDCFoundation {
   }
 
   /**
+   * Updates the focus outline for outlined text fields.
+   */
+  updateOutline() {
+    if (!this.outline_) {
+      return;
+    }
+    const width = this.adapter_.getWidth();
+    const height = this.adapter_.getHeight();
+    const labelWidth = this.adapter_.getLabelWidth();
+    const radius = parseFloat(this.adapter_.getIdleOutlineStyleValue('border-radius'));
+    const isRtl = this.adapter_.isRtl();
+    this.outline_.updateSvgPath(width, height, labelWidth, radius, isRtl);
+  }
+
+  /**
    * Activates the text field focus state.
    */
   activateFocus() {
@@ -167,6 +185,9 @@ class MDCTextFieldFoundation extends MDCFoundation {
     }
     if (this.helperText_) {
       this.helperText_.showToScreenReader();
+    }
+    if (this.outline_) {
+      this.updateOutline();
     }
     this.isFocused_ = true;
   }

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -60,6 +60,11 @@ class MDCTextFieldFoundation extends MDCFoundation {
       registerBottomLineEventHandler: () => {},
       deregisterBottomLineEventHandler: () => {},
       getNativeInput: () => {},
+      getWidth: () => {},
+      getHeight: () => {},
+      getLabelWidth: () => {},
+      getIdleOutlineStyleValue: () => {},
+      isRtl: () => {},
     });
   }
 
@@ -165,10 +170,7 @@ class MDCTextFieldFoundation extends MDCFoundation {
     }
     const width = this.adapter_.getWidth();
     const height = this.adapter_.getHeight();
-    let labelWidth = this.adapter_.getLabelWidth();
-    if (!this.label_.isFloating()) {
-      labelWidth = labelWidth * 0.75;
-    }
+    const labelWidth = this.adapter_.getLabelWidth() * 0.75;
     const radius = parseFloat(this.adapter_.getIdleOutlineStyleValue('border-radius'));
     const isRtl = this.adapter_.isRtl();
     this.outline_.updateSvgPath(width, height, labelWidth, radius, isRtl);

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -157,15 +157,13 @@ class MDCTextFieldFoundation extends MDCFoundation {
     if (!this.outline_) {
       return;
     }
-    const width = this.adapter_.getWidth();
-    const height = this.adapter_.getHeight();
     // The label is scaled 75% when it floats above the text field.
     const labelWidth = this.adapter_.getLabelWidth() * 0.75;
     const radiusStyleValue = this.adapter_.getIdleOutlineStyleValue('border-radius') ||
       /* Firefox requires specifying the corner. */ this.adapter_.getIdleOutlineStyleValue('border-top-left-radius');
     const radius = parseFloat(radiusStyleValue);
     const isRtl = this.adapter_.isRtl();
-    this.outline_.updateSvgPath(width, height, labelWidth, radius, isRtl);
+    this.outline_.updateSvgPath(labelWidth, radius, isRtl);
   }
 
   /**

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -170,6 +170,7 @@ class MDCTextFieldFoundation extends MDCFoundation {
     }
     const width = this.adapter_.getWidth();
     const height = this.adapter_.getHeight();
+    // The label is scaled 75% when it floats above the text field.
     const labelWidth = this.adapter_.getLabelWidth() * 0.75;
     const radius = parseFloat(this.adapter_.getIdleOutlineStyleValue('border-radius'));
     const isRtl = this.adapter_.isRtl();

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -165,7 +165,10 @@ class MDCTextFieldFoundation extends MDCFoundation {
     }
     const width = this.adapter_.getWidth();
     const height = this.adapter_.getHeight();
-    const labelWidth = this.adapter_.getLabelWidth();
+    let labelWidth = this.adapter_.getLabelWidth();
+    if (!this.label_.isFloating()) {
+      labelWidth = labelWidth * 0.75;
+    }
     const radius = parseFloat(this.adapter_.getIdleOutlineStyleValue('border-radius'));
     const isRtl = this.adapter_.isRtl();
     this.outline_.updateSvgPath(width, height, labelWidth, radius, isRtl);
@@ -180,14 +183,14 @@ class MDCTextFieldFoundation extends MDCFoundation {
     if (this.bottomLine_) {
       this.bottomLine_.activate();
     }
+    if (this.outline_) {
+      this.updateOutline();
+    }
     if (this.label_) {
       this.label_.floatAbove();
     }
     if (this.helperText_) {
       this.helperText_.showToScreenReader();
-    }
-    if (this.outline_) {
-      this.updateOutline();
     }
     this.isFocused_ = true;
   }

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -203,7 +203,7 @@ class MDCTextField extends MDCComponent {
         getHeight: () => this.root_.offsetHeight,
         getLabelWidth: () => {
           const labelElement = this.root_.querySelector(strings.LABEL_SELECTOR);
-          return labelElement.offsetWidth;
+          return labelElement.getBoundingClientRect().width;
         },
         getIdleOutlineStyleValue: (propertyName) => {
           const idleOutlineElement = this.root_.querySelector(strings.IDLE_OUTLINE_SELECTOR);

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -214,8 +214,6 @@ class MDCTextField extends MDCComponent {
             this.bottomLine_.unlisten(evtType, handler);
           }
         },
-        getWidth: () => this.root_.offsetWidth,
-        getHeight: () => this.root_.offsetHeight,
         getLabelWidth: () => {
           const labelElement = this.root_.querySelector(strings.LABEL_SELECTOR);
           return labelElement.offsetWidth;

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -214,10 +214,6 @@ class MDCTextField extends MDCComponent {
             this.bottomLine_.unlisten(evtType, handler);
           }
         },
-        getLabelWidth: () => {
-          const labelElement = this.root_.querySelector(strings.LABEL_SELECTOR);
-          return labelElement.offsetWidth;
-        },
         getIdleOutlineStyleValue: (propertyName) => {
           const idleOutlineElement = this.root_.querySelector(strings.IDLE_OUTLINE_SELECTOR);
           if (idleOutlineElement) {

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -203,7 +203,7 @@ class MDCTextField extends MDCComponent {
         getHeight: () => this.root_.offsetHeight,
         getLabelWidth: () => {
           const labelElement = this.root_.querySelector(strings.LABEL_SELECTOR);
-          return labelElement.getBoundingClientRect().width;
+          return labelElement.offsetWidth;
         },
         getIdleOutlineStyleValue: (propertyName) => {
           const idleOutlineElement = this.root_.querySelector(strings.IDLE_OUTLINE_SELECTOR);

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -44,8 +44,8 @@ class MDCTextField extends MDCComponent {
     this.input_;
     /** @private {?MDCTextFieldLabel} */
     this.label_;
-    /** @private {?MDCRipple} */
-    this.ripple_;
+    /** @type {?MDCRipple} */
+    this.ripple;
     /** @private {?MDCTextFieldOutline} */
     this.outline_;
     /** @private {?MDCTextFieldBottomLine} */
@@ -78,7 +78,7 @@ class MDCTextField extends MDCComponent {
     if (labelElement) {
       this.label_ = new MDCTextFieldLabel(labelElement);
     }
-    this.ripple_ = null;
+    this.ripple = null;
     if (this.root_.classList.contains(cssClasses.BOX)) {
       const MATCHES = getMatchesProperty(HTMLElement.prototype);
       const adapter = Object.assign(MDCRipple.createAdapter(this), {
@@ -87,7 +87,7 @@ class MDCTextField extends MDCComponent {
         deregisterInteractionHandler: (type, handler) => this.input_.removeEventListener(type, handler),
       });
       const foundation = new MDCRippleFoundation(adapter);
-      this.ripple_ = rippleFactory(this.root_, foundation);
+      this.ripple = rippleFactory(this.root_, foundation);
     }
     const bottomLineElement = this.root_.querySelector(strings.BOTTOM_LINE_SELECTOR);
     if (bottomLineElement) {
@@ -109,8 +109,8 @@ class MDCTextField extends MDCComponent {
   }
 
   destroy() {
-    if (this.ripple_) {
-      this.ripple_.destroy();
+    if (this.ripple) {
+      this.ripple.destroy();
     }
     if (this.bottomLine_) {
       this.bottomLine_.destroy();
@@ -172,8 +172,8 @@ class MDCTextField extends MDCComponent {
     if (this.outline_) {
       this.foundation_.updateOutline();
     }
-    if (this.ripple_) {
-      this.ripple_.layout();
+    if (this.ripple) {
+      this.ripple.layout();
     }
   }
 

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -69,10 +69,13 @@ class MDCTextField extends MDCComponent {
    * creates a new MDCRipple.
    * @param {(function(!Element): !MDCTextFieldBottomLine)=} bottomLineFactory A function which
    * creates a new MDCTextFieldBottomLine.
+   * @param {(function(!Element): !MDCTextFieldOutline)=} outlineFactory A function which
+   * creates a new MDCTextFieldOutline.
    */
   initialize(
     rippleFactory = (el, foundation) => new MDCRipple(el, foundation),
-    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el)) {
+    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el),
+    outlineFactory = (el) => new MDCTextFieldOutline(el)) {
     this.input_ = this.root_.querySelector(strings.INPUT_SELECTOR);
     const labelElement = this.root_.querySelector(strings.LABEL_SELECTOR);
     if (labelElement) {
@@ -95,7 +98,7 @@ class MDCTextField extends MDCComponent {
     }
     const outlineElement = this.root_.querySelector(strings.OUTLINE_SELECTOR);
     if (outlineElement) {
-      this.outline_ = new MDCTextFieldOutline(outlineElement);
+      this.outline_ = outlineFactory(outlineElement);
     }
     if (this.input_.hasAttribute(strings.ARIA_CONTROLS)) {
       const helperTextElement = document.getElementById(this.input_.getAttribute(strings.ARIA_CONTROLS));

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -81,7 +81,7 @@ class MDCTextField extends MDCComponent {
    */
   initialize(
     rippleFactory = (el, foundation) => new MDCRipple(el, foundation),
-    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el)
+    bottomLineFactory = (el) => new MDCTextFieldBottomLine(el),
     helperTextFactory = (el) => new MDCTextFieldHelperText(el),
     iconFactory = (el) => new MDCTextFieldIcon(el),
     labelFactory = (el) => new MDCTextFieldLabel(el),

--- a/packages/mdc-textfield/label/README.md
+++ b/packages/mdc-textfield/label/README.md
@@ -34,8 +34,13 @@ Method Signature | Description
 --- | ---
 addClass(className: string) => void | Adds a class to the label element
 removeClass(className: string) => void | Removes a class from the label element
+getWidth() => number | Returns the width of the label element
 
 #### The full foundation API
+
+##### MDCTextFieldLabelFoundation.getFloatingWidth()
+
+Returns the width of the label element when it floats above the text field.
 
 ##### MDCTextFieldLabelFoundation.floatAbove()
 

--- a/packages/mdc-textfield/label/adapter.js
+++ b/packages/mdc-textfield/label/adapter.js
@@ -39,6 +39,12 @@ class MDCTextFieldLabelAdapter {
    * @param {string} className
    */
   removeClass(className) {}
+
+  /**
+   * Returns the width of the label element.
+   * @return {number}
+   */
+  getWidth() {}
 }
 
 export default MDCTextFieldLabelAdapter;

--- a/packages/mdc-textfield/label/adapter.js
+++ b/packages/mdc-textfield/label/adapter.js
@@ -39,6 +39,13 @@ class MDCTextFieldLabelAdapter {
    * @param {string} className
    */
   removeClass(className) {}
+
+  /**
+   * Returns whether or not the helper text element contains the given class.
+   * @param {string} className
+   * @return {boolean}
+   */
+  hasClass(className) {}
 }
 
 export default MDCTextFieldLabelAdapter;

--- a/packages/mdc-textfield/label/adapter.js
+++ b/packages/mdc-textfield/label/adapter.js
@@ -39,13 +39,6 @@ class MDCTextFieldLabelAdapter {
    * @param {string} className
    */
   removeClass(className) {}
-
-  /**
-   * Returns whether or not the helper text element contains the given class.
-   * @param {string} className
-   * @return {boolean}
-   */
-  hasClass(className) {}
 }
 
 export default MDCTextFieldLabelAdapter;

--- a/packages/mdc-textfield/label/foundation.js
+++ b/packages/mdc-textfield/label/foundation.js
@@ -39,7 +39,6 @@ class MDCTextFieldLabelFoundation extends MDCFoundation {
     return /** @type {!MDCTextFieldLabelAdapter} */ ({
       addClass: () => {},
       removeClass: () => {},
-      hasClass: () => {},
     });
   }
 
@@ -54,14 +53,6 @@ class MDCTextFieldLabelFoundation extends MDCFoundation {
   floatAbove() {
     this.adapter_.addClass(cssClasses.LABEL_FLOAT_ABOVE);
     this.adapter_.removeClass(cssClasses.LABEL_SHAKE);
-  }
-
-  /**
-   * Returns whether the label is floating above the input.
-   * @return {boolean}
-   */
-  isFloating() {
-    return this.adapter_.hasClass(cssClasses.LABEL_FLOAT_ABOVE);
   }
 
   /**

--- a/packages/mdc-textfield/label/foundation.js
+++ b/packages/mdc-textfield/label/foundation.js
@@ -39,6 +39,7 @@ class MDCTextFieldLabelFoundation extends MDCFoundation {
     return /** @type {!MDCTextFieldLabelAdapter} */ ({
       addClass: () => {},
       removeClass: () => {},
+      getWidth: () => {},
     });
   }
 
@@ -47,6 +48,15 @@ class MDCTextFieldLabelFoundation extends MDCFoundation {
    */
   constructor(adapter = /** @type {!MDCTextFieldLabelAdapter} */ ({})) {
     super(Object.assign(MDCTextFieldLabelFoundation.defaultAdapter, adapter));
+  }
+
+  /**
+   * Returns the width of the label element when it floats above the text field.
+   * @return {number} 
+   */
+  getFloatingWidth() {
+    // The label is scaled 75% when it floats above the text field.
+    return this.adapter_.getWidth() * 0.75;
   }
 
   /** Makes the label float above the text field. */

--- a/packages/mdc-textfield/label/foundation.js
+++ b/packages/mdc-textfield/label/foundation.js
@@ -52,7 +52,7 @@ class MDCTextFieldLabelFoundation extends MDCFoundation {
 
   /**
    * Returns the width of the label element when it floats above the text field.
-   * @return {number} 
+   * @return {number}
    */
   getFloatingWidth() {
     // The label is scaled 75% when it floats above the text field.

--- a/packages/mdc-textfield/label/foundation.js
+++ b/packages/mdc-textfield/label/foundation.js
@@ -39,6 +39,7 @@ class MDCTextFieldLabelFoundation extends MDCFoundation {
     return /** @type {!MDCTextFieldLabelAdapter} */ ({
       addClass: () => {},
       removeClass: () => {},
+      hasClass: () => {},
     });
   }
 
@@ -53,6 +54,14 @@ class MDCTextFieldLabelFoundation extends MDCFoundation {
   floatAbove() {
     this.adapter_.addClass(cssClasses.LABEL_FLOAT_ABOVE);
     this.adapter_.removeClass(cssClasses.LABEL_SHAKE);
+  }
+
+  /**
+   * Returns whether the label is floating above the input.
+   * @return {boolean}
+   */
+  isFloating() {
+    return this.adapter_.hasClass(cssClasses.LABEL_FLOAT_ABOVE);
   }
 
   /**

--- a/packages/mdc-textfield/label/index.js
+++ b/packages/mdc-textfield/label/index.js
@@ -47,6 +47,7 @@ class MDCTextFieldLabel extends MDCComponent {
     return new MDCTextFieldLabelFoundation(/** @type {!MDCTextFieldLabelAdapter} */ (Object.assign({
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
+      hasClass: (className) => this.root_.classList.contains(className),
     })));
   }
 }

--- a/packages/mdc-textfield/label/index.js
+++ b/packages/mdc-textfield/label/index.js
@@ -47,7 +47,6 @@ class MDCTextFieldLabel extends MDCComponent {
     return new MDCTextFieldLabelFoundation(/** @type {!MDCTextFieldLabelAdapter} */ (Object.assign({
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
-      hasClass: (className) => this.root_.classList.contains(className),
     })));
   }
 }

--- a/packages/mdc-textfield/label/index.js
+++ b/packages/mdc-textfield/label/index.js
@@ -47,6 +47,7 @@ class MDCTextFieldLabel extends MDCComponent {
     return new MDCTextFieldLabelFoundation(/** @type {!MDCTextFieldLabelAdapter} */ (Object.assign({
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
+      getWidth: () => this.root_.offsetWidth,
     })));
   }
 }

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -124,9 +124,11 @@
 
     overflow: hidden;
   }
-  
+
   height: 56px;
   border: none;
+
+  // stylelint-disable plugin/selector-bem-pattern
 
   .mdc-text-field__input {
     display: flex;
@@ -141,7 +143,6 @@
     }
   }
 
-  // stylelint-disable plugin/selector-bem-pattern
   .mdc-text-field__label {
     @include mdc-rtl-reflexive-position(left, 16px);
 
@@ -153,7 +154,7 @@
 
     &--float-above {
       @include mdc-theme-prop(color, primary);
-  
+
       transform: scale(.75) translateY(-170%);
 
       &.mdc-text-field__label--shake {
@@ -177,11 +178,10 @@
   .mdc-text-field__label--float-above ~ .mdc-text-field__outline {
     opacity: 1;
   }
-  // stylelint-enable plugin/selector-bem-pattern
 
   &.mdc-text-field--disabled {
     @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
-    
+
     .mdc-text-field__input {
       border-bottom: none;
     }
@@ -203,6 +203,8 @@
       @include mdc-theme-prop(color, $mdc-text-field-disabled-icon-on-light);
     }
   }
+
+  // stylelint-enable plugin/selector-bem-pattern
 }
 
 .mdc-text-field--box {
@@ -391,6 +393,7 @@
   box-sizing: border-box;
   margin-top: 16px;
 
+  // stylelint-disable-next-line selector-max-specificity
   &:not(.mdc-text-field--textarea):not(.mdc-text-field--outlined) {
     height: 48px;
   }
@@ -421,7 +424,7 @@
     border-color: $mdc-text-field-error-on-light;
   }
 
-  svg .mdc-text-field__outline-path {
+  .mdc-text-field__outline .mdc-text-field__outline-path {
     stroke: $mdc-text-field-error-on-light;
   }
 }

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -157,14 +157,14 @@
     }
   }
 
-  &.mdc-text-field--focused .mdc-text-field__idle-outline, 
-  .mdc-text-field__label--float-above ~ .mdc-text-field__idle-outline{
-      opacity: 0;
+  &.mdc-text-field--focused .mdc-text-field__idle-outline,
+  .mdc-text-field__label--float-above ~ .mdc-text-field__idle-outline {
+    opacity: 0;
   }
-    
+
   &.mdc-text-field--focused .mdc-text-field__outline,
   .mdc-text-field__label--float-above ~ .mdc-text-field__outline {
-      opacity: 1;
+    opacity: 1;
   }
 
   &:not(.mdc-text-field--focused) .mdc-text-field__outline-path {

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -156,24 +156,14 @@
     }
   }
 
-  &.mdc-text-field--focused {
-    .mdc-text-field__idle-outline {
+  &.mdc-text-field--focused .mdc-text-field__idle-outline, 
+  .mdc-text-field__label--float-above ~ .mdc-text-field__idle-outline{
       opacity: 0;
-    }
-
-    .mdc-text-field__outline {
-      opacity: 1;
-    }
   }
-
-  .mdc-text-field__label--float-above {
-    ~ .mdc-text-field__idle-outline {
-      opacity: 0;
-    }
-
-    ~ .mdc-text-field__outline {
+    
+  &.mdc-text-field--focused .mdc-text-field__outline,
+  .mdc-text-field__label--float-above ~ .mdc-text-field__outline {
       opacity: 1;
-    }
   }
 
   &:not(.mdc-text-field--focused) .mdc-text-field__outline-path {

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -180,6 +180,10 @@
     opacity: 1;
   }
 
+  &:not(.mdc-text-field--focused) .mdc-text-field__outline-path {
+    stroke-width: 1px;
+  }
+
   &.mdc-text-field--disabled {
     @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
 

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -121,15 +121,6 @@
   height: 56px;
   border: none;
 
-  .mdc-text-field__outline {
-    @include mdc-ripple-surface;
-    @include mdc-states(text-primary-on-light);
-    @include mdc-ripple-radius;
-    @include mdc-text-field-outlined-corner-radius($mdc-text-field-border-radius);
-
-    overflow: hidden;
-  }
-
   // stylelint-disable plugin/selector-bem-pattern
 
   .mdc-text-field__input {
@@ -165,20 +156,24 @@
     }
   }
 
-  &.mdc-text-field--focused .mdc-text-field__idle-outline {
-    opacity: 0;
+  &.mdc-text-field--focused {
+    .mdc-text-field__idle-outline {
+      opacity: 0;
+    }
+
+    .mdc-text-field__outline {
+      opacity: 1;
+    }
   }
 
-  &.mdc-text-field--focused .mdc-text-field__outline {
-    opacity: 1;
-  }
+  .mdc-text-field__label--float-above {
+    ~ .mdc-text-field__idle-outline {
+      opacity: 0;
+    }
 
-  .mdc-text-field__label--float-above ~ .mdc-text-field__idle-outline {
-    opacity: 0;
-  }
-
-  .mdc-text-field__label--float-above ~ .mdc-text-field__outline {
-    opacity: 1;
+    ~ .mdc-text-field__outline {
+      opacity: 1;
+    }
   }
 
   &:not(.mdc-text-field--focused) .mdc-text-field__outline-path {

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -26,9 +26,11 @@
 @import "@material/typography/variables";
 @import "./bottom-line/mdc-text-field-bottom-line";
 @import "./helper-text/mdc-text-field-helper-text";
+@import "./outline/mdc-text-field-outline";
 @import "./label/mdc-text-field-label";
 @include mdc-text-field-invalid-label-shake-keyframes_(standard, 100%);
 @include mdc-text-field-invalid-label-shake-keyframes_(box, 50%);
+@include mdc-text-field-invalid-label-shake_keyframes_(outlined, 130%);
 
 // postcss-bem-linter: define text-field
 
@@ -111,6 +113,96 @@
     cursor: auto;
   }
   // stylelint-enable plugin/selector-bem-pattern
+}
+
+.mdc-text-field--outlined {
+  .mdc-text-field__outline {
+    @include mdc-ripple-surface;
+    @include mdc-states(text-primary-on-light);
+    @include mdc-ripple-radius;
+    @include mdc-text-field-outlined-corner-radius($mdc-text-field-border-radius);
+
+    overflow: hidden;
+  }
+  
+  height: 56px;
+  border: none;
+
+  .mdc-text-field__input {
+    display: flex;
+    height: 30px;
+    padding: 12px;
+    border: none;
+    background-color: transparent;
+    z-index: 3;
+
+    &:hover ~ .mdc-text-field__idle-outline {
+      border: 1px solid $mdc-text-field-outlined-hover-border;
+    }
+  }
+
+  // stylelint-disable plugin/selector-bem-pattern
+  .mdc-text-field__label {
+    @include mdc-rtl-reflexive-position(left, 16px);
+
+    position: absolute;
+    bottom: 20px;
+    left: 16px;
+    transition: transform 260ms ease;
+    z-index: 2;
+
+    &--float-above {
+      @include mdc-theme-prop(color, primary);
+  
+      transform: scale(.75) translateY(-170%);
+
+      &.mdc-text-field__label--shake {
+        animation: invalid-shake-float-above-outlined 250ms 1;
+      }
+    }
+  }
+
+  &.mdc-text-field--focused .mdc-text-field__idle-outline {
+    opacity: 0;
+  }
+
+  &.mdc-text-field--focused .mdc-text-field__outline {
+    opacity: 1;
+  }
+
+  .mdc-text-field__label--float-above ~ .mdc-text-field__idle-outline {
+    opacity: 0;
+  }
+
+  .mdc-text-field__label--float-above ~ .mdc-text-field__outline {
+    opacity: 1;
+  }
+  // stylelint-enable plugin/selector-bem-pattern
+
+  &.mdc-text-field--disabled {
+    @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
+    
+    .mdc-text-field__input {
+      border-bottom: none;
+    }
+
+    .mdc-text-field__outline-path {
+      stroke: $mdc-text-field-outlined-disabled-border;
+      stroke-width: 1px;
+    }
+
+    .mdc-text-field__idle-outline {
+      border-color: $mdc-text-field-outlined-disabled-border;
+    }
+
+    .mdc-text-field__label {
+      bottom: 20px;
+    }
+
+    .mdc-text-field__icon {
+      @include mdc-theme-prop(color, $mdc-text-field-disabled-icon-on-light);
+    }
+  }
 }
 
 .mdc-text-field--box {
@@ -299,7 +391,7 @@
   box-sizing: border-box;
   margin-top: 16px;
 
-  &:not(.mdc-text-field--textarea) {
+  &:not(.mdc-text-field--textarea):not(.mdc-text-field--outlined) {
     height: 48px;
   }
 
@@ -319,6 +411,18 @@
 
   .mdc-text-field__bottom-line {
     background-color: $mdc-text-field-error-on-light;
+  }
+
+  .mdc-text-field__idle-outline {
+    border-color: $mdc-text-field-error-on-light;
+  }
+
+  .mdc-text-field__input:hover ~ .mdc-text-field__idle-outline {
+    border-color: $mdc-text-field-error-on-light;
+  }
+
+  svg .mdc-text-field__outline-path {
+    stroke: $mdc-text-field-error-on-light;
   }
 }
 

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -116,6 +116,9 @@
 }
 
 .mdc-text-field--outlined {
+  height: 56px;
+  border: none;
+
   .mdc-text-field__outline {
     @include mdc-ripple-surface;
     @include mdc-states(text-primary-on-light);
@@ -124,9 +127,6 @@
 
     overflow: hidden;
   }
-
-  height: 56px;
-  border: none;
 
   // stylelint-disable plugin/selector-bem-pattern
 

--- a/packages/mdc-textfield/outline/README.md
+++ b/packages/mdc-textfield/outline/README.md
@@ -9,7 +9,7 @@ path: /catalog/input-controls/text-fields/outline/
 
 # Text Field Outline
 
-The outline is a border around all sides of the text field.
+The outline is a border around all sides of the text field. This is used for the Outlined variation of Text Fields.
 
 ## Design & API Documentation
 
@@ -18,7 +18,6 @@ The outline is a border around all sides of the text field.
     <a href="https://material.io/guidelines/components/text-fields.html#text-fields-field-variations">Material Design guidelines: Text Field Variations</a>
   </li>
 </ul>
-
 
 ## Usage
 

--- a/packages/mdc-textfield/outline/README.md
+++ b/packages/mdc-textfield/outline/README.md
@@ -31,6 +31,8 @@ MDCTextFieldOutlineFoundation. This allows the parent MDCTextField component to 
 
 Method Signature | Description
 --- | ---
+getWidth() => number | Returns the width of the outline element
+getHeight() => number | Returns the height of the outline element
 setOutlinePathAttr(value: string) => void | Sets the SVG path of the outline element
 
 #### The full foundation API

--- a/packages/mdc-textfield/outline/README.md
+++ b/packages/mdc-textfield/outline/README.md
@@ -31,7 +31,7 @@ MDCTextFieldOutlineFoundation. This allows the parent MDCTextField component to 
 
 Method Signature | Description
 --- | ---
-setOutlinePathAttr(className: string) => void | Sets the SVG path of the outline element
+setOutlinePathAttr(value: string) => void | Sets the SVG path of the outline element
 
 #### The full foundation API
 

--- a/packages/mdc-textfield/outline/README.md
+++ b/packages/mdc-textfield/outline/README.md
@@ -33,7 +33,7 @@ Method Signature | Description
 --- | ---
 getWidth() => number | Returns the width of the outline element
 getHeight() => number | Returns the height of the outline element
-setOutlinePathAttr(value: string) => void | Sets the SVG path of the outline element
+setOutlinePathAttr(value: string) => void | Sets the "d" attribute of the outline element's SVG path
 
 #### The full foundation API
 

--- a/packages/mdc-textfield/outline/README.md
+++ b/packages/mdc-textfield/outline/README.md
@@ -1,0 +1,41 @@
+<!--docs:
+title: "Text Field Outline"
+layout: detail
+section: components
+excerpt: "The outline is a border around the text field"
+iconId: text_field
+path: /catalog/input-controls/text-fields/outline/
+-->
+
+# Text Field Outline
+
+The outline is a border around all sides of the text field.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/components/text-fields.html#text-fields-field-variations">Material Design guidelines: Text Field Variations</a>
+  </li>
+</ul>
+
+
+## Usage
+
+#### MDCTextFieldOutline API
+
+##### MDCTextFieldOutline.foundation
+
+MDCTextFieldOutlineFoundation. This allows the parent MDCTextField component to access the public methods on the MDCTextFieldOutlineFoundation class.
+
+### Using the foundation class
+
+Method Signature | Description
+--- | ---
+setOutlinePathAttr(className: string) => void | Sets the SVG path of the outline element
+
+#### The full foundation API
+
+##### MDCTextFieldOutlineFoundation.updateSvgPath(width: number, height: number, labelWidth: number, radius: number, isRtl: boolean)
+
+Updates the SVG path of the focus outline element based on the given width and height of the text field element, the width of the label element, the corner radius, and the RTL context.

--- a/packages/mdc-textfield/outline/adapter.js
+++ b/packages/mdc-textfield/outline/adapter.js
@@ -29,6 +29,17 @@
  */
 class MDCTextFieldOutlineAdapter {
   /**
+   * Returns the width of the root element.
+   * @return {number}
+   */
+  getWidth() {}
+
+  /**
+   * Returns the height of the root element.
+   * @return {number}
+   */
+  getHeight() {}
+  /**
    * Sets the SVG path of the outline element.
    * @param {string} value
    */

--- a/packages/mdc-textfield/outline/adapter.js
+++ b/packages/mdc-textfield/outline/adapter.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint no-unused-vars: [2, {"args": "none"}] */
+
+/**
+ * Adapter for MDC Text Field Outline.
+ *
+ * Defines the shape of the adapter expected by the foundation. Implement this
+ * adapter to integrate the Text Field outline into your framework. See
+ * https://github.com/material-components/material-components-web/blob/master/docs/authoring-components.md
+ * for more information.
+ *
+ * @record
+ */
+class MDCTextFieldOutlineAdapter {
+  /**
+   * Set the SVG path of the outline element.
+   * @param {string} value
+   */
+  setOutlinePathAttr(value) {}
+}
+
+export default MDCTextFieldOutlineAdapter;

--- a/packages/mdc-textfield/outline/adapter.js
+++ b/packages/mdc-textfield/outline/adapter.js
@@ -39,9 +39,9 @@ class MDCTextFieldOutlineAdapter {
    * @return {number}
    */
   getHeight() {}
-  
+
   /**
-   * Sets the SVG path of the outline element.
+   * Sets the "d" attribute of the outline element's SVG path.
    * @param {string} value
    */
   setOutlinePathAttr(value) {}

--- a/packages/mdc-textfield/outline/adapter.js
+++ b/packages/mdc-textfield/outline/adapter.js
@@ -39,6 +39,7 @@ class MDCTextFieldOutlineAdapter {
    * @return {number}
    */
   getHeight() {}
+  
   /**
    * Sets the SVG path of the outline element.
    * @param {string} value

--- a/packages/mdc-textfield/outline/adapter.js
+++ b/packages/mdc-textfield/outline/adapter.js
@@ -29,7 +29,7 @@
  */
 class MDCTextFieldOutlineAdapter {
   /**
-   * Set the SVG path of the outline element.
+   * Sets the SVG path of the outline element.
    * @param {string} value
    */
   setOutlinePathAttr(value) {}

--- a/packages/mdc-textfield/outline/constants.js
+++ b/packages/mdc-textfield/outline/constants.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @enum {string} */
+const strings = {
+  PATH_SELECTOR: '.mdc-text-field__outline-path',
+};
+
+export {strings};

--- a/packages/mdc-textfield/outline/foundation.js
+++ b/packages/mdc-textfield/outline/foundation.js
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from '@material/base/foundation';
+import MDCTextFieldOutlineAdapter from './adapter';
+import {strings} from './constants';
+
+/**
+ * @extends {MDCFoundation<!MDCTextFieldOutlineAdapter>}
+ * @final
+ */
+class MDCTextFieldOutlineFoundation extends MDCFoundation {
+  /** @return enum {string} */
+  static get strings() {
+    return strings;
+  }
+
+  /**
+   * {@see MDCTextFieldOutlineAdapter} for typing information on parameters and return
+   * types.
+   * @return {!MDCTextFieldOutlineAdapter}
+   */
+  static get defaultAdapter() {
+    return /** @type {!MDCTextFieldOutlineAdapter} */ ({
+    });
+  }
+
+  /**
+   * @param {!MDCTextFieldOutlineAdapter=} adapter
+   */
+  constructor(adapter = /** @type {!MDCTextFieldOutlineAdapter} */ ({})) {
+    super(Object.assign(MDCTextFieldOutlineFoundation.defaultAdapter, adapter));
+  }
+
+  /**
+   * Updates the SVG path of the focus outline element.
+   */
+  updateSvgPath(width, height, labelWidth, radius, isRtl = false) {
+    let path;
+    if (!isRtl) {
+      path = 'M' + labelWidth + ',' + 1
+        + 'h' + (width - radius - labelWidth - 2)
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
+        + 'v' + (height - 2.7 * radius)
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
+        + 'h' + (-width + 2.7 * radius)
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
+        + 'v' + (-height + 2.7 * radius)
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
+        + 'h' + 6;
+    } else {
+      path = 'M' + (width - radius - 6) + ',' + 1
+        + 'h' + 4
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
+        + 'v' + (height - 2.7 * radius)
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
+        + 'h' + (-width + 2.7 * radius)
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
+        + 'v' + (-height + 2.7 * radius)
+        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
+        + 'h' + (width - radius - labelWidth);
+    }
+
+    this.adapter_.setOutlinePathAttr(path);
+  }
+}
+
+export default MDCTextFieldOutlineFoundation;

--- a/packages/mdc-textfield/outline/foundation.js
+++ b/packages/mdc-textfield/outline/foundation.js
@@ -48,16 +48,15 @@ class MDCTextFieldOutlineFoundation extends MDCFoundation {
   }
 
   /**
-   * Updates the SVG path of the focus outline element based on the given width and height
-   * of the text field element, the width of the label element, the corner radius, and
-   * the RTL context.
-   * @param {number} width
-   * @param {number} height
+   * Updates the SVG path of the focus outline element based on the given width of the
+   * label element, the corner radius, and the RTL context.
    * @param {number} labelWidth
    * @param {number} radius
    * @param {boolean=} isRtl
    */
-  updateSvgPath(width, height, labelWidth, radius, isRtl = false) {
+  updateSvgPath(labelWidth, radius, isRtl = false) {
+    const width = this.adapter_.getWidth() + 2;
+    const height = this.adapter_.getHeight() + 2;
     let path;
     if (!isRtl) {
       path = 'M' + (radius + 2.1 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1

--- a/packages/mdc-textfield/outline/foundation.js
+++ b/packages/mdc-textfield/outline/foundation.js
@@ -48,7 +48,9 @@ class MDCTextFieldOutlineFoundation extends MDCFoundation {
   }
 
   /**
-   * Updates the SVG path of the focus outline element.
+   * Updates the SVG path of the focus outline element based on the given width and height
+   * of the text field element, the width of the label element, the corner radius, and
+   * the RTL context.
    * @param {number} width
    * @param {number} height
    * @param {number} labelWidth

--- a/packages/mdc-textfield/outline/foundation.js
+++ b/packages/mdc-textfield/outline/foundation.js
@@ -36,6 +36,7 @@ class MDCTextFieldOutlineFoundation extends MDCFoundation {
    */
   static get defaultAdapter() {
     return /** @type {!MDCTextFieldOutlineAdapter} */ ({
+      setOutlinePathAttr: () => {},
     });
   }
 
@@ -48,31 +49,36 @@ class MDCTextFieldOutlineFoundation extends MDCFoundation {
 
   /**
    * Updates the SVG path of the focus outline element.
+   * @param {number} width
+   * @param {number} height
+   * @param {number} labelWidth
+   * @param {number} radius
+   * @param {boolean=} isRtl
    */
   updateSvgPath(width, height, labelWidth, radius, isRtl = false) {
     let path;
     if (!isRtl) {
-      path = 'M' + labelWidth + ',' + 1
-        + 'h' + (width - radius - labelWidth - 2)
+      path = 'M' + (radius + 1.5 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
+        + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-        + 'v' + (height - 2.7 * radius)
+        + 'v' + (height - 2 * (radius + 1.5))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-        + 'h' + (-width + 2.7 * radius)
+        + 'h' + (-width + 2 * (radius + 1.5))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-        + 'v' + (-height + 2.7 * radius)
+        + 'v' + (-height + 2 * (radius + 1.5))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
-        + 'h' + 6;
+        + 'h' + Math.abs(10 - radius);
     } else {
-      path = 'M' + (width - radius - 6) + ',' + 1
-        + 'h' + 4
+      path = 'M' + (width - radius - 1.5 - Math.abs(10 - radius)) + ',' + 1
+        + 'h' + Math.abs(10 - radius)
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-        + 'v' + (height - 2.7 * radius)
+        + 'v' + (height - 2 * (radius + 1.5))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-        + 'h' + (-width + 2.7 * radius)
+        + 'h' + (-width + 2 * (radius + 1.5))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-        + 'v' + (-height + 2.7 * radius)
+        + 'v' + (-height + 2 * (radius + 1.5))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
-        + 'h' + (width - radius - labelWidth);
+        + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius));
     }
 
     this.adapter_.setOutlinePathAttr(path);

--- a/packages/mdc-textfield/outline/foundation.js
+++ b/packages/mdc-textfield/outline/foundation.js
@@ -59,28 +59,25 @@ class MDCTextFieldOutlineFoundation extends MDCFoundation {
   updateSvgPath(labelWidth, radius, isRtl = false) {
     const width = this.adapter_.getWidth() + 2;
     const height = this.adapter_.getHeight() + 2;
+    // The right, bottom, and left sides of the outline follow the same SVG path.
+    const pathMiddle = 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
+      + 'v' + (height - 2 * (radius + 2.1))
+      + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
+      + 'h' + (-width + 2 * (radius + 1.7))
+      + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
+      + 'v' + (-height + 2 * (radius + 2.1))
+      + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius;
+
     let path;
     if (!isRtl) {
       path = 'M' + (radius + 2.1 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
         + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius))
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-        + 'v' + (height - 2 * (radius + 2.1))
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-        + 'h' + (-width + 2 * (radius + 1.7))
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-        + 'v' + (-height + 2 * (radius + 2.1))
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
+        + pathMiddle
         + 'h' + Math.abs(10 - radius);
     } else {
       path = 'M' + (width - radius - 2.1 - Math.abs(10 - radius)) + ',' + 1
         + 'h' + Math.abs(10 - radius)
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-        + 'v' + (height - 2 * (radius + 2.1))
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-        + 'h' + (-width + 2 * (radius + 1.7))
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-        + 'v' + (-height + 2 * (radius + 2.1))
-        + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
+        + pathMiddle
         + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius));
     }
 

--- a/packages/mdc-textfield/outline/foundation.js
+++ b/packages/mdc-textfield/outline/foundation.js
@@ -36,6 +36,8 @@ class MDCTextFieldOutlineFoundation extends MDCFoundation {
    */
   static get defaultAdapter() {
     return /** @type {!MDCTextFieldOutlineAdapter} */ ({
+      getWidth: () => {},
+      getHeight: () => {},
       setOutlinePathAttr: () => {},
     });
   }

--- a/packages/mdc-textfield/outline/foundation.js
+++ b/packages/mdc-textfield/outline/foundation.js
@@ -60,27 +60,27 @@ class MDCTextFieldOutlineFoundation extends MDCFoundation {
   updateSvgPath(width, height, labelWidth, radius, isRtl = false) {
     let path;
     if (!isRtl) {
-      path = 'M' + (radius + 1.5 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
-        + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius))
+      path = 'M' + (radius + 2.1 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
+        + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-        + 'v' + (height - 2 * (radius + 1.5))
+        + 'v' + (height - 2 * (radius + 2.1))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-        + 'h' + (-width + 2 * (radius + 1.5))
+        + 'h' + (-width + 2 * (radius + 1.7))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-        + 'v' + (-height + 2 * (radius + 1.5))
+        + 'v' + (-height + 2 * (radius + 2.1))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
         + 'h' + Math.abs(10 - radius);
     } else {
-      path = 'M' + (width - radius - 1.5 - Math.abs(10 - radius)) + ',' + 1
+      path = 'M' + (width - radius - 2.1 - Math.abs(10 - radius)) + ',' + 1
         + 'h' + Math.abs(10 - radius)
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-        + 'v' + (height - 2 * (radius + 1.5))
+        + 'v' + (height - 2 * (radius + 2.1))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-        + 'h' + (-width + 2 * (radius + 1.5))
+        + 'h' + (-width + 2 * (radius + 1.7))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-        + 'v' + (-height + 2 * (radius + 1.5))
+        + 'v' + (-height + 2 * (radius + 2.1))
         + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
-        + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius));
+        + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius));
     }
 
     this.adapter_.setOutlinePathAttr(path);

--- a/packages/mdc-textfield/outline/index.js
+++ b/packages/mdc-textfield/outline/index.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from '@material/base/component';
+
+import {strings} from './constants';
+import MDCTextFieldOutlineAdapter from './adapter';
+import MDCTextFieldOutlineFoundation from './foundation';
+
+/**
+ * @extends {MDCComponent<!MDCTextFieldOutlineFoundation>}
+ * @final
+ */
+class MDCTextFieldOutline extends MDCComponent {
+  /**
+   * @param {!Element} root
+   * @return {!MDCTextFieldOutline}
+   */
+  static attachTo(root) {
+    return new MDCTextFieldOutline(root);
+  }
+
+  /**
+   * @return {!MDCTextFieldOutlineFoundation}
+   */
+  get foundation() {
+    return this.foundation_;
+  }
+
+  /**
+   * @return {!MDCTextFieldOutlineFoundation}
+   */
+  getDefaultFoundation() {
+    return new MDCTextFieldOutlineFoundation(/** @type {!MDCTextFieldOutlineAdapter} */ (Object.assign({
+      setOutlinePathAttr: (value) => {
+        const path = this.root_.querySelector(strings.PATH_SELECTOR);
+        path.setAttribute('d', value);
+      },
+    })));
+  }
+}
+
+export {MDCTextFieldOutline, MDCTextFieldOutlineFoundation};

--- a/packages/mdc-textfield/outline/index.js
+++ b/packages/mdc-textfield/outline/index.js
@@ -46,6 +46,8 @@ class MDCTextFieldOutline extends MDCComponent {
    */
   getDefaultFoundation() {
     return new MDCTextFieldOutlineFoundation(/** @type {!MDCTextFieldOutlineAdapter} */ (Object.assign({
+      getWidth: () => this.root_.offsetWidth,
+      getHeight: () => this.root_.offsetHeight,
       setOutlinePathAttr: (value) => {
         const path = this.root_.querySelector(strings.PATH_SELECTOR);
         path.setAttribute('d', value);

--- a/packages/mdc-textfield/outline/mdc-text-field-outline.scss
+++ b/packages/mdc-textfield/outline/mdc-text-field-outline.scss
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-@import "../functions";
 @import "../mixins";
 @import "../variables";
 @import "@material/theme/mixins";

--- a/packages/mdc-textfield/outline/mdc-text-field-outline.scss
+++ b/packages/mdc-textfield/outline/mdc-text-field-outline.scss
@@ -1,0 +1,62 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@import "../functions";
+@import "../mixins";
+@import "../variables";
+@import "@material/theme/mixins";
+
+.mdc-text-field__idle-outline {
+  @include mdc-text-field-outlined-corner-radius($mdc-text-field-border-radius);
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
+  transition: opacity 100ms ease;
+  border: 1px solid $mdc-text-field-outlined-idle-border;
+  opacity: 1;
+  z-index: 2;
+}
+
+.mdc-text-field__outline {
+  @include mdc-theme-prop(color, primary);
+  @include mdc-text-field-outlined-corner-radius($mdc-text-field-border-radius);
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(100% - 1px);
+  height: calc(100% - 2px);
+  transition: opacity 250ms ease;
+  opacity: 0;
+  z-index: 2;
+
+  svg {
+    position: absolute;  
+    width: 100%;
+    height: 100%;  
+  
+    .mdc-text-field__outline-path {
+      @include mdc-theme-prop(stroke, primary);
+    
+      stroke-width: 2px;
+      transition: opacity 250ms ease;
+      fill: transparent;
+    }
+  }
+}

--- a/packages/mdc-textfield/outline/mdc-text-field-outline.scss
+++ b/packages/mdc-textfield/outline/mdc-text-field-outline.scss
@@ -41,7 +41,7 @@
   left: 0;
   width: calc(100% - 1px);
   height: calc(100% - 2px);
-  transition: opacity 250ms ease;
+  transition: mdc-text-field-transition(opacity);
   opacity: 0;
   z-index: 2;
 
@@ -54,7 +54,7 @@
       @include mdc-theme-prop(stroke, primary);
     
       stroke-width: 2px;
-      transition: opacity 250ms ease;
+      transition: mdc-text-field-transition(stroke-width), mdc-text-field-transition(opacity);
       fill: transparent;
     }
   }

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -403,9 +403,9 @@ test('on keydown sets receivedUserInput to true when input is enabled', () => {
     .thenDo((evtType, handler) => {
       keydown = handler;
     });
-    td.when(mockAdapter.getNativeInput()).thenReturn({
-      disabled: false,
-    });
+  td.when(mockAdapter.getNativeInput()).thenReturn({
+    disabled: false,
+  });
   foundation.init();
   assert.equal(foundation.receivedUserInput_, false);
   keydown();

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -39,8 +39,7 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'registerTextFieldInteractionHandler', 'deregisterTextFieldInteractionHandler',
     'registerInputInteractionHandler', 'deregisterInputInteractionHandler',
     'registerBottomLineEventHandler', 'deregisterBottomLineEventHandler',
-    'getNativeInput', 'getWidth', 'getHeight', 'getLabelWidth',
-    'getIdleOutlineStyleValue', 'isRtl',
+    'getNativeInput', 'getIdleOutlineStyleValue', 'isRtl',
   ]);
 });
 
@@ -64,6 +63,7 @@ const setupTest = () => {
     handleInteraction: () => {},
   });
   const label = td.object({
+    getFloatingWidth: () => {},
     floatAbove: () => {},
     deactivateFocus: () => {},
     setValidity: () => {},
@@ -216,15 +216,13 @@ test('#setHelperTextContent sets the content of the helper text element', () => 
 });
 
 test('#updateOutline updates the SVG path of the outline element', () => {
-  const {foundation, mockAdapter, outline} = setupTest();
-  td.when(mockAdapter.getWidth()).thenReturn(100);
-  td.when(mockAdapter.getHeight()).thenReturn(100);
-  td.when(mockAdapter.getLabelWidth()).thenReturn(30);
+  const {foundation, mockAdapter, label, outline} = setupTest();
+  td.when(label.getFloatingWidth()).thenReturn(30);
   td.when(mockAdapter.getIdleOutlineStyleValue('border-radius')).thenReturn('8px');
   td.when(mockAdapter.isRtl()).thenReturn(false);
 
   foundation.updateOutline();
-  td.verify(outline.updateSvgPath(100, 100, 30 * 0.75, 8, false));
+  td.verify(outline.updateSvgPath(30, 8, false));
 });
 
 test('on input floats label if input event occurs without any other events', () => {

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -279,6 +279,18 @@ test('on focus adds mdc-text-field--focused class', () => {
   td.verify(mockAdapter.addClass(cssClasses.FOCUSED));
 });
 
+test('on focus activates bottom line', () => {
+  const {foundation, mockAdapter, bottomLine} = setupTest();
+  let focus;
+  td.when(mockAdapter.registerInputInteractionHandler('focus', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      focus = handler;
+    });
+  foundation.init();
+  focus();
+  td.verify(bottomLine.activate());
+});
+
 test('on focus floats label', () => {
   const {foundation, mockAdapter, label} = setupTest();
   let focus;
@@ -382,6 +394,22 @@ test('on blur handles getNativeInput() not returning anything gracefully', () =>
   const {mockAdapter, blur} = setupBlurTest();
   td.when(mockAdapter.getNativeInput()).thenReturn(null);
   assert.doesNotThrow(blur);
+});
+
+test('on keydown sets receivedUserInput to true when input is enabled', () => {
+  const {foundation, mockAdapter} = setupTest();
+  let keydown;
+  td.when(mockAdapter.registerTextFieldInteractionHandler('keydown', td.matchers.isA(Function)))
+    .thenDo((evtType, handler) => {
+      keydown = handler;
+    });
+    td.when(mockAdapter.getNativeInput()).thenReturn({
+      disabled: false,
+    });
+  foundation.init();
+  assert.equal(foundation.receivedUserInput_, false);
+  keydown();
+  assert.equal(foundation.receivedUserInput_, true);
 });
 
 test('on transition end deactivates the bottom line if this.isFocused_ is false', () => {

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -40,7 +40,8 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'deregisterTextFieldInteractionHandler', 'notifyIconAction',
     'registerInputInteractionHandler', 'deregisterInputInteractionHandler',
     'registerBottomLineEventHandler', 'deregisterBottomLineEventHandler',
-    'getNativeInput',
+    'getNativeInput', 'getWidth', 'getHeight', 'getLabelWidth',
+    'getIdleOutlineStyleValue', 'isRtl',
   ]);
 });
 
@@ -62,13 +63,17 @@ const setupTest = () => {
     deactivateFocus: () => {},
     setValidity: () => {},
   });
+  const outline = td.object({
+    updateSvgPath: () => {},
+  });
   const foundationMap = {
     bottomLine: bottomLine,
     helperText: helperText,
     label: label,
+    outline: outline,
   };
   const foundation = new MDCTextFieldFoundation(mockAdapter, foundationMap);
-  return {foundation, mockAdapter, bottomLine, helperText, label};
+  return {foundation, mockAdapter, bottomLine, helperText, label, outline};
 };
 
 test('#constructor sets disabled to false', () => {
@@ -208,6 +213,18 @@ test('#setHelperTextContent sets the content of the helper text element', () => 
   const {foundation, helperText} = setupTest();
   foundation.setHelperTextContent('foo');
   td.verify(helperText.setContent('foo'));
+});
+
+test('#updateOutline updates the SVG path of the outline element', () => {
+  const {foundation, mockAdapter, outline} = setupTest();
+  td.when(mockAdapter.getWidth()).thenReturn(100);
+  td.when(mockAdapter.getHeight()).thenReturn(100);
+  td.when(mockAdapter.getLabelWidth()).thenReturn(30);
+  td.when(mockAdapter.getIdleOutlineStyleValue('border-radius')).thenReturn('8px');
+  td.when(mockAdapter.isRtl()).thenReturn(false);
+
+  foundation.updateOutline();
+  td.verify(outline.updateSvgPath(100, 100, 30 * 0.75, 8, false));
 });
 
 test('on input floats label if input event occurs without any other events', () => {

--- a/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
@@ -31,11 +31,18 @@ test('exports cssClasses', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTextFieldLabelFoundation, [
-    'addClass', 'removeClass',
+    'addClass', 'removeClass', 'getWidth',
   ]);
 });
 
 const setupTest = () => setupFoundationTest(MDCTextFieldLabelFoundation);
+
+test('#getFloatingWidth returns the width of the label element scaled by 75%', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const width = 100;
+  td.when(mockAdapter.getWidth()).thenReturn(width);
+  assert.equal(foundation.getFloatingWidth(), width * 0.75);
+});
 
 test('#floatAbove adds mdc-text-field__label--float-above class', () => {
   const {foundation, mockAdapter} = setupTest();

--- a/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
@@ -31,7 +31,7 @@ test('exports cssClasses', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTextFieldLabelFoundation, [
-    'addClass', 'removeClass', 'hasClass',
+    'addClass', 'removeClass',
   ]);
 });
 
@@ -41,12 +41,6 @@ test('#floatAbove adds mdc-text-field__label--float-above class', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.floatAbove();
   td.verify(mockAdapter.addClass(cssClasses.LABEL_FLOAT_ABOVE));
-});
-
-test('#isFloating returns whether mdc-text-field__label--float-above class is present', () => {
-  const {foundation, mockAdapter} = setupTest();
-  foundation.isFloating();
-  td.verify(mockAdapter.hasClass(cssClasses.LABEL_FLOAT_ABOVE));
 });
 
 test('#deactivateFocus does not remove mdc-text-field__label--float-above class' +

--- a/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
@@ -31,7 +31,7 @@ test('exports cssClasses', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTextFieldLabelFoundation, [
-    'addClass', 'removeClass',
+    'addClass', 'removeClass', 'hasClass',
   ]);
 });
 
@@ -41,6 +41,12 @@ test('#floatAbove adds mdc-text-field__label--float-above class', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.floatAbove();
   td.verify(mockAdapter.addClass(cssClasses.LABEL_FLOAT_ABOVE));
+});
+
+test('#isFloating returns whether mdc-text-field__label--float-above class is present', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.isFloating();
+  td.verify(mockAdapter.hasClass(cssClasses.LABEL_FLOAT_ABOVE));
 });
 
 test('#deactivateFocus does not remove mdc-text-field__label--float-above class' +

--- a/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-label-foundation.test.js
@@ -61,3 +61,9 @@ test('#setValidity adds mdc-text-field__label--shake class if isValid is false',
   foundation.setValidity(false);
   td.verify(mockAdapter.addClass(cssClasses.LABEL_SHAKE));
 });
+
+test('#setValidity does nothing if isValid is true', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setValidity(true);
+  td.verify(mockAdapter.addClass(cssClasses.LABEL_SHAKE), {times: 0});
+});

--- a/test/unit/mdc-textfield/mdc-text-field-label.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-label.test.js
@@ -47,3 +47,8 @@ test('#adapter.removeClass removes a class from the element', () => {
   component.getDefaultFoundation().adapter_.removeClass('foo');
   assert.isFalse(root.classList.contains('foo'));
 });
+
+test('#adapter.getWidth returns the width of the label element', () => {
+  const {root, component} = setupTest();
+  assert.equal(component.getDefaultFoundation().adapter_.getWidth(), root.offsetWidth);
+});

--- a/test/unit/mdc-textfield/mdc-text-field-label.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-label.test.js
@@ -47,11 +47,3 @@ test('#adapter.removeClass removes a class from the element', () => {
   component.getDefaultFoundation().adapter_.removeClass('foo');
   assert.isFalse(root.classList.contains('foo'));
 });
-
-test('#adapter.hasClass returns whether or not the element contains a certain class', () => {
-  const {root, component} = setupTest();
-  root.classList.add('foo');
-  assert.isOk(component.getDefaultFoundation().adapter_.hasClass('foo'));
-  root.classList.remove('foo');
-  assert.isNotOk(component.getDefaultFoundation().adapter_.hasClass('foo'));
-});

--- a/test/unit/mdc-textfield/mdc-text-field-label.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-label.test.js
@@ -47,3 +47,11 @@ test('#adapter.removeClass removes a class from the element', () => {
   component.getDefaultFoundation().adapter_.removeClass('foo');
   assert.isFalse(root.classList.contains('foo'));
 });
+
+test('#adapter.hasClass returns whether or not the element contains a certain class', () => {
+  const {root, component} = setupTest();
+  root.classList.add('foo');
+  assert.isOk(component.getDefaultFoundation().adapter_.hasClass('foo'));
+  root.classList.remove('foo');
+  assert.isNotOk(component.getDefaultFoundation().adapter_.hasClass('foo'));
+});

--- a/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
@@ -29,7 +29,7 @@ test('exports strings', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTextFieldOutlineFoundation, [
-    'setOutlinePathAttr',
+    'getWidth', 'getHeight', 'setOutlinePathAttr',
   ]);
 });
 
@@ -51,7 +51,9 @@ test('#updateSvgPath sets the path of the outline element when isRtl=false by de
     + 'v' + (-height + 2 * (radius + 2.1))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
     + 'h' + Math.abs(10 - radius);
-  foundation.updateSvgPath(width, height, labelWidth, radius);
+  td.when(mockAdapter.getWidth()).thenReturn(width - 2);
+  td.when(mockAdapter.getHeight()).thenReturn(height - 2);
+  foundation.updateSvgPath(labelWidth, radius);
   td.verify(mockAdapter.setOutlinePathAttr(path));
 });
 
@@ -72,6 +74,8 @@ test('#updateSvgPath sets the path of the outline element when isRtl=true', () =
     + 'v' + (-height + 2 * (radius + 2.1))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
     + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius));
-  foundation.updateSvgPath(width, height, labelWidth, radius, true /* isRtl */);
+  td.when(mockAdapter.getWidth()).thenReturn(width - 2);
+  td.when(mockAdapter.getHeight()).thenReturn(height - 2);
+  foundation.updateSvgPath(labelWidth, radius, true /* isRtl */);
   td.verify(mockAdapter.setOutlinePathAttr(path));
 });

--- a/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from 'chai';
+import td from 'testdouble';
+
+import {verifyDefaultAdapter} from '../helpers/foundation';
+import {setupFoundationTest} from '../helpers/setup';
+import MDCTextFieldOutlineFoundation from '../../../packages/mdc-textfield/outline/foundation';
+
+suite('MDCTextFieldOutlineFoundation');
+
+test('exports strings', () => {
+  assert.isOk('strings' in MDCTextFieldOutlineFoundation);
+});
+
+test('defaultAdapter returns a complete adapter implementation', () => {
+  verifyDefaultAdapter(MDCTextFieldOutlineFoundation, [
+    'setOutlinePathAttr',
+  ]);
+});
+
+const setupTest = () => setupFoundationTest(MDCTextFieldOutlineFoundation);
+
+test('#updateSvgPath sets the path of the outline element when isRtl=false by default', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const width = 100;
+  const height = 100;
+  const labelWidth = 30;
+  const radius = 8;
+  const path = 'M' + (radius + 1.5 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
+    + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius))
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
+    + 'v' + (height - 2 * (radius + 1.5))
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
+    + 'h' + (-width + 2 * (radius + 1.5))
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
+    + 'v' + (-height + 2 * (radius + 1.5))
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
+    + 'h' + Math.abs(10 - radius);
+  foundation.updateSvgPath(width, height, labelWidth, radius);
+  td.verify(mockAdapter.setOutlinePathAttr(path));
+});
+
+
+test('#updateSvgPath sets the path of the outline element when isRtl=true', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const width = 100;
+  const height = 100;
+  const labelWidth = 30;
+  const radius = 8;
+  const path = 'M' + (width - radius - 1.5 - Math.abs(10 - radius)) + ',' + 1
+    + 'h' + Math.abs(10 - radius)
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
+    + 'v' + (height - 2 * (radius + 1.5))
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
+    + 'h' + (-width + 2 * (radius + 1.5))
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
+    + 'v' + (-height + 2 * (radius + 1.5))
+    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
+    + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius));
+  foundation.updateSvgPath(width, height, labelWidth, radius, true /* isRtl */);
+  td.verify(mockAdapter.setOutlinePathAttr(path));
+});

--- a/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
@@ -35,47 +35,11 @@ test('defaultAdapter returns a complete adapter implementation', () => {
 
 const setupTest = () => setupFoundationTest(MDCTextFieldOutlineFoundation);
 
-test('#updateSvgPath sets the path of the outline element when isRtl=false by default', () => {
+test('#updateSvgPath sets the path of the outline element', () => {
   const {foundation, mockAdapter} = setupTest();
-  const width = 100;
-  const height = 100;
   const labelWidth = 30;
   const radius = 8;
-  const path = 'M' + (radius + 2.1 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
-    + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius))
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-    + 'v' + (height - 2 * (radius + 2.1))
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-    + 'h' + (-width + 2 * (radius + 1.7))
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-    + 'v' + (-height + 2 * (radius + 2.1))
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
-    + 'h' + Math.abs(10 - radius);
-  td.when(mockAdapter.getWidth()).thenReturn(width - 2);
-  td.when(mockAdapter.getHeight()).thenReturn(height - 2);
-  foundation.updateSvgPath(labelWidth, radius);
-  td.verify(mockAdapter.setOutlinePathAttr(path));
-});
-
-
-test('#updateSvgPath sets the path of the outline element when isRtl=true', () => {
-  const {foundation, mockAdapter} = setupTest();
-  const width = 100;
-  const height = 100;
-  const labelWidth = 30;
-  const radius = 8;
-  const path = 'M' + (width - radius - 2.1 - Math.abs(10 - radius)) + ',' + 1
-    + 'h' + Math.abs(10 - radius)
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-    + 'v' + (height - 2 * (radius + 2.1))
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-    + 'h' + (-width + 2 * (radius + 1.7))
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-    + 'v' + (-height + 2 * (radius + 2.1))
-    + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
-    + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius));
-  td.when(mockAdapter.getWidth()).thenReturn(width - 2);
-  td.when(mockAdapter.getHeight()).thenReturn(height - 2);
-  foundation.updateSvgPath(labelWidth, radius, true /* isRtl */);
-  td.verify(mockAdapter.setOutlinePathAttr(path));
+  const isRtl = true;
+  foundation.updateSvgPath(labelWidth, radius, isRtl);
+  td.verify(mockAdapter.setOutlinePathAttr(td.matchers.anything()));
 });

--- a/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.foundation.test.js
@@ -41,14 +41,14 @@ test('#updateSvgPath sets the path of the outline element when isRtl=false by de
   const height = 100;
   const labelWidth = 30;
   const radius = 8;
-  const path = 'M' + (radius + 1.5 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
-    + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius))
+  const path = 'M' + (radius + 2.1 + Math.abs(10 - radius) + labelWidth + 8) + ',' + 1
+    + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-    + 'v' + (height - 2 * (radius + 1.5))
+    + 'v' + (height - 2 * (radius + 2.1))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-    + 'h' + (-width + 2 * (radius + 1.5))
+    + 'h' + (-width + 2 * (radius + 1.7))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-    + 'v' + (-height + 2 * (radius + 1.5))
+    + 'v' + (-height + 2 * (radius + 2.1))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
     + 'h' + Math.abs(10 - radius);
   foundation.updateSvgPath(width, height, labelWidth, radius);
@@ -62,16 +62,16 @@ test('#updateSvgPath sets the path of the outline element when isRtl=true', () =
   const height = 100;
   const labelWidth = 30;
   const radius = 8;
-  const path = 'M' + (width - radius - 1.5 - Math.abs(10 - radius)) + ',' + 1
+  const path = 'M' + (width - radius - 2.1 - Math.abs(10 - radius)) + ',' + 1
     + 'h' + Math.abs(10 - radius)
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + radius
-    + 'v' + (height - 2 * (radius + 1.5))
+    + 'v' + (height - 2 * (radius + 2.1))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + radius
-    + 'h' + (-width + 2 * (radius + 1.5))
+    + 'h' + (-width + 2 * (radius + 1.7))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + -radius + ',' + -radius
-    + 'v' + (-height + 2 * (radius + 1.5))
+    + 'v' + (-height + 2 * (radius + 2.1))
     + 'a' + radius + ',' + radius + ' 0 0 1 ' + radius + ',' + -radius
-    + 'h' + (width - (2 * (radius + 1.5)) - labelWidth - 8.5 - Math.abs(10 - radius));
+    + 'h' + (width - (2 * (radius + 2.1)) - labelWidth - 8.5 - Math.abs(10 - radius));
   foundation.updateSvgPath(width, height, labelWidth, radius, true /* isRtl */);
   td.verify(mockAdapter.setOutlinePathAttr(path));
 });

--- a/test/unit/mdc-textfield/mdc-text-field-outline.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.test.js
@@ -41,7 +41,7 @@ function setupTest() {
 
 test('#adapter.setOutlinePathAttr sets the SVG path of the element', () => {
   const {root, component} = setupTest();
-  component.getDefaultFoundation().adapter_.setOutlinePathAttr('foo');
+  component.getDefaultFoundation().adapter_.setOutlinePathAttr('M0,1');
   const path = root.querySelector('.mdc-text-field__outline-path');
-  assert.equal(path.getAttribute('d'), 'foo');
+  assert.equal(path.getAttribute('d'), 'M0,1');
 });

--- a/test/unit/mdc-textfield/mdc-text-field-outline.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import bel from 'bel';
+import {assert} from 'chai';
+
+import {MDCTextFieldOutline} from '../../../packages/mdc-textfield/outline';
+
+const getFixture = () => bel`
+  <div class="mdc-text-field__outline">
+    <svg>
+      <path class="mdc-text-field__outline-path">
+    </svg>
+  </div>
+`;
+
+suite('MDCTextFieldOutline');
+
+test('attachTo returns an MDCTextFieldOutline instance', () => {
+  assert.isOk(MDCTextFieldOutline.attachTo(getFixture()) instanceof MDCTextFieldOutline);
+});
+
+function setupTest() {
+  const root = getFixture();
+  const component = new MDCTextFieldOutline(root);
+  return {root, component};
+}
+
+test('#adapter.setOutlinePathAttr sets the SVG path of the element', () => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setOutlinePathAttr('foo');
+  const path = root.querySelector('.mdc-text-field__outline-path');
+  assert.equal(path.getAttribute('d'), 'foo');
+});

--- a/test/unit/mdc-textfield/mdc-text-field-outline.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.test.js
@@ -39,6 +39,18 @@ function setupTest() {
   return {root, component};
 }
 
+test('#adapter.getWidth returns the width of the element', () => {
+  const {root, component} = setupTest();
+  const width = component.getDefaultFoundation().adapter_.getWidth();
+  assert.equal(width, root.offsetWidth);
+});
+
+test('#adapter.getHeight returns the height of the element', () => {
+  const {root, component} = setupTest();
+  const height = component.getDefaultFoundation().adapter_.getWidth();
+  assert.equal(height, root.offsetHeight);
+});
+
 test('#adapter.setOutlinePathAttr sets the SVG path of the element', () => {
   const {root, component} = setupTest();
   component.getDefaultFoundation().adapter_.setOutlinePathAttr('M 0 1');

--- a/test/unit/mdc-textfield/mdc-text-field-outline.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-outline.test.js
@@ -41,7 +41,7 @@ function setupTest() {
 
 test('#adapter.setOutlinePathAttr sets the SVG path of the element', () => {
   const {root, component} = setupTest();
-  component.getDefaultFoundation().adapter_.setOutlinePathAttr('M0,1');
+  component.getDefaultFoundation().adapter_.setOutlinePathAttr('M 0 1');
   const path = root.querySelector('.mdc-text-field__outline-path');
-  assert.equal(path.getAttribute('d'), 'M0,1');
+  assert.equal(path.getAttribute('d'), 'M 0 1');
 });

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -59,12 +59,12 @@ test('#constructor when given a `mdc-text-field--box` element instantiates a rip
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
   const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el));
-  assert.equal(component.ripple_.root, root);
+  assert.equal(component.ripple.root, root);
 });
 
 test('#constructor sets the ripple property to `null` when given a non `mdc-text-field--box` element', () => {
   const component = new MDCTextField(getFixture());
-  assert.isNull(component.ripple_);
+  assert.isNull(component.ripple);
 });
 
 test('#constructor when given a `mdc-text-field--box` element, initializes a default ripple when no ' +
@@ -72,7 +72,7 @@ test('#constructor when given a `mdc-text-field--box` element, initializes a def
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
   const component = new MDCTextField(root);
-  assert.instanceOf(component.ripple_, MDCRipple);
+  assert.instanceOf(component.ripple, MDCRipple);
 });
 
 const getHelperTextElement = () => bel`<p id="helper-text">helper text</p>`;
@@ -93,7 +93,7 @@ test('#destroy cleans up the ripple if present', () => {
   root.classList.add(cssClasses.BOX);
   const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el));
   component.destroy();
-  td.verify(component.ripple_.destroy());
+  td.verify(component.ripple.destroy());
 });
 
 test('#destroy accounts for ripple nullability', () => {

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -147,7 +147,7 @@ function setupTest(root = getFixture()) {
     () => label,
     () => outline
   );
-  return {root, component, bottomLine, helperText, icon, label};
+  return {root, component, bottomLine, helperText, icon, label, outline};
 }
 
 test('#destroy cleans up the ripple if present', () => {
@@ -190,10 +190,11 @@ test('#destroy cleans up the label if present', () => {
 test('#destroy cleans up the outline if present', () => {
   const root = getFixture();
   root.appendChild(bel`<div class="mdc-text-field__outline"></div>`);
-  const component = new MDCTextField(root, undefined, undefined, undefined, (el) => new FakeOutline(el));
+  const {component, outline} = setupTest(root);
+  console.log(outline);
   component.destroy();
-  td.verify(component.outline_.destroy());
-}
+  td.verify(outline.destroy());
+});
 
 test('#destroy accounts for ripple nullability', () => {
   const component = new MDCTextField(getFixture());

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -20,8 +20,8 @@ import td from 'testdouble';
 import {assert} from 'chai';
 
 import {MDCRipple} from '../../../packages/mdc-ripple';
-import {MDCTextField, MDCTextFieldFoundation, MDCTextFieldBottomLine,
-  MDCTextFieldHelperText, MDCTextFieldIcon, MDCTextFieldLabel} from '../../../packages/mdc-textfield';
+import {MDCTextField, MDCTextFieldFoundation, MDCTextFieldBottomLine, MDCTextFieldHelperText,
+  MDCTextFieldIcon, MDCTextFieldLabel, MDCTextFieldOutline} from '../../../packages/mdc-textfield';
 
 const {cssClasses} = MDCTextFieldFoundation;
 
@@ -217,7 +217,7 @@ test('#destroy handles undefined optional sub-elements gracefully', () => {
       <input type="text" class="mdc-text-field__input" id="my-text-field">
     </div>
   `;
-  const component = new MDCTextField(getFixture());
+  const component = new MDCTextField(root);
   assert.doesNotThrow(() => component.destroy());
 });
 

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -59,12 +59,12 @@ test('#constructor when given a `mdc-text-field--box` element instantiates a rip
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
   const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el));
-  assert.equal(component.ripple.root, root);
+  assert.equal(component.ripple_.root, root);
 });
 
 test('#constructor sets the ripple property to `null` when given a non `mdc-text-field--box` element', () => {
   const component = new MDCTextField(getFixture());
-  assert.isNull(component.ripple);
+  assert.isNull(component.ripple_);
 });
 
 test('#constructor when given a `mdc-text-field--box` element, initializes a default ripple when no ' +
@@ -72,7 +72,7 @@ test('#constructor when given a `mdc-text-field--box` element, initializes a def
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
   const component = new MDCTextField(root);
-  assert.instanceOf(component.ripple, MDCRipple);
+  assert.instanceOf(component.ripple_, MDCRipple);
 });
 
 const getHelperTextElement = () => bel`<p id="helper-text">helper text</p>`;
@@ -93,7 +93,7 @@ test('#destroy cleans up the ripple if present', () => {
   root.classList.add(cssClasses.BOX);
   const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el));
   component.destroy();
-  td.verify(component.ripple.destroy());
+  td.verify(component.ripple_.destroy());
 });
 
 test('#destroy accounts for ripple nullability', () => {

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -131,6 +131,22 @@ test('#constructor instantiates a label on the `.mdc-text-field__label` element 
   assert.instanceOf(component.label_, MDCTextFieldLabel);
 });
 
+test('#constructor instantiates an outline on the `.mdc-text-field__outline` element if present', () => {
+  const root = getFixture();
+  root.appendChild(bel`<div class="mdc-text-field__outline"></div>`);
+  const component = new MDCTextField(root);
+  assert.instanceOf(component.outline_, MDCTextFieldOutline);
+});
+
+test('#constructor handles undefined optional sub-elements gracefully', () => {
+  const root = bel`
+    <div class="mdc-text-field">
+      <input type="text" class="mdc-text-field__input" id="my-text-field">
+    </div>
+  `;
+  assert.doesNotThrow(() => new MDCTextField(root));
+});
+
 function setupTest(root = getFixture()) {
   const bottomLine = new FakeBottomLine();
   const helperText = new FakeHelperText();
@@ -191,12 +207,16 @@ test('#destroy cleans up the outline if present', () => {
   const root = getFixture();
   root.appendChild(bel`<div class="mdc-text-field__outline"></div>`);
   const {component, outline} = setupTest(root);
-  console.log(outline);
   component.destroy();
   td.verify(outline.destroy());
 });
 
-test('#destroy accounts for ripple nullability', () => {
+test('#destroy handles undefined optional sub-elements gracefully', () => {
+  const root = bel`
+    <div class="mdc-text-field">
+      <input type="text" class="mdc-text-field__input" id="my-text-field">
+    </div>
+  `;
   const component = new MDCTextField(getFixture());
   assert.doesNotThrow(() => component.destroy());
 });

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -237,7 +237,7 @@ test('#adapter.getNativeInput returns the component input element', () => {
   );
 });
 
-test(`#adapter.notifyIconAction emits ${strings.ICON_EVENT}`, () => {
+test('#adapter.notifyIconAction emits ${strings.ICON_EVENT}', () => {
   const {component} = setupTest();
   const handler = td.func('leadingHandler');
 
@@ -245,4 +245,46 @@ test(`#adapter.notifyIconAction emits ${strings.ICON_EVENT}`, () => {
   component.getDefaultFoundation().adapter_.notifyIconAction();
 
   td.verify(handler(td.matchers.anything()));
+});
+
+test('#adapter.getWidth returns the width of the root element', () => {
+  const {root, component} = setupTest();
+  const width = component.getDefaultFoundation().adapter_.getWidth();
+  assert.equal(width, root.offsetWidth);
+});
+
+test('#adapter.getHeight returns the height of the root element', () => {
+  const {root, component} = setupTest();
+  const height = component.getDefaultFoundation().adapter_.getWidth();
+  assert.equal(height, root.offsetHeight);
+});
+
+test('#adapter.getLabelWidth returns the width of the label element', () => {
+  const {root, component} = setupTest();
+  const labelElement = root.querySelector('.mdc-text-field__label');
+  const labelWidth = component.getDefaultFoundation().adapter_.getLabelWidth();
+  assert.equal(labelWidth, labelElement.offsetWidth);
+});
+
+test('#adapter.getIdleOutlineStyleValue returns the value of the given property on the idle outline element', () => {
+  const root = getFixture();
+  root.appendChild(bel`<div class="mdc-text-field__idle-outline"></div>`);
+  const idleOutline = root.querySelector('.mdc-text-field__idle-outline');
+  idleOutline.style.width = '500px';
+  console.log(root);
+  const component = new MDCTextField(root);
+  assert.equal(component.getDefaultFoundation().adapter_.getIdleOutlineStyleValue('width'), '500px');
+});
+
+test('#adapter.isRtl returns true when the root element is in an RTL context' +
+  'and false otherwise', () => {
+  const wrapper = bel`<div dir="rtl"></div>`;
+  const {root, component} = setupTest();
+  assert.isFalse(component.getDefaultFoundation().adapter_.isRtl());
+
+  wrapper.appendChild(root);
+  document.body.appendChild(wrapper);
+  assert.isTrue(component.getDefaultFoundation().adapter_.isRtl());
+
+  document.body.removeChild(wrapper);
 });

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -339,25 +339,6 @@ test('#adapter.getNativeInput returns the component input element', () => {
   );
 });
 
-test('#adapter.getWidth returns the width of the root element', () => {
-  const {root, component} = setupTest();
-  const width = component.getDefaultFoundation().adapter_.getWidth();
-  assert.equal(width, root.offsetWidth);
-});
-
-test('#adapter.getHeight returns the height of the root element', () => {
-  const {root, component} = setupTest();
-  const height = component.getDefaultFoundation().adapter_.getWidth();
-  assert.equal(height, root.offsetHeight);
-});
-
-test('#adapter.getLabelWidth returns the width of the label element', () => {
-  const {root, component} = setupTest();
-  const labelElement = root.querySelector('.mdc-text-field__label');
-  const labelWidth = component.getDefaultFoundation().adapter_.getLabelWidth();
-  assert.equal(labelWidth, labelElement.offsetWidth);
-});
-
 test('#adapter.getIdleOutlineStyleValue returns the value of the given property on the idle outline element', () => {
   const root = getFixture();
   root.appendChild(bel`<div class="mdc-text-field__idle-outline"></div>`);

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -158,6 +158,14 @@ test('set helperTextContent has no effect when no helper text element is present
   });
 });
 
+test('#layout recomputes all dimensions and positions for the ripple element', () => {
+  const root = getFixture();
+  root.classList.add(cssClasses.BOX);
+  const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el));
+  component.layout();
+  td.verify(component.ripple.layout());
+});
+
 test('#adapter.setIconAttr sets a given attribute to a given value to the icon element', () => {
   const {icon, component} = setupTest();
 
@@ -271,9 +279,12 @@ test('#adapter.getIdleOutlineStyleValue returns the value of the given property 
   root.appendChild(bel`<div class="mdc-text-field__idle-outline"></div>`);
   const idleOutline = root.querySelector('.mdc-text-field__idle-outline');
   idleOutline.style.width = '500px';
-  console.log(root);
+
   const component = new MDCTextField(root);
-  assert.equal(component.getDefaultFoundation().adapter_.getIdleOutlineStyleValue('width'), '500px');
+  assert.equal(
+    component.getDefaultFoundation().adapter_.getIdleOutlineStyleValue('width'),
+    getComputedStyle(idleOutline).getPropertyValue('width')
+  );
 });
 
 test('#adapter.isRtl returns true when the root element is in an RTL context' +

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -55,6 +55,12 @@ class FakeBottomLine {
   }
 }
 
+class FakeOutline {
+  constructor() {
+    this.destroy = td.func('.destroy');
+  }
+}
+
 test('#constructor when given a `mdc-text-field--box` element instantiates a ripple on the root element', () => {
   const root = getFixture();
   root.classList.add(cssClasses.BOX);
@@ -94,6 +100,14 @@ test('#destroy cleans up the ripple if present', () => {
   const component = new MDCTextField(root, undefined, (el) => new FakeRipple(el));
   component.destroy();
   td.verify(component.ripple.destroy());
+});
+
+test('#destroy cleans up the outline if present', () => {
+  const root = getFixture();
+  root.appendChild(bel`<div class="mdc-text-field__outline"></div>`);
+  const component = new MDCTextField(root, undefined, undefined, undefined, (el) => new FakeOutline(el));
+  component.destroy();
+  td.verify(component.outline_.destroy());
 });
 
 test('#destroy accounts for ripple nullability', () => {


### PR DESCRIPTION
Add an outline subcomponent and wire it into the parent component for the outlined variation of MDC Text Field. It uses an SVG path when the text field is focused and a div border when it's idle.
The demo of outlined text field includes:
- disabled
- RTL
- usage with helper text

These will come in later PRs:
- ripple
- leading/trailing icons
- dense variant
- CSS-only variation