### PR TITLE
docs(text-field): Fix broken image URL

### DIFF
--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -11,7 +11,7 @@ path: /catalog/input-controls/text-field/
 <!--<div class="article__asset">
   <a class="article__asset-link"
      href="https://material-components-web.appspot.com/text-field.html">
-    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/text-fields.png" width="240" alt="Text fields screenshot">
+    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/textfields.png" width="240" alt="Text fields screenshot">
   </a>
 </div>-->
 


### PR DESCRIPTION
Hero screenshot is broken on live catalog site: https://material.io/components/web/catalog/input-controls/text-field/  