### PR TITLE
chore(demos): Use demo-* class names for custom styles instead of mdc-* in radio demo

### DIFF
--- a/demos/radio.html
+++ b/demos/radio.html
@@ -24,16 +24,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      .mdc-theme--dark {
-        background-color: #303030;
-      }
-
-      .example {
-        margin: 24px;
-        padding: 24px;
-      }
-    </style>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed">
@@ -165,7 +155,7 @@
         </div>
       </section>
 
-      <section class="example mdc-theme--dark">
+      <section class="example mdc-theme--dark demo-theme-dark">
         <h2 class="mdc-theme--text-primary-on-dark">Dark Theme</h2>
 
         <div class="demo-radio-row">
@@ -239,7 +229,7 @@
             <label id="ex4a-radio2-label" for="ex4a-radio2">Disabled Radio 2</label>
           </div>
         </div>
-        <div class="mdc-theme--dark">
+        <div class="mdc-theme--dark demo-theme-dark">
           <div class="mdc-form-field">
             <div class="mdc-radio mdc-radio--disabled">
               <input class="mdc-radio__native-control" type="radio" id="ex4b-radio1" checked disabled name="ex4b">

--- a/demos/radio.scss
+++ b/demos/radio.scss
@@ -20,7 +20,7 @@
 @import "../packages/mdc-ripple/mixins";
 @import "../packages/mdc-theme/color-palette";
 
-.mdc-radio.demo-radio--custom {
+.demo-radio--custom {
   $color: $material-color-red-500;
 
   @include mdc-radio-unchecked-stroke-color($color);
@@ -28,4 +28,8 @@
   @include mdc-radio-ink-color($material-color-orange-500);
   @include mdc-radio-focus-indicator-color($color);
   @include mdc-states($color);
+}
+
+.demo-theme-dark {
+  background-color: #303030;
 }


### PR DESCRIPTION
partial fix of #1687