### PR TITLE
docs: Update documentation for `setStyle` in `linear-progress`.

### DIFF
--- a/packages/mdc-linear-progress/README.md
+++ b/packages/mdc-linear-progress/README.md
@@ -81,7 +81,7 @@ The adapter for linear progress must provide the following functions, with corre
 | `hasClass(className: string) => boolean` | Returns boolean indicating whether the root element has a given class. |
 | `getPrimaryBar() => Element` | Returns the primary bar element. |
 | `getBuffer() => Element` | Returns the buffer element. |
-| `setTransform(el: Element, value: string) => void` | Sets the css transform property on the given element. |
+| `setStyle(el: Element, styleProperty: string, value: string) => void` | Sets the inline style on the given element. |
 
 ### MDCLinearProgressFoundation API
 

--- a/packages/mdc-linear-progress/foundation.js
+++ b/packages/mdc-linear-progress/foundation.js
@@ -35,7 +35,7 @@ export default class MDCLinearProgressFoundation extends MDCFoundation {
       getBuffer: () => /* el: Element */ {},
       hasClass: (/* className: string */) => false,
       removeClass: (/* className: string */) => {},
-      setStyle: (/* el: Element, styleProperty: string, value: number */) => {},
+      setStyle: (/* el: Element, styleProperty: string, value: string */) => {},
     };
   }
 


### PR DESCRIPTION
Fixes #1680

@bonniezhou I made a PR like you suggested in #1680.
One question: The current `setStyle` implementation returns the value. See https://github.com/material-components/material-components-web/blob/master/packages/mdc-linear-progress/index.js#L58 Is that intended? If not I can update my PR. Thanks!