### PR TITLE
feat(text-field): Move final JS colors to mixins. Update demos

### DIFF
--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -120,10 +120,6 @@
           <label for="alternate-colors">Alternate Colors</label>
         </div>
         <div>
-          <input id="alternate-error-colors" type="checkbox">
-          <label for="alternate-error-colors">Alternate Error Colors</label>
-        </div>
-        <div>
           <input id="use-helper-text" type="checkbox">
           <label for="use-helper-text">Use Helper Text</label>
         </div>
@@ -168,8 +164,7 @@
             </div>
             <div class="mdc-text-field__idle-outline"></div>
           </div>
-          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg"
-            id="name-validation-msg">
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg">
             Must be at least 8 characters
           </p>
         </div>
@@ -221,7 +216,7 @@
         <h2>Text Field box</h2>
         <div id="demo-tf-box-wrapper">
           <div id="tf-box-example" class="mdc-text-field mdc-text-field--box" data-demo-no-auto-js>
-            <input required pattern=".{8,}" type="text" id="tf-box" class="mdc-text-field__input"
+            <input type="text" id="tf-box" class="mdc-text-field__input"
                    aria-controls="name-validation-message">
             <label for="tf-box" class="mdc-text-field__label">Your Name</label>
             <div class="mdc-text-field__bottom-line"></div>
@@ -246,6 +241,14 @@
         <div>
           <input id="box-dense" type="checkbox">
           <label for="box-dense">Dense</label>
+        </div>
+        <div>
+          <input id="box-alternate-colors" type="checkbox">
+          <label for="box-alternate-colors">Alternate Colors</label>
+        </div>
+        <div>
+          <input id="box-required" type="checkbox">
+          <label for="box-required">Required</label>
         </div>
         <script>
           demoReady(function() {
@@ -273,6 +276,17 @@
             document.getElementById('box-dense').addEventListener('change', function(evt) {
               tfEl.classList[evt.target.checked ? 'add' : 'remove']('mdc-text-field--dense');
               tf.layout();
+            });
+
+            document.getElementById('box-alternate-colors').addEventListener('change', function (evt) {
+              var target = evt.target;
+              tfEl.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+              tfEl.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
+            });
+
+            document.getElementById('box-required').addEventListener('change', function(evt) {
+              var target = evt.target;
+              tfEl.querySelector('.mdc-text-field__input').required = target.checked;
             });
           });
         </script>
@@ -347,51 +361,12 @@
           <label for="unclickable-leading-trailing">Unclickable icons</label>
         </div>
         <div>
+          <input id="leading-trailing-alternate-colors" type="checkbox">
+          <label for="leading-trailing-alternate-colors">Alternate Colors</label>
+        </div>
+        <div>
           <input id="required-leading-trailing" type="checkbox">
           <label for="required-leading-trailing">Required</label>
-        </div>
-      </section>
-
-      <section class="example">
-        <h2>CSS Only Text Field</h2>
-        <div class="mdc-form-field mdc-form-field--align-end" id="css-only-text-field-wrapper">
-          <div class="mdc-text-field" data-demo-no-auto-js>
-            <input type="text" class="mdc-text-field__input" id="css-only-text-field"
-                   placeholder="Name">
-            <div class="mdc-text-field__bottom-line"></div>
-          </div>
-          <label for="css-only-text-field">Your name:</label>
-        </div>
-
-        <div>
-          <input id="css-only-tf-disabled" type="checkbox">
-          <label for="css-only-tf-disabled">Disabled</label>
-        </div>
-        <div>
-          <input id="css-only-dark-theme-tf" type="checkbox">
-          <label for="css-only-dark-theme-tf">Dark Theme</label>
-        </div>
-      </section>
-
-      <section class="example">
-        <h2>CSS Only Text Field box</h2>
-        <div>
-          <label for="css-only-text-field-box">Your name:</label>
-          <div class="mdc-text-field mdc-text-field--box" data-demo-no-auto-js>
-            <input type="text" class="mdc-text-field__input" id="css-only-text-field-box"
-                   placeholder="Name">
-          </div>
-        </div>
-      </section>
-
-      <section class="example">
-        <h2>CSS-Only Outlined Text Field</h2>
-        <div>
-          <label for="css-only-outlined-text-field">Your name:</label>
-          <div class="mdc-text-field mdc-text-field--outlined" data-demo-no-auto-js>
-            <input type="text" class="mdc-text-field__input" id="css-only-outlined-text-field"
-                   placeholder="Name">
-          </div>
         </div>
       </section>
 
@@ -427,18 +402,13 @@
           <label for="textarea-dark-theme">Dark Theme</label>
         </div>
         <div>
+          <input id="textarea-alternate-colors" type="checkbox">
+          <label for="textarea-alternate-colors">Alternate Colors</label>
+        </div>
+        <div>
           <input id="textarea-required" type="checkbox">
           <label for="textarea-required">Required</label>
         </div>
-      </section>
-
-      <section class="example">
-        <h2>CSS Only Textarea</h2>
-        <section>
-          <div class="mdc-text-field mdc-text-field--textarea" data-demo-no-auto-js>
-            <textarea id="textarea-css-only" class="mdc-text-field__input" rows="8" cols="40" placeholder="Enter something about yourself"></textarea>
-          </div>
-        </section>
       </section>
 
       <section class="example">
@@ -464,6 +434,14 @@
         <div>
           <input type="checkbox" id="fullwidth-dark-theme">
           <label for="fullwidth-dark-theme">Dark Theme</label>
+        </div>
+        <div>
+          <input id="fullwidth-required" type="checkbox">
+          <label for="fullwidth-required">Required</label>
+        </div>
+        <div>
+          <input id="fullwidth-alternate-colors" type="checkbox">
+          <label for="fullwidth-alternate-colors">Alternate Colors</label>
         </div>
       </section>
     </main>
@@ -499,6 +477,7 @@
         var wrapperOutlinedTrailing = document.getElementById('demo-tf-outlined-trailing-wrapper');
 
         var tfIcons = document.querySelectorAll('.mdc-text-field__icon');
+        var tfInputs = tfIconContainer.querySelectorAll('.mdc-text-field__input');
 
         document.getElementById('disable-leading-trailing').addEventListener('change', function(evt) {
           tfBoxLeading.disabled = evt.target.checked;
@@ -550,22 +529,24 @@
         });
 
         document.getElementById('required-leading-trailing').addEventListener('change', function(evt) {
-          tfIconContainer.querySelectorAll('.mdc-text-field__input')
-              .forEach(function(input) {
+          [].slice.call(tfInputs).forEach(function(input) {
                 input.required = evt.target.checked;
               });
         });
-      });
 
-      demoReady(function() {
-        var wrapperCssOnly = document.getElementById('css-only-text-field-wrapper');
-        var tfCssOnly = document.getElementById('css-only-text-field');
-
-        document.getElementById('css-only-tf-disabled').addEventListener('change', function(evt) {
-          tfCssOnly.disabled = evt.target.checked;
-        });
-        document.getElementById('css-only-dark-theme-tf').addEventListener('change', function(evt) {
-          wrapperCssOnly.classList[evt.target.checked ? 'add' : 'remove']('mdc-theme--dark');
+        document.getElementById('leading-trailing-alternate-colors').addEventListener('change', function(evt) {
+          tfBoxLeadingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+          tfBoxLeadingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
+          tfBoxLeading.layout();
+          tfBoxTrailingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+          tfBoxTrailingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
+          tfBoxTrailing.layout();
+          tfOutlinedLeadingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+          tfOutlinedLeadingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
+          tfOutlinedLeading.layout();
+          tfOutlinedTrailingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+          tfOutlinedTrailingEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
+          tfOutlinedTrailing.layout();
         });
       });
 
@@ -602,9 +583,6 @@
         document.getElementById('alternate-colors').addEventListener('change', function (evt) {
           var target = evt.target;
           tfRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
-        });
-        document.getElementById('alternate-error-colors').addEventListener('change', function (evt) {
-          var target = evt.target;
           tfRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
         });
         document.getElementById('use-helper-text').addEventListener('change', function(evt) {
@@ -647,9 +625,19 @@
           var target = evt.target;
           section.classList[target.checked ? 'add' : 'remove']('mdc-theme--dark');
         });
+
+        document.getElementById('textarea-alternate-colors').addEventListener('change', function (evt) {
+          var target = evt.target;
+          tfRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+          tfRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
+        });
+
         document.getElementById('textarea-required').addEventListener('change', function(evt) {
           var target = evt.target;
-          tfRoot.querySelector('.mdc-text-field__input').required = target.checked;
+          [].slice.call(tfRoot.querySelectorAll('.mdc-text-field__input'))
+              .forEach(function(input) {
+                input.required = target.checked;
+              })
         });
       });
 
@@ -677,6 +665,22 @@
         document.getElementById('fullwidth-dark-theme').addEventListener('change', function(evt) {
           var target = evt.target;
           section.classList[target.checked ? 'add' : 'remove']('mdc-theme--dark');
+        });
+
+        document.getElementById('fullwidth-required').addEventListener('change', function(evt) {
+          var target = evt.target;
+          [].slice.call(section.querySelectorAll('.mdc-text-field__input'))
+              .forEach(function(input) {
+                input.required = target.checked;
+              })
+        });
+
+        document.getElementById('fullwidth-alternate-colors').addEventListener('change', function (evt) {
+          var target = evt.target;
+          tfRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+          tfRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
+          tfMultiRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
+          tfMultiRoot.classList[target.checked ? 'add' : 'remove']('demo-text-field-custom-error-colors');
         });
       });
     </script>

--- a/demos/text-field.scss
+++ b/demos/text-field.scss
@@ -20,30 +20,49 @@
 
 // stylelint-disable selector-class-pattern
 .demo-text-field-custom-colors:not(.mdc-text-field--invalid) {
-  @include mdc-text-field-bottom-line-color(rgba(blue, .38));
-  @include mdc-text-field-hover-bottom-line-color(rgba(blue, .6));
-  @include mdc-text-field-focused-bottom-line-color(blue);
+  $idle-border: rgba(blue, .38);
+  $hover-border: rgba(blue, .6);
+  $focused-border: rgba(blue, 1);
+
+  @include mdc-text-field-bottom-line-color($idle-border);
+  @include mdc-text-field-hover-bottom-line-color($hover-border);
+  @include mdc-text-field-focused-bottom-line-color($focused-border);
   @include mdc-text-field-ink-color(black);
   @include mdc-text-field-label-color(rgba(blue, .5));
-  @include mdc-text-field-outline-color(rgba(blue, .38));
-  @include mdc-text-field-hover-outline-color(rgba(blue, .6));
-  @include mdc-text-field-focused-outline-color(rgba(blue, 1));
-  @include mdc-text-field-helper-text-color(rgba(blue, .38));
+  @include mdc-text-field-outline-color($idle-border);
+  @include mdc-text-field-hover-outline-color($hover-border);
+  @include mdc-text-field-focused-outline-color($focused-border);
+  @include mdc-text-field-helper-text-color($idle-border);
+  @include mdc-text-field-textarea-stroke-color($idle-border);
+  @include mdc-text-field-icon-color($hover-border);
 
   &.mdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(blue, .87));
+    @include mdc-text-field-focused-textarea-stroke-color($focused-border);
+    @include mdc-text-field-icon-color($focused-border);
   }
 }
 
 .demo-text-field-custom-error-colors.mdc-text-field--invalid {
-  @include mdc-text-field-bottom-line-color(rgba(orange, .38));
-  @include mdc-text-field-hover-bottom-line-color(rgba(orange, .6));
-  @include mdc-text-field-focused-bottom-line-color(orange);
+  $idle-border: rgba(orange, .38);
+  $hover-border: rgba(orange, .6);
+  $focused-border: rgba(orange, 1);
+
+  @include mdc-text-field-bottom-line-color($idle-border);
+  @include mdc-text-field-hover-bottom-line-color($hover-border);
+  @include mdc-text-field-focused-bottom-line-color($focused-border);
   @include mdc-text-field-ink-color(orange);
   @include mdc-text-field-label-color(rgba(orange, .87));
-  @include mdc-text-field-outline-color(rgba(orange, .38));
-  @include mdc-text-field-hover-outline-color(rgba(orange, .6));
-  @include mdc-text-field-focused-outline-color(rgba(orange, 1));
-  @include mdc-text-field-helper-text-validation-color(rgba(orange, .6));
+  @include mdc-text-field-outline-color($idle-border);
+  @include mdc-text-field-hover-outline-color($hover-border);
+  @include mdc-text-field-focused-outline-color($focused-border);
+  @include mdc-text-field-helper-text-validation-color($hover-border);
+  @include mdc-text-field-textarea-stroke-color($idle-border);
+  @include mdc-text-field-focused-textarea-stroke-color($focused-border);
+
+  @include mdc-text-field-icon-color($focused-border);
+
+  // Example for --invalid textfield when helper text is not a validation message.
+  @include mdc-text-field-helper-text-color(rgba(blue, .6));
 }
 // stylelint-enable selector-class-pattern

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -215,6 +215,7 @@ Mixin | Description
 `mdc-text-field-focused-outline-color($color)` | Customizes the outlined border color when the text-field is focused.
 `mdc-text-field-helper-text-color($color)` | Customizes the color of the helper text following a text-field.
 `mdc-text-field-helper-text-validation-color($color)` | Customizes the color of the helper text when it's used as a validation message.
+`mdc-text-field-box-background-color($color)` | Customized the background color of the text-field box. 
 
 ### `MDCTextField`
 

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -18,6 +18,7 @@
 @import "outline/mixins";
 @import "label/mixins";
 @import "helper-text/mixins";
+@import "icon/mixins";
 
 @mixin mdc-text-field-outlined-corner-radius($radius) {
   border-radius: $radius;
@@ -45,6 +46,8 @@
     border-radius: max($radius - 2, 0);
   }
 }
+
+// Private mixins
 
 @mixin mdc-text-field-invalid-label-shake-keyframes_($modifier, $positionY, $scale: .75) {
   @keyframes invalid-shake-float-above-#{$modifier} {
@@ -74,6 +77,36 @@
   }
 }
 
+@mixin mdc-text-field-box-background-color($color) {
+  &:not(.mdc-text-field--disabled) {
+    @include mdc-text-field-box-background-color_($color);
+  }
+}
+
+@mixin mdc-text-field-textarea-stroke-color($color) {
+  &:not(.mdc-text-field--disabled) {
+    @include mdc-text-field-textarea-stroke-color_($color);
+  }
+}
+
+@mixin mdc-text-field-textarea-background-color($color) {
+  &:not(.mdc-text-field--disabled) {
+    @include mdc-text-field-textarea-background-color_($color);
+  }
+}
+
+@mixin mdc-text-field-focused-textarea-stroke-color($color) {
+  &:not(.mdc-text-field--disabled) {
+    @include mdc-text-field-focused-textarea-stroke-color_($color);
+  }
+}
+
+@mixin mdc-text-field-fullwidth-bottom-line-color($color) {
+  &:not(.mdc-text-field--disabled) {
+    @include mdc-text-field-fullwidth-bottom-line-color_($color);
+  }
+}
+
 // Private mixins
 
 // Common
@@ -83,6 +116,8 @@
   @include mdc-text-field-ink-color_(text-disabled-on-light);
   @include mdc-text-field-label-color_(text-disabled-on-light);
   @include mdc-text-field-helper-text-color_(text-disabled-on-light);
+  @include mdc-text-field-icon-color_($mdc-text-field-disabled-icon-on-light);
+  @include mdc-text-field-fullwidth-bottom-line-color_($mdc-text-field-divider-on-light);
 
   @include mdc-theme-dark(".mdc-text-field") {
     @include mdc-text-field-bottom-line-color_($mdc-text-field-disabled-border-on-dark);
@@ -125,6 +160,10 @@
   @include mdc-text-field-outline-color($mdc-text-field-error-on-light);
   @include mdc-text-field-hover-outline-color($mdc-text-field-error-on-light);
   @include mdc-text-field-focused-outline-color($mdc-text-field-error-on-light);
+
+  // Textarea specific mixins
+  @include mdc-text-field-focused-textarea-stroke-color($mdc-text-field-error-on-light);
+  @include mdc-text-field-textarea-stroke-color($mdc-text-field-error-on-light);
 
   + .mdc-text-field-helper-text--validation-msg {
     opacity: 1;
@@ -174,71 +213,39 @@
   .mdc-text-field__label {
     bottom: 20px;
   }
-
-  .mdc-text-field__icon {
-    @include mdc-theme-prop(color, $mdc-text-field-disabled-icon-on-light);
-  }
 }
 
 // Box
 
 @mixin mdc-text-field-box-disabled_ {
-  @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
+  @include mdc-text-field-box-background-color_($mdc-text-field-box-disabled-background);
+  @include mdc-text-field-bottom-line-color_($mdc-text-field-outlined-disabled-border);
+  @include mdc-text-field-label-color(text-hint-on-light);
 
   border-bottom: none;
-  background-color: $mdc-text-field-box-disabled-background;
-
-  @include mdc-theme-dark(".mdc-text-field", true) {
-    @include mdc-theme-prop(background-color, $mdc-text-field-dark-background);
-    @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
-
-    border-bottom: none;
-  }
 
   .mdc-text-field__label {
     bottom: 20px;
-  }
-
-  .mdc-text-field__icon {
-    @include mdc-theme-prop(color, $mdc-text-field-disabled-icon-on-light);
-
-    @include mdc-theme-dark() {
-      @include mdc-theme-prop(color, $mdc-text-field-disabled-icon-on-dark);
-    }
   }
 }
 
 // Textarea
 
 @mixin mdc-text-field-textarea-disabled_ {
+  @include mdc-text-field-label-background-color_($mdc-textarea-disabled-background-on-light);
+  @include mdc-text-field-textarea-stroke-color_($mdc-text-field-disabled-border-on-light);
+  @include mdc-text-field-textarea-background-color_($mdc-textarea-disabled-background-on-light);
+
   border-style: solid;
-  border-color: $mdc-text-field-disabled-border-on-light;
-  background-color: $mdc-textarea-disabled-background-on-light;
 
   @include mdc-theme-dark(".mdc-text-field") {
-    border-color: $mdc-text-field-disabled-border-on-dark;
     background-color: $mdc-textarea-disabled-background-on-dark;
   }
-
-  .mdc-text-field__label {
-    background-color: $mdc-textarea-disabled-background-on-light;
-
-    @include mdc-theme-dark(".mdc-text-field") {
-      background-color: $mdc-textarea-disabled-background-on-dark;
-    }
-  }
-}
-
-@mixin mdc-text-field-textarea-invalid_ {
-  border-color: $mdc-text-field-error-on-light;
-}
-
-@mixin mdc-text-field-textarea-focused_ {
-  @include mdc-theme-prop(border-color, primary);
 }
 
 @mixin mdc-text-field-textarea_ {
   @include mdc-text-field-textarea-corner-radius($mdc-text-field-border-radius);
+  @include mdc-text-field-label-background-color($mdc-textarea-light-background);
 
   $padding-inset: 16px;
   $label-offset-y: $padding-inset + 2;
@@ -248,7 +255,7 @@
   width: fit-content;
   height: initial;
   transition: none;
-  border: 1px solid $mdc-textarea-border-on-light;
+  border: 1px solid ;
   overflow: hidden;
 
   @include mdc-theme-dark(".mdc-text-field") {
@@ -261,28 +268,6 @@
     padding: $padding-inset;
     padding-top: $padding-inset * 2;
     border: 1px solid transparent;
-
-    &:focus {
-      @include mdc-theme-prop(border-color, primary);
-    }
-
-    &:invalid:not(:focus) {
-      border-color: $mdc-text-field-error-on-light;
-    }
-
-    @include mdc-theme-dark(".mdc-text-field") {
-      &:hover {
-        border-bottom-color: transparent;
-      }
-
-      &:focus {
-        @include mdc-theme-prop(border-color, secondary);
-      }
-
-      &:invalid:not(:focus) {
-        border-color: $mdc-text-field-error-on-dark;
-      }
-    }
   }
 
   .mdc-text-field__label {
@@ -291,7 +276,6 @@
     top: $label-offset-y;
     bottom: auto;
     padding: 8px 16px;
-    background-color: $mdc-textarea-light-background;
     line-height: 1.15;
 
     @include mdc-theme-dark(".mdc-text-field") {
@@ -316,12 +300,8 @@
     }
   }
 
-  &.mdc-text-field--invalid {
-    @include mdc-text-field-textarea-invalid_;
-  }
-
-  &.mdc-text-field--focused {
-    @include mdc-text-field-textarea-focused_;
+  &.mdc-text-field--focused:not(.mdc-text-field--invalid) {
+    @include mdc-text-field-focused-textarea-stroke-color(primary);
   }
 }
 
@@ -332,5 +312,31 @@
 @mixin mdc-text-field-ink-color_($color) {
   .mdc-text-field__input {
     @include mdc-theme-prop(color, $color);
+  }
+}
+
+@mixin mdc-text-field-box-background-color_($color) {
+  @include mdc-theme-prop(background-color, $color);
+}
+
+@mixin mdc-text-field-textarea-stroke-color_($color) {
+  @include mdc-theme-prop(border-color, $color);
+}
+
+@mixin mdc-text-field-textarea-background-color_($color) {
+  @include mdc-theme-prop(background-color, $color);
+}
+
+@mixin mdc-text-field-focused-textarea-stroke-color_($color) {
+  .mdc-text-field__input {
+    @include mdc-theme-prop(border-color, $color);
+  }
+
+  @include mdc-theme-prop(border-color, $color);
+}
+
+@mixin mdc-text-field-fullwidth-bottom-line-color_($color) {
+  &.mdc-text-field--fullwidth:not(.mdc-text-field--textarea) {
+    @include mdc-theme-prop(border-bottom-color, $color);
   }
 }

--- a/packages/mdc-textfield/bottom-line/_mixins.scss
+++ b/packages/mdc-textfield/bottom-line/_mixins.scss
@@ -17,19 +17,19 @@
 //Public
 
 @mixin mdc-text-field-bottom-line-color($color) {
-  &:not(.mdc-text-field--disabled) {
+  &:not(.mdc-text-field--disabled):not(.mdc-text-field--outlined):not(.mdc-text-field--textarea) {
     @include mdc-text-field-bottom-line-color_($color);
   }
 }
 
 @mixin mdc-text-field-hover-bottom-line-color($color) {
-  &:not(.mdc-text-field--disabled) {
+  &:not(.mdc-text-field--disabled):not(.mdc-text-field--outlined):not(.mdc-text-field--textarea) {
     @include mdc-text-field-hover-bottom-line-color_($color);
   }
 }
 
 @mixin mdc-text-field-focused-bottom-line-color($color) {
-  &:not(.mdc-text-field--disabled) {
+  &:not(.mdc-text-field--disabled):not(.mdc-text-field--outlined):not(.mdc-text-field--textarea) {
     @include mdc-text-field-focused-bottom-line-color_($color);
   }
 }
@@ -38,13 +38,13 @@
 
 @mixin mdc-text-field-bottom-line-color_($color) {
   .mdc-text-field__input {
-    @include mdc-theme-prop(border-color, $color);
+    @include mdc-theme-prop(border-bottom-color, $color);
   }
 }
 
 @mixin mdc-text-field-hover-bottom-line-color_($color) {
   .mdc-text-field__input:hover {
-    @include mdc-theme-prop(border-color, $color);
+    @include mdc-theme-prop(border-bottom-color, $color);
   }
 }
 

--- a/packages/mdc-textfield/helper-text/_mixins.scss
+++ b/packages/mdc-textfield/helper-text/_mixins.scss
@@ -37,7 +37,7 @@
 }
 
 @mixin mdc-text-field-helper-text-validation-color_($color) {
-  + .mdc-text-field-helper-text--validation-msg {
+  &.mdc-text-field--invalid + .mdc-text-field-helper-text--validation-msg {
     @include mdc-theme-prop(color, $color);
   }
 }

--- a/packages/mdc-textfield/icon/_mixins.scss
+++ b/packages/mdc-textfield/icon/_mixins.scss
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,18 +14,18 @@
 // limitations under the License.
 //
 
-@import "@material/theme/variables";
-@import "@material/theme/mixins";
+// Public mixins
 
-.mdc-text-field--with-leading-icon .mdc-text-field__icon,
-.mdc-text-field--with-trailing-icon .mdc-text-field__icon {
-  position: absolute;
-  bottom: 16px;
-  cursor: pointer;
+@mixin mdc-text-field-icon-color($color) {
+  &:not(.mdc-text-field--disabled) {
+    @include mdc-text-field-icon-color_($color);
+  }
 }
 
-.mdc-text-field__icon:not([tabindex]),
-.mdc-text-field__icon[tabindex="-1"] {
-  cursor: default;
-  pointer-events: none;
+// Private mixins
+
+@mixin mdc-text-field-icon-color_($color) {
+  .mdc-text-field__icon {
+    @include mdc-theme-prop(color, $color);
+  }
 }

--- a/packages/mdc-textfield/label/_mixins.scss
+++ b/packages/mdc-textfield/label/_mixins.scss
@@ -22,11 +22,24 @@
   }
 }
 
+@mixin mdc-text-field-label-background-color($color) {
+  &:not(.mdc-text-field--disabled).mdc-text-field--textarea {
+    @include mdc-text-field-label-background-color_($color);
+  }
+}
+
 // Private
 
 @mixin mdc-text-field-label-color_($color) {
   .mdc-text-field__label,
   .mdc-text-field__input::placeholder { // placeholder used in place of label on css only version
     @include mdc-theme-prop(color, $color);
+  }
+}
+
+// Used for textarea in case of scrolling
+@mixin mdc-text-field-label-background-color_($color) {
+  .mdc-text-field__label {
+    @include mdc-theme-prop(background-color, $color);
   }
 }

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -44,11 +44,8 @@
   @include mdc-text-field-ink-color(text-primary-on-light);
   @include mdc-text-field-label-color($mdc-text-field-light-label);
   @include mdc-text-field-helper-text-color(text-hint-on-light);
-
-  // Outline specific colors
-  @include mdc-text-field-outline-color($mdc-text-field-outlined-idle-border);
-  @include mdc-text-field-hover-outline-color($mdc-text-field-outlined-hover-border);
-  @include mdc-text-field-focused-outline-color(primary);
+  @include mdc-text-field-fullwidth-bottom-line-color($mdc-text-field-divider-on-light);
+  @include mdc-text-field-icon-color($mdc-text-field-underline-on-light);
 
   display: inline-block;
   position: relative;
@@ -123,6 +120,11 @@
 }
 
 .mdc-text-field--outlined {
+  // Outline specific colors
+  @include mdc-text-field-outline-color($mdc-text-field-outlined-idle-border);
+  @include mdc-text-field-hover-outline-color($mdc-text-field-outlined-hover-border);
+  @include mdc-text-field-focused-outline-color(primary);
+
   height: 56px;
   border: none;
 
@@ -218,11 +220,13 @@
   @include mdc-ripple-radius;
   @include mdc-text-field-box-corner-radius($mdc-text-field-border-radius);
 
+  // Colors
+  @include mdc-text-field-box-background-color($mdc-text-field-box-background);
+
   display: inline-flex;
   position: relative;
   height: 56px;
   margin-top: 16px;
-  background-color: $mdc-text-field-box-background;
   overflow: hidden;
 
   @include mdc-theme-dark(".mdc-text-field", true) {
@@ -251,7 +255,6 @@
     position: absolute;
     bottom: 20px;
     width: calc(100% - #{$mdc-text-field-icon-padding});
-    color: $mdc-text-field-box-secondary-text;
     text-overflow: ellipsis;
     white-space: nowrap;
     pointer-events: none;
@@ -435,7 +438,7 @@
     height: 56px;
     margin: 0;
     border: none;
-    border-bottom: 1px solid $mdc-text-field-divider-on-light;
+    border-bottom: 1px solid;
     outline: none;
 
     .mdc-text-field__input {
@@ -458,85 +461,6 @@
 
   // stylelint-enable plugin/selector-bem-pattern
 }
-
-// Graceful degredation for css-only inputs
-
-.mdc-text-field {
-  &:not(.mdc-text-field--upgraded) .mdc-text-field__input {
-    border-bottom: 1px solid $mdc-text-field-divider-on-light;
-
-    &:focus {
-      @include mdc-theme-prop(border-color, primary);
-    }
-
-    &:disabled {
-      @include mdc-theme-prop(color, $mdc-text-field-light-placeholder);
-
-      border-bottom-style: dotted;
-    }
-
-    // stylelint-disable selector-max-specificity
-    &:invalid:not(:focus) {
-      border-color: $mdc-text-field-error-on-light;
-    }
-    // stylelint-enable selector-max-specificity
-  }
-
-  @include mdc-theme-dark {
-    &:not(.mdc-text-field--upgraded) .mdc-text-field__input {
-      &:not(:focus) {
-        border-color: $mdc-text-field-underline-on-dark-idle;
-      }
-
-      &:disabled {
-        @include mdc-theme-prop(color, $mdc-text-field-dark-placeholder);
-
-        border-color: $mdc-text-field-disabled-border-on-dark;
-        background-color: $mdc-textarea-disabled-background-on-dark;
-      }
-
-      // stylelint-disable selector-max-specificity
-      &:invalid:not(:focus) {
-        border-color: $mdc-text-field-error-on-dark;
-      }
-      // stylelint-enable selector-max-specificity
-    }
-  }
-}
-
-.mdc-text-field--outlined:not(.mdc-text-field--upgraded) {
-  height: 56px;
-
-  .mdc-text-field__input {
-    @include mdc-text-field-outlined-corner-radius($mdc-text-field-border-radius);
-
-    height: 100%;
-    padding: 0 0 0 12px;
-    border: 1px solid $mdc-text-field-outlined-idle-border;
-
-    &:hover {
-      border-color: $mdc-text-field-outlined-hover-border;
-    }
-
-    &:focus {
-      @include mdc-theme-prop(border-color, primary);
-    }
-  }
-}
-
-.mdc-text-field--box:not(.mdc-text-field--upgraded) {
-  height: 56px;
-
-  &::before,
-  &::after {
-    border-radius: 0;
-  }
-
-  .mdc-text-field__input {
-    padding-top: 0;
-  }
-}
-// postcss-bem-linter: end
 
 // postcss-bem-linter: define text-field-helper-text
 


### PR DESCRIPTION
BREAKING CHANGE: Moves the text-field colors to mixins. Removes css only. Refer to the docs/demo for usage. 
