### PR TITLE
docs: Update list of already available components

### DIFF
--- a/docs/migrating-from-mdl.md
+++ b/docs/migrating-from-mdl.md
@@ -330,13 +330,13 @@ The following table summarizes the current situation (TBI = to be implemented):
 | `mdl-layout` | Split into [`@material/drawer`](../packages/mdc-drawer/README.md), [`@material/toolbar`](../packages/mdc-toolbar/README.md), and [`@material/layout-grid`](../packages/mdc-layout-grid/README.md) | No tabs component in MDC-Web at the moment, [TBI](https://github.com/material-components/material-components-web/issues/37). |
 | `mdl-list` | [`@material/list`](../packages/mdc-list/README.md) | Very different DOM. |
 | `mdl-menu` | [`@material/menu`](../packages/mdc-menu/README.md) | Very different DOM. |
-| `mdl-palette` | TBI | [#27](https://github.com/material-components/material-components-web/issues/27) |
-| `mdl-progress` | TBI | [#29](https://github.com/material-components/material-components-web/issues/29) |
+| `mdl-palette` | [`@material/theme`](../packages/mdc-theme/README.md) | All theming is handled via [`@material/theme`](../packages/mdc-theme/README.md) |
+| `mdl-progress` | [`@material/linear-progress`](../packages/mdc-linear-progress/README.md) | Very different DOM. |
 | `mdl-radio` | [`@material/radio`](../packages/mdc-radio/README.md) | Very different DOM. Recommended use with [`@material/form-field`](../packages/mdc-form-field/README.md). |
 | `mdl-resets` | None. | There are plans for an [optional resets/defaults library](https://github.com/material-components/material-components-web/issues/42). |
 | `mdl-ripple` | [`@material/ripple`](../packages/mdc-ripple/README.md) | Very different usage; much improved in MDC-Web. |
 | `mdl-shadow` | [`@material/elevation`](../packages/mdc-elevation/README.md) | Similar usage. |
-| `mdl-slider` | TBI | [#25](https://github.com/material-components/material-components-web/issues/25) |
+| `mdl-slider` | [`@material/slider`](../packages/mdc-slider/README.md) | Very different DOM. |
 | `mdl-snackbar` | [`@material/snackbar`](../packages/mdc-snackbar/README.md) | Very different DOM. |
 | `mdl-spinner` | TBI | [#30](https://github.com/material-components/material-components-web/issues/30) |
 | `mdl-switch` | [`@material/switch`](../packages/mdc-switch/README.md) | Very different DOM. |


### PR DESCRIPTION
Please update the list of available components within the MDL migration guide to ensure interested parties for migration know the available component coverage.

See: https://github.com/material-components/material-components-web/issues/1444 (The Migration guide is out of date)