### PR TITLE
chore(textfield): Update README to follow best practices

### DIFF
--- a/docs/importing-js.md
+++ b/docs/importing-js.md
@@ -1,0 +1,47 @@
+# Importing the JS component
+
+Most components ship with Component / Foundation classes which are used to provide a full-fidelity Material Design component. Depending on what technology you use in your stack, there are several ways to import the JavaScript.
+
+## ES2015
+
+```javascript
+import {MDCFoo, MDCFooFoundation} from '@material/foo';
+```
+
+## CommonJS
+
+```javascript
+const mdcFoo = require('mdc-foo');
+const MDCFoo = mdcFoo.MDCFoo;
+const MDCFooFoundation = mdcFoo.MDCFooFoundation;
+```
+
+## AMD
+
+```javascript
+require(['path/to/mdc-foo'], mdcFoo => {
+  const MDCFoo = mdcFoo.MDCFoo;
+  const MDCFooFoundation = mdcFoo.MDCFooFoundation;
+});
+```
+
+## Global
+
+```javascript
+const MDCFoo = mdc.foo.MDCFoo;
+const MDCFooFoundation = mdc.foo.MDCFooFoundation;
+```
+
+## Automatic Instantiation
+
+```javascript
+mdc.foo.MDCFoo.attachTo(document.querySelector('.mdc-foo'));
+```
+
+## Manual Instantiation
+
+```javascript
+import {MDCFoo} from '@material/foo';
+
+const foo = new MDCFoo(document.querySelector('.mdc-foo'));
+```

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -125,8 +125,6 @@ included as part of the DOM structure of a full width text field.
 > _NOTE_: Only use `mdc-text-field__label` within `mdc-text-field--textarea` _if you plan on using
 > Javascript_. Otherwise, use the `placeholder` attribute, as shown below.
 
-##### CSS Only
-
 ```html
 <div class="mdc-text-field mdc-text-field--textarea">
   <textarea id="textarea-css-only"

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -137,6 +137,8 @@ included as part of the DOM structure of a full width text field.
 
 #### Disabled
 
+Add the `disabled` attribute to `<input>` if the `mdc-text-field` is disabled. You also need to add `mdc-text-field--disabled` to the `mdc-text-field`.
+
 ```html
 <div class="mdc-text-field mdc-text-field--disabled">
   <input type="text" id="disabled-text-field" class="mdc-text-field__input" disabled>
@@ -161,7 +163,6 @@ See [here](icon/) for more information on using icons.
 CSS Class | Description
 --- | ---
 `mdc-text-field` | Mandatory
-`mdc-text-field__input` | Mandatory
 `mdc-text-field--upgraded` | Indicates the text field is upgraded, normally by JavaScript
 `mdc-text-field--box` | Styles the text field as a box text field
 `mdc-text-field--fullwidth` | Styles the text field as a full width text field
@@ -181,23 +182,20 @@ Mixin | Description
 
 ### `MDCTextField`
 
-#### `MDCTextField.disable`
+See [Importing the JS component](../docs/importing-js.md) for more information on how to import JavaScript.
 
-Boolean. Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set
-respectively.
-
-#### `MDCTextField.valid`
-
-Boolean setter. Proxies to the foundation's `setValid` method when set.
-
-#### `MDCTextField.helperTextContent`
-
-String setter. Proxies to the foundation's `setHelperTextContent` method when set.
+Property | Value Type | Description
+--- | ---
+`disable` | Boolean | Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set
+respectively
+`valid` | Boolean | Proxies to the foundation's `setValid` method when set
+`helperTextContent` | String | Proxies to the foundation's `setHelperTextContent` method when set
+`ripple` | `MDCRipple` | The `MDCRipple` instance for the root element that `MDCTextField`
+initializes
 
 ##### `MDCTextField.ripple`
 
-`MDCRipple` instance. Set to the `MDCRipple` instance for the root element that `MDCTextField`
-initializes when given an `mdc-text-field--box` root element. Otherwise, the field is set to `null`.
+The `MDCRipple` instance for the root element that `MDCTextField` initializes when given an `mdc-text-field--box` root element. Otherwise, the field is set to `null`.
 
 ### `MDCTextFieldAdapter`
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -186,7 +186,7 @@ See [Importing the JS component](../../docs/importing-js.md) for more informatio
 
 Property | Value Type | Description
 --- | --- | ---
-`disable` | Boolean | Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set respectively
+`disable` | Boolean | Proxies to the foundation's `isDisabled`/`setDisabled` methods when retrieved/set respectively
 `valid` | Boolean | Proxies to the foundation's `setValid` method when set
 `helperTextContent` | String | Proxies to the foundation's `setHelperTextContent` method when set
 `ripple` | `MDCRipple` | The `MDCRipple` instance for the root element that `MDCTextField` initializes

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -90,8 +90,6 @@ Un-styled Content (**FOUC**).
 </div>
 ```
 
-##### Box Variant
-
 > _NOTE_: Do not use `mdc-text-field__bottom-line` inside of `mdc-text-field` _if you plan on using `mdc-text-field--box`, and do not plan on using JavaScript_. Bottom line should not be included as part of the DOM structure of a box text field.
 
 ```html
@@ -185,81 +183,54 @@ Mixin | Description
 
 ### `MDCTextField`
 
-#### MDCTextField.disabled
+#### `MDCTextField.disable`
 
 Boolean. Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set
 respectively.
 
-#### MDCTextField.valid
+#### `MDCTextField.valid`
 
 Boolean setter. Proxies to the foundation's `setValid` method when set.
 
-#### MDCTextField.helperTextContent
+#### `MDCTextField.helperTextContent`
 
 String setter. Proxies to the foundation's `setHelperTextContent` method when set.
 
-##### MDCTextField.ripple
+##### `MDCTextField.ripple`
 
 `MDCRipple` instance. Set to the `MDCRipple` instance for the root element that `MDCTextField`
 initializes when given an `mdc-text-field--box` root element. Otherwise, the field is set to `null`.
 
-### Using the foundation class
+### `MDCTextFieldAdapter`
 
-Because MDC Text Field is a feature-rich and relatively complex component, its adapter is a bit more
-complicated.
+Method Signature | Description
+--- | ---
+`addClass(className: string) => void` | Adds a class to the root element
+`removeClass(className: string) => void` | Removes a class from the root element
+`registerTextFieldInteractionHandler(evtType: string, handler: EventListener)` => void | Registers an event handler on the root element for a given event
+`deregisterTextFieldInteractionHandler(evtType: string, handler: EventListener)` => void | Deregisters an event handler on the root element for a given event
+`registerInputInteractionHandler(evtType: string, handler: EventListener)` => void | Registers an event listener on the native input element for a given event
+`deregisterInputInteractionHandler(evtType: string, handler: EventListener)` => void | Deregisters an event listener on the native input element for a given event
+`registerBottomLineEventHandler(evtType: string, handler: EventListener)` => void | Registers an event listener on the bottom line element for a given event
+`deregisterBottomLineEventHandler(evtType: string, handler: EventListener)` => void | Deregisters an event listener on the bottom line element for a given event
+`getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}?` | Returns an object representing the native text input element, with a similar API shape.
 
-| Method Signature | Description |
-| --- | --- |
-| addClass(className: string) => void | Adds a class to the root element |
-| removeClass(className: string) => void | Removes a class from the root element |
-| registerTextFieldInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event handler on the root element for a given event |
-| deregisterTextFieldInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event handler on the root element for a given event |
-| registerInputInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the native input element for a given event |
-| deregisterInputInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the native input element for a given event |
-| registerBottomLineEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the bottom line element for a given event |
-| deregisterBottomLineEventHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener on the bottom line element for a given event |
-| getNativeInput() => {value: string, disabled: boolean, badInput: boolean, checkValidity: () => boolean}? | Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully. |
+#### `MDCTextFieldAdapter.getNativeInput()`
 
-MDC Text Field has multiple optional sub-elements: bottom line and helper text. The foundations of these sub-elements must be passed in as constructor arguments for the `MDCTextField` foundation. Since the `MDCTextField` component takes care of creating its foundation, we need to pass sub-element foundations through the `MDCTextField` component. This is typically done in the component's implementation of `getDefaultFoundation()`.
+Returns an object representing the native text input element, with a similar API shape. The object returned should include the `value`, `disabled` and `badInput` properties, as well as the `checkValidity()` function. We _never_ alter the value within our code, however we _do_ update the disabled property, so if you choose to duck-type the return value for this method in your implementation it's important to keep this in mind. Also note that this method can return null, which the foundation will handle gracefully.
 
-#### The full foundation API
+### `MDCTextFieldFoundation`
 
-##### MDCTextFieldFoundation.isDisabled() => boolean
+Method Signature | Description
+--- | ---
+`isDisabled() => boolean` | Returns whether or not the input is disabled
+`setDisabled(disabled: boolean) => void` | Updates the input's disabled state
+`setValid(isValid: boolean) => void` | Sets the validity state of the Text Field. Triggers custom validity checking
+`setHelperTextContent(content: string) => void` | 
+`handleTextFieldInteraction(evt: Event) => void` | Handles click and keydown events originating from inside the Text Field component
+`activateFocus() => void` | Activates the focus state of the Text Field. Normally called in response to the input focus event.
+`deactivateFocus() => void` | Deactivates the focus state of the Text Field. Normally called in response to the input blur event.
+`handleBottomLineAnimationEnd(evt: Event) => void` | Handles the end of the bottom line animation, performing actions that must wait for animations to finish. Expects a transition-end event.
+`setHelperTextContent(content: string) => void` | Sets the content of the helper text
 
-Returns a boolean specifying whether or not the input is disabled.
-
-##### MDCTextFieldFoundation.setDisabled(disabled: boolean)
-
-Updates the input's disabled state.
-
-##### MDCTextFieldFoundation.setValid(isValid: boolean)
-
-Sets the validity state of the Text Field. Triggers custom validity checking.
-
-##### MDCTextFieldFoundation.handleTextFieldInteraction(evt: Event)
-
-Handles click and keydown events originating from inside the Text Field component.
-
-##### MDCTextFieldFoundation.activateFocus()
-
-Activates the focus state of the Text Field. Normally called in response to the input focus event.
-
-##### MDCTextFieldFoundation.deactivateFocus()
-
-Deactivates the focus state of the Text Field. Normally called in response to the input blur event.
-
-##### MDCTextFieldFoundation.handleBottomLineAnimationEnd(evt: Event)
-
-Handles the end of the bottom line animation, performing actions that must wait for animations to
-finish. Expects a transition-end event.
-
-##### MDCTextFieldFoundation.setHelperTextContent(content)
-
-Sets the content of the helper text, if it exists.
-
-### Theming
-
-MDC Text Field components use the configured theme's primary color for its underline and label text
-when the input is focused.
-
-MDC Text Field components support dark themes.
+`MDCTextFieldFoundation` supports multiple optional sub-elements: bottom line and helper text. The foundations of these sub-elements must be passed in as constructor arguments to `MDCTextFieldFoundation`.

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -186,12 +186,10 @@ See [Importing the JS component](../../docs/importing-js.md) for more informatio
 
 Property | Value Type | Description
 --- | --- | ---
-`disable` | Boolean | Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set
-respectively
+`disable` | Boolean | Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set respectively
 `valid` | Boolean | Proxies to the foundation's `setValid` method when set
 `helperTextContent` | String | Proxies to the foundation's `setHelperTextContent` method when set
-`ripple` | `MDCRipple` | The `MDCRipple` instance for the root element that `MDCTextField`
-initializes
+`ripple` | `MDCRipple` | The `MDCRipple` instance for the root element that `MDCTextField` initializes
 
 ##### `MDCTextField.ripple`
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -1,12 +1,12 @@
 <!--docs:
-title: "Text Fields"
+title: "Text Field"
 layout: detail
 section: components
 iconId: text_field
-path: /catalog/input-controls/text-fields/
+path: /catalog/input-controls/text-field/
 -->
 
-# Text Fields
+# Text Field
 
 <!--<div class="article__asset">
   <a class="article__asset-link"
@@ -15,9 +15,7 @@ path: /catalog/input-controls/text-fields/
   </a>
 </div>-->
 
-The MDC Text Field component provides a textual input field adhering to the [Material Design Specification](https://material.io/guidelines/components/text-fields.html).
-It is fully accessible, ships with RTL support, and includes a gracefully-degraded version that does
-not require any javascript.
+Text fields allow users to input, edit, and select text.
 
 ## Design & API Documentation
 
@@ -38,7 +36,7 @@ npm install --save @material/textfield
 
 ## Usage
 
-### Single-line - with Javascript
+### HTML Structure
 
 ```html
 <div class="mdc-text-field">
@@ -48,61 +46,9 @@ npm install --save @material/textfield
 </div>
 ```
 
-It's also possible to wrap an input within a `<label>` to avoid dynamic id generation:
+#### HTML5 Validation
 
-```html
-<label class="mdc-text-field">
-  <input type="text" class="mdc-text-field__input">
-  <span class="mdc-text-field__label">Hint Text</span>
-  <div class="mdc-text-field__bottom-line"></div>
-</label>
-```
-
-> _NOTE_: Only place an `mdc-text-field__label` inside of a text field _if you plan on using
-> Javascript_. Otherwise, the label must go outside of the text-field, as shown below.
-
-### Single-line - Gracefully degraded
-
-```html
-<label for="text-field-no-js">TextField with no JS: </label>
-<div class="mdc-text-field">
-  <input type="text" id="text-field-no-js" class="mdc-text-field__input" placeholder="Hint text">
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-```
-
-### Disabled Text Fields
-
-```html
-<div class="mdc-text-field mdc-text-field--disabled">
-  <input type="text" id="disabled-text-field" class="mdc-text-field__input" disabled>
-  <label class="mdc-text-field__label" for="disabled-text-field">Disabled text field</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-```
-
-### Pre-filled text fields
-
-When dealing with JS-driven text fields that already have values, you'll want to ensure that you
-render the text field label with the `mdc-text-field__label--float-above` modifier class. This will
-ensure that the label moves out of the way of the text field's value and prevents a Flash Of
-Un-styled Content (**FOUC**). You'll also want to add the `mdc-text-field--upgraded` modifier class
-on the text-field root element. The JS component does for you automatically on initialization, but
-since it won't be added until that JS runs, adding it manually will prevent an initial FOUC.
-
-```html
-<div class="mdc-text-field mdc-text-field--upgraded">
-  <input type="text" id="pre-filled" class="mdc-text-field__input" value="Pre-filled value">
-  <label class="mdc-text-field__label mdc-text-field__label--float-above" for="pre-filled">
-    Label in correct place
-  </label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-```
-
-### Validation
-
-MDC Text Field provides validity styling by using the `:invalid` and `:required` attributes provided
+`MDCTextFieldFoundation` provides validity styling by using the `:invalid` and `:required` attributes provided
 by HTML5's form validation API.
 
 ```html
@@ -113,9 +59,38 @@ by HTML5's form validation API.
 </div>
 ```
 
-By default an input's validity is checked via `checkValidity()` on blur, and the styles are updated
-accordingly. Set the MDCTextField.valid field to set the input's validity explicitly. MDC Text Field
-automatically appends an asterisk to the label text if the required attribute is set.
+`MDCTextFieldFoundation` automatically appends an asterisk to the label text if the required attribute is set.
+
+#### Pre-filled
+
+When dealing with JS-driven text fields that already have values, you'll want to ensure that you
+render `mdc-text-field__label` with the `mdc-text-field__label--float-above` modifier class, and `mdc-text-field` with the `mdc-text-field--upgraded` modifier class. This will
+ensure that the label moves out of the way of the text field's value and prevents a Flash Of
+Un-styled Content (**FOUC**).
+
+```html
+<div class="mdc-text-field mdc-text-field--upgraded">
+  <input type="text" id="pre-filled" class="mdc-text-field__input" value="Pre-filled value">
+  <label class="mdc-text-field__label mdc-text-field__label--float-above" for="pre-filled">
+    Label in correct place
+  </label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
+> _NOTE_: Only place an `mdc-text-field__label` inside of `mdc-text-field` _if you plan on using
+> JavaScript_. Otherwise, the label must go outside of `mdc-text-field`, as shown below.
+
+#### CSS Only
+
+```html
+<label for="text-field-no-js">TextField with no JS: </label>
+<div class="mdc-text-field">
+  <input type="text" id="text-field-no-js" class="mdc-text-field__input" placeholder="Hint text">
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
+
+##### Box Variant
 
 ### Using Helper Text
 
@@ -137,7 +112,10 @@ See [here](icon/) for more information on using icons.
 </div>
 ```
 
-### Textarea - CSS Only
+> _NOTE_: Only use `mdc-text-field__label` within `mdc-text-field--textarea` _if you plan on using
+> Javascript_. Otherwise, use the `placeholder` attribute, as shown below.
+
+##### CSS Only
 
 ```html
 <div class="mdc-text-field mdc-text-field--textarea">
@@ -149,145 +127,62 @@ See [here](icon/) for more information on using icons.
 </div>
 ```
 
-### Full-width
+#### Disabled
 
 ```html
-<div class="mdc-text-field mdc-text-field--fullwidth">
-  <input class="mdc-text-field__input"
-         type="text"
-         placeholder="Full-Width Text Field"
-         aria-label="Full-Width Text Field">
-</div>
-
-<div class="mdc-text-field mdc-text-field--fullwidth mdc-text-field--textarea">
-  <textarea id="full-width-textarea" class="mdc-text-field__input" rows="8"></textarea>
-  <label for="full-width-textarea" class="mdc-text-field__label">Textarea Label</label>
-</div>
-```
-
-Note that **full-width text fields do not support floating labels**. Labels should not be
-included as part of the DOM structure for full-width text fields. Full-width textareas
-behave normally.
-
-### Text Field Boxes
-
-```html
-<div class="mdc-text-field mdc-text-field--box">
-  <input type="text" id="tf-box" class="mdc-text-field__input">
-  <label for="tf-box" class="mdc-text-field__label">Your Name</label>
+<div class="mdc-text-field mdc-text-field--disabled">
+  <input type="text" id="disabled-text-field" class="mdc-text-field__input" disabled>
+  <label class="mdc-text-field__label" for="disabled-text-field">Disabled text field</label>
   <div class="mdc-text-field__bottom-line"></div>
 </div>
 ```
 
-Note that Text field boxes support all of the same features as normal text-fields, including helper
-text, validation, and dense UI.
+#### Helper Text
 
-#### CSS-only text field boxes
+The helper text provides supplemental information and/or validation messages to users. It appears on input field focus
+and disappears on input field blur by default, or it can be persistent. 
+See [here](helper-text/) for more information on using helper text.
 
-```html
-<label for="css-only-text-field-box">Your name:</label>
-<div class="mdc-text-field mdc-text-field--box">
-  <input type="text" class="mdc-text-field__input" id="css-only-text-field-box" placeholder="Name">
-</div>
-```
+#### Leading and Trailing Icons
+
+Leading and trailing icons can be added to MDC Text Fields as visual indicators as well as interaction targets.
+See [here](icon/) for more information on using icons.
+
+### CSS Classes
+
+CSS Class | Description
+--- | ---
+`mdc-text-field` | Mandatory
+`mdc-text-field__input` | Mandatory
+`mdc-text-field--upgraded` | Indicates the text field is upgraded, normally by JavaScript
+`mdc-text-field--box` | Styles the text field as a box text field
+`mdc-text-field--fullwidth` | Styles the text field as a full width text field
+`mdc-text-field--textarea` | Indicates the text field is a `<textarea>`
+`mdc-text-field--disabled` | Styles the text field as a disabled text field
+`mdc-text-field--dense` | Styles the text field as a dense text field
+`mdc-text-field--with-leading-icon` | Styles the text field as a text field with a leading icon
+`mdc-text-field--with-trailing-icon` | Styles the text field as a text field with a trailing icon
+`mdc-text-field--focused` | Styles the text field as a text field in focus
 
 ### Sass Mixins
 
-To customize a Filled Text Field or a Text Field `textarea`'s border radius, you can use the following mixins.
-Alternatively, if you would like to change the border radius for every instance of MDC Text Field uniformly, regardless
-of the variant, you can override $mdc-text-field-border-radius in Sass.
+Mixin | Description
+--- | ---
+`mdc-text-field-box-corner-radius($radius)` | Customizes the border radius for a box text field
+`mdc-text-field-textarea-corner-radius($radius)` | Customizes the border radius for a `<textarea>` text field
 
-#### `mdc-text-field-box-corner-radius($radius)`
+### `MDCTextField`
 
-This mixin customizes the border radius for a Text Field Box.
-
-#### `mdc-text-field-textarea-corner-radius($radius)`
-
-This mixin customizes the border radius for a Text Field `textarea`.
-
-### Using the JS component
-
-MDC Text Field ships with Component / Foundation classes which are used to provide a full-fidelity
-Material Design text field component.
-
-#### Including in code
-
-##### ES2015
-
-```javascript
-import {MDCTextField, MDCTextFieldFoundation} from '@material/textfield';
-```
-
-##### CommonJS
-
-```javascript
-const mdcTextField = require('mdc-text-field');
-const MDCTextField = mdcTextField.MDCTextField;
-const MDCTextFieldFoundation = mdcTextField.MDCTextFieldFoundation;
-```
-
-##### AMD
-
-```javascript
-require(['path/to/mdc-textfield'], mdcTextField => {
-  const MDCTextField = mdcTextField.MDCTextField;
-  const MDCTextFieldFoundation = mdcTextField.MDCTextFieldFoundation;
-});
-```
-
-##### Global
-
-```javascript
-const MDCTextField = mdc.textField.MDCTextField;
-const MDCTextFieldFoundation = mdc.textField.MDCTextFieldFoundation;
-```
-
-#### Automatic Instantiation
-
-```javascript
-mdc.textField.MDCTextField.attachTo(document.querySelector('.mdc-text-field'));
-```
-
-#### Manual Instantiation
-
-```javascript
-import {MDCTextField} from '@material/textfield';
-
-const textField = new MDCTextField(document.querySelector('.mdc-text-field'));
-```
-
-#### Controlling ripple instantiation
-
-When `MDCTextField` is instantiated with a root element containing the `mdc-text-field--box` class,
-it instantiates an `MDCRipple` instance on the element in order to facilitate the correct
-interaction UX for text field boxes as outlined in the spec. The way this ripple is instantiated
-can be controlled by passing a ripple factory argument to the constructor.
-
-```js
-const textFieldBoxEl = document.querySelector('.mdc-text-field--box');
-const textField = new MDCTextField(textFieldBoxEl, /* MDCTextFieldFoundation */ undefined, (el, foundation) => {
-  // Optionally do something with the element or the Ripple foundation...
-  return new MDCRipple(el, foundation);
-});
-```
-
-By default the ripple factory simply calls `new MDCRipple(el, foundation)` and returns the result.
-
-#### MDCTextField API
-
-Similar to regular DOM elements, the `MDCTextField` functionality is exposed through accessor
-methods.
-
-##### MDCTextField.disabled
+#### MDCTextField.disabled
 
 Boolean. Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set
 respectively.
 
-##### MDCTextField.valid
+#### MDCTextField.valid
 
 Boolean setter. Proxies to the foundation's `setValid` method when set.
 
-##### MDCTextField.helperTextContent
+#### MDCTextField.helperTextContent
 
 String setter. Proxies to the foundation's `setHelperTextContent` method when set.
 

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -182,10 +182,10 @@ Mixin | Description
 
 ### `MDCTextField`
 
-See [Importing the JS component](../docs/importing-js.md) for more information on how to import JavaScript.
+See [Importing the JS component](../../docs/importing-js.md) for more information on how to import JavaScript.
 
 Property | Value Type | Description
---- | ---
+--- | --- | ---
 `disable` | Boolean | Proxies to the foundation's `isDisabled/setDisabled` methods when retrieved/set
 respectively
 `valid` | Boolean | Proxies to the foundation's `setValid` method when set

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -92,18 +92,30 @@ Un-styled Content (**FOUC**).
 
 ##### Box Variant
 
-### Using Helper Text
+> _NOTE_: Do not use `mdc-text-field__bottom-line` inside of `mdc-text-field` _if you plan on using `mdc-text-field--box`, and do not plan on using JavaScript_. Bottom line should not be included as part of the DOM structure of a box text field.
 
-The helper text provides supplemental information and/or validation messages to users. It appears on input field focus
-and disappears on input field blur by default, or it can be persistent. 
-See [here](helper-text/) for more information on using helper text.
+```html
+<label for="css-only-text-field-box">Your name:</label>
+<div class="mdc-text-field mdc-text-field--box">
+  <input type="text" class="mdc-text-field__input" id="css-only-text-field-box" placeholder="Name">
+</div>
+```
 
-### Leading and Trailing Icons
+#### Full Width
 
-Leading and trailing icons can be added to MDC Text Fields as visual indicators as well as interaction targets.
-See [here](icon/) for more information on using icons.
+```html
+<div class="mdc-text-field mdc-text-field--fullwidth">
+  <input class="mdc-text-field__input"
+         type="text"
+         placeholder="Full-Width Text Field"
+         aria-label="Full-Width Text Field">
+</div>
+```
 
-### Textarea
+> _NOTE_: Do not use `mdc-text-field__label` within `mdc-text-field--fullwidth`. Labels should not be
+included as part of the DOM structure of a full width text field.
+
+#### Textarea
 
 ```html
 <div class="mdc-text-field mdc-text-field--textarea">

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -184,6 +184,7 @@ CSS Class | Description
 `mdc-text-field` | Mandatory
 `mdc-text-field--upgraded` | Indicates the text field is upgraded, normally by JavaScript
 `mdc-text-field--box` | Styles the text field as a box text field
+`mdc-text-field--outlined` | Styles the text field as an outlined text field
 `mdc-text-field--fullwidth` | Styles the text field as a full width text field
 `mdc-text-field--textarea` | Indicates the text field is a `<textarea>`
 `mdc-text-field--disabled` | Styles the text field as a disabled text field
@@ -249,7 +250,6 @@ Method Signature | Description
 `isDisabled() => boolean` | Returns whether or not the input is disabled
 `setDisabled(disabled: boolean) => void` | Updates the input's disabled state
 `setValid(isValid: boolean) => void` | Sets the validity state of the Text Field. Triggers custom validity checking
-`setHelperTextContent(content: string) => void` | 
 `handleTextFieldInteraction(evt: Event) => void` | Handles click and keydown events originating from inside the Text Field component
 `activateFocus() => void` | Activates the focus state of the Text Field. Normally called in response to the input focus event.
 `deactivateFocus() => void` | Deactivates the focus state of the Text Field. Normally called in response to the input blur event.

--- a/packages/mdc-textfield/bottom-line/README.md
+++ b/packages/mdc-textfield/bottom-line/README.md
@@ -4,7 +4,7 @@ layout: detail
 section: components
 excerpt: "The bottom line indicates where to enter text, displayed below the label"
 iconId: text_field
-path: /catalog/input-controls/text-fields/bottom-line/
+path: /catalog/input-controls/text-field/bottom-line/
 -->
 
 # Text Field Bottom Line
@@ -19,41 +19,53 @@ The bottom line indicates where to enter text, displayed below the label. When a
   </li>
 </ul>
 
-
 ## Usage
 
-#### MDCTextFieldBottomLine API
+### HTML Structure
 
-##### MDCTextFieldBottomLine.foundation
+```html
+<div class="mdc-text-field__bottom-line"></div>
+```
 
-MDCTextFieldBottomLineFoundation. This allows the parent MDCTextField component to access the public methods on the MDCTextFieldBottomLineFoundation class.
+### Usage within `mdc-text-field`
 
-### Using the foundation class
+```html
+<div class="mdc-text-field">
+  <input type="text" id="my-text-field-id" class="mdc-text-field__input">
+  <label class="mdc-text-field__label" for="my-text-field-id">Hint text</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
 
+### CSS Classes
+
+CSS Class | Description
+--- | ---
+`mdc-text-field-bottom-line` | Mandatory
+`mdc-text-field-bottom-line--active` | Styles the bottom line as an active bottom line
+
+### `MDCTextFieldBottomLine`
+
+##### `MDCTextFieldBottomLine.foundation`
+
+This allows the parent `MDCTextField` component to access the public methods on the `MDCTextFieldBottomLineFoundation` class.
+
+### `MDCTextFieldBottomLineAdapter`
 
 Method Signature | Description
 --- | ---
-addClass(className: string) => void | Adds a class to the root element
-removeClass(className: string) => void | Removes a class from the root element
-setAttr(attr: string, value: string) => void | Sets an attribute with a given value on the root element
-registerEventHandler(evtType: string, handler: EventListener) => void | Registers an event listener on the root element for a given event
-deregisterEventHandler(handler: EventListener) => void | Deregisters an event listener on the root element for a given event
-notifyAnimationEnd() => void | Emits a custom event "MDCTextFieldBottomLine:animation-end" denoting the bottom line has finished its animation; either the activate or deactivate animation |
+`addClass(className: string) => void` | Adds a class to the root element
+`removeClass(className: string) => void` | Removes a class from the root element
+`setAttr(attr: string, value: string) => void` | Sets an attribute with a given value on the root element
+`registerEventHandler(evtType: string, handler: EventListener) => void` | Registers an event listener on the root element for a given event
+`deregisterEventHandler(handler: EventListener) => void` | Deregisters an event listener on the root element for a given event
+`notifyAnimationEnd() => void` | Emits a custom event "MDCTextFieldBottomLine:animation-end" denoting the bottom line has finished its animation; either the activate or deactivate animation
 
-#### The full foundation API
+### `MDCTextFieldBottomLineFoundation`
 
-##### MDCTextFieldBottomLineFoundation.activate()
-
-Activates the bottom line
-
-##### MDCTextFieldBottomLineFoundation.deactivate()
-
-Deactivates the bottom line
-
-##### MDCTextFieldBottomLineFoundation.setTransformOrigin(evt: Event)
-
-Sets the transform origin given a user's click location.
-
-##### MDCTextFieldBottomLineFoundation.handleTransitionEnd(evt: Event)
-
-Handles a transition end event
+Method Signature | Description
+--- | ---
+`activate() => void` | Activates the bottom line
+`deactivate => void` | Deactivates the bottom line
+`setTransformOrigin(evt: Event) => void` | Sets the transform origin given a user's click location
+`handleTransitionEnd(evt: Event) => void` | Handles a transition end event

--- a/packages/mdc-textfield/helper-text/README.md
+++ b/packages/mdc-textfield/helper-text/README.md
@@ -4,12 +4,12 @@ layout: detail
 section: components
 excerpt: "The helper text provides supplemental information and/or validation messages to users"
 iconId: text_field
-path: /catalog/input-controls/text-fields/helper-text/
+path: /catalog/input-controls/text-field/helper-text/
 -->
 
 # Text Field Helper Text
 
-The helper text provides supplemental information and/or validation messages to users. It appears on input field focus and disappears on input field blur by default, or it can be persistent.
+Helper text gives context about a field’s input, such as how the input will be used. It should be visible either persistently or only on focus.
 
 ## Design & API Documentation
 
@@ -19,12 +19,15 @@ The helper text provides supplemental information and/or validation messages to 
   </li>
 </ul>
 
-
 ## Usage
 
-### Using helper text
+### HTML Structure
 
-MDC Text Fields can include helper text that is useful for providing supplemental information to users.
+```html
+<p class="mdc-text-field-helper-text" aria-hidden="true">
+```
+
+### Usage within `mdc-text-field`
 
 ```html
 <div class="mdc-text-field">
@@ -37,25 +40,7 @@ MDC Text Fields can include helper text that is useful for providing supplementa
 </p>
 ```
 
-Helper text appears on input field focus and disappears on input field blur by default when using
-the Text Field JS component.
-
-#### Persistent helper text
-
-If you'd like the helper text to always be visible, add the `mdc-text-field-helper-text--persistent` modifier class to the element.
-
-```html
-<div class="mdc-text-field">
-  <input type="email" id="email" class="mdc-text-field__input">
-  <label for="email" class="mdc-text-field__label">Email address</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-<p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent">
-  We will <em>never</em> share your email address with third parties
-</p>
-```
-
-#### Helper text and accessibility
+#### Accessibility
 
 Note that in every example where the helper text is dependent on the state of the input element, we
 assign an id to the `mdc-text-field-helper-text` element and set that id to the value of the
@@ -80,55 +65,35 @@ text element, taking care of adding/removing `aria-hidden` and other accessibili
 and removing classes and attributes to the helper text element can also be done using the
 MDCTextFieldHelperText API, which is described below.
 
-### Validation
+### CSS Classes
 
-Helper text can be used to provide validation messages in addition to the validity styling provided by
-MDC TextField. Use `mdc-text-field-helper-text--validation-msg` to provide styles for using the helper
-text as a validation message. This can be combined with `mdc-text-field-helper-text--persistent` to
-provide a robust UX for client-side form field validation.
+CSS Class | Description
+--- | ---
+`mdc-text-field-helper-text` | Mandatory
+`mdc-text-field-helper-text--persistent` | Makes the helper text permanently visible
+`mdc-text-field-helper-text--validation-msg` | Indicates the helper text is a validation message
 
-```html
-<div class="mdc-text-field">
-  <input required minlength=8 type="password" class="mdc-text-field__input" id="pw"
-         aria-controls="pw-validation-msg">
-  <label for="pw" class="mdc-text-field__label">Choose password</label>
-  <div class="mdc-text-field__bottom-line"></div>
-</div>
-<p class="mdc-text-field-helper-text
-          mdc-text-field-helper-text--persistent
-          mdc-text-field-helper-text--validation-msg"
-   id="pw-validation-msg">
-  Must be at least 8 characters long
-</p>
-```
+### `MDCTextFieldHelperText`
 
-#### MDCTextFieldHelperText API
+##### `MDCTextFieldHelperText.foundation`
 
-##### MDCTextFieldHelperText.foundation
+This allows the parent `MDCTextField` component to access the public methods on the `MDCTextFieldHelperTextFoundation` class.
 
-MDCTextFieldHelperTextFoundation. This allows the parent MDCTextField component to access the public methods on the MDCTextFieldHelperTextFoundation class.
-
-### Using the foundation class
+### `MDCTextFieldHelperTextAdapter`
 
 Method Signature | Description
 --- | ---
-addClass(className: string) => void | Adds a class to the helper text element
-removeClass(className: string) => void | Removes a class from the helper text element
-hasClass(className: string) => boolean | Returns true if classname exists for the helper text element
-setAttr(attr: string, value: string) => void | Sets an attribute with a given value on the helper text element
-removeAttr(attr: string) => void | Removes an attribute on the helper text element
-setContent(attr: string) => void | Sets the text content for the helper text element
+`addClass(className: string) => void` | Adds a class to the helper text element
+`removeClass(className: string) => void` | Removes a class from the helper text element
+`hasClass(className: string) => boolean` | Returns true if classname exists for the helper text element
+`setAttr(attr: string, value: string) => void` | Sets an attribute with a given value on the helper text element
+`removeAttr(attr: string) => void` | Removes an attribute on the helper text element
+`setContent(attr: string) => void` | Sets the text content for the helper text element
 
-#### The full foundation API
+### `MDCTextFieldHelperTextFoundation`
 
-##### MDCTextFieldHelperTextFoundation.setContent()
-
-Sets the content of the helper text.
-
-##### MDCTextFieldHelperTextFoundation.showToScreenReader()
-
-Makes the helper text visible to the screen reader.
-
-##### MDCTextFieldHelperTextFoundation.setValidity(inputIsValid)
-
-Sets the validity of the helper text based on the input validity.
+Method Signature | Description
+--- | ---
+`setContent(content: string) => void` | Sets the content of the helper text
+`showToScreenReader() => void` | Makes the helper text visible to the screen reader
+`setValidity(inputIsValid: boolean) => void` | Sets the validity of the helper text based on the input validity

--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -60,27 +60,24 @@ an `i` element with your preferred icon, and give it a class of `mdc-text-field_
 and the css will ensure the cursor is set to default, and that actioning on an icon doesn't
 do anything unexpected.
 
-#### MDCTextFieldIcon API
+### `MDCTextFieldIcon`
 
-##### MDCTextFieldIcon.foundation
+##### `MDCTextFieldIcon.foundation`
 
-MDCTextFieldIconFoundation. This allows the parent MDCTextField component to access the public methods on the MDCTextFieldIconFoundation class.
+This allows the parent `MDCTextField` component to access the public methods on the `MDCTextFieldIconFoundation` class.
 
-### Using the foundation class
+### `MDCTextFieldIconAdapter`
 
 Method Signature | Description
 --- | ---
-setAttr(attr: string, value: string) => void | Sets an attribute with a given value on the icon element
-registerInteractionHandler(evtType: string, handler: EventListener) => void | Registers an event listener for a given event
-deregisterInteractionHandler(evtType: string, handler: EventListener) => void | Deregisters an event listener for a given event
-notifyIconAction() => void | Emits a custom event "MDCTextField:icon" denoting a user has clicked the icon, which bubbles to the top-level text field element
+`setAttr(attr: string, value: string) => void` | Sets an attribute with a given value on the icon element
+`registerInteractionHandler(evtType: string, handler: EventListener) => void` | Registers an event listener for a given event
+`deregisterInteractionHandler(evtType: string, handler: EventListener) => void` | Deregisters an event listener for a given event
+`notifyIconAction() => void` | Emits a custom event "MDCTextField:icon" denoting a user has clicked the icon, which bubbles to the top-level text field element
 
-#### The full foundation API
+### `MDCTextFieldIconFoundation`
 
-##### MDCTextFieldIconFoundation.setDisabled(disabled: boolean)
-
-Updates the icon's disabled state.
-
-##### MDCTextFieldIconFoundation.handleInteraction(evt: Event)
-
-Handles a text field interaction event.
+Method Signature | Description
+--- | ---
+`setDisabled(disabled: boolean) => void` | Updates the icon's disabled state
+`handleInteraction(evt: Event) => void` | Handles a text field interaction event

--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -4,7 +4,7 @@ layout: detail
 section: components
 excerpt: "Icons describe the type of input a text field requires"
 iconId: text_field
-path: /catalog/input-controls/text-fields/icon/
+path: /catalog/input-controls/text-field/icon/
 -->
 
 # Text Field Icon
@@ -21,13 +21,21 @@ Icons describe the type of input a text field requires. They can also be interac
 
 ## Usage
 
-### Leading and Trailing Icons
-Leading and trailing icons can be added to MDC Text Fields as visual indicators
+### HTML Structure
+
+```html
+<i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
+```
+
+### Usage within `mdc-text-field`
+
+Leading and trailing icons can be added to `mdc-text-field` as visual indicators
 as well as interaction targets. To do so, add the relevant classes
 (`mdc-text-field--with-leading-icon` or `mdc-text-field--with-trailing-icon`) to the root element, add
 an `i` element with your preferred icon, and give it a class of `mdc-text-field__icon`.
 
 #### Leading:
+
 ```html
 <div class="mdc-text-field mdc-text-field--box mdc-text-field--with-leading-icon">
   <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
@@ -38,6 +46,7 @@ an `i` element with your preferred icon, and give it a class of `mdc-text-field_
 ```
 
 #### Trailing:
+
 ```html
 <div class="mdc-text-field mdc-text-field--box mdc-text-field--with-trailing-icon">
   <input type="text" id="my-input" class="mdc-text-field__input">

--- a/packages/mdc-textfield/label/README.md
+++ b/packages/mdc-textfield/label/README.md
@@ -4,12 +4,12 @@ layout: detail
 section: components
 excerpt: "The label is a text caption or description for the text field."
 iconId: text_field
-path: /catalog/input-controls/text-fields/label/
+path: /catalog/input-control/text-field/label/
 -->
 
 # Text Field Label
 
-The label is a text caption or description for the text field.
+Text field labels display the type of input a field requires. Every text field should have a label. Labels are aligned with the input line and always visible. They can be resting (when a field is inactive and empty) or floating. The label is a text caption or description for the text field.
 
 ## Design & API Documentation
 
@@ -19,32 +19,75 @@ The label is a text caption or description for the text field.
   </li>
 </ul>
 
-
 ## Usage
 
-#### MDCTextFieldLabel API
+### HTML Structure
 
-##### MDCTextFieldLabel.foundation
+```html
+<label class="mdc-text-field__label" for="my-text-field-id">Hint text</label>
+```
 
-MDCTextFieldLabelFoundation. This allows the parent MDCTextField component to access the public methods on the MDCTextFieldLabelFoundation class.
+### Usage within `mdc-text-field`
 
-### Using the foundation class
+```html
+<div class="mdc-text-field">
+  <input type="text" id="my-text-field-id" class="mdc-text-field__input">
+  <label class="mdc-text-field__label" for="my-text-field-id">Hint text</label>
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
+
+#### Avoid Dynamic ID Generation
+
+It's also possible to wrap `mdc-text-field__input` within a `<label>` to avoid dynamic id generation:
+
+```html
+<label class="mdc-text-field">
+  <input type="text" class="mdc-text-field__input">
+  <span class="mdc-text-field__label">Hint Text</span>
+  <div class="mdc-text-field__bottom-line"></div>
+</label>
+```
+
+> _NOTE_: Only place an `mdc-text-field__label` inside of a text field _if you plan on using
+> Javascript_. Otherwise, the label must go outside of the text-field, as shown below.
+
+#### Single Line, CSS Only
+
+```html
+<label for="text-field-no-js">TextField with no JS: </label>
+<div class="mdc-text-field">
+  <input type="text" id="text-field-no-js" class="mdc-text-field__input" placeholder="Hint text">
+  <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
+
+### CSS Classes
+
+CSS Class | Description
+--- | ---
+`mdc-text-field__label` | Mandatory
+`mdc-text-field__label--float-above` | Indicates the label is floating above the text field
+`mdc-text-field__label--shake` | Shakes the label
+
+### `MDCTextFieldLabel`
+
+##### `MDCTextFieldLabel.foundation`
+
+This allows the parent `MDCTextField` component to access the public methods on the `MDCTextFieldLabelFoundation` class.
+
+### `MDCTextFieldLabelAdapter`
 
 Method Signature | Description
 --- | ---
-addClass(className: string) => void | Adds a class to the label element
-removeClass(className: string) => void | Removes a class from the label element
+`addClass(className: string) => void` | Adds a class to the label element
+`removeClass(className: string) => void` | Removes a class from the label element
 
-#### The full foundation API
 
-##### MDCTextFieldLabelFoundation.floatAbove()
+### `MDCTextFieldLabelFoundation`
 
-Makes the label float above the text field.
-
-##### MDCTextFieldLabelFoundation.deactivateFocus(shouldRemoveLabelFloat: boolean)
-
-Deactivates the label's focus state. `shouldRemoveLabelFloat` indicates whether to also reset the label's position and size.
-
-##### MDCTextFieldLabelFoundation.setValidity(isValid: boolean)
-
-Updates the label's valid state based on the supplied validity.
+Method Signature | Description
+--- | ---
+`floatAbove() => void` | Makes the label float above the text field
+`deactivateFocus(shouldRemoveLabelFloat: boolean) => void` | Deactivates the label's focus state. `shouldRemoveLabelFloat` indicates whether to also reset the label's position and size.
+`setValidity(isValid: boolean)` | Updates the label's valid state based on the supplied validity


### PR DESCRIPTION
I've cleaned up each README of each subelement follow the structure of
* Intro (simple one line from spec)
* HTML Structure
* Usage within `mdc-text-field`
* CSS Classes
* `MDCTextFieldFoo` API documentation
* `MDCTextFieldFooAdapter` API documentation
* `MDCTextFieldFooFoundation` API documentation

I've also cleaned up the main text field README to follow a very similar structure. There are a lot of 
> _NOTE_

in packages/textfield/README.md...which is concerning...but it represents how complicated the HTML structure is.

The idea, going forward, is that any breaking change to `MDCTextField` or its sub elements will require a change to these READMEs.

CHANGELOG only allows for a very short description of a breaking change. The idea is to have READMEs be the more detailed documentation for what APIs changed.