### PR TITLE
fix(base): `shouldBubble` param now defaults to `true` in `emit()`

### DIFF
--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -172,7 +172,7 @@ export class MyComponent extends MDCComponent {
 | `destroy()` | Subclasses may override this method if they wish to perform any additional cleanup work when a component is destroyed. For example, a component may want to deregister a window resize listener. |
 | `listen(type: string, handler: EventListener)` | Adds an event listener to the component's root node for the given `type`. Note that this is simply a proxy to `this.root_.addEventListener`. |
 | `unlisten(type: string, handler: EventListener)` | Removes an event listener from the component's root node. Note that this is simply a proxy to `this.root_.removeEventListener`. |
-| `emit(type: string, data: Object, shouldBubble: boolean = false)` | Dispatches a custom event of type `type` with detail `data` from the component's root node. It also takes an optional shouldBubble argument to specify if the event should bubble. This is the preferred way of dispatching events within our vanilla components. |
+| `emit(type: string, data: Object, shouldBubble: boolean = true)` | Dispatches a custom event of type `type` with detail `data` from the component's root node. It also takes an optional shouldBubble argument to specify if the event should bubble. This is the preferred way of dispatching events within our vanilla components. |
 
 #### Static Methods
 

--- a/packages/mdc-base/component.js
+++ b/packages/mdc-base/component.js
@@ -106,7 +106,7 @@ class MDCComponent {
    * @param {!Object} evtData
    * @param {boolean=} shouldBubble
    */
-  emit(evtType, evtData, shouldBubble = false) {
+  emit(evtType, evtData, shouldBubble = true) {
     let evt;
     if (typeof CustomEvent === 'function') {
       evt = new CustomEvent(evtType, {


### PR DESCRIPTION
BREAKING CHANGE: The `shouldBubble` param of `MDCComponent#emit()` is now opt-out rather than opt-in. This matches the behavior of most standard Web events. Without this change, there's no way to listen to delegated events.