### PR TITLE
fix(ripple): Ensure hover/focus states have proper z-index

### DIFF
--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -41,6 +41,7 @@
 
   &::before {
     transition: opacity $mdc-states-wash-duration linear;
+    z-index: 1; // Ensure that the ripple wash for hover/focus states is displayed on top of positioned child elements
   }
 
   // Common styles for upgraded surfaces (some of these depend on custom properties set via JS or other mixins)


### PR DESCRIPTION
Previously, if the ripple surface had a non-statically-positioned child element (e.g., `position: absolute`), the hover/focus wash was displayed _below_ the child instead of _above_ it.