### PR TITLE
revert: chore(text-field): reduce scss specificity (#2163)

### DIFF
--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -33,7 +33,11 @@
 // postcss-bem-linter: define text-field
 
 .mdc-text-field {
+  @include mdc-text-field-bottom-line-color($mdc-text-field-underline-idle);
+  @include mdc-text-field-hover-bottom-line-color($mdc-text-field-underline-hover);
   @include mdc-text-field-line-ripple-color_(primary);
+  @include mdc-text-field-ink-color(text-primary-on-background);
+  @include mdc-text-field-label-color($mdc-text-field-label);
   @include mdc-text-field-helper-text-color(text-hint-on-background);
   @include mdc-text-field-fullwidth-bottom-line-color($mdc-text-field-divider);
   @include mdc-text-field-icon-color($mdc-text-field-underline-hover);
@@ -42,13 +46,6 @@
   position: relative;
   margin-bottom: 8px;
   will-change: opacity, transform, color;
-}
-
-@at-root {
-  @include mdc-text-field-bottom-line-color($mdc-text-field-underline-idle);
-  @include mdc-text-field-hover-bottom-line-color($mdc-text-field-underline-hover);
-  @include mdc-text-field-ink-color(text-primary-on-background);
-  @include mdc-text-field-label-color($mdc-text-field-label);
 }
 
 .mdc-text-field__input {


### PR DESCRIPTION
This reverts #2163, which moved @includes that involve `&:not(...)` selectors out of their parent class and under an `@at-root` selector, causing them to always match.