### PR TITLE
chore(demos): Use demo-* class names for custom styles instead of mdc-* in drawer demo

### DIFF
--- a/demos/drawer/drawer.scss
+++ b/demos/drawer/drawer.scss
@@ -18,3 +18,66 @@
 @import "../../packages/mdc-drawer/mdc-drawer";
 @import "../../packages/mdc-elevation/mdc-elevation";
 @import "../../packages/mdc-list/mdc-list";
+
+/* Ensure layout covers the entire screen. */
+html {
+  height: 100%;
+}
+
+/* Place drawer and content side by side. */
+.demo-body {
+  display: flex;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  min-height: 100%;
+}
+
+/* Stack toolbar and main on top of each other. */
+.demo-content {
+  height: 100%;
+  box-sizing: border-box;
+}
+
+/* Place drawer above toolbar shadow. */
+.demo-drawer-above-permanent {
+  z-index: 2;
+}
+
+.demo-main {
+  padding-left: 16px;
+}
+
+.extra-content-wrapper {
+  padding: 10px;
+}
+
+#extra-wide-content {
+  width: 200vw;
+}
+
+#extra-tall-content {
+  height: 200vh;
+}
+
+.demo-body--drawer-above,
+.demo-body--drawer-persistent {
+  flex-direction: row;
+  width: 100%;
+}
+
+.demo-body--drawer-below {
+  flex-direction: column;
+}
+
+.demo-content--drawer-below {
+  display: flex;
+  flex: 1 1 auto;
+}
+
+.demo-content--drawer-above,
+.demo-content--drawer-persistent {
+  display: inline-flex;
+  flex-direction: column;
+  flex-grow: 1;
+}

--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -24,56 +24,9 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      /* Ensure layout covers the entire screen. */
-      html {
-        height: 100%;
-      }
-
-      /* Place drawer and content side by side. */
-      .demo-body {
-        display: flex;
-        flex-direction: row;
-        padding: 0;
-        margin: 0;
-        box-sizing: border-box;
-        min-height: 100%;
-        width: 100%;
-      }
-
-      /* Stack toolbar and main on top of each other. */
-      .demo-content {
-        display: inline-flex;
-        flex-direction: column;
-        flex-grow: 1;
-        height: 100%;
-        box-sizing: border-box;
-      }
-
-      /* Place drawer above toolbar shadow. */
-      .mdc-permanent-drawer {
-        z-index: 2;
-      }
-
-      .demo-main {
-        padding-left: 16px;
-      }
-
-      .extra-content-wrapper {
-        padding: 10px;
-      }
-
-      #extra-wide-content {
-        width: 200vw;
-      }
-
-      #extra-tall-content {
-        height: 200vh;
-      }
-    </style>
   </head>
   <body class="mdc-typography demo-body">
-    <nav class="mdc-permanent-drawer">
+    <nav class="mdc-permanent-drawer demo-drawer-above-permanent">
       <div class="mdc-permanent-drawer__toolbar-spacer"></div>
       <div class="mdc-list-group">
         <nav class="mdc-list">
@@ -106,7 +59,7 @@
           </nav>
         </div>
     </nav>
-    <div class="demo-content">
+    <div class="demo-content demo-content--drawer-above">
       <!-- TODO: #324 - Should switch to .mdc-toolbar--fixed -->
       <header class="mdc-toolbar mdc-elevation--z4">
         <div class="mdc-toolbar__row">

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -24,48 +24,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      /* Ensure layout covers the entire screen. */
-      html {
-        height: 100%;
-      }
-
-      /* Stack toolbar and content on top of each other. */
-      .demo-body {
-        display: flex;
-        flex-direction: column;
-        padding: 0;
-        margin: 0;
-        box-sizing: border-box;
-        min-height: 100%;
-      }
-
-      /* Place drawer and main next to each other. */
-      .demo-content {
-        display: flex;
-        flex: 1 1 auto;
-        height: 100%;
-        box-sizing: border-box;
-      }
-
-      .demo-main {
-        padding-left: 16px;
-      }
-
-      .extra-content-wrapper {
-        padding: 10px;
-      }
-
-      #extra-wide-content {
-        width: 200vw;
-      }
-
-      #extra-tall-content {
-        height: 200vh;
-      }
-    </style>
   </head>
-  <body class="mdc-typography demo-body">
+  <body class="mdc-typography demo-body demo-body--drawer-below">
     <header class="mdc-toolbar mdc-toolbar--fixed">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
@@ -77,7 +37,7 @@
       </div>
     </header>
 
-    <div class="demo-content mdc-toolbar-fixed-adjust">
+    <div class="demo-content demo-content--drawer-below mdc-toolbar-fixed-adjust">
       <nav class="mdc-permanent-drawer">
         <div class="mdc-list-group">
           <nav class="mdc-list">

--- a/demos/drawer/persistent-drawer.html
+++ b/demos/drawer/persistent-drawer.html
@@ -24,38 +24,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      /* Ensure layout covers the entire screen. */
-      html {
-        height: 100%;
-      }
-
-      /* Place drawer and content side by side. */
-      .demo-body {
-        display: flex;
-        flex-direction: row;
-        padding: 0;
-        margin: 0;
-        box-sizing: border-box;
-        height: 100%;
-        width: 100%;
-      }
-
-      /* Stack toolbar and main on top of each other. */
-      .demo-content {
-        display: inline-flex;
-        flex-direction: column;
-        flex-grow: 1;
-        height: 100%;
-        box-sizing: border-box;
-      }
-
-      .demo-main {
-        padding-left: 16px;
-      }
-    </style>
   </head>
-  <body class="mdc-typography demo-body">
+  <body class="mdc-typography demo-body demo-body--drawer-persistent">
     <aside class="mdc-persistent-drawer">
       <nav class="mdc-persistent-drawer__drawer">
         <div class="mdc-persistent-drawer__toolbar-spacer"></div>
@@ -91,7 +61,7 @@
           </div>
       </nav>
     </aside>
-    <div class="demo-content">
+    <div class="demo-content demo-content--drawer-persistent">
       <header class="mdc-toolbar mdc-elevation--z4">
         <div class="mdc-toolbar__row">
           <section class="mdc-toolbar__section mdc-toolbar__section--align-start">

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -24,18 +24,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      .demo-body {
-        padding: 0;
-        margin: 0;
-        box-sizing: border-box;
-      }
-
-      .demo-main {
-        padding-left: 16px;
-        overflow: auto;
-      }
-    </style>
   </head>
   <body class="mdc-typography demo-body">
     <div class="mdc-toolbar mdc-toolbar--fixed">


### PR DESCRIPTION
partial fix https://github.com/material-components/material-components-web/issues/1687