### PR TITLE
fix(text-field): Fix focused hover state on outlined text field

### DIFF
--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -184,7 +184,7 @@
     }
 
     // stylelint-disable-next-line selector-max-specificity
-    .mdc-text-field__input:hover ~ .mdc-text-field__outline .mdc-text-field__outline-path {
+    &:not(.mdc-text-field--focused) .mdc-text-field__input:hover ~ .mdc-text-field__outline .mdc-text-field__outline-path {
       stroke: $mdc-text-field-outlined-hover-border;
     }
   }


### PR DESCRIPTION
The outline color should be the primary color on hover when focused (before this fix, it turns black on hover when focused)