### PR TITLE
fix(toolbar): Title position for desktops

### DIFF
--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -169,16 +169,9 @@
 
       align-self: flex-end;
       font-weight: #{map-get($mdc-typography-font-weight-values, normal)};
-      line-height: 1.5rem;
-    }
 
-    @media (min-width: 600px) {
-      &.mdc-toolbar--fixed-lastrow-only {
-        .mdc-toolbar__title,
-        .mdc-toolbar__menu-icon,
-        .mdc-toolbar__icon {
-          line-height: 2rem;
-        }
+      @media (max-width: $mdc-toolbar-mobile-breakpoint) { 
+        line-height: 1.5rem;
       }
     }
 

--- a/packages/mdc-toolbar/mdc-toolbar.scss
+++ b/packages/mdc-toolbar/mdc-toolbar.scss
@@ -172,6 +172,16 @@
       line-height: 1.5rem;
     }
 
+    @media (min-width: 600px) {
+      &.mdc-toolbar--fixed-lastrow-only {
+        .mdc-toolbar__title,
+        .mdc-toolbar__menu-icon,
+        .mdc-toolbar__icon {
+          line-height: 2rem;
+        }
+      }
+    }
+
     .mdc-toolbar__row:first-child::after {
       top: 0;
       left: 0;


### PR DESCRIPTION
When opening the following demo page (with a window which is at least 600px wide) and scrolling the toolbar until it is minimized (mdc-toolbar--flexible-space-minimized class is added), the title is aligned incorrectly with the menu icon. This PR fixes that issue.

https://material-components-web.appspot.com/toolbar/waterfall-toolbar-fix-last-row.html