### PR TITLE
feat(demos): Add consistent RTL toggle to most demo pages

### DIFF
--- a/demos/card.html
+++ b/demos/card.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .hero .demo-card {
         width: 320px;
@@ -112,12 +113,11 @@
         margin: 24px;
         min-width: 320px;
       }
-
     </style>
   </head>
 
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -125,10 +125,15 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Card</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
+
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
         <div class="mdc-card demo-card">
           <section class="mdc-card__media demo-card__16-9-media"></section>
@@ -141,21 +146,6 @@
             <button class="mdc-button mdc-button--compact mdc-card__action">Action 2</button>
           </section>
         </div>
-      </section>
-
-      <section class="example">
-          <div class="mdc-form-field">
-            <div class="mdc-checkbox">
-              <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
-              <div class="mdc-checkbox__background">
-                <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                  <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-                </svg>
-                <div class="mdc-checkbox__mixedmark"></div>
-              </div>
-            </div>
-            <label for="toggle-rtl" id="toggle-rtl-label">Toggle RTL</label>
-          </div>
       </section>
 
       <section class="demo-typography--section" id="demo-wrapper">
@@ -316,22 +306,10 @@
             </div>
           </div>
         </div>
-
       </section>
-
     </main>
-    <script>
-      // var formField = new mdc.formField.MDCFormField(document.querySelector('.mdc-form-field'));
-      // var cb = mdc.checkbox.MDCCheckbox.attachTo(document.querySelector('.mdc-checkbox'));
-      // formField.input = cb;
-      var demoWrapper = document.getElementById('demo-wrapper');
-      document.getElementById('toggle-rtl').addEventListener('change', function () {
-        if (this.checked) {
-          demoWrapper.setAttribute('dir', 'rtl');
-        } else {
-          demoWrapper.removeAttribute('dir');
-        }
-      });
-    </script>
+
+    <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
   </body>
 </html>

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -35,14 +35,6 @@
         margin-top: 0;
       }
 
-      .example--with-js .mdc-form-field {
-        min-width: 450px;
-      }
-
-      .demo-toggle-group {
-        display: inline-block;
-      }
-
       @media (max-width: 600px) {
         .mdc-button {
           margin-bottom: 4px;
@@ -54,8 +46,9 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -63,27 +56,45 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Checkbox</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
+
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
-        <div class="mdc-checkbox">
-          <input type="checkbox"
-                 id="hero-checkbox"
-                 class="mdc-checkbox__native-control"/>
-          <div class="mdc-checkbox__background">
-            <svg class="mdc-checkbox__checkmark"
-                 viewBox="0 0 24 24">
-              <path class="mdc-checkbox__checkmark__path"
-                    fill="none"
-                    stroke="white"
-                    d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-            </svg>
-            <div class="mdc-checkbox__mixedmark"></div>
+        <div class="mdc-form-field">
+          <div class="mdc-checkbox">
+            <input type="checkbox"
+                   id="hero-checkbox"
+                   class="mdc-checkbox__native-control"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark__path"
+                      fill="none"
+                      stroke="white"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
           </div>
+          <label for="hero-checkbox" id="hero-checkbox-label">Checkbox</label>
         </div>
-        <label for="hero-checkbox" id="hero-checkbox-label">Checkbox</label>
+      </section>
+
+      <section class="example">
+        <button type="button" class="mdc-button mdc-button--stroked" id="align-end-toggle-button">
+          Toggle <code>--align-end</code>
+        </button>
+        <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate" id="indeterminate-toggle-button">
+          Toggle <code>indeterminate</code>
+        </button>
+        <button type="button" class="mdc-button mdc-button--stroked toggle-disabled" id="disabled-toggle-button">
+          Toggle <code>disabled</code>
+        </button>
       </section>
 
       <section class="example">
@@ -106,10 +117,6 @@
               </div>
             </div>
             <label for="basic-checkbox">Default checkbox</label>
-          </div>
-          <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact" onclick="this.parentElement.parentElement.hasAttribute('dir') ? this.parentElement.parentElement.removeAttribute('dir') : this.parentElement.parentElement.setAttribute('dir', 'rtl');">Toggle RTL</button>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact" onclick="document.querySelector('.mdc-form-field').classList.toggle('mdc-form-field--align-end');">Toggle <code>--align-end</code></button>
           </div>
         </div>
         <div>
@@ -198,7 +205,7 @@
         </div>
       </section>
 
-      <section class="example example--with-js">
+      <section class="example">
         <h2>With JavaScript</h2>
         <div>
           <div class="mdc-form-field">
@@ -218,10 +225,6 @@
               </div>
             </div>
             <label for="native-js-checkbox">Default checkbox</label>
-          </div>
-          <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-indeterminate">Toggle <code>indeterminate</code></button>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-disabled">Toggle <code>disabled</code></button>
           </div>
         </div>
         <div>
@@ -243,10 +246,6 @@
               </div>
             </div>
             <label for="native-js-checkbox-indeterminate">Indeterminate checkbox</label>
-          </div>
-          <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-indeterminate">Toggle <code>indeterminate</code></button>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-disabled">Toggle <code>disabled</code></button>
           </div>
           <script>
             document.getElementById('native-js-checkbox-indeterminate').indeterminate = true;
@@ -271,10 +270,6 @@
             </div>
             <label for="native-js-checkbox-custom-all">Custom colored checkbox (stroke, fill, ripple, and focus)</label>
           </div>
-          <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-indeterminate">Toggle <code>indeterminate</code></button>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-disabled">Toggle <code>disabled</code></button>
-          </div>
         </div>
         <div>
           <div class="mdc-form-field">
@@ -294,10 +289,6 @@
               </div>
             </div>
             <label for="native-js-checkbox-custom-stroke-and-fill">Custom colored checkbox (stroke and fill only)</label>
-          </div>
-          <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-indeterminate">Toggle <code>indeterminate</code></button>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--compact toggle-disabled">Toggle <code>disabled</code></button>
           </div>
         </div>
       </section>
@@ -364,7 +355,7 @@
             </div>
             <label for="basic-indeterminate-checkbox-dark">Indeterminate checkbox</label>
           </div>
-          <script type="text/javascript">
+          <script>
             document.getElementById('basic-indeterminate-checkbox-dark').indeterminate = true;
           </script>
         </div>
@@ -472,7 +463,7 @@
             </div>
             <label for="basic-indeterminate-checkbox-dark-2">Indeterminate checkbox</label>
           </div>
-          <script type="text/javascript">
+          <script>
             document.getElementById('basic-indeterminate-checkbox-dark-2').indeterminate = true;
           </script>
         </div>
@@ -517,37 +508,57 @@
           </div>
         </div>
       </section>
-
     </main>
+
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var MDCCheckbox = mdc.checkbox.MDCCheckbox;
         var MDCFormField = mdc.formField.MDCFormField;
 
-        var checkboxes = [].slice.call(document.querySelectorAll('.mdc-checkbox[data-js]'));
-        checkboxes.forEach(function(checkbox) {
-          var checkboxInstance = new MDCCheckbox(checkbox);
+        var indeterminateToggleHandlers = [];
+        var disabledToggleHandlers = [];
 
-          var formField = checkbox.parentElement;
-          var formFieldInstance = new MDCFormField(formField);
-          formFieldInstance.input = checkboxInstance;
+        // JS-enabled
+        [].slice.call(document.querySelectorAll('.mdc-checkbox')).forEach(function(checkboxEl) {
+          var target;
 
-          var row = formField.parentElement;
-
-          var indeterminateToggle = row.querySelector('.toggle-indeterminate');
-          if (indeterminateToggle) {
-            indeterminateToggle.addEventListener('click', function() {
-              checkboxInstance.indeterminate = !checkboxInstance.indeterminate;
-            });
+          if (checkboxEl.hasAttribute('data-js')) {
+            var formFieldEl = checkboxEl.parentElement;
+            var formFieldInstance = new MDCFormField(formFieldEl);
+            var checkboxInstance = new MDCCheckbox(checkboxEl);
+            formFieldInstance.input = checkboxInstance;
+            target = checkboxInstance;
+          } else {
+            target = checkboxEl.querySelector('.mdc-checkbox__native-control');
           }
 
-          var disabledToggle = row.querySelector('.toggle-disabled');
-          if (disabledToggle) {
-            disabledToggle.addEventListener('click', function() {
-              checkboxInstance.disabled = !checkboxInstance.disabled;
-            });
-          }
+          indeterminateToggleHandlers.push(function() {
+            target.indeterminate = !target.indeterminate;
+          });
+
+          disabledToggleHandlers.push(function() {
+            target.disabled = !target.disabled;
+          });
+        });
+
+        document.querySelector('#align-end-toggle-button').addEventListener('click', function() {
+          [].slice.call(document.querySelectorAll('.mdc-form-field')).forEach(function(formField) {
+            formField.classList.toggle('mdc-form-field--align-end');
+          });
+        });
+
+        document.querySelector('#indeterminate-toggle-button').addEventListener('click', function() {
+          indeterminateToggleHandlers.forEach(function(handler) {
+            handler();
+          });
+        });
+
+        document.querySelector('#disabled-toggle-button').addEventListener('click', function() {
+          disabledToggleHandlers.forEach(function(handler) {
+            handler();
+          });
         });
       });
     </script>

--- a/demos/common.scss
+++ b/demos/common.scss
@@ -26,7 +26,7 @@ $mdc-theme-secondary: #018786 !default; // baseline teal, 600 tone
 
 // Import button and ripple mixins to apply overrides for dark theme
 // TODO(kfranqueiro): Pending further design discussion around how to manage dark theme
-@import "../packages/mdc-button/mixins";
+@import "../packages/mdc-button/mdc-button";
 @import "../packages/mdc-ripple/mixins";
 // All demo pages have a top toolbar, and most of them use theme variables.
 // Import these *after* setting theme colors to override defaults in mdc-theme.

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -31,18 +31,12 @@
         margin: 0;
         box-sizing: border-box;
       }
-      .demo-content > button {
-        margin-bottom: 6px;
-      }
+
       .mdc-theme--dark {
         background-color: #303030;
       }
 
-      section.demo-content {
-        padding: 24px;
-      }
-
-      .catalog-dialog-demo {
+      .demo-dialog {
         position: relative;
         width: 320px;
         z-index: auto;
@@ -54,14 +48,16 @@
         justify-content: center;
       }
 
-      .mdc-theme--dark, .section-dark-theme {
+      .mdc-theme--dark,
+      .section-dark-theme {
         background: #262626;
         color: white;
       }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -69,19 +65,27 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Dialog</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
+
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
-        <aside class="catalog-dialog-demo mdc-dialog mdc-dialog--open">
+        <aside class="mdc-dialog mdc-dialog--open demo-dialog"
+               role="alertdialog"
+               aria-labelledby="demo-dialog-hero-title"
+               aria-describedby="demo-dialog-hero-body">
           <div class="mdc-dialog__surface">
             <header class="mdc-dialog__header">
-              <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
+              <h2 class="mdc-dialog__header__title" id="demo-dialog-hero-title">
                 Are you happy?
               </h2>
             </header>
-            <section id="mdc-dialog-default-description" class="mdc-dialog__body">
+            <section class="mdc-dialog__body" id="demo-dialog-hero-body">
               Please check the left and right side of this element for fun.
             </section>
             <footer class="mdc-dialog__footer">
@@ -93,19 +97,20 @@
       </section>
 
       <div class="demo-body">
-        <aside id="mdc-dialog-default"
+        <aside id="expanding-modal-dialog"
                class="mdc-dialog"
                role="alertdialog"
                aria-hidden="true"
-               aria-labelledby="mdc-dialog-default-label"
-               aria-describedby="mdc-dialog-default-description">
+               aria-labelledby="expanding-modal-dialog-title"
+               aria-describedby="expanding-modal-dialog-body"
+               data-open-button-id="open-expanding-modal-dialog-button">
           <div class="mdc-dialog__surface">
             <header class="mdc-dialog__header">
-              <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
+              <h2 class="mdc-dialog__header__title" id="expanding-modal-dialog-title">
                 Use Google's location service?
               </h2>
             </header>
-            <section id="mdc-dialog-default-description" class="mdc-dialog__body">
+            <section class="mdc-dialog__body" id="expanding-modal-dialog-body">
               Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
             </section>
             <footer class="mdc-dialog__footer">
@@ -116,42 +121,20 @@
           <div class="mdc-dialog__backdrop"></div>
         </aside>
 
-        <aside id="mdc-dialog-colored-footer-buttons"
+        <aside id="scrolling-modal-dialog"
                class="mdc-dialog"
                role="alertdialog"
                aria-hidden="true"
-               aria-labelledby="mdc-dialog-colored-footer-button-label"
-               aria-describedby="mdc-dialog-colored-footer-button-description">
+               aria-labelledby="scrolling-modal-dialog-title"
+               aria-describedby="scrolling-modal-dialog-body"
+               data-open-button-id="open-scrolling-modal-dialog-button">
           <div class="mdc-dialog__surface">
             <header class="mdc-dialog__header">
-              <h2 id="mdc-dialog-colored-footer-button-label" class="mdc-dialog__header__title">
-                Use Google's location service?
-              </h2>
-            </header>
-            <section id="mdc-dialog-colored-footer-button-description" class="mdc-dialog__body">
-              Let Google help apps determine location. This means sending anonymous location data to Google, even when no apps are running.
-            </section>
-            <footer class="mdc-dialog__footer">
-              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--cancel">Decline</button>
-              <button type="button" class="mdc-button mdc-dialog__footer__button mdc-dialog__footer__button--accept mdc-dialog__action">Accept</button>
-            </footer>
-          </div>
-          <div class="mdc-dialog__backdrop"></div>
-        </aside>
-
-        <aside id="mdc-dialog-with-list"
-               class="mdc-dialog"
-               role="alertdialog"
-               aria-hidden="true"
-               aria-labelledby="mdc-dialog-with-list-label"
-               aria-describedby="mdc-dialog-with-list-description">
-          <div class="mdc-dialog__surface">
-            <header class="mdc-dialog__header">
-              <h2 id="mdc-dialog-with-list-label" class="mdc-dialog__header__title">
+              <h2 class="mdc-dialog__header__title" id="scrolling-modal-dialog-title">
                 Choose a Ringtone
               </h2>
             </header>
-            <section id="mdc-dialog-with-list-description" class="mdc-dialog__body mdc-dialog__body--scrollable">
+            <section class="mdc-dialog__body mdc-dialog__body--scrollable" id="scrolling-modal-dialog-body">
               <ul class="mdc-list">
                 <li class="mdc-list-item">None</li>
                 <li class="mdc-list-item">Callisto</li>
@@ -174,41 +157,23 @@
           <div class="mdc-dialog__backdrop"></div>
         </aside>
       </div>
+
       <section class="example">
-        <button id="default-dialog-activation" class="mdc-button mdc-button--raised">Show Dialog</button>
-        <button id="colored-footer-button-dialog-activation" class="mdc-button mdc-button--raised">Show Colored Footer Button Dialog</button>
-        <button id="dialog-with-list-activation" class="mdc-button mdc-button--raised">Show Scrolling Dialog</button>
-        <div class="mdc-form-field">
-          <div class="mdc-checkbox">
-            <input type="checkbox"
-                   id="toggle-rtl"
-                   class="mdc-checkbox__native-control"/>
-            <div class="mdc-checkbox__background">
-              <svg class="mdc-checkbox__checkmark"
-                  viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark__path"
-                      fill="none"
-                      stroke="white"
-                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-              </svg>
-              <div class="mdc-checkbox__mixedmark"></div>
-            </div>
-          </div>
-          <label for="toggle-rtl">Toggle RTL</label>
-        </div>
+        <button id="open-expanding-modal-dialog-button" class="mdc-button mdc-button--stroked">Show Dialog</button>
+        <button id="open-scrolling-modal-dialog-button" class="mdc-button mdc-button--stroked">Show Scrolling Dialog</button>
       </section>
 
       <section class="example mdc-theme--dark">
         <h2>Dark Theme (mdc-theme--dark)</h2>
         <div class="dialog-container">
-          <aside class="catalog-dialog-demo mdc-dialog mdc-dialog--open">
+          <aside class="demo-dialog mdc-dialog mdc-dialog--open">
             <div class="mdc-dialog__surface">
               <header class="mdc-dialog__header">
-                <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
+                <h2 class="mdc-dialog__header__title">
                   Are you happy?
                 </h2>
               </header>
-              <section id="mdc-dialog-default-description" class="mdc-dialog__body">
+              <section class="mdc-dialog__body">
                 Please check the left and right side of this element for fun.
               </section>
               <footer class="mdc-dialog__footer">
@@ -223,14 +188,14 @@
       <section class="example section-dark-theme">
         <h2>Dark Theme (mdc-dialog--theme-dark)</h2>
         <div class="dialog-container">
-          <aside class="catalog-dialog-demo mdc-dialog mdc-dialog--theme-dark mdc-dialog--open">
+          <aside class="demo-dialog mdc-dialog mdc-dialog--theme-dark mdc-dialog--open">
             <div class="mdc-dialog__surface">
               <header class="mdc-dialog__header">
-                <h2 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
+                <h2 class="mdc-dialog__header__title">
                   Are you happy?
                 </h2>
               </header>
-              <section id="mdc-dialog-default-description" class="mdc-dialog__body">
+              <section class="mdc-dialog__body">
                 Please check the left and right side of this element for fun.
               </section>
               <footer class="mdc-dialog__footer">
@@ -244,45 +209,31 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
-        var dialog = new mdc.dialog.MDCDialog(document.querySelector('#mdc-dialog-default'));
-        dialog.listen('MDCDialog:accept', function() {
-          console.log('accepted');
-        });
-        dialog.listen('MDCDialog:cancel', function() {
-          console.log('canceled');
-        });
-        document.querySelector('#default-dialog-activation').addEventListener('click', function (evt) {
-          dialog.lastFocusedTarget = evt.target;
-          dialog.show();
-        });
-        var dialogScrollable = new mdc.dialog.MDCDialog(document.querySelector('#mdc-dialog-with-list'));
-        document.querySelector('#dialog-with-list-activation').addEventListener('click', function (evt) {
-          dialogScrollable.lastFocusedTarget = evt.target;
-          dialogScrollable.show();
-        });
-        var dialogColoredButton = new mdc.dialog.MDCDialog(document.querySelector('#mdc-dialog-colored-footer-buttons'));
-        document.querySelector('#colored-footer-button-dialog-activation').addEventListener('click', function (evt) {
-          dialogColoredButton.lastFocusedTarget = evt.target;
-          dialogColoredButton.show();
-        });
+        [].forEach.call(document.querySelectorAll('.mdc-dialog'), function(dialogEl) {
+          var dialog = new mdc.dialog.MDCDialog(dialogEl);
+          dialog.listen('MDCDialog:accept', function() {
+            console.log('accepted');
+          });
+          dialog.listen('MDCDialog:cancel', function() {
+            console.log('canceled');
+          });
 
-        mdc.dialog.MDCDialog.attachTo(document.querySelector('.mdc-dialog'));
-        var demoWrapper = document.querySelector('.demo-body');
-        var hero = document.querySelector('.hero');
-        document.getElementById('toggle-rtl').addEventListener('change', function() {
-          if (this.checked) {
-            demoWrapper.setAttribute('dir', 'rtl');
-            hero.setAttribute('dir', 'rtl');
-          } else {
-            demoWrapper.removeAttribute('dir');
-            hero.removeAttribute('dir');
+          var buttonId = dialogEl.getAttribute('data-open-button-id');
+          var buttonEl = document.getElementById(buttonId);
+          if (buttonEl) {
+            buttonEl.addEventListener('click', function (evt) {
+              dialog.lastFocusedTarget = evt.target;
+              dialog.show();
+            });
           }
         });
-        mdc.ripple.MDCRipple.attachTo(document.querySelector('#default-dialog-activation'));
-        mdc.ripple.MDCRipple.attachTo(document.querySelector('#dialog-with-list-activation'));
-        mdc.ripple.MDCRipple.attachTo(document.querySelector('#colored-footer-button-dialog-activation'));
+
+        document.querySelectorAll('.mdc-button').forEach(function(button) {
+          mdc.ripple.MDCRipple.attachTo(button);
+        });
       });
     </script>
   </body>

--- a/demos/drawer/drawer.scss
+++ b/demos/drawer/drawer.scss
@@ -55,3 +55,9 @@
 .demo-form-field {
   margin: 16px 0;
 }
+
+.demo-page-large-content {
+  min-height: 100px;
+  min-width: 100px;
+  margin: 32px 0;
+}

--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -25,6 +25,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       /* Ensure layout covers the entire screen. */
       html {
@@ -73,6 +74,7 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography demo-body">
     <nav id="demo-drawer" class="mdc-drawer mdc-drawer--permanent demo-drawer">
       <div class="mdc-list-group">
@@ -106,6 +108,7 @@
         </nav>
       </div>
     </nav>
+
     <div class="demo-content">
       <!-- TODO: #324 - Should switch to .mdc-toolbar--fixed -->
       <header class="mdc-toolbar mdc-elevation--z4">
@@ -115,6 +118,9 @@
               <a href="/" class="mdc-toolbar__menu-icon"><i class="material-icons">&#xE5C4;</i></a>
             </span>
             <span class="mdc-toolbar__title catalog-title">Permanent Drawer Above Toolbar</span>
+          </section>
+          <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+            <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
           </section>
         </div>
       </header>
@@ -157,55 +163,57 @@
         </div>
 
         <div class="extra-content-wrapper">
-          <button id="toggle-wide">Toggle extra-wide content</button>
-          <div id="extra-wide-content" class="mdc-elevation--z2">&nbsp;</div>
+          <button class="mdc-button mdc-button--stroked" id="toggle-wide">Toggle extra-wide content</button>
+          <div id="extra-wide-content" class="demo-page-large-content mdc-elevation--z8" style="display: none">&nbsp;</div>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-tall">Toggle extra-tall content</button>
-          <div id="extra-tall-content" class="mdc-elevation--z2">&nbsp;</div>
+          <button class="mdc-button mdc-button--stroked" id="toggle-tall">Toggle extra-tall content</button>
+          <div id="extra-tall-content" class="demo-page-large-content mdc-elevation--z8" style="display: none">&nbsp;</div>
         </div>
       </main>
     </div>
 
+    <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
-      var extraWide = document.querySelector('#extra-wide-content');
-      extraWide.style.display = 'none';
-      document.querySelector('#toggle-wide').addEventListener('click', function() {
-        extraWide.style.display = extraWide.style.display ? '' : 'none';
-      });
-      var extraTall = document.querySelector('#extra-tall-content');
-      extraTall.style.display = 'none';
-      document.querySelector('#toggle-tall').addEventListener('click', function() {
-        extraTall.style.display = extraTall.style.display ? '' : 'none';
-      });
+      demoReady(function() {
+        var extraWide = document.querySelector('#extra-wide-content');
+        document.querySelector('#toggle-wide').addEventListener('click', function() {
+          extraWide.style.display = extraWide.style.display ? '' : 'none';
+        });
+        var extraTall = document.querySelector('#extra-tall-content');
+        document.querySelector('#toggle-tall').addEventListener('click', function() {
+          extraTall.style.display = extraTall.style.display ? '' : 'none';
+        });
 
-      // Demonstrate application of --activated modifier to drawer menu items
-      var activatedClass = 'mdc-list-item--selected';
-      document.querySelector('.mdc-drawer').addEventListener('click', function(event) {
-        var el = event.target;
-        while (el && !el.classList.contains('mdc-list-item')) {
-          el = el.parentElement;
-        }
-        if (el) {
-          var activatedItem = document.querySelector('.' + activatedClass);
-          if (activatedItem) {
-            activatedItem.classList.remove(activatedClass);
+        // Demonstrate application of --activated modifier to drawer menu items
+        var activatedClass = 'mdc-list-item--selected';
+        document.querySelector('.mdc-drawer').addEventListener('click', function(event) {
+          var el = event.target;
+          while (el && !el.classList.contains('mdc-list-item')) {
+            el = el.parentElement;
           }
-          event.target.classList.add(activatedClass);
-        }
-      });
+          if (el) {
+            var activatedItem = document.querySelector('.' + activatedClass);
+            if (activatedItem) {
+              activatedItem.classList.remove(activatedClass);
+            }
+            event.target.classList.add(activatedClass);
+          }
+        });
 
-      var drawerEl = document.getElementById('demo-drawer');
-      var radioEl = document.querySelector('#demo-radio-buttons');
-      radioEl.addEventListener('change', function(e) {
-        drawerEl.classList.remove('demo-drawer--custom');
-        drawerEl.classList.remove('demo-drawer--accessible');
+        var drawerEl = document.getElementById('demo-drawer');
+        var radioEl = document.querySelector('#demo-radio-buttons');
+        radioEl.addEventListener('change', function(e) {
+          drawerEl.classList.remove('demo-drawer--custom');
+          drawerEl.classList.remove('demo-drawer--accessible');
 
-        if(e.target.id === 'theme-radio-accessible') {
-          drawerEl.classList.add('demo-drawer--accessible');
-        } else if(e.target.id === 'theme-radio-custom') {
-          drawerEl.classList.add('demo-drawer--custom');
-        }
+          if(e.target.id === 'theme-radio-accessible') {
+            drawerEl.classList.add('demo-drawer--accessible');
+          } else if(e.target.id === 'theme-radio-custom') {
+            drawerEl.classList.add('demo-drawer--custom');
+          }
+        });
       });
     </script>
   </body>

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -25,6 +25,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       /* Ensure layout covers the entire screen. */
       html {
@@ -66,6 +67,7 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography demo-body">
     <header class="mdc-toolbar mdc-toolbar--fixed">
       <div class="mdc-toolbar__row">
@@ -74,6 +76,9 @@
             <a href="/" class="mdc-toolbar__menu-icon"><i class="material-icons">&#xE5C4;</i></a>
           </span>
           <span class="mdc-toolbar__title catalog-title">Permanent Drawer Below Toolbar</span>
+        </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
         </section>
       </div>
     </header>
@@ -111,6 +116,7 @@
           </nav>
         </div>
       </nav>
+
       <main class="demo-main">
         <h1 class="mdc-typography--display1">Permanent Drawer</h1>
         <p class="mdc-typography--body1">It sits to the left of this content.</p>
@@ -149,55 +155,57 @@
         </div>
 
         <div class="extra-content-wrapper">
-          <button id="toggle-wide">Toggle extra-wide content</button>
-          <div id="extra-wide-content" class="mdc-elevation--z2">&nbsp;</div>
+          <button class="mdc-button mdc-button--stroked" id="toggle-wide">Toggle extra-wide content</button>
+          <div id="extra-wide-content" class="demo-page-large-content mdc-elevation--z8" style="display: none">&nbsp;</div>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-tall">Toggle extra-tall content</button>
-          <div id="extra-tall-content" class="mdc-elevation--z2">&nbsp;</div>
+          <button class="mdc-button mdc-button--stroked" id="toggle-tall">Toggle extra-tall content</button>
+          <div id="extra-tall-content" class="demo-page-large-content mdc-elevation--z8" style="display: none">&nbsp;</div>
         </div>
       </main>
     </div>
 
+    <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
-      var extraWide = document.querySelector('#extra-wide-content');
-      extraWide.style.display = 'none';
-      document.querySelector('#toggle-wide').addEventListener('click', function() {
-        extraWide.style.display = extraWide.style.display ? '' : 'none';
-      });
-      var extraTall = document.querySelector('#extra-tall-content');
-      extraTall.style.display = 'none';
-      document.querySelector('#toggle-tall').addEventListener('click', function() {
-        extraTall.style.display = extraTall.style.display ? '' : 'none';
-      });
+      demoReady(function() {
+        var extraWide = document.querySelector('#extra-wide-content');
+        document.querySelector('#toggle-wide').addEventListener('click', function() {
+          extraWide.style.display = extraWide.style.display ? '' : 'none';
+        });
+        var extraTall = document.querySelector('#extra-tall-content');
+        document.querySelector('#toggle-tall').addEventListener('click', function() {
+          extraTall.style.display = extraTall.style.display ? '' : 'none';
+        });
 
-      // Demonstrate application of --activated modifier to drawer menu items
-      var activatedClass = 'mdc-list-item--selected';
-      document.querySelector('.mdc-drawer').addEventListener('click', function(event) {
-        var el = event.target;
-        while (el && !el.classList.contains('mdc-list-item')) {
-          el = el.parentElement;
-        }
-        if (el) {
-          var activatedItem = document.querySelector('.' + activatedClass);
-          if (activatedItem) {
-            activatedItem.classList.remove(activatedClass);
+        // Demonstrate application of --activated modifier to drawer menu items
+        var activatedClass = 'mdc-list-item--selected';
+        document.querySelector('.mdc-drawer').addEventListener('click', function(event) {
+          var el = event.target;
+          while (el && !el.classList.contains('mdc-list-item')) {
+            el = el.parentElement;
           }
-          event.target.classList.add(activatedClass);
-        }
-      });
+          if (el) {
+            var activatedItem = document.querySelector('.' + activatedClass);
+            if (activatedItem) {
+              activatedItem.classList.remove(activatedClass);
+            }
+            event.target.classList.add(activatedClass);
+          }
+        });
 
-      var drawerEl = document.getElementById('demo-drawer');
-      var radioEl = document.querySelector('#demo-radio-buttons');
-      radioEl.addEventListener('change', function(e) {
-        drawerEl.classList.remove('demo-drawer--custom');
-        drawerEl.classList.remove('demo-drawer--accessible');
+        var drawerEl = document.getElementById('demo-drawer');
+        var radioEl = document.querySelector('#demo-radio-buttons');
+        radioEl.addEventListener('change', function(e) {
+          drawerEl.classList.remove('demo-drawer--custom');
+          drawerEl.classList.remove('demo-drawer--accessible');
 
-        if(e.target.id === 'theme-radio-accessible') {
-          drawerEl.classList.add('demo-drawer--accessible');
-        } else if(e.target.id === 'theme-radio-custom') {
-          drawerEl.classList.add('demo-drawer--custom');
-        }
+          if(e.target.id === 'theme-radio-accessible') {
+            drawerEl.classList.add('demo-drawer--accessible');
+          } else if(e.target.id === 'theme-radio-custom') {
+            drawerEl.classList.add('demo-drawer--custom');
+          }
+        });
       });
     </script>
   </body>

--- a/demos/drawer/persistent-drawer.html
+++ b/demos/drawer/persistent-drawer.html
@@ -22,10 +22,10 @@
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/drawer/drawer.css">
     <link rel="stylesheet" href="/assets/radio.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       /* Ensure layout covers the entire screen. */
       html {
@@ -58,6 +58,7 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography demo-body">
     <aside class="mdc-drawer mdc-drawer--persistent demo-drawer">
       <nav class="mdc-drawer__drawer">
@@ -94,6 +95,7 @@
         </div>
       </nav>
     </aside>
+
     <div class="demo-content">
       <header class="mdc-toolbar mdc-elevation--z4">
         <div class="mdc-toolbar__row">
@@ -103,6 +105,9 @@
             </span>
             <button class="demo-menu material-icons mdc-toolbar__menu-icon">menu</button>
             <span class="mdc-toolbar__title catalog-title">Persistent Drawer</span>
+          </section>
+          <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+            <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
           </section>
         </div>
       </header>
@@ -146,6 +151,7 @@
       </main>
 
       <script src="/assets/material-components-web.js" async></script>
+      <script src="/assets/common.js" async></script>
       <script>
         demoReady(function() {
           var drawerEl = document.querySelector('.mdc-drawer');

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -42,7 +42,7 @@
   </head>
 
   <body class="mdc-typography demo-body">
-    <div class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span>
@@ -55,7 +55,7 @@
           <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
         </section>
       </div>
-    </div>
+    </header>
 
     <aside class="mdc-drawer mdc-drawer--temporary demo-drawer">
       <nav class="mdc-drawer__drawer">

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -22,10 +22,10 @@
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/drawer/drawer.css">
     <link rel="stylesheet" href="/assets/radio.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .demo-body {
         padding: 0;
@@ -40,6 +40,7 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography demo-body">
     <div class="mdc-toolbar mdc-toolbar--fixed">
       <div class="mdc-toolbar__row">
@@ -49,6 +50,9 @@
           </span>
           <button class="demo-menu material-icons mdc-toolbar__menu-icon">menu</button>
           <span class="mdc-toolbar__title catalog-title">Temporary Drawer</span>
+        </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
         </section>
       </div>
     </div>
@@ -60,7 +64,7 @@
             Header here
           </div>
         </header>
-        <nav class="mdc-drawer__content mdc-list-group">
+        <div class="mdc-drawer__content mdc-list-group">
           <div id="icon-with-text-demo" class="mdc-list">
             <a class="mdc-list-item mdc-list-item--selected demo-drawer-list-item" href="#">
               <i class="material-icons mdc-list-item__graphic" aria-hidden="true">inbox</i>Inbox
@@ -89,9 +93,10 @@
               <i class="material-icons mdc-list-item__graphic" aria-hidden="true">report</i>Spam
             </a>
           </div>
-        </nav>
+        </div>
       </nav>
     </aside>
+
     <main class="demo-main mdc-toolbar-fixed-adjust">
       <h1 class="mdc-typography--display1">Temporary Drawer</h1>
       <p class="mdc-typography--body1">Click the menu icon above to open.</p>
@@ -130,6 +135,7 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var drawerEl = document.querySelector('.mdc-drawer');

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/grid-list.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .demo-grid-tile-content {
         background-image: url("images/16-9.jpg");
@@ -54,8 +54,9 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -63,8 +64,12 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Grid List</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
+
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
@@ -85,21 +90,6 @@
             <li class="mdc-grid-tile"><div class="mdc-grid-tile__primary"></div></li>
             <li class="mdc-grid-tile"><div class="mdc-grid-tile__primary"></div></li>
           </ul>
-        </div>
-      </section>
-
-      <section class="example">
-        <div class="mdc-form-field">
-          <div class="mdc-checkbox">
-            <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
-            <div class="mdc-checkbox__background">
-              <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
-              </svg>
-              <div class="mdc-checkbox__mixedmark"></div>
-            </div>
-          </div>
-          <label for="toggle-rtl" id="toggle-rtl-label">Toggle RTL</label>
         </div>
       </section>
 
@@ -721,21 +711,13 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var nodes = document.querySelectorAll('.mdc-grid-list');
         for (var i = 0, node; node = nodes[i]; i++) {
           mdc.gridList.MDCGridList.attachTo(node);
         }
-
-        var demoWrapper = document.querySelector('.examples');
-        document.getElementById('toggle-rtl').addEventListener('change', function () {
-          if (this.checked) {
-            demoWrapper.setAttribute('dir', 'rtl');
-          } else {
-            demoWrapper.removeAttribute('dir');
-          }
-        });
       });
     </script>
   </body>

--- a/demos/interactivity.js
+++ b/demos/interactivity.js
@@ -28,6 +28,7 @@ const attrs = {
 };
 
 const ids = {
+  RTL_TOGGLE: 'rtl-toggle',
   TOOLBAR_PROGRESS_BAR: 'demo-toolbar-progress-bar',
 };
 
@@ -295,7 +296,67 @@ export class HotSwapper extends InteractivityProvider {
   }
 }
 
+export class RtlToggler extends InteractivityProvider {
+  /** @param {!Element|!Document} root */
+  static attachTo(root) {
+    const instance = new RtlToggler(root);
+    instance.lazyInit();
+    return instance;
+  }
+
+  /** @override */
+  lazyInit() {
+    /**
+     * @type {?Element}
+     * @private
+     */
+    this.rtlActionEl_ = this.root_.getElementById(ids.RTL_TOGGLE);
+
+    /**
+     * @type {HTMLElement}
+     * @private
+     */
+    this.rtlTargetEl_ = this.document_.documentElement;
+
+    this.registerRTLToggleHandler_();
+    this.syncWithDom_();
+  }
+
+  /** @private */
+  registerRTLToggleHandler_() {
+    if (!this.rtlActionEl_) {
+      return;
+    }
+    this.rtlActionEl_.addEventListener('click', () => this.toggleRTL_());
+  }
+
+  /** @private */
+  syncWithDom_() {
+    this.setRTL_(this.rtlTargetEl_.getAttribute('dir') === 'rtl' ? 'rtl' : 'ltr');
+  }
+
+  /** @private */
+  toggleRTL_() {
+    this.setRTL_(this.rtlTargetEl_.getAttribute('dir') === 'rtl' ? 'ltr' : 'rtl');
+  }
+
+  /**
+   * @param {string} newDirection One of ['ltr', 'rtl']
+   * @private
+   */
+  setRTL_(newDirection) {
+    if (newDirection === 'rtl') {
+      this.rtlTargetEl_.setAttribute('dir', 'rtl');
+      this.rtlActionEl_.innerHTML = 'format_align_right';
+    } else {
+      this.rtlTargetEl_.setAttribute('dir', 'ltr');
+      this.rtlActionEl_.innerHTML = 'format_align_left';
+    }
+  }
+}
+
 /** @param {!Document|!Element} root */
 export function init(root) {
   HotSwapper.getInstance(root);
+  RtlToggler.attachTo(root);
 }

--- a/demos/interactivity.js
+++ b/demos/interactivity.js
@@ -345,6 +345,10 @@ export class RtlToggler extends InteractivityProvider {
    * @private
    */
   setRTL_(newDirection) {
+    if (!(this.rtlTargetEl_ && this.rtlActionEl_)) {
+      return;
+    }
+
     if (newDirection === 'rtl') {
       this.rtlTargetEl_.setAttribute('dir', 'rtl');
       this.rtlActionEl_.innerHTML = 'format_align_right';

--- a/demos/layout-grid.html
+++ b/demos/layout-grid.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .demo-grid {
         background-color: #DDDDDD;
@@ -118,7 +119,7 @@
     </style>
   </head>
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -126,13 +127,16 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Layout Grid</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
 
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
-      <section class="hero">
 
+      <section class="hero">
         <div class="demo-grid mdc-layout-grid">
           <div class="mdc-layout-grid__inner">
             <div class="demo-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-4"></div>
@@ -140,7 +144,6 @@
             <div class="demo-cell mdc-layout-grid__cell mdc-layout-grid__cell--span-4"></div>
           </div>
         </div>
-
       </section>
 
       <section class="examples">
@@ -419,8 +422,10 @@
       </section>
     </main>
 
+    <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
-      (function() {
+      demoReady(function() {
         var fluidContainerSection = document.getElementById('layout-grid-in-fluid-container');
         var fixedWidthSection = document.getElementById('fixed-column-width-layout-grid');
 
@@ -511,7 +516,7 @@
         };
         window.addEventListener('resize', update);
         update();
-      })();
+      });
     </script>
   </body>
 </html>

--- a/demos/linear-progress.html
+++ b/demos/linear-progress.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/linear-progress.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       fieldset {
         margin: 24px;
@@ -47,8 +47,9 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -56,10 +57,13 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Linear Progress Indicators</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
-    <main class="mdc-toolbar-fixed-adjust">
 
+    <main class="mdc-toolbar-fixed-adjust">
       <section class="hero">
         <div role="progressbar" class="mdc-linear-progress mdc-linear-progress--indeterminate">
           <div class="mdc-linear-progress__buffering-dots"></div>
@@ -180,6 +184,7 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var determinates = document.querySelectorAll('.mdc-linear-progress');

--- a/demos/list.html
+++ b/demos/list.html
@@ -21,13 +21,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/list.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -35,10 +36,15 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">List</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
+
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
         <ul class="mdc-list mdc-list--two-line mdc-list--avatar-list demo-list demo-list--with-avatars">
           <li class="mdc-list-item">
@@ -95,22 +101,6 @@
           take up as much width as possible (since it's a block element).
           </p>
         </aside>
-        <div class="mdc-form-field">
-          <div class="mdc-checkbox">
-            <input type="checkbox"
-                   class="mdc-checkbox__native-control"
-                   id="toggle-rtl"
-                   aria-labelledby="toggle-rtl-label" />
-            <div class="mdc-checkbox__background">
-              <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white"
-                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-              </svg>
-              <div class="mdc-checkbox__mixedmark"></div>
-            </div>
-          </div>
-          <label for="toggle-rtl" id="toggle-rtl-label">Toggle RTL</label>
-        </div>
       </section>
 
       <div id="demo-wrapper">
@@ -1114,23 +1104,9 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
-        var formField = new mdc.formField.MDCFormField(document.querySelector('.mdc-form-field'));
-        var cb = mdc.checkbox.MDCCheckbox.attachTo(document.querySelector('.mdc-checkbox'));
-        formField.input = cb;
-        var demoWrapper = document.getElementById('demo-wrapper');
-        var hero = document.querySelector('.hero');
-        document.getElementById('toggle-rtl').addEventListener('change', function() {
-          if (this.checked) {
-            demoWrapper.setAttribute('dir', 'rtl');
-            hero.setAttribute('dir', 'rtl');
-          } else {
-            demoWrapper.removeAttribute('dir');
-            hero.removeAttribute('dir');
-          }
-        });
-
         var interactiveListItems = document.querySelectorAll(
           '[data-demo-interactive-list] .mdc-list-item, .hero .mdc-list-item'
         );

--- a/demos/select.html
+++ b/demos/select.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/select.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .mdc-theme--dark {
         background-color: #303030;
@@ -51,8 +51,9 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -60,11 +61,15 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Select</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
 
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
         <div id="hero-js-select" class="mdc-select" role="listbox">
           <div class="mdc-select__surface" tabindex="0">
@@ -127,10 +132,6 @@
           <label for="dark-theme">Dark Theme</label>
         </div>
         <div>
-          <input type="checkbox" id="rtl">
-          <label for="rtl">RTL</label>
-        </div>
-        <div>
           <input type="checkbox" id="alternate-colors">
           <label for="alternate-colors">Alternate Colors</label>
         </div>
@@ -158,6 +159,7 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         mdc.select.MDCSelect.attachTo(document.getElementById('hero-js-select'));
@@ -175,19 +177,11 @@
 
         var boxDemoWrapper = document.getElementById('box-demo-wrapper');
         var darkThemeCb = document.getElementById('dark-theme');
-        var rtlCb = document.getElementById('rtl');
         var alternateColorsCb = document.getElementById('alternate-colors');
         var disabledCb = document.getElementById('disabled');
 
         darkThemeCb.addEventListener('change', function() {
           boxDemoWrapper.classList[darkThemeCb.checked ? 'add' : 'remove']('mdc-theme--dark');
-        });
-        rtlCb.addEventListener('change', function() {
-          if (rtlCb.checked) {
-            boxDemoWrapper.setAttribute('dir', 'rtl');
-          } else {
-            boxDemoWrapper.removeAttribute('dir');
-          }
         });
         alternateColorsCb.addEventListener('change', function() {
           root.classList[alternateColorsCb.checked ? 'add' : 'remove']('demo-select-custom-colors');

--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/simple-menu.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       html,
       body,
@@ -48,9 +48,12 @@
       }
 
       .demo-controls {
-        margin-left: auto;
-        margin-right: auto;
-        width: 360px;
+        margin: 0 auto;
+        width: 500px;
+      }
+
+      .demo-menu-config-fieldset {
+        margin-bottom: 32px;
       }
 
       .mdc-menu-anchor {
@@ -64,7 +67,7 @@
       }
 
       .margin-inputs input {
-        width: 2em;
+        width: 3.5em;
       }
 
       .left-column-controls {
@@ -74,7 +77,7 @@
 
       .right-column-controls {
         display: inline-block;
-        margin-left: 2em;
+        margin-left: 4em;
         vertical-align: top;
       }
 
@@ -99,10 +102,21 @@
       .demo-menu--extra-long .demo-menu__extra-long-items {
         display: inline;
       }
+
+      .demo-numeric-config-label {
+        display: block;
+        margin: 5px 0;
+      }
+
+      .demo-numeric-config-label__text {
+        display: inline-block;
+        min-width: 4em;
+      }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
+    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -110,11 +124,15 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Simple Menu</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
 
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
         <div class="mdc-simple-menu mdc-simple-menu--open">
           <ul class="mdc-simple-menu__items mdc-list">
@@ -127,6 +145,7 @@
           </ul>
         </div>
       </section>
+
       <div class="demo-content">
         <div id="demo-wrapper">
           <div class="mdc-menu-anchor">
@@ -166,87 +185,100 @@
 
         <div class="demo-controls-container">
           <div class="demo-controls">
-            <div class="left-column-controls">
-              Button Position:
-              <div>
-                <label><input type="radio" name="position" value="top left" checked> Top left</label>
-              </div>
-              <div>
-                <label><input type="radio" name="position" value="top right"> Top right</label>
-              </div>
-              <div>
-                <label><input type="radio" name="position" value="middle left"> Middle left</label>
-              </div>
-              <div>
-                <label><input type="radio" name="position" value="middle right"> Middle right</label>
-              </div>
-              <div>
-                <label><input type="radio" name="position" value="bottom left"> Bottom left</label>
-              </div>
-              <div>
-                <label><input type="radio" name="position" value="bottom right"> Bottom right</label>
-              </div>
+            <div>
+              <fieldset class="demo-menu-config-fieldset left-column-controls">
+                <legend class="mdc-typography--subheading2">Button Position:</legend>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="position" value="top left" checked> Top left</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="position" value="top right"> Top right</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="position" value="middle left"> Middle left</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="position" value="middle right"> Middle right</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="position" value="bottom left"> Bottom left</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="position" value="bottom right"> Bottom right</label>
+                </div>
+              </fieldset>
+              <fieldset class="demo-menu-config-fieldset right-column-controls">
+                <legend class="mdc-typography--subheading2">Default Menu Position:</legend>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="menu-position" value="top start" checked> Top start</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="menu-position" value="top end"> Top end</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="menu-position" value="bottom start"> Bottom start</label>
+                </div>
+                <div class="mdc-form-field">
+                  <label><input type="radio" name="menu-position" value="bottom end"> Bottom end</label>
+                </div>
+              </fieldset>
             </div>
-            <div class="right-column-controls">
-              Default Menu Position:
-              <div>
-                <label><input type="radio" name="menu-position" value="top start" checked> Top start</label>
-              </div>
 
-              <div>
-                <label><input type="radio" name="menu-position" value="top end"> Top end</label>
-              </div>
-
-              <div>
-                <label><input type="radio" name="menu-position" value="bottom start"> Bottom start</label>
-              </div>
-
-              <div>
-                <label><input type="radio" name="menu-position" value="bottom end"> Bottom end</label>
-              </div>
-            </div>
-            <p>
-              Anchor Margins:
+            <fieldset class="demo-menu-config-fieldset">
+              <legend class="mdc-typography--subheading2">Anchor Margins:</legend>
               <div id="margin-inputs" class="margin-inputs">
-                <label>T: <input type="text" id="top-margin" value="0" size="3" max-length="3"></label>
-                <label>B: <input type="text" id="bottom-margin" value="0" size="3"></label>
-                <label>L: <input type="text" id="left-margin" value="0" size="3"></label>
-                <label>R: <input type="text" id="right-margin" value="0" size="3"></label>
+                <label class="demo-numeric-config-label">
+                  <span class="demo-numeric-config-label__text">Top:</span>
+                  <input type="number" id="top-margin" value="0" maxlength="3">px
+                </label>
+                <label class="demo-numeric-config-label">
+                  <span class="demo-numeric-config-label__text">Right:</span>
+                  <input type="number" id="right-margin" value="0" maxlength="3">px
+                </label>
+                <label class="demo-numeric-config-label">
+                  <span class="demo-numeric-config-label__text">Bottom:</span>
+                  <input type="number" id="bottom-margin" value="0" maxlength="3">px
+                </label>
+                <label class="demo-numeric-config-label">
+                  <span class="demo-numeric-config-label__text">Left:</span>
+                  <input type="number" id="left-margin" value="0" maxlength="3">px
+                </label>
               </div>
-            </p>
-            <div class="left-column-controls">
-              <label><input type="checkbox" name="is-rtl"> RTL</label>
-            </div>
-            <div class="right-column-controls">
-              <label><input type="checkbox" name="dark"> Dark mode</label>
-            </div>
-            <p>
-              <div class="left-column-controls">
-                Menu Sizes:
-                <div>
+            </fieldset>
+
+            <div>
+              <fieldset class="demo-menu-config-fieldset left-column-controls">
+                <legend class="mdc-typography--subheading2">Menu Sizes:</legend>
+                <div class="mdc-form-field">
                   <label><input type="radio" name="menu-length" value="small" checked> Regular menu</label>
                 </div>
-                <div>
+                <div class="mdc-form-field">
                   <label><input type="radio" name="menu-length" value="large"> Large menu</label>
                 </div>
-                <div>
+                <div class="mdc-form-field">
                   <label><input type="radio" name="menu-length" value="tall"> Extra tall menu</label>
                 </div>
-              </div>
-              <div class="right-column-controls">
-                Anchor Widths
-                <div>
+              </fieldset>
+              <fieldset class="demo-menu-config-fieldset right-column-controls">
+                <legend class="mdc-typography--subheading2">Anchor Widths</legend>
+                <div class="mdc-form-field">
                   <label><input type="radio" name="anchor-width" value="tiny"> Small button</label>
                 </div>
-                <div>
+                <div class="mdc-form-field">
                   <label><input type="radio" name="anchor-width" value="regular" checked> Comparable to menu</label>
                 </div>
-                <div>
+                <div class="mdc-form-field">
                   <label><input type="radio" name="anchor-width" value="wide"> Wider than menu</label>
                 </div>
-              </div>
-            </p>
+              </fieldset>
+            </div>
+
+            <div>
+              <label><input type="checkbox" name="dark"> Dark mode</label>
+            </div>
+
             <hr>
+
             <div>
               <span>Last Selected item: <em id="last-selected">&lt;none selected&gt;</em></span>
             </div>
@@ -256,6 +288,7 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var menuEl = document.querySelector('#demo-menu');
@@ -276,6 +309,23 @@
             menuEl.classList.remove('mdc-simple-menu--theme-dark');
           }
         });
+
+        function scrollIntoView(el) {
+          var docEl = document.documentElement;
+          var elRecto = el.getBoundingClientRect();
+          var viewportRect = {
+            left: 0,
+            right: docEl.clientWidth,
+            top: document.querySelector('.mdc-toolbar').offsetHeight + 24,
+            bottom: docEl.clientHeight,
+          };
+
+          if (elRecto.top < viewportRect.top) {
+            docEl.scrollBy(0, elRecto.top - viewportRect.top);
+          } else if (elRecto.bottom > viewportRect.bottom) {
+            docEl.scrollBy(0, elRecto.bottom - viewportRect.bottom);
+          }
+        }
 
         var radios = document.querySelectorAll('input[name="position"]');
         var anchor = document.querySelector('.mdc-menu-anchor');
@@ -301,6 +351,8 @@
                 anchor.style.setProperty(horizontal, '0');
               }
             }
+
+            scrollIntoView(anchor);
           });
         }
 
@@ -327,9 +379,9 @@
         }
 
         const marginInputsEl = document.querySelector('#margin-inputs');
-        var inputs = marginInputsEl.querySelectorAll('input[type="text"]');
+        var inputs = marginInputsEl.querySelectorAll('input');
         for (var i = 0; i < inputs.length; i++) {
-          inputs[i].addEventListener('change', function(evt) {
+          inputs[i].addEventListener('change', function() {
             const topMarginInput = document.getElementById('top-margin');
             const bottomMarginInput = document.getElementById('bottom-margin');
             const rightMarginInput = document.getElementById('right-margin');
@@ -341,16 +393,6 @@
             menu.setAnchorMargin(margin);
           });
         }
-
-        const rtl = document.querySelector('input[name="is-rtl"]');
-        rtl.addEventListener('change', function() {
-          const demoWrapper = document.getElementById('demo-wrapper');
-          if (rtl.checked) {
-            demoWrapper.setAttribute('dir', 'rtl');
-          } else {
-            demoWrapper.removeAttribute('dir');
-          }
-        });
 
         radios = document.querySelectorAll('input[name="menu-length"]');
         for (var i = 0; i < radios.length; i++) {

--- a/demos/slider.html
+++ b/demos/slider.html
@@ -340,8 +340,8 @@
         });
 
         darkTheme.addEventListener('change', function() {
-          [].slice.call(demoRoot.querySelectorAll('.example-slider-wrapper')).forEach(function(example) {
-            example.classList[ darkTheme.checked ? 'add' : 'remove']('mdc-theme--dark');
+          [].forEach.call(demoRoot.querySelectorAll('.example-slider-wrapper'), function(example) {
+            example.classList[darkTheme.checked ? 'add' : 'remove']('mdc-theme--dark');
           });
         });
 
@@ -353,7 +353,7 @@
         });
 
         useCustomColor.addEventListener('change', function() {
-          [].slice.call(demoRoot.querySelectorAll('.example-slider-wrapper')).forEach(function(example) {
+          [].forEach.call(demoRoot.querySelectorAll('.example-slider-wrapper'), function(example) {
             example.classList[ useCustomColor.checked ? 'add' : 'remove' ]('custom-bg');
           });
         });

--- a/demos/slider.html
+++ b/demos/slider.html
@@ -264,7 +264,7 @@
     <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
-        mdc.slider.MDCSlider.attachTo(document.getElementById('hero-slider'));
+        var heroSlider = mdc.slider.MDCSlider.attachTo(document.getElementById('hero-slider'));
 
         var demoRoot = document.getElementById('slider-example')
         var min = demoRoot.querySelector('[name="min"]');
@@ -360,6 +360,7 @@
 
         document.querySelector('#rtl-toggle').addEventListener('click', function() {
           setTimeout(function() {
+            heroSlider.layout();
             continuousSlider.layout();
             discreteSlider.layout();
             discreteWMarkerSlider.layout();

--- a/demos/slider.html
+++ b/demos/slider.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/slider.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       #hero-slider-wrapper {
         margin: 0 auto;
@@ -70,8 +70,9 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -79,10 +80,22 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Slider</span>
         </section>
+        <div class="mdc-toolbar__row">
+          <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+          <span class="catalog-back">
+            <a href="/" class="mdc-toolbar__menu-icon"><i class="material-icons">&#xE5C4;</i></a>
+          </span>
+            <span class="mdc-toolbar__title catalog-title">Checkbox</span>
+          </section>
+          <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+            <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+          </section>
       </div>
     </header>
+
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
         <div id="hero-slider-wrapper">
           <div id="hero-slider" class="mdc-slider" tabindex="0"
@@ -126,7 +139,6 @@
             Value from <code>MDCSlider:change</code> event: <span id="continuous-slider-committed-value"></span>
           </p>
         </div>
-
 
         <h2>Discrete Slider</h2>
         <div class="slider-example">
@@ -243,15 +255,12 @@
             <input type="checkbox" name="use-custom-color">
             Use Custom BG Color
           </label>
-          <label class="demo-param-field">
-            <input type="checkbox" name="rtl">
-            RTL
-          </label>
         </div>
       </section>
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         mdc.slider.MDCSlider.attachTo(document.getElementById('hero-slider'));
@@ -263,7 +272,6 @@
         var darkTheme = demoRoot.querySelector('[name="dark-theme"]');
         var disabled = demoRoot.querySelector('[name="disabled"]');
         var useCustomColor = demoRoot.querySelector('[name="use-custom-color"]');
-        var rtl = demoRoot.querySelector('[name="rtl"]');
 
         var continuousValue = demoRoot.querySelector('#continuous-slider-value');
         var continuousCommittedValue = demoRoot.querySelector('#continuous-slider-committed-value');
@@ -349,18 +357,13 @@
           });
         });
 
-        rtl.addEventListener('change', function() {
-          [].slice.call(demoRoot.querySelectorAll('.example-slider-wrapper')).forEach(function(example) {
-            if (rtl.checked) {
-              example.setAttribute('dir', 'rtl');
-            } else {
-              example.removeAttribute('dir');
-            }
-          });
-          continuousSlider.layout();
-          discreteSlider.layout();
-          discreteWMarkerSlider.layout();
-          customDiscreteWMarkerSlider.layout();
+        document.querySelector('#rtl-toggle').addEventListener('click', function() {
+          setTimeout(function() {
+            continuousSlider.layout();
+            discreteSlider.layout();
+            discreteWMarkerSlider.layout();
+            customDiscreteWMarkerSlider.layout();
+          }, 10);
         });
       });
     </script>

--- a/demos/slider.html
+++ b/demos/slider.html
@@ -90,6 +90,7 @@
           <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
             <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
           </section>
+        </div>
       </div>
     </header>
 

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/snackbar.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       /* initialize it off screen. */
       .loading .example .mdc-snackbar { transform: translateY(200%); }
@@ -55,10 +55,22 @@
         margin-top: 14px;
       }
 
+      .demo-text-field--message {
+        width: 300px;
+      }
+
+      .demo-text-field--action {
+        width: 150px;
+      }
+
+      .demo-form-field--indented {
+        margin-left: 32px;
+      }
     </style>
   </head>
+
   <body class="mdc-typography loading">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -66,11 +78,15 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Snackbar</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
 
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
         <div class="mdc-snackbar mdc-snackbar--active"
              aria-live="assertive"
@@ -86,6 +102,37 @@
       <section class="example">
         <h2 class="mdc-typography--title">Basic Example</h2>
 
+        <div class="demo-text-fields">
+          <div class="mdc-text-field demo-text-field demo-text-field--message">
+            <input type="text" id="message" class="mdc-text-field__input" value="Message deleted">
+            <label class="mdc-text-field__label" for="message">Message Text</label>
+            <div class="mdc-text-field__bottom-line"></div>
+          </div>
+          <br>
+
+          <div class="mdc-text-field demo-text-field demo-text-field--action">
+            <input type="text" id="action" class="mdc-text-field__input" value="Undo">
+            <label class="mdc-text-field__label" for="action">Action Text</label>
+            <div class="mdc-text-field__bottom-line"></div>
+          </div>
+        </div>
+        <br/>
+
+        <div class="mdc-form-field">
+          <div class="mdc-checkbox">
+            <input type="checkbox" checked class="mdc-checkbox__native-control" id="dismiss-on-action" aria-labelledby="dismiss-on-action-label" />
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+          <label for="dismiss-on-action" id="dismiss-on-action-label">Dismiss On Action</label>
+        </div>
+        <br/>
+
         <div class="mdc-form-field">
           <div class="mdc-checkbox">
             <input type="checkbox" class="mdc-checkbox__native-control" id="multiline" aria-labelledby="multiline-label" />
@@ -100,7 +147,7 @@
         </div>
         <br/>
 
-        <div class="mdc-form-field">
+        <div class="mdc-form-field demo-form-field--indented">
           <div class="mdc-checkbox" id="action-on-bottom-checkbox">
             <input type="checkbox" class="mdc-checkbox__native-control" id="action-on-bottom" aria-labelledby="action-on-bottom-label" />
             <div class="mdc-checkbox__background">
@@ -117,7 +164,7 @@
 
         <div class="mdc-form-field">
             <div class="mdc-checkbox">
-              <input type="checkbox" checked class="mdc-checkbox__native-control" id="dismiss-on-action" aria-labelledby="dismiss-on-action-label" />
+              <input type="checkbox" class="mdc-checkbox__native-control" id="dark-theme" aria-labelledby="dark-theme-label" />
               <div class="mdc-checkbox__background">
                 <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark__path" fill="none" stroke="white"
@@ -126,31 +173,12 @@
               <div class="mdc-checkbox__mixedmark"></div>
             </div>
           </div>
-          <label for="dismiss-on-action" id="dismiss-on-action-label">Dismiss On Action</label>
+          <label for="dark-theme" id="dark-theme-label">Dark Theme</label>
         </div>
         <br/>
 
-        <button type="button" class="mdc-button mdc-button--raised" id="toggle-dark-theme">Toggle Dark Theme</button>
-        <br/>
-
-        <div class="mdc-text-field">
-          <input type="text" id="message" class="mdc-text-field__input" value="Message deleted">
-          <label class="mdc-text-field__label" for="message">Message Text</label>
-          <div class="mdc-text-field__bottom-line"></div>
-        </div>
-        <br/>
-
-        <div class="mdc-text-field">
-          <input type="text" id="action" class="mdc-text-field__input" value="Undo">
-          <label class="mdc-text-field__label" for="action">Action Text</label>
-          <div class="mdc-text-field__bottom-line"></div>
-        </div>
-        <br/>
-
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised" id="show-snackbar">Show</button>
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised" id="show-rtl-snackbar">Show RTL</button>
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised" id="show-start-aligned-snackbar">Show Start Aligned</button>
-        <button type="button" class="demo-activate-button mdc-button mdc-button--raised" id="show-start-aligned-rtl-snackbar">Show Start Aligned (RTL)</button>
+        <button type="button" class="demo-activate-button mdc-button mdc-button--stroked" id="show-snackbar">Show</button>
+        <button type="button" class="demo-activate-button mdc-button mdc-button--stroked" id="show-start-aligned-snackbar">Show Start Aligned</button>
 
         <div id="mdc-js-snackbar"
              class="mdc-snackbar demo-hidden"
@@ -160,18 +188,6 @@
           <div class="mdc-snackbar__text"></div>
           <div class="mdc-snackbar__action-wrapper">
             <button type="button" class="mdc-snackbar__action-button"></button>
-          </div>
-        </div>
-        <div dir="rtl">
-          <div id="mdc-rtl-js-snackbar"
-               class="mdc-snackbar demo-hidden"
-               aria-live="assertive"
-               aria-atomic="true"
-               aria-hidden="true">
-            <div class="mdc-snackbar__text"></div>
-            <div class="mdc-snackbar__action-wrapper">
-              <button type="button" class="mdc-snackbar__action-button"></button>
-            </div>
           </div>
         </div>
         <div id="mdc-align-start-js-snackbar"
@@ -184,31 +200,18 @@
             <button type="button" class="mdc-snackbar__action-button"></button>
           </div>
         </div>
-        <div dir="rtl">
-          <div id="mdc-align-start-rtl-js-snackbar"
-               class="mdc-snackbar mdc-snackbar--align-start demo-hidden"
-               aria-live="assertive"
-               aria-atomic="true"
-               aria-hidden="true">
-            <div class="mdc-snackbar__text"></div>
-            <div class="mdc-snackbar__action-wrapper">
-              <button type="button" class="mdc-snackbar__action-button"></button>
-            </div>
-          </div>
-        </div>
       </section>
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var MDCSnackbar = mdc.snackbar.MDCSnackbar;
         var MDCTextField = mdc.textField.MDCTextField;
 
         var snackbar = new MDCSnackbar(document.getElementById('mdc-js-snackbar'));
-        var rtlSnackbar = new MDCSnackbar(document.getElementById('mdc-rtl-js-snackbar'));
         var alignStartSnackbar = new MDCSnackbar(document.getElementById('mdc-align-start-js-snackbar'));
-        var alignStartRTLSnackbar = new MDCSnackbar(document.getElementById('mdc-align-start-rtl-js-snackbar'));
 
         var messageInput = document.getElementById('message');
         var actionInput = document.getElementById('action');
@@ -266,24 +269,20 @@
           show(snackbar);
         });
 
-        document.getElementById('show-rtl-snackbar').addEventListener('click', function() {
-          show(rtlSnackbar);
-        });
-
         document.getElementById('show-start-aligned-snackbar').addEventListener('click', function() {
           show(alignStartSnackbar);
         });
 
-        document.getElementById('show-start-aligned-rtl-snackbar').addEventListener('click', function() {
-          show(alignStartRTLSnackbar);
+        document.getElementById('dark-theme').addEventListener('change', function(evt) {
+          evt.target.checked ? document.body.classList.add('mdc-theme--dark') : document.body.classList.remove('mdc-theme--dark');
         });
 
-        document.getElementById('toggle-dark-theme').addEventListener('click', function() {
-          document.body.classList.contains('mdc-theme--dark') ? document.body.classList.remove('mdc-theme--dark') : document.body.classList.add('mdc-theme--dark');
-        });
-
-        [].slice.call(document.querySelectorAll('.mdc-text-field')).forEach(function(tf) {
+        [].forEach.call(document.querySelectorAll('.mdc-text-field'), function(tf) {
           MDCTextField.attachTo(tf);
+        });
+
+        [].forEach.call(document.querySelectorAll('.mdc-button'), function(button) {
+          mdc.ripple.MDCRipple.attachTo(button);
         });
 
         document.body.classList.remove('loading');

--- a/demos/tabs.html
+++ b/demos/tabs.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/tabs.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       fieldset {
         padding: 24px;
@@ -36,19 +36,8 @@
         margin: 16px;
       }
 
-      .mdc-theme--dark fieldset {
+      .mdc-theme--dark {
         background-color: #333;
-      }
-
-      .mdc-theme--dark fieldset legend {
-        color: #f0f0f0;
-      }
-
-      .mdc-theme--dark .demo-tabs__scroller {
-        background-color: #333;
-      }
-
-      .mdc-theme--dark .demo-tabs__scroller .demo-title {
         color: #f0f0f0;
       }
 
@@ -89,6 +78,10 @@
         padding: 20px;
         margin: 20px 0;
         background-color: #f2f2f2;
+      }
+
+      .mdc-theme--dark .demo-note {
+        background-color: #444;
       }
 
       #dynamic-demo-toolbar h1 {
@@ -144,17 +137,20 @@
         right: auto;
         left: 0;
       }
-
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
+    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
             <a href="/" class="mdc-toolbar__menu-icon"><i class="material-icons">&#xE5C4;</i></a>
           </span>
           <span class="mdc-toolbar__title catalog-title">Tabs</span>
+        </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
         </section>
       </div>
     </header>
@@ -170,8 +166,7 @@
       </section>
 
       <section class="demo-buttons">
-        <button type="button" class="mdc-button mdc-button--raised" id="toggle-rtl">Toggle RTL</button>
-        <button type="button" class="mdc-button mdc-button--raised" id="toggle-dark-theme">Toggle Dark Theme</button>
+        <button type="button" class="mdc-button mdc-button--stroked" id="toggle-dark-theme">Toggle Dark Theme</button>
       </section>
 
       <section>
@@ -739,6 +734,7 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         window.demoTabBar = new mdc.tabs.MDCTabBar(document.querySelector('#demo-tab-bar'));
@@ -809,29 +805,29 @@
           updateDot(dotIndex);
         });
 
-        document.getElementById('toggle-rtl').addEventListener('click', function(evt) {
-          var mainElement = document.querySelector('#tabs-demo-main-section');
-          mainElement.hasAttribute('dir') ? mainElement.removeAttribute('dir') : mainElement.setAttribute('dir', 'rtl');
-
-          window.demoTabBar.layout();
-          window.basicTabBar.layout();
-          window.basicTabBarCustomLabel.layout();
-          window.tabBarScroller.layout();
-          window.tabBarScroller.tabBar.layout();
-          window.iconTabBarCustomIcon.layout();
-          window.iconTabBar.layout();
-          window.iconTextTabBar.layout();
-          window.iconTextTabBarLabel.layout();
-          window.toolbarTabBar.layout();
-          window.primaryIndicatorTabBar.layout();
-          window.secondaryIndicatorTabBar.layout();
-          window.primaryIndicatorToolbarTabBar.layout();
-          window.secondaryIndicatorToolbarTabBar.layout();
-          window.dynamicTabBar.layout();
-          toolbarTabBarModified.layout();
+        document.querySelector('#rtl-toggle').addEventListener('click', function() {
+          setTimeout(function() {
+            window.demoTabBar.layout();
+            window.basicTabBar.layout();
+            window.basicTabBarCustomLabel.layout();
+            window.tabBarScroller.layout();
+            window.tabBarScroller.tabBar.layout();
+            window.iconTabBarCustomIcon.layout();
+            window.iconTabBar.layout();
+            window.iconTextTabBar.layout();
+            window.iconTextTabBarLabel.layout();
+            window.toolbarTabBar.layout();
+            window.primaryIndicatorTabBar.layout();
+            window.secondaryIndicatorTabBar.layout();
+            window.primaryIndicatorToolbarTabBar.layout();
+            window.secondaryIndicatorToolbarTabBar.layout();
+            window.dynamicTabBar.layout();
+            toolbarTabBarModified.layout();
+          }, 10);
         });
+
         document.getElementById('toggle-dark-theme').addEventListener('click', function(evt) {
-          document.body.classList.contains('mdc-theme--dark') ? document.body.classList.remove('mdc-theme--dark') : document.body.classList.add('mdc-theme--dark');
+          document.body.classList.toggle('mdc-theme--dark');
         });
       });
     </script>

--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -21,10 +21,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
     <link rel="stylesheet" href="/assets/text-field.css">
-    <script src="/ready.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .mdc-theme--dark {
         --mdc-theme-primary: var(--mdc-theme-secondary, #64dd17);
@@ -54,9 +54,13 @@
         margin-top: 16px;
       }
     </style>
+    <script>
+      window.allTextFields = [];
+    </script>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
+    <header class="mdc-toolbar mdc-toolbar--fixed" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -64,10 +68,15 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Text Field</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
+
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
+
       <section class="hero">
         <div class="mdc-text-field">
           <input type="text" class="mdc-text-field__input" id="my-text-field" aria-controls="my-text-field-helper-text">
@@ -98,10 +107,6 @@
         <div>
           <input id="disable" type="checkbox">
           <label for="disable">Disabled</label>
-        </div>
-        <div>
-          <input id="rtl" type="checkbox">
-          <label for="rtl">RTL</label>
         </div>
         <div>
           <input id="dark-theme" type="checkbox">
@@ -168,18 +173,13 @@
             </div>
             <div class="mdc-text-field__idle-outline"></div>
           </div>
-          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg"
-            id="name-validation-msg">
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg">
             Must be at least 8 characters
           </p>
         </div>
         <div>
           <input id="outlined-disable" type="checkbox">
           <label for="outlined-disable">Disabled</label>
-        </div>
-        <div>
-          <input id="outlined-rtl" type="checkbox">
-          <label for="outlined-rtl">RTL</label>
         </div>
         <div>
           <input id="outlined-custom-colors" type="checkbox">
@@ -193,17 +193,11 @@
           demoReady(function() {
             var tfEl = document.getElementById('tf-outlined-example');
             var tf = new mdc.textField.MDCTextField(tfEl);
-            var wrapper = document.getElementById('demo-tf-outlined-wrapper');
+
+            allTextFields.push(tf);
+
             document.getElementById('outlined-disable').addEventListener('change', function(evt) {
               tf.disabled = evt.target.checked;
-            });
-            document.getElementById('outlined-rtl').addEventListener('change', function(evt) {
-              if (evt.target.checked) {
-                wrapper.setAttribute('dir', 'rtl');
-              } else {
-                wrapper.removeAttribute('dir');
-              }
-              tf.layout();
             });
             document.getElementById('outlined-custom-colors').addEventListener('change', function(evt) {
               tfEl.classList[evt.target.checked ? 'add' : 'remove']('demo-text-field-custom-colors');
@@ -226,18 +220,13 @@
             <label for="tf-box" class="mdc-text-field__label">Your Name</label>
             <div class="mdc-text-field__bottom-line"></div>
           </div>
-          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg"
-             id="name-validation-msg">
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg">
             Must be at least 8 characters
           </p>
         </div>
         <div>
           <input id="box-disable" type="checkbox">
           <label for="box-disable">Disabled</label>
-        </div>
-        <div>
-          <input id="box-rtl" type="checkbox">
-          <label for="box-rtl">RTL</label>
         </div>
         <div>
           <input id="box-dark-theme" type="checkbox">
@@ -253,17 +242,10 @@
             var tf = new mdc.textField.MDCTextField(tfEl);
             var wrapper = document.getElementById('demo-tf-box-wrapper');
 
+            allTextFields.push(tf);
+
             document.getElementById('box-disable').addEventListener('change', function(evt) {
               tf.disabled = evt.target.checked;
-            });
-
-            document.getElementById('box-rtl').addEventListener('change', function(evt) {
-              if (evt.target.checked) {
-                wrapper.setAttribute('dir', 'rtl');
-              } else {
-                wrapper.removeAttribute('dir');
-              }
-              tf.layout();
             });
 
             document.getElementById('box-dark-theme').addEventListener('change', function(evt) {
@@ -329,10 +311,6 @@
         <div>
           <input id="disable-leading-trailing" type="checkbox">
           <label for="disable-leading-trailing">Disabled</label>
-        </div>
-        <div>
-          <input id="rtl-leading-trailing" type="checkbox">
-          <label for="rtl-leading-trailing">RTL</label>
         </div>
         <div>
           <input id="dark-theme-leading-trailing" type="checkbox">
@@ -419,10 +397,6 @@
           <label for="textarea-disable">Disabled</label>
         </div>
         <div>
-          <input id="textarea-rtl" type="checkbox">
-          <label for="textarea-rtl">RTL</label>
-        </div>
-        <div>
           <input id="textarea-dark-theme" type="checkbox">
           <label for="textarea-dark-theme">Dark Theme</label>
         </div>
@@ -469,14 +443,20 @@
     </main>
 
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
-        var tfs = document.querySelectorAll(
-          '.mdc-text-field:not([data-demo-no-auto-js])'
-        );
-        for (var i = 0, tf; tf = tfs[i]; i++) {
-          mdc.textField.MDCTextField.attachTo(tf);
-        }
+        [].forEach.call(document.querySelectorAll('.mdc-text-field:not([data-demo-no-auto-js])'), function(tf) {
+          allTextFields.push(mdc.textField.MDCTextField.attachTo(tf));
+        });
+
+        document.querySelector('#rtl-toggle').addEventListener('click', function() {
+          setTimeout(function() {
+            allTextFields.forEach(function(tf) {
+              tf.layout();
+            });
+          }, 10);
+        });
       });
 
       demoReady(function() {
@@ -498,31 +478,13 @@
         var tfOutlinedTrailing = new mdc.textField.MDCTextField(tfOutlinedTrailingEl);
         var wrapperOutlinedTrailing = document.getElementById('demo-tf-outlined-trailing-wrapper');
 
-        var tfIcons = document.querySelectorAll('.mdc-text-field__icon');
+        allTextFields.push(tfBoxLeading, tfBoxTrailing, tfOutlinedLeading, tfOutlinedTrailing);
 
         document.getElementById('disable-leading-trailing').addEventListener('change', function(evt) {
           tfBoxLeading.disabled = evt.target.checked;
           tfBoxTrailing.disabled = evt.target.checked;
           tfOutlinedLeading.disabled = evt.target.checked;
           tfOutlinedTrailing.disabled = evt.target.checked;
-        });
-
-        document.getElementById('rtl-leading-trailing').addEventListener('change', function(evt) {
-          if (evt.target.checked) {
-            wrapperBoxLeading.setAttribute('dir', 'rtl');
-            wrapperBoxTrailing.setAttribute('dir', 'rtl');
-            wrapperOutlinedLeading.setAttribute('dir', 'rtl');
-            wrapperOutlinedTrailing.setAttribute('dir', 'rtl');
-          } else {
-            wrapperBoxLeading.removeAttribute('dir');
-            wrapperBoxTrailing.removeAttribute('dir');
-            wrapperOutlinedLeading.removeAttribute('dir');
-            wrapperOutlinedTrailing.removeAttribute('dir');
-          }
-          tfBoxLeading.layout();
-          tfBoxTrailing.layout();
-          tfOutlinedLeading.layout();
-          tfOutlinedTrailing.layout();
         });
 
         document.getElementById('dark-theme-leading-trailing').addEventListener('change', function(evt) {
@@ -544,16 +506,15 @@
         });
 
         document.getElementById('unclickable-leading-trailing').addEventListener('change', function(evt) {
-          [].slice.call(tfIcons).forEach(function (icon) {
+          [].forEach.call(document.querySelectorAll('.mdc-text-field__icon'), function (icon) {
             icon.setAttribute('tabindex', evt.target.checked ? '-1' : '0');
           });
         });
 
         document.getElementById('required-leading-trailing').addEventListener('change', function(evt) {
-          tfIconContainer.querySelectorAll('.mdc-text-field__input')
-              .forEach(function(input) {
-                input.required = evt.target.checked;
-              });
+          [].forEach.call(tfIconContainer.querySelectorAll('.mdc-text-field__input'), function(input) {
+            input.required = evt.target.checked;
+          });
         });
       });
 
@@ -575,17 +536,11 @@
         var helperText = section.querySelector('.mdc-text-field-helper-text');
         var tf = new mdc.textField.MDCTextField(tfRoot);
 
+        allTextFields.push(tf);
+
         document.getElementById('disable').addEventListener('change', function(evt) {
           var target = evt.target;
           tf.disabled = target.checked;
-        });
-        document.getElementById('rtl').addEventListener('change', function(evt) {
-          var target = evt.target;
-          if (target.checked) {
-            section.setAttribute('dir', 'rtl');
-          } else {
-            section.removeAttribute('dir');
-          }
         });
         document.getElementById('dark-theme').addEventListener('change', function(evt) {
           var target = evt.target;
@@ -631,17 +586,12 @@
         var section = document.getElementById('demo-text-field-textarea-wrapper');
         var tfRoot = section.querySelector('.mdc-text-field');
         var tf = new mdc.textField.MDCTextField(tfRoot);
+
+        allTextFields.push(tf);
+
         document.getElementById('textarea-disable').addEventListener('change', function(evt) {
           var target = evt.target;
           tf.disabled = target.checked;
-        });
-        document.getElementById('textarea-rtl').addEventListener('change', function(evt) {
-          var target = evt.target;
-          if (target.checked) {
-            section.setAttribute('dir', 'rtl');
-          } else {
-            section.removeAttribute('dir');
-          }
         });
         document.getElementById('textarea-dark-theme').addEventListener('change', function(evt) {
           var target = evt.target;
@@ -659,6 +609,8 @@
         var tfMultiRoot = section.querySelector('.mdc-text-field--textarea');
         var tf = new mdc.textField.MDCTextField(tfRoot);
         var tfMulti = new mdc.textField.MDCTextField(tfMultiRoot);
+
+        allTextFields.push(tf, tfMulti);
 
         document.getElementById('fullwidth-disable').addEventListener('change', function(evt) {
           var target = evt.target;

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -485,11 +485,11 @@
         <aside class="mdc-dialog mdc-dialog--open demo-dialog">
           <div class="mdc-dialog__surface">
             <header class="mdc-dialog__header">
-              <h3 id="mdc-dialog-default-label" class="mdc-dialog__header__title">
+              <h3 class="mdc-dialog__header__title">
                 Fire photon torpedoes?
               </h3>
             </header>
-            <section id="mdc-dialog-default-description" class="mdc-dialog__body">
+            <section class="mdc-dialog__body">
               Shields at 60% and falling, captain.
             </section>
             <footer class="mdc-dialog__footer">

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .demo-container {
         height: 500px;
@@ -73,8 +74,9 @@
       }
     </style>
   </head>
+
   <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
+    <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar" dir="auto">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
           <span class="catalog-back">
@@ -82,8 +84,12 @@
           </span>
           <span class="mdc-toolbar__title catalog-title">Toolbar</span>
         </section>
+        <section class="mdc-toolbar__section mdc-toolbar__section--align-end mdc-toolbar__section--shrink-to-fit" role="toolbar">
+          <button id="rtl-toggle" class="mdc-toolbar__icon material-icons demo-toolbar-icon" title="Toggle RTL">format_align_left</button>
+        </section>
       </div>
     </header>
+
     <main class="mdc-toolbar-fixed-adjust">
       <div class="hero">
         <div class="catalog-toolbar-container">
@@ -119,7 +125,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Normal Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./default-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./default-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -127,7 +133,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Fixed Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./fixed-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./fixed-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -135,7 +141,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Fixed Toolbar with Menu</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./menu-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./menu-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -143,7 +149,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./waterfall-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -151,7 +157,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Default Flexible Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./default-flexible-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./default-flexible-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -159,7 +165,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Flexible Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./waterfall-flexible-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-flexible-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -167,7 +173,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Toolbar Fix Last Row</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./waterfall-toolbar-fix-last-row.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-toolbar-fix-last-row.html" width="320" height="600"></iframe>
         </div>
@@ -175,7 +181,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Flexible Toolbar with Custom Style</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./waterfall-flexible-toolbar-custom-style.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-flexible-toolbar-custom-style.html" width="320" height="600"></iframe>
         </div>
@@ -183,17 +189,24 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Custom Colored Toolbar and Icons</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+          </h2>
           <p><a href="./custom-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./custom-toolbar.html" width="320" height="600"></iframe>
         </div>
       </section>
     </main>
+
+    <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
-      [].slice.call(document.querySelectorAll('.examples button')).forEach(function(button) {
-        button.addEventListener('click', function(event) {
-          var iframeMainEl = event.target.parentNode.parentNode.querySelector('iframe').contentWindow.document.querySelector('body');
-          iframeMainEl.setAttribute('dir', iframeMainEl.getAttribute('dir') === 'rtl' ? 'ltr' : 'rtl');
+      demoReady(function() {
+        document.querySelector('#rtl-toggle').addEventListener('click', function() {
+          setTimeout(function() {
+            [].forEach.call(document.querySelectorAll('iframe'), function(iframeEl) {
+              var iframeDocEl = iframeEl.contentWindow.document.documentElement;
+              iframeDocEl.setAttribute('dir', document.documentElement.getAttribute('dir'));
+            });
+          }, 10);
         });
       });
     </script>

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -204,7 +204,7 @@ dialog.listen('MDCDialog:cancel', function() {
   console.log('canceled');
 })
 
-document.querySelector('#default-dialog-activation').addEventListener('click', function (evt) {
+document.querySelector('#show-dialog-button').addEventListener('click', function (evt) {
   dialog.lastFocusedTarget = evt.target;
   dialog.show();
 })


### PR DESCRIPTION
Every component that supports RTL now has an RTL toggle button in the top-right corner of their demo page toolbar. Any existing RTL toggle buttons/checkboxes that were scattered around the page have been removed, as they are no longer needed.

On all pages except the drawer demos, the top toolbar is the only element on the page that is _not_ affected by toggling RTL. This ensures that you can flip back and forth quickly without having to move the mouse.

The specific demo pages now have an RTL toggle:

- Card
- Checkbox
- Dialog
- Drawer
- Grid List
- Layout Grid
- Linear Progress
- List
- Select
- Simple Menu
- Slider
- Snackbar
- Tabs
- Text Field
- Toolbar

Pages not specifically listed above do not require an RTL toggle because there's nothing to demonstrate.