### PR TITLE
docs(text-field): Update icon docs with outlined text field

### DIFF
--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -29,13 +29,11 @@ Icons describe the type of input a text field requires. They can also be interac
 
 ### Usage within `mdc-text-field`
 
-Leading and trailing icons can be added to `mdc-text-field` as visual indicators
-as well as interaction targets. To do so, add the relevant classes
-(`mdc-text-field--with-leading-icon` or `mdc-text-field--with-trailing-icon`) to the root element, add
-an `i` element with your preferred icon, and give it a class of `mdc-text-field__icon`.
+Leading and trailing icons can be applied to text fields styled as `mdc-text-field--box` or `mdc-text-field--outlined`. To add an icon, add the relevant class (either `mdc-text-field--with-leading-icon` or `mdc-text-field--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-text-field__icon`.
 
-#### Leading:
+#### Leading icon
 
+In box text field:
 ```html
 <div class="mdc-text-field mdc-text-field--box mdc-text-field--with-leading-icon">
   <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
@@ -45,14 +43,45 @@ an `i` element with your preferred icon, and give it a class of `mdc-text-field_
 </div>
 ```
 
-#### Trailing:
+In outlined text field:
+```html
+<div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon">
+  <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
+  <input type="text" id="my-input" class="mdc-text-field__input">
+  <label for="my-input" class="mdc-text-field__label">Your Name</label>
+  <div class="mdc-text-field__outline">
+    <svg>
+      <path class="mdc-text-field__outline-path"/>
+    </svg>
+  </div>
+  <div class="mdc-text-field__idle-outline"></div>
+</div>
+```
 
+#### Trailing icon
+
+In box text field:
 ```html
 <div class="mdc-text-field mdc-text-field--box mdc-text-field--with-trailing-icon">
   <input type="text" id="my-input" class="mdc-text-field__input">
   <label for="my-input" class="mdc-text-field__label">Your Name</label>
   <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
   <div class="mdc-text-field__bottom-line"></div>
+</div>
+```
+
+In outlined text field:
+```html
+<div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
+  <input type="text" id="my-input" class="mdc-text-field__input">
+  <label for="my-input" class="mdc-text-field__label">Your Name</label>
+  <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
+  <div class="mdc-text-field__outline">
+    <svg>
+      <path class="mdc-text-field__outline-path"/>
+    </svg>
+  </div>
+  <div class="mdc-text-field__idle-outline"></div>
 </div>
 ```
 

--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -33,7 +33,7 @@ Leading and trailing icons can be applied to text fields styled as `mdc-text-fie
 
 #### Leading icon
 
-In box text field:
+In text field box:
 ```html
 <div class="mdc-text-field mdc-text-field--box mdc-text-field--with-leading-icon">
   <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
@@ -60,7 +60,7 @@ In outlined text field:
 
 #### Trailing icon
 
-In box text field:
+In text field box:
 ```html
 <div class="mdc-text-field mdc-text-field--box mdc-text-field--with-trailing-icon">
   <input type="text" id="my-input" class="mdc-text-field__input">


### PR DESCRIPTION
Adds outlined text field example to the icon README, and clarify that icons can only be used with box or outlined text fields.