### PR TITLE
fix: Use `var` instead of `const` in demos/ready.js

### DIFF
--- a/demos/ready.js
+++ b/demos/ready.js
@@ -79,7 +79,7 @@ window.demoReady = (function(root) {
       return;
     }
 
-    const elapsedTimeMs = Date.now() - startTimeMs;
+    var elapsedTimeMs = Date.now() - startTimeMs;
     if (elapsedTimeMs > POLL_MAX_WAIT_MS) {
       clearInterval(pollTimer);
       removeDetectionDom();


### PR DESCRIPTION
Safari 9.x and IE 10 do not support `const`.

This change is necessary because `ready.js` is not transpiled to ES5.