### PR TITLE
fix(text-field): bottom line height should be 1px

### DIFF
--- a/packages/mdc-textfield/bottom-line/mdc-text-field-bottom-line.scss
+++ b/packages/mdc-textfield/bottom-line/mdc-text-field-bottom-line.scss
@@ -25,7 +25,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
-    height: 2px;
+    height: 1px;
     transform: scaleX(0);
     transition: mdc-text-field-transition(transform), mdc-text-field-transition(opacity);
     opacity: 0;


### PR DESCRIPTION
According to the Material Design guidelines, the bottom line should only be 1px high.