### PR TITLE
fix(demos): Fix CSS selector for dark theme buttons

### DIFF
--- a/demos/common.scss
+++ b/demos/common.scss
@@ -54,7 +54,12 @@ fieldset {
   }
 }
 
-.mdc-button--raised,
+.mdc-button--raised {
+  @include mdc-theme-dark(".mdc-button", true) {
+    @include mdc-button-filled-accessible($dark-button-color);
+  }
+}
+
 .mdc-button--unelevated {
   @include mdc-theme-dark(".mdc-button", true) {
     @include mdc-button-filled-accessible($dark-button-color);


### PR DESCRIPTION
The `mdc-theme-dark` mixin uses Sass's `&` to append to the parent CSS selector. Unfortunately, Sass isn't smart enough to handle multiple comma-separated selectors; it only appends to the last one.

We need to split up the parent rule into two separate rules to ensure that we don't apply `$dark-button-color` in light mode.

The unelevated button on the [theme demo page](https://material-components-web.appspot.com/theme/index.html) actually has a green background applied to it due to this bug, but the order of our CSS imports on the theme demo page happens to prevent us from seeing it.