### PR TITLE
fix(dialog): Remove code that does nothing

### DIFF
--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -165,10 +165,6 @@ $mdc-dialog-dark-theme-bg-color: #303030 !default;
     transition: mdc-animation-enter(opacity, 120ms);
   }
 
-  .mdc-dialog--open .mdc-dialog__surface {
-    transition: mdc-animation-enter(opacity, 120ms), mdc-animation-enter(transform, 120ms);
-  }
-
   .mdc-dialog__surface {
     transition: mdc-animation-enter(opacity, 120ms), mdc-animation-enter(transform, 120ms);
   }


### PR DESCRIPTION
`.mdc-dialog__surface` already has `transition: mdc-animation-enter(opacity, 120ms), mdc-animation-enter(transform, 120ms);` at line 169. So I dont think we need to apply it within the `.mdc-dialog--open .mdc-dialog__surface`.

Furthermore, `.mdc-dialog--open .mdc-dialog__surface` is nested within `.mdc-dialog--animating`, which does not make any sense, since `.mdc-dialog--open` and `.mdc-dialog--animating` shoud be used in conjunction. So I think this is just dead code