### PR TITLE
fix(textfield): Never show a border on the input of an outlined textfield.

### DIFF
--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -128,7 +128,8 @@
     display: flex;
     height: 30px;
     padding: 12px;
-    border: none;
+    // Use !important here to override all other border treatments
+    border: none !important;
     background-color: transparent;
     z-index: 3;
 


### PR DESCRIPTION


Fixes #1817