### PR TITLE
docs(menu): wrong boolean value

### DIFF
--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -141,7 +141,7 @@ CSS Class | Description
   menu.setAnchorCorner(Corner.BOTTOM_END); 
   
   // Turn off menu open animations
-  menu.quickOpen = false;
+  menu.quickOpen = true;
 ```
 
 ### `MDCMenu`


### PR DESCRIPTION
I think it quickOpen should be set to true in order to turn off menu animation.