### PR TITLE
fix(checkbox): Remove duplicate background props

### DIFF
--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -250,12 +250,13 @@
 }
 
 @mixin mdc-checkbox__background_ {
-  @include mdc-checkbox__child--cover-parent_;
   @include mdc-rtl-reflexive-position(
     left, ($mdc-checkbox-touch-area - $mdc-checkbox-size) / 2, ".mdc-checkbox");
 
   display: inline-flex;
+  position: absolute;
   top: ($mdc-checkbox-touch-area - $mdc-checkbox-size) / 2;
+  bottom: 0;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;


### PR DESCRIPTION
The `mdc-checkbox__background` mixin included the
`mdc-checkbox__child--cover-parent-` mixin which set the positioning for
the element on all sides to 0. However, the `mdc-rtl-reflexive-position`
mixin **also** sets left and right positioning and the
`mdc-checkbox__background` mixin **also** set the top positioning,
resulting in duplicate properties when compiled out to CSS. This fix
removes the colliding `mdc-checkbox__child--cover-parent-` mixin and
sets only the remaining properties (`position` and `bottom`) to what
they would've been with the `mdc-checkbos__child--cover-parent-` mixin.