### PR TITLE
chore(infrastructure): Remove goog.module dashes

### DIFF
--- a/scripts/closure-test.sh
+++ b/scripts/closure-test.sh
@@ -49,6 +49,7 @@ echo ''
 set +e
 for pkg in $CLOSURIZED_PKGS; do
   entry_point="goog:mdc.${pkg/mdc-/}"
+  entry_point=${entry_point//-/}
   # Note that the jscomp_error flags turn all default warnings into errors, so that
   # closure exits with a non-zero status if any of them are caught.
   # Also note that we disable accessControls checks due to

--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -163,11 +163,9 @@ function transform(srcFile, rootDir) {
   const packageParts = relativePath.replace('mdc-', '').replace(/-/g, '').replace('.js', '').split('/');
   const packageStr = 'mdc.' + packageParts.join('.').replace('.index', '');
 
-  console.log(packageParts);
-
   outputCode = 'goog.module(\'' + packageStr + '\');\n' + outputCode;
   fs.writeFileSync(srcFile, outputCode, 'utf8');
-  // console.log(`[rewrite] ${srcFile}`);
+  console.log(`[rewrite] ${srcFile}`);
 }
 
 function rewriteDeclarationSource(node, srcFile, rootDir) {

--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -160,12 +160,14 @@ function transform(srcFile, rootDir) {
   });
 
   const relativePath = path.relative(rootDir, srcFile);
-  const packageParts = relativePath.replace('mdc-', '').replace('.js', '').split('/');
+  const packageParts = relativePath.replace('mdc-', '').replace(/-/g, '').replace('.js', '').split('/');
   const packageStr = 'mdc.' + packageParts.join('.').replace('.index', '');
+
+  console.log(packageParts);
 
   outputCode = 'goog.module(\'' + packageStr + '\');\n' + outputCode;
   fs.writeFileSync(srcFile, outputCode, 'utf8');
-  console.log(`[rewrite] ${srcFile}`);
+  // console.log(`[rewrite] ${srcFile}`);
 }
 
 function rewriteDeclarationSource(node, srcFile, rootDir) {
@@ -200,7 +202,7 @@ function patchNodeForDeclarationSource(source, srcFile, rootDir, node) {
       }));
     }
   }
-  const packageParts = resolvedSource.replace('mdc-', '').replace('.js', '').split('/');
+  const packageParts = resolvedSource.replace('mdc-', '').replace(/-/g, '').replace('.js', '').split('/');
   const packageStr = 'mdc.' + packageParts.join('.').replace('.index', '');
   return packageStr;
 }


### PR DESCRIPTION
To follow internal Google build tool formatting, dashes must not be present in the `goog.module` names. Dashed module names like `goog.module('mdc.form-field.adapter')` now become `goog.module('mdc.formfield.adapter')`. I chose no dashes over underscores to keep keystrokes low (underscore is 2 while **nothing** is 0 which is less than 2).

Fixes #1671