### PR TITLE
fix(checkbox): use background-aware colors instead of hard-coded black

### DIFF
--- a/demos/theme/theme-dark.scss
+++ b/demos/theme/theme-dark.scss
@@ -28,10 +28,6 @@ $mdc-theme-background: $material-color-grey-900;
 
 // TODO: Call theme mixins for mdc-select
 
-.demo-checkbox {
-  @include mdc-checkbox-container-colors(text-secondary-on-dark);
-}
-
 .demo-radio {
   @include mdc-radio-unchecked-stroke-color(text-secondary-on-dark);
 }

--- a/packages/mdc-checkbox/_variables.scss
+++ b/packages/mdc-checkbox/_variables.scss
@@ -15,8 +15,8 @@
 //
 
 $mdc-checkbox-mark-color: white !default;
-$mdc-checkbox-border-color: rgba(black, .54) !default;
-$mdc-checkbox-disabled-color: rgba(black, .26) !default;
+$mdc-checkbox-border-color: text-secondary-on-background !default;
+$mdc-checkbox-disabled-color: text-disabled-on-background !default;
 $mdc-checkbox-baseline-theme-color: secondary !default;
 
 $mdc-checkbox-touch-area: 40px;


### PR DESCRIPTION
Not sure if this is a regression from when the dark theme was removed or if this is intentional.

Closes #2248 
