### PR TITLE
fix(toolbar): Use transparent bg for menu icon to avoid IE 11 bug

### DIFF
--- a/packages/mdc-toolbar/_mixins.scss
+++ b/packages/mdc-toolbar/_mixins.scss
@@ -51,7 +51,7 @@
   justify-content: center;
   padding: $mdc-toolbar-element-vertical-padding;
   border: none;
-  background-color: inherit;
+  background-color: transparent;
   color: inherit;
   text-decoration: none;
   cursor: pointer;


### PR DESCRIPTION
IE 11 renders the toolbar menu icon with a grey background when the icon's `background-color` is set to `inherit`. Changing the value to `transparent` fixes the bug and doesn't seem to have any adverse affects in other browsers.

Fixes #881

![Screenshot comparison of the bug and the fix](https://user-images.githubusercontent.com/409245/34734739-bd3a7a4c-f521-11e7-8202-c5e6c9b03b0e.png)

  