### PR TITLE
fix(checkbox): Delay checked-unchecked fade

### DIFF
--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -273,6 +273,10 @@
   will-change: background-color, border-color;
 }
 
+@mixin mdc-checkbox__background--unmarked_ {
+  transition-delay: $mdc-checkbox-transition-duration;
+}
+
 @mixin mdc-checkbox__background--marked_ {
   transition:
     mdc-checkbox-transition-enter(border-color),

--- a/packages/mdc-checkbox/mdc-checkbox.scss
+++ b/packages/mdc-checkbox/mdc-checkbox.scss
@@ -74,6 +74,10 @@
   @include mdc-checkbox--anim_;
 }
 
+.mdc-checkbox__native-control:not(:checked) ~ .mdc-checkbox__background {
+  @include mdc-checkbox__background--unmarked_;
+}
+
 .mdc-checkbox__native-control:checked ~ .mdc-checkbox__background,
 .mdc-checkbox__native-control:indeterminate ~ .mdc-checkbox__background {
   @include mdc-checkbox__background--marked_;


### PR DESCRIPTION
Delay the fade of the checkbox background by 90ms during the transition from checked to unchecked. This makes the checked to unchecked animation a better inversion of the unchecked to checked animation.