### PR TITLE
fix(textfield): placeholder colors

### DIFF
--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -319,8 +319,8 @@
 
       <section class="example">
         <h2>CSS Only Text Field</h2>
-        <div class="mdc-form-field mdc-form-field--align-end">
-          <div class="mdc-text-field" data-demo-no-auto-js id="css-only-text-field-wrapper">
+        <div class="mdc-form-field mdc-form-field--align-end" id="css-only-text-field-wrapper">
+          <div class="mdc-text-field" data-demo-no-auto-js>
             <input type="text" class="mdc-text-field__input" id="css-only-text-field"
                    placeholder="Name">
             <div class="mdc-text-field__bottom-line"></div>

--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -320,12 +320,21 @@
       <section class="example">
         <h2>CSS Only Text Field</h2>
         <div class="mdc-form-field mdc-form-field--align-end">
-          <div class="mdc-text-field" data-demo-no-auto-js>
+          <div class="mdc-text-field" data-demo-no-auto-js id="css-only-text-field-wrapper">
             <input type="text" class="mdc-text-field__input" id="css-only-text-field"
                    placeholder="Name">
             <div class="mdc-text-field__bottom-line"></div>
           </div>
           <label for="css-only-text-field">Your name:</label>
+        </div>
+
+        <div>
+          <input id="css-only-tf-disabled" type="checkbox">
+          <label for="css-only-tf-disabled">Disabled</label>
+        </div>
+        <div>
+          <input id="css-only-dark-theme-tf" type="checkbox">
+          <label for="css-only-dark-theme-tf">Dark Theme</label>
         </div>
       </section>
       <section class="example">
@@ -469,6 +478,19 @@
         });
 
       }, 0);
+    </script>
+    <script>
+    (function() {
+      var wrapperCssOnly = document.getElementById('css-only-text-field-wrapper');
+      var tfCssOnly = document.getElementById('css-only-text-field');
+
+      document.getElementById('css-only-tf-disabled').addEventListener('change', function(evt) {
+        tfCssOnly.disabled = evt.target.checked;
+      });
+      document.getElementById('css-only-dark-theme-tf').addEventListener('change', function(evt) {
+        wrapperCssOnly.classList[evt.target.checked ? 'add' : 'remove']('mdc-theme--dark');
+      });
+    })();
     </script>
     <script>
       (function() {

--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -90,8 +90,8 @@
         <h2>Full Functionality JS Component (Floating Label, Validation)</h2>
         <section id="demo-text-field-wrapper">
           <div class="mdc-text-field">
-            <input type="text" class="mdc-text-field__input" id="my-text-field" aria-controls="my-text-field-helper-text">
-            <label for="my-text-field" class="mdc-text-field__label">Email Address</label>
+            <input type="text" class="mdc-text-field__input" id="full-func-text-field" aria-controls="my-text-field-helper-text">
+            <label for="full-func-text-field" class="mdc-text-field__label">Email Address</label>
             <div class="mdc-text-field__bottom-line"></div>
           </div>
           <p id="my-text-field-helper-text" class="mdc-text-field-helper-text"

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -32,10 +32,10 @@ $mdc-text-field-underline-on-dark: rgba(white, 1);
 $mdc-text-field-underline-on-dark-idle: rgba(white, .5);
 $mdc-text-field-dark-background: rgba(48, 48, 48, 1);
 $mdc-text-field-dark-label: rgba(white, .6);
-$mdc-text-field-dark-placeholder: rgba(black, .38);
+$mdc-text-field-dark-placeholder: rgba(white, .3);
 $mdc-text-field-light-background: rgba(white, 1);
 $mdc-text-field-light-label: rgba(white, .7);
-$mdc-text-field-light-placeholder: rgba(white, .3);
+$mdc-text-field-light-placeholder: rgba(black, .38);
 
 $mdc-text-field-box-background: rgba(black, .04);
 $mdc-text-field-box-background-dark: rgba(white, .1);

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -619,7 +619,7 @@
     }
 
     &:disabled {
-      @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
+      @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
 
       border-bottom-style: dotted;
     }

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -634,7 +634,7 @@
   @include mdc-theme-dark {
     &:not(.mdc-text-field--upgraded) .mdc-text-field__input {
       &:not(:focus) {
-        border-color: rgba(white, .12);
+        border-color: $mdc-text-field-underline-on-dark-idle;
       }
 
       &:disabled {


### PR DESCRIPTION
Fixes: https://github.com/material-components/material-components-web/issues/1505. Also added a dark theme and disabled checkbox on the CSS Only textfield to showcase fix.