### PR TITLE
docs(toolbar): Avoid demo page jumping when clicking toolbar icons

### DIFF
--- a/demos/ready.js
+++ b/demos/ready.js
@@ -37,7 +37,8 @@ window.demoReady = (function(root) {
       return true;
     }
     ensureDetectionDom();
-    isReadyCached = Boolean(window.mdc) && getComputedStyle(testDom).position === 'relative';
+    isReadyCached = getComputedStyle(testDom).position === 'relative' &&
+      (Boolean(window.mdc) || !root.querySelector('script[src$="material-components-web.js"]'));
     return isReadyCached;
   }
 

--- a/demos/ready.js
+++ b/demos/ready.js
@@ -38,7 +38,7 @@ window.demoReady = (function(root) {
     }
     ensureDetectionDom();
     isReadyCached = getComputedStyle(testDom).position === 'relative' &&
-      (Boolean(window.mdc) || !root.querySelector('script[src$="material-components-web.js"]'));
+      (Boolean(window.mdc) || !root.querySelector('script[src*="material-components-web.js"]'));
     return isReadyCached;
   }
 

--- a/demos/toolbar/custom-toolbar.html
+++ b/demos/toolbar/custom-toolbar.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar demo-toolbar demo-toolbar--custom">
@@ -50,5 +51,6 @@
         Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
       </p>
     </main>
+    <script src="/assets/common.js" async></script>
   </body>
 </html>

--- a/demos/toolbar/custom-toolbar.html
+++ b/demos/toolbar/custom-toolbar.html
@@ -51,6 +51,7 @@
         Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
       </p>
     </main>
+
     <script src="/assets/common.js" async></script>
   </body>
 </html>

--- a/demos/toolbar/default-flexible-toolbar.html
+++ b/demos/toolbar/default-flexible-toolbar.html
@@ -55,6 +55,7 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
+    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
     <script>
       demoReady(function() {

--- a/demos/toolbar/default-flexible-toolbar.html
+++ b/demos/toolbar/default-flexible-toolbar.html
@@ -55,8 +55,8 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
-    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var ratioSpan = document.querySelector("#ratio");

--- a/demos/toolbar/default-toolbar.html
+++ b/demos/toolbar/default-toolbar.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar demo-toolbar">
@@ -50,5 +51,6 @@
         Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
       </p>
     </main>
+    <script src="/assets/common.js" async></script>
   </body>
 </html>

--- a/demos/toolbar/default-toolbar.html
+++ b/demos/toolbar/default-toolbar.html
@@ -51,6 +51,7 @@
         Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est.
       </p>
     </main>
+
     <script src="/assets/common.js" async></script>
   </body>
 </html>

--- a/demos/toolbar/fixed-toolbar.html
+++ b/demos/toolbar/fixed-toolbar.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
   </head>
   <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed demo-toolbar">
@@ -52,5 +53,6 @@
         </p>
       </div>
     </main>
+    <script src="/assets/common.js" async></script>
   </body>
 </html>

--- a/demos/toolbar/fixed-toolbar.html
+++ b/demos/toolbar/fixed-toolbar.html
@@ -53,6 +53,7 @@
         </p>
       </div>
     </main>
+
     <script src="/assets/common.js" async></script>
   </body>
 </html>

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script src="/ready.js"></script>
     <style>
       .demo-container {
         height: 500px;
@@ -189,6 +190,8 @@
         </div>
       </section>
     </main>
+
+    <script src="/assets/common.js" async></script>
     <script>
       [].forEach.call(document.querySelectorAll('.examples button'), function(button) {
         button.addEventListener('click', function(event) {

--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -71,8 +71,8 @@
       </div>
     </main>
 
-    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var menuEl = document.querySelector('#demo-menu');

--- a/demos/toolbar/menu-toolbar.html
+++ b/demos/toolbar/menu-toolbar.html
@@ -71,6 +71,7 @@
       </div>
     </main>
 
+    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
     <script>
       demoReady(function() {

--- a/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
+++ b/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
@@ -65,6 +65,7 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
+    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
     <script>
       demoReady(function() {

--- a/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
+++ b/demos/toolbar/waterfall-flexible-toolbar-custom-style.html
@@ -65,8 +65,8 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
-    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var initialR = 100;

--- a/demos/toolbar/waterfall-flexible-toolbar.html
+++ b/demos/toolbar/waterfall-flexible-toolbar.html
@@ -58,6 +58,7 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
+    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
     <script>
       demoReady(function() {

--- a/demos/toolbar/waterfall-flexible-toolbar.html
+++ b/demos/toolbar/waterfall-flexible-toolbar.html
@@ -58,8 +58,8 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
-    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var ratioSpan = document.querySelector("#ratio");

--- a/demos/toolbar/waterfall-toolbar-fix-last-row.html
+++ b/demos/toolbar/waterfall-toolbar-fix-last-row.html
@@ -68,8 +68,8 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
-    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var ratioSpan = document.querySelector("#ratio");

--- a/demos/toolbar/waterfall-toolbar-fix-last-row.html
+++ b/demos/toolbar/waterfall-toolbar-fix-last-row.html
@@ -68,6 +68,7 @@
       <span>Flexible Expansion Ratio: <span id="ratio">0</span></span>
     </footer>
 
+    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
     <script>
       demoReady(function() {

--- a/demos/toolbar/waterfall-toolbar.html
+++ b/demos/toolbar/waterfall-toolbar.html
@@ -54,6 +54,7 @@
       </div>
     </main>
 
+    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
     <script>
       demoReady(function() {

--- a/demos/toolbar/waterfall-toolbar.html
+++ b/demos/toolbar/waterfall-toolbar.html
@@ -54,8 +54,8 @@
       </div>
     </main>
 
-    <script src="/assets/common.js" async></script>
     <script src="/assets/material-components-web.js" async></script>
+    <script src="/assets/common.js" async></script>
     <script>
       demoReady(function() {
         var toolbar = mdc.toolbar.MDCToolbar.attachTo(document.querySelector('.mdc-toolbar'));


### PR DESCRIPTION
This adds ready.js and common.js to the toolbar demo pages so that they get # link canceling behavior, and fixes an issue with ready.js so it also works for demos that only need styles and no JS.