### PR TITLE
fix(select): Work around glitch with new list styles in Chrome

### DIFF
--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -263,6 +263,7 @@ $mdc-select-menu-transition: transform 180ms $mdc-animation-standard-curve-timin
     }
 
     // Styles to override mdc-ripple-radius from mdc-list, which causes display glitches in Chrome
+    // (See https://github.com/material-components/material-components-web/pull/1737#issuecomment-351105800)
     @include mdc-ripple-radius(50%);
 
     &::before,

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -261,6 +261,14 @@ $mdc-select-menu-transition: transform 180ms $mdc-animation-standard-curve-timin
         @include mdc-theme-prop(color, text-primary-on-dark);
       }
     }
+
+    // Styles to override mdc-ripple-radius from mdc-list, which causes display glitches in Chrome
+    @include mdc-ripple-radius(50%);
+
+    &::before,
+    &::after {
+      border-radius: 0;
+    }
   }
 
   .mdc-list-group,


### PR DESCRIPTION
This resolves the Chrome-specific select menu glitch I discovered while testing #1737 (see screenshot in https://github.com/material-components/material-components-web/pull/1737#issuecomment-351105800).