### PR TITLE
fix(text-field): allow commit message text-field with dash

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
           "snackbar",
           "switch",
           "tabs",
-          "textfield",
+          "text-field",
           "theme",
           "toolbar",
           "typography",


### PR DESCRIPTION
Update to package.json to allow `text-field` commit messages to have dash instead of being 1 word. 