### PR TITLE
chore: Fix ordering of assert params

### DIFF
--- a/test/build/webpack-config-loader.js
+++ b/test/build/webpack-config-loader.js
@@ -61,8 +61,8 @@ module.exports = class {
       const expectedWebpackConfig = normalizeForDiffing(fsx.readFileSync(goldenPath, {encoding: 'utf8'}));
 
       return {
-        generatedWebpackConfig,
         expectedWebpackConfig,
+        generatedWebpackConfig,
       };
     } finally {
       env.restoreAll();

--- a/test/build/webpack-module-exports.test.js
+++ b/test/build/webpack-module-exports.test.js
@@ -28,34 +28,34 @@ const webpackConfigLoader = new WebpackConfigLoader();
 describe('webpack.config.js', () => {
   describe('MDC_ENV=""', () => {
     it('module exports should match build-config-no-env.golden.json', () => {
-      const {generatedWebpackConfig, expectedWebpackConfig} = webpackConfigLoader.setupTest({
+      const {expectedWebpackConfig, generatedWebpackConfig} = webpackConfigLoader.setupTest({
         configPath: path.join(__dirname, '../../webpack.config.js'),
         goldenPath: path.join(__dirname, './goldens/build-config-no-env.golden.json'),
         mdcEnv: '',
       });
-      assert.equal(generatedWebpackConfig, expectedWebpackConfig);
+      assert.equal(expectedWebpackConfig, generatedWebpackConfig);
     });
   });
 
   describe('MDC_ENV="production"', () => {
     it('module exports should match build-config-prod-env.golden.json', () => {
-      const {generatedWebpackConfig, expectedWebpackConfig} = webpackConfigLoader.setupTest({
+      const {expectedWebpackConfig, generatedWebpackConfig} = webpackConfigLoader.setupTest({
         configPath: path.join(__dirname, '../../webpack.config.js'),
         goldenPath: path.join(__dirname, './goldens/build-config-prod-env.golden.json'),
         mdcEnv: 'production',
       });
-      assert.equal(generatedWebpackConfig, expectedWebpackConfig);
+      assert.equal(expectedWebpackConfig, generatedWebpackConfig);
     });
   });
 
   describe('MDC_ENV="development"', () => {
     it('module exports should match build-config-dev-env.golden.json', () => {
-      const {generatedWebpackConfig, expectedWebpackConfig} = webpackConfigLoader.setupTest({
+      const {expectedWebpackConfig, generatedWebpackConfig} = webpackConfigLoader.setupTest({
         configPath: path.join(__dirname, '../../webpack.config.js'),
         goldenPath: path.join(__dirname, './goldens/build-config-dev-env.golden.json'),
         mdcEnv: 'development',
       });
-      assert.equal(generatedWebpackConfig, expectedWebpackConfig);
+      assert.equal(expectedWebpackConfig, generatedWebpackConfig);
     });
   });
 });


### PR DESCRIPTION
Otherwise, the test output is backwards and confusing. E.g., if you add a line, it will show that you removed it, and vice versa.

To test, add or remove a line in a `test/build/goldens/*.golden.json` file and run:

```bash
npm run test:buildconfig
```