### PR TITLE
fix(text-field): Inherit padding on fullwidth withleadingicon textfields

### DIFF
--- a/demos/text-field.html
+++ b/demos/text-field.html
@@ -420,6 +420,11 @@
             <input class="mdc-text-field__input" type="text" placeholder="Subject" aria-label="Subject">
             <div class="mdc-text-field__bottom-line"></div>
           </div>
+          <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--fullwidth">
+            <i class="material-icons mdc-text-field__icon" tabindex="0">event</i>
+            <input class="mdc-text-field__input" type="text" placeholder="Subject" aria-label="Subject">
+            <div class="mdc-text-field__bottom-line"></div>
+          </div>
           <div class="mdc-text-field mdc-text-field--textarea mdc-text-field--fullwidth full-width-textarea-example">
             <textarea id="full-width-textarea" class="mdc-text-field__input" rows="8"></textarea>
             <label for="full-width-textarea" class="mdc-text-field__label">Textarea Label</label>

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -338,7 +338,6 @@
     .mdc-text-field__input {
       width: 100%;
       height: 100%;
-      padding: 0;
       resize: none;
       // Use !important here to override all other border treatments
       border: none !important;


### PR DESCRIPTION
fixes #2044
Remove the 0 padding from full width text fields with leading icons and
allow the fields to inherit padding from text field with leading icon.
When this padding is 0, the text field's placeholder and value collide
with the leading icon.