### PR TITLE
fix(select): Disable ripple/state pseudos for native multiselect

### DIFF
--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -353,6 +353,16 @@ $mdc-select-menu-transition: transform 180ms $mdc-animation-standard-curve-timin
     &:last-child {
       margin-bottom: 8px;
     }
+
+    // Browsers are inconsistent in what they allow us to override, and some (e.g. Chrome) don't allow overriding the
+    // OS-determined selection color, which states styles are not going to play well with.
+    // Additionally, Firefox seems to ignore position: relative on option elements, which causes the pseudo elements
+    // that we use for ripple/states to position and size themselves relative to the entire body instead.
+    // Disabling states-specific styles on multi-select options altogether is the most straightforward recourse.
+    &::before,
+    &::after {
+      content: none;
+    }
   }
   // stylelint-enable plugin/selector-bem-pattern
 


### PR DESCRIPTION
See https://github.com/material-components/material-components-web/pull/1737#issuecomment-351742347 for what this addresses, and see the comment in the added code as to why I'm resorting to this approach.

I could probably arguably do this specifically only for Firefox with a supports clause instead, but I don't think this is doing us any favors in other browsers either because of how generally flaky they are with allowing native selects to be styled.