### PR TITLE
chore: Remove obsolete env var from webpack.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "npm run clean && mkdirp build && webpack --progress --colors",
-    "build:demo": "cross-env MDC_ENV=development MDC_BUILD_STATIC_DEMO_ASSETS=true MDC_WRAP_CSS_IN_JS=false npm run build",
     "build:min": "mkdirp build && cross-env MDC_ENV=production webpack -p --progress --colors",
     "changelog": "standard-changelog -i CHANGELOG.md -k packages/material-components-web/package.json -w",
     "clean": "del-cli build/** build .closure-tmp/** .closure-tmp",

--- a/test/build/goldens/build-config-dev-env.golden.json
+++ b/test/build/goldens/build-config-dev-env.golden.json
@@ -156,8 +156,7 @@
           "entryOnly": true
         },
         "banner": "/*!\n Material Components for the web\n Copyright (c) 2018 Google Inc.\n License: Apache-2.0\n*/"
-      },
-      {}
+      }
     ]
   },
   {


### PR DESCRIPTION
`MDC_BUILD_STATIC_DEMO_ASSETS` is no longer necessary because we're going to create entirely separate HTML pages for screenshot tests.

Also removed the `npm run build:demo` command, which used the obsolete env var.