### PR TITLE
chore(demos): Use demo-* class names for custom styles instead of mdc-* in icon-toggle demo

### DIFF
--- a/demos/icon-toggle.html
+++ b/demos/icon-toggle.html
@@ -90,7 +90,7 @@
           </div>
         </div>
 
-        <div class="toggle-example mdc-theme--dark">
+        <div class="toggle-example mdc-theme--dark demo-theme-dark">
           <h2 class="mdc-theme--text-primary-on-dark">Dark Theme</h2>
           <div class="demo-wrapper">
             <i class="mdc-icon-toggle material-icons"
@@ -119,7 +119,7 @@
               favorite_border
             </i>
           </div>
-          <div class="mdc-theme--dark">
+          <div class="mdc-theme--dark demo-theme-dark">
             <div class="demo-wrapper">
               <i class="mdc-icon-toggle mdc-icon-toggle--disabled material-icons"
                  role="button"
@@ -166,7 +166,7 @@
               </div>
               <div>Dark icon on background</div>
             </div>
-            <div id="custom-on-dark" class="demo-color-combo mdc-theme--dark">
+            <div id="custom-on-dark" class="demo-color-combo mdc-theme--dark demo-theme-dark">
               <div>
                 <i class="mdc-icon-toggle material-icons"
                    role="button"

--- a/demos/icon-toggle.scss
+++ b/demos/icon-toggle.scss
@@ -18,7 +18,7 @@
 @import "../packages/mdc-icon-toggle/mdc-icon-toggle";
 @import "../packages/mdc-ripple/mixins";
 
-.mdc-theme--dark {
+.demo-theme-dark {
   background: #303030;
 }
 


### PR DESCRIPTION
partial fix of #1687