### PR TITLE
feat(elevation): Automatically set high-contrast color

### DIFF
--- a/packages/mdc-elevation/_mixins.scss
+++ b/packages/mdc-elevation/_mixins.scss
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-@import "@material/theme/variables";
+@import "@material/theme/functions";
 @import "./variables";
 
 /**
@@ -23,7 +23,7 @@
  * If $color has an alpha channel, it will be ignored and overridden. To increase the opacity of the shadow, use
  * $opacity-boost.
  */
-@mixin mdc-elevation($z-value, $color: $mdc-elevation-baseline-color, $opacity-boost: 0) {
+@mixin mdc-elevation($z-value, $color: text-primary-on-background, $opacity-boost: 0) {
   @if type-of($z-value) != number or not unitless($z-value) {
     @error "$z-value must be a unitless number, but received '#{$z-value}'";
   }
@@ -32,13 +32,7 @@
     @error "$z-value must be between 0 and 24, but received '#{$z-value}'";
   }
 
-  @if map-has-key($mdc-theme-property-values, $color) {
-    $color: map-get($mdc-theme-property-values, $color);
-  }
-
-  @if type-of($color) != color {
-    @error "$color must be a valid color, but '#{$color}' is of type #{type-of($color)}";
-  }
+  $color: mdc-theme-prop-value($color);
 
   $umbra-z-value: map-get($mdc-elevation-umbra-map, $z-value);
   $penumbra-z-value: map-get($mdc-elevation-penumbra-map, $z-value);

--- a/packages/mdc-elevation/_variables.scss
+++ b/packages/mdc-elevation/_variables.scss
@@ -16,7 +16,6 @@
 
 @import "@material/animation/variables";
 
-$mdc-elevation-baseline-color: black;
 $mdc-elevation-umbra-opacity: .2;
 $mdc-elevation-penumbra-opacity: .14;
 $mdc-elevation-ambient-opacity: .12;


### PR DESCRIPTION
BREAKING CHANGE: The `$mdc-elevation-baseline-color` constant has been removed. The default elevation color is now selected automatically to have high contrast against the background.