### PR TITLE
fix(ripple): Relax deduplication conditions for touch devices

### DIFF
--- a/packages/mdc-ripple/constants.js
+++ b/packages/mdc-ripple/constants.js
@@ -40,6 +40,7 @@ const numbers = {
   INITIAL_ORIGIN_SCALE: 0.6,
   DEACTIVATION_TIMEOUT_MS: 225, // Corresponds to $mdc-ripple-translate-duration (i.e. activation animation duration)
   FG_DEACTIVATION_MS: 150, // Corresponds to $mdc-ripple-fade-out-duration (i.e. deactivation animation duration)
+  TAP_DELAY_MS: 300, // Delay between touch and simulated mouse events on touch devices
 };
 
 export {cssClasses, strings, numbers};

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -295,8 +295,7 @@ class MDCRippleFoundation extends MDCFoundation {
 
     // Avoid reacting to follow-on events fired by touch device after an already-processed user interaction
     const previousActivationEvent = this.previousActivationEvent_;
-    const isSameInteraction = previousActivationEvent && e && previousActivationEvent.type !== e.type &&
-      previousActivationEvent.clientX === e.clientX && previousActivationEvent.clientY === e.clientY;
+    const isSameInteraction = previousActivationEvent && e && previousActivationEvent.type !== e.type;
     if (isSameInteraction) {
       return;
     }
@@ -428,7 +427,7 @@ class MDCRippleFoundation extends MDCFoundation {
     this.activationState_ = this.defaultActivationState_();
     // Touch devices may fire additional events for the same interaction within a short time.
     // Store the previous event until it's safe to assume that subsequent events are for new interactions.
-    setTimeout(() => this.previousActivationEvent_ = null, 100);
+    setTimeout(() => this.previousActivationEvent_ = null, MDCRippleFoundation.numbers.TAP_DELAY_MS);
   }
 
   /**

--- a/test/unit/mdc-ripple/foundation-deactivation.test.js
+++ b/test/unit/mdc-ripple/foundation-deactivation.test.js
@@ -333,7 +333,7 @@ testFoundation('only re-activates when there are no additional pointer events to
 
     documentHandlers.mouseup();
     mockRaf.flush();
-    clock.tick(DEACTIVATION_TIMEOUT_MS);
+    clock.tick(numbers.TAP_DELAY_MS);
 
     // Finally, verify that since mouseup happened, we can re-activate the ripple.
     handlers.mousedown({pageX: 0, pageY: 0});


### PR DESCRIPTION
This fixes problems where a ripple surface would show the ripple twice on touch events, observable on [ripple.html](http://material-components-web.appspot.com/ripple.html) on Chrome on Android or Chrome on desktop with device emulation enabled.

The issue is fixed by relaxing the delay to 300ms to match tap delay on touch devices, and by removing the event x/y coordinate comparisons, as apparently sometimes the coordinates can change from the original user-initiated touch event to the simulated mouse event fired by the user agent.