### PR TITLE
fix(text-field): Remove extra adapter method

### DIFF
--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -130,14 +130,6 @@ class MDCTextFieldAdapter {
   getNativeInput() {}
 
   /**
-   * Returns the idle outline element's computed style value of the given css property `propertyName`.
-   * We achieve this via `getComputedStyle(...).getPropertyValue(propertyName)`.
-   * @param {string} propertyName
-   * @return {string}
-   */
-  getIdleOutlineStyleValue(propertyName) {}
-
-  /**
    * Returns true if the textfield is focused.
    * We achieve this via `document.activeElement === this.root_`.
    * @return {boolean}


### PR DESCRIPTION
Remove `getIdleOutlineStyleValue` method from text field adapter as it
was unused following the merge of #1911