### PR TITLE
updated typography.html demo to include h1-h4. Previously all h1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .DS_Store
 /build
+/.c9/
 /coverage
 packages/*/dist
 *.log

--- a/demos/typography.html
+++ b/demos/typography.html
@@ -50,10 +50,10 @@
       <section class="demo-typography--section">
         <h2 class="mdc-typography--display1">Styles</h2>
         <h1 class="mdc-typography--display4">Display 4</h1>
-        <h1 class="mdc-typography--display3">Display 3</h1>
-        <h1 class="mdc-typography--display2">Display 2</h1>
-        <h1 class="mdc-typography--display1">Display 1</h1>
-        <h1 class="mdc-typography--headline">Headline</h1>
+        <h2 class="mdc-typography--display3">Display 3</h2>
+        <h3 class="mdc-typography--display2">Display 2</h3>
+        <h4 class="mdc-typography--display1">Display 1</h4>
+        <h5 class="mdc-typography--headline">Headline</h1>
         <h2 class="mdc-typography--title">
           Title <span class="mdc-typography--caption">Caption.</span>
         </h2>
@@ -69,10 +69,10 @@
       <section class="demo-typography--section">
         <h2 class="mdc-typography--display1">Styles with margin adjustments</h2>
         <h1 class="mdc-typography--display4 mdc-typography--adjust-margin">Display 4</h1>
-        <h1 class="mdc-typography--display3 mdc-typography--adjust-margin">Display 3</h1>
-        <h1 class="mdc-typography--display2 mdc-typography--adjust-margin">Display 2</h1>
-        <h1 class="mdc-typography--display1 mdc-typography--adjust-margin">Display 1</h1>
-        <h1 class="mdc-typography--headline mdc-typography--adjust-margin">Headline</h1>
+        <h2 class="mdc-typography--display3 mdc-typography--adjust-margin">Display 3</h2>
+        <h3 class="mdc-typography--display2 mdc-typography--adjust-margin">Display 2</h3>
+        <h4 class="mdc-typography--display1 mdc-typography--adjust-margin">Display 1</h4>
+        <h5 class="mdc-typography--headline mdc-typography--adjust-margin">Headline</h1>
         <h2 class="mdc-typography--title mdc-typography--adjust-margin">
           Title <span class="mdc-typography--caption mdc-typography--adjust-margin">Caption.</span>
         </h2>


### PR DESCRIPTION
Updated mdc-web demo page here to reintroduce semantically ranked `header` elements. Previously the demo source code used `mdc-typography--display` classes only on `h1` elements suggesting this was how to do it. W3C mandates use of semantic `header` rankings (1-6) for page hierarchy / assistive technologies.

Previously:
```
  | <h1 class="mdc-typography--display4">Display 4</h1>
  | <h1 class="mdc-typography--display3">Display 3</h1>
  | <h1 class="mdc-typography--display2">Display 2</h1>
  | <h1 class="mdc-typography--display1">Display 1</h1>
  | <h1 class="mdc-typography--headline">Headline</h1>
  | <h2 class="mdc-typography--title">
```
Now:

```
  | <h1 class="mdc-typography--display4">Display 4</h1>
  | <h2 class="mdc-typography--display3">Display 3</h2>
  | <h3 class="mdc-typography--display2">Display 2</h3>
  | <h4 class="mdc-typography--display1">Display 1</h4>
  | <h5 class="mdc-typography--headline">Headline</h1>
  | <h2 class="mdc-typography--title">
```


