### PR TITLE
chore(demos): Use CSS files directly instead of Webpack's .css.js

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <script src="/assets/button.css.js"></script>
+    <link rel="stylesheet" href="/assets/button.css">
     <style>
       .demo-wrapper {
         padding-bottom: 100px;

--- a/demos/card.html
+++ b/demos/card.html
@@ -20,7 +20,7 @@
     <title>Card - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/card.css.js"></script>
+    <link rel="stylesheet" href="/assets/card.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -20,7 +20,7 @@
     <title>Checkbox - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/checkbox.css.js"></script>
+    <link rel="stylesheet" href="/assets/checkbox.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -20,7 +20,7 @@
     <title>Dialog - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/dialog.css.js"></script>
+    <link rel="stylesheet" href="/assets/dialog.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -20,8 +20,8 @@
     <title>Drawer Above Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/drawer/drawer.css.js"></script>
-    <script src="/assets/radio.css.js"></script>
+    <link rel="stylesheet" href="/assets/drawer/drawer.css">
+    <link rel="stylesheet" href="/assets/radio.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -20,8 +20,8 @@
     <title>Drawer Below Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/drawer/drawer.css.js"></script>
-    <script src="/assets/radio.css.js"></script>
+    <link rel="stylesheet" href="/assets/drawer/drawer.css">
+    <link rel="stylesheet" href="/assets/radio.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/drawer/persistent-drawer.html
+++ b/demos/drawer/persistent-drawer.html
@@ -20,8 +20,8 @@
     <title>Drawer (Persistent) - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/drawer/drawer.css.js"></script>
-    <script src="/assets/radio.css.js"></script>
+    <link rel="stylesheet" href="/assets/drawer/drawer.css">
+    <link rel="stylesheet" href="/assets/radio.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -20,8 +20,8 @@
     <title>Drawer (Temporary) - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/drawer/drawer.css.js"></script>
-    <script src="/assets/radio.css.js"></script>
+    <link rel="stylesheet" href="/assets/drawer/drawer.css">
+    <link rel="stylesheet" href="/assets/radio.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/elevation.html
+++ b/demos/elevation.html
@@ -20,7 +20,7 @@
     <title>Elevation - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/elevation.css.js"></script>
+    <link rel="stylesheet" href="/assets/elevation.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/fab.html
+++ b/demos/fab.html
@@ -20,7 +20,7 @@
     <title>Floating Action Button - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/fab.css.js"></script>
+    <link rel="stylesheet" href="/assets/fab.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -20,7 +20,7 @@
     <title>Grid List - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/grid-list.css.js"></script>
+    <link rel="stylesheet" href="/assets/grid-list.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -28,10 +28,6 @@
       .demo-grid-tile-content {
         background-image: url("images/16-9.jpg");
       }
-      /* Hack for webpack async loading: Hide grid list until styles have loaded */
-      .mdc-grid-list-demo {
-        visibility: hidden;
-      }
 
       .example {
         padding: 24px;
@@ -57,7 +53,7 @@
       }
     </style>
   </head>
-  <body class="mdc-typography mdc-grid-list-demo">
+  <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
@@ -87,24 +83,23 @@
             <li class="mdc-grid-tile"><div class="mdc-grid-tile__primary"></div></li>
             <li class="mdc-grid-tile"><div class="mdc-grid-tile__primary"></div></li>
             <li class="mdc-grid-tile"><div class="mdc-grid-tile__primary"></div></li>
-
           </ul>
         </div>
       </section>
 
       <section class="example">
-          <div class="mdc-form-field">
-            <div class="mdc-checkbox">
-              <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
-              <div class="mdc-checkbox__background">
-                <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                  <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-                </svg>
-                <div class="mdc-checkbox__mixedmark"></div>
-              </div>
+        <div class="mdc-form-field">
+          <div class="mdc-checkbox">
+            <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
             </div>
-            <label for="toggle-rtl" id="toggle-rtl-label">Toggle RTL</label>
           </div>
+          <label for="toggle-rtl" id="toggle-rtl-label">Toggle RTL</label>
+        </div>
       </section>
 
       <section class="example examples">
@@ -746,9 +741,6 @@
       // This is not needed when using pre-built css and js
       setTimeout(function() {
         initGridList();
-        setTimeout (function() {
-          document.querySelector('.mdc-grid-list-demo').style.visibility = 'visible';
-        }, 250);
       }, 100);
     </script>
   </body>

--- a/demos/icon-toggle.html
+++ b/demos/icon-toggle.html
@@ -20,7 +20,7 @@
     <title>Icon Toggle - Material Components Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/icon-toggle.css.js"></script>
+    <link rel="stylesheet" href="/assets/icon-toggle.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/index.html
+++ b/demos/index.html
@@ -20,7 +20,7 @@
     <title>Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/index.css.js"></script>
+    <link rel="stylesheet" href="/assets/index.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
   </head>

--- a/demos/layout-grid.html
+++ b/demos/layout-grid.html
@@ -20,7 +20,7 @@
     <title>Layout Grid - Material Components</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/layout-grid.css.js"></script>
+    <link rel="stylesheet" href="/assets/layout-grid.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -20,7 +20,7 @@
     <title>Linear Progress - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/linear-progress.css.js"></script>
+    <link rel="stylesheet" href="/assets/linear-progress.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/list.html
+++ b/demos/list.html
@@ -20,7 +20,7 @@
     <title>List Item - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/list.css.js"></script>
+    <link rel="stylesheet" href="/assets/list.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/radio.html
+++ b/demos/radio.html
@@ -20,7 +20,7 @@
     <title>Radio Button - Material Components Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/radio.css.js"></script>
+    <link rel="stylesheet" href="/assets/radio.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -20,7 +20,7 @@
     <title>Ripple - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/ripple.css.js"></script>
+    <link rel="stylesheet" href="/assets/ripple.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/select.html
+++ b/demos/select.html
@@ -20,7 +20,7 @@
     <title>Select Menu - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/select.css.js"></script>
+    <link rel="stylesheet" href="/assets/select.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -20,7 +20,7 @@
     <title>Simple Menu - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/simple-menu.css.js"></script>
+    <link rel="stylesheet" href="/assets/simple-menu.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/slider.html
+++ b/demos/slider.html
@@ -20,7 +20,7 @@
     <title>Slider - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/slider.css.js"></script>
+    <link rel="stylesheet" href="/assets/slider.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -20,7 +20,7 @@
     <title>Snackbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/snackbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/snackbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/switch.html
+++ b/demos/switch.html
@@ -20,7 +20,7 @@
     <title>Switch - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/switch.css.js"></script>
+    <link rel="stylesheet" href="/assets/switch.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -20,7 +20,7 @@
     <title>Tabs - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/tabs.css.js"></script>
+    <link rel="stylesheet" href="/assets/tabs.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -20,7 +20,7 @@
     <title>Text Field - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/text-field.css.js"></script>
+    <link rel="stylesheet" href="/assets/text-field.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <script src="/assets/theme/index.css.js"></script>
+    <link rel="stylesheet" href="/assets/theme/index.css">
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed">

--- a/demos/toolbar/custom-toolbar.html
+++ b/demos/toolbar/custom-toolbar.html
@@ -20,7 +20,7 @@
     <title>Custom Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/default-flexible-toolbar.html
+++ b/demos/toolbar/default-flexible-toolbar.html
@@ -20,7 +20,7 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/default-toolbar.html
+++ b/demos/toolbar/default-toolbar.html
@@ -20,7 +20,7 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/fixed-toolbar.html
+++ b/demos/toolbar/fixed-toolbar.html
@@ -20,7 +20,7 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -20,7 +20,7 @@
     <title>Toolbar - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -19,7 +19,7 @@
     <meta charset="utf-8">
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
+++ b/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
@@ -20,7 +20,7 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/waterfall-flexible-toolbar.html
+++ b/demos/toolbar/waterfall-flexible-toolbar.html
@@ -20,7 +20,7 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/waterfall-toolbar-fix-last-row.html
+++ b/demos/toolbar/waterfall-toolbar-fix-last-row.html
@@ -20,7 +20,7 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/toolbar/waterfall-toolbar.html
+++ b/demos/toolbar/waterfall-toolbar.html
@@ -20,7 +20,7 @@
     <title>MDC Toolbar Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/toolbar/toolbar.css.js"></script>
+    <link rel="stylesheet" href="/assets/toolbar/toolbar.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/demos/typography.html
+++ b/demos/typography.html
@@ -20,7 +20,7 @@
     <title>Typography - Material Components Catalog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <script src="/assets/typography.css.js"></script>
+    <link rel="stylesheet" href="/assets/typography.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const DEMO_ASSET_DIR_REL = '/assets/'; // Used by webpack-dev-server and MDC_BUI
 const IS_DEV = process.env.MDC_ENV === 'development';
 const IS_PROD = process.env.MDC_ENV === 'production';
 
-const WRAP_CSS_IN_JS = process.env.MDC_WRAP_CSS_IN_JS !== 'false' && IS_DEV;
+const WRAP_CSS_IN_JS = process.env.MDC_WRAP_CSS_IN_JS === 'true' && IS_DEV;
 // Source maps break extract-text-webpack-plugin, so they need to be disabled when WRAP_CSS_IN_JS is set to false.
 const GENERATE_SOURCE_MAPS =
     process.env.MDC_GENERATE_SOURCE_MAPS === 'true' ||


### PR DESCRIPTION
BREAKING CHANGE: Sass source maps and hot reloading no longer work on demo pages. We can address those issues in future PRs if they become a problem. In addition, the `MDC_WRAP_CSS_IN_JS` env var now defaults to `false`.

This change:

1. Makes it possible to dynamically switch themes at runtime (follow-up PR)
2. Fixes the FOUC on all demo pages
3. Fixes sporadic rendering errors on all demo pages that call `getComputedStyle()` on page load (e.g., ripple)
4. Allows us to remove CSS polling from our demo JS (follow-up PR)
5. Reduces Chrome devtools memory leaks after hot reloading

