### PR TITLE
fix(form-field): add suite identifiers to unit tests

### DIFF
--- a/test/unit/mdc-form-field/foundation.test.js
+++ b/test/unit/mdc-form-field/foundation.test.js
@@ -21,6 +21,8 @@ import MDCFormFieldFoundation from '../../../packages/mdc-form-field/foundation'
 import {cssClasses, strings} from '../../../packages/mdc-form-field/constants';
 import {verifyDefaultAdapter} from '../helpers/foundation';
 
+suite('MDCFormFieldFoundation');
+
 test('exports cssClasses', () => {
   assert.isOk('cssClasses' in MDCFormFieldFoundation);
   assert.deepEqual(MDCFormFieldFoundation.cssClasses, cssClasses);

--- a/test/unit/mdc-form-field/mdc-form-field.test.js
+++ b/test/unit/mdc-form-field/mdc-form-field.test.js
@@ -36,6 +36,8 @@ function setupTest() {
   return {root, component};
 }
 
+suite('MDCFormField');
+
 test('attachTo initializes and returns an MDCFormField instance', () => {
   assert.isOk(MDCFormField.attachTo(getFixture()) instanceof MDCFormField);
 });


### PR DESCRIPTION
Currently, form field tests are appearing under the MDCDrawer - util test suites.