### PR TITLE
chore: Require function URL quotes in stylelintrc

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -10,8 +10,8 @@ plugins:
 rules:
   # Follow best practices
   font-family-name-quotes: always-where-recommended
-  # http://stackoverflow.com/questions/2168855/is-quoting-the-value-of-url-really-necessary
-  function-url-quotes: never
+  # https://stackoverflow.com/a/34383157/467582
+  function-url-quotes: always
   # https://www.w3.org/TR/selectors/#attribute-selectors
   # http://stackoverflow.com/q/3851091
   selector-attribute-quotes: always


### PR DESCRIPTION
CSS3 spec requires the quotes. Unquoted strings are only supported for legacy reasons.

We don't currently use function URLs (e.g., `@import url("...")`) in any of our `packages/`, but we _do_ use them in our demo pages, and we'll soon be using them in our screenshot tests.

I want to lint all of our screenshot test code, so this PR is a step in that direction.