### PR TITLE
fix(slider): Add MDCSliderFoundation export

### DIFF
--- a/packages/mdc-slider/index.js
+++ b/packages/mdc-slider/index.js
@@ -202,4 +202,4 @@ class MDCSlider extends MDCComponent {
   }
 }
 
-export {MDCSlider};
+export {MDCSliderFoundation, MDCSlider};


### PR DESCRIPTION
Re-adds an MDCSliderFoundation export to `index.js`.