### PR TITLE
chore(demos): Use demo-* class names for custom styles instead of mdc-* in toolbar demo

### DIFF
--- a/demos/toolbar/default-flexible-toolbar.html
+++ b/demos/toolbar/default-flexible-toolbar.html
@@ -24,8 +24,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-    </style>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--flexible mdc-toolbar--flexible-default-behavior demo-toolbar">

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -24,55 +24,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      .demo-container {
-        height: 500px;
-        margin: 0px;
-        font-size: 16px;
-        overflow: scroll;
-      }
-
-      .demo-header-toolbar {
-        z-index: 10;
-      }
-
-      .hero .catalog-toolbar-container {
-        width: 480px;
-        height: 72px;
-      }
-
-      .hero .catalog-toolbar-container .mdc-toolbar {
-        box-shadow:
-          0px 2px 4px -1px rgba(0, 0, 0, 0.2),
-          0px 4px 5px 0px rgba(0, 0, 0, 0.14),
-          0px 1px 10px 0px rgba(0, 0, 0, 0.12);
-      }
-
-      .examples {
-        display: block;
-      }
-
-      .example {
-        display: inline-block;
-        width: 320px;
-        height: 600px;
-        margin: 24px;
-      }
-
-      .example iframe {
-        border: 1px solid #eee;
-      }
-
-      .examples h2 {
-        font-size: 24px;
-        margin-bottom: 16px;
-      }
-
-      div.intro {
-        padding: 48px 24px;
-      }
-
-    </style>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">

--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -23,12 +23,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      #demo-menu {
-        margin-top: 8px;
-        margin-right: 8px;
-      }
-    </style>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed demo-toolbar">
@@ -42,7 +36,7 @@
           <a href="#" class="material-icons mdc-toolbar__icon" aria-label="Print this page" alt="Print this page">print</a>
           <a href="#" class="material-icons mdc-toolbar__icon toggle" aria-label="More" alt="More">more_vert</a>
           <div class="mdc-menu-anchor">
-            <div class="mdc-simple-menu" tabindex="-1" id="demo-menu">
+            <div class="mdc-simple-menu" tabindex="-1" id="demo-toolbar-menu">
               <ul class="mdc-simple-menu__items mdc-list" role="menu" aria-hidden="true" style="transform: scale(1, 1);">
                 <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.069s;">Back</li>
                 <li class="mdc-list-item" role="menuitem" tabindex="0" style="transition-delay: 0.124s;">Forward</li>
@@ -72,7 +66,7 @@
 
     <script src="/assets/material-components-web.js"></script>
     <script>
-      var menuEl = document.querySelector('#demo-menu');
+      var menuEl = document.querySelector('#demo-toolbar-menu');
       var menu = new mdc.menu.MDCSimpleMenu(menuEl);
       var toggle = document.querySelector('.toggle');
       toggle.addEventListener('click', function() {

--- a/demos/toolbar/toolbar.scss
+++ b/demos/toolbar/toolbar.scss
@@ -86,3 +86,77 @@
   color: white;
   background-color: rgba(0, 0, 0, 0.7);
 }
+
+.demo-container {
+  height: 500px;
+  margin: 0px;
+  font-size: 16px;
+  overflow: scroll;
+}
+
+.demo-header-toolbar {
+  z-index: 10;
+}
+
+.hero .catalog-toolbar-container {
+  width: 480px;
+  height: 72px;
+}
+
+.hero .catalog-toolbar-container .mdc-toolbar {
+  box-shadow:
+    0px 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0px 4px 5px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+}
+
+.examples {
+  display: block;
+}
+
+.example {
+  display: inline-block;
+  width: 320px;
+  height: 600px;
+  margin: 24px;
+}
+
+.example iframe {
+  border: 1px solid #eee;
+}
+
+.examples h2 {
+  font-size: 24px;
+  margin-bottom: 16px;
+}
+
+div.intro {
+  padding: 48px 24px;
+}
+
+
+// waterfall flexible toolbar custom
+.demo-custom-scroll-title {
+  line-height: 130%;
+  margin-left: 0;
+}
+#my-flexible-header {
+  --mdc-toolbar-ratio-to-extend-flexible: 2;
+  background-color: rgb(255, 64, 129);
+}
+#my-flexible-header .mdc-toolbar__title {
+  font-size: 5rem;
+  transform: translateY(-30px);
+}
+
+// menu toolbar custom
+#demo-toolbar-menu {
+  margin-top: 8px;
+  margin-right: 8px;
+}
+
+
+.demo-toolbar--fixed-lastrow-only {
+  background-color: #141395;
+  transition: background-color .2s ease;
+}

--- a/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
+++ b/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
@@ -24,20 +24,6 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      .demo-custom-scroll-title {
-        line-height: 130%;
-        margin-left: 0;
-      }
-      #my-flexible-header {
-        --mdc-toolbar-ratio-to-extend-flexible: 2;
-        background-color: rgb(255, 64, 129);
-      }
-      #my-flexible-header .mdc-toolbar__title {
-        font-size: 5rem;
-        transform: translateY(-30px);
-      }
-    </style>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed mdc-toolbar--waterfall mdc-toolbar--flexible demo-toolbar" id="my-flexible-header">

--- a/demos/toolbar/waterfall-toolbar-fix-last-row.html
+++ b/demos/toolbar/waterfall-toolbar-fix-last-row.html
@@ -24,18 +24,9 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <style>
-      .demo-toolbar {
-        background-color: #141395;
-        transition: background-color .2s ease;
-      }
-      .demo-toolbar.mdc-toolbar--flexible-space-minimized {
-        background-color: #3f51b5;
-      }
-    </style>
   </head>
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed mdc-toolbar--fixed-lastrow-only mdc-toolbar--waterfall mdc-toolbar--flexible mdc-toolbar--flexible-default-behavior demo-toolbar">
+    <header class="mdc-toolbar mdc-toolbar--fixed mdc-toolbar--fixed-lastrow-only mdc-toolbar--waterfall mdc-toolbar--flexible mdc-toolbar--flexible-default-behavior demo-toolbar demo-toolbar--fixed-lastrow-only">
       <div class="mdc-toolbar__row demo-toolbar__row--with-image">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <a href="#" class="material-icons mdc-toolbar__menu-icon">menu</a>


### PR DESCRIPTION
partial fix of https://github.com/material-components/material-components-web/issues/1687