### PR TITLE
Fix demos’ RTL ↔ LTR toggling in Safari

### DIFF
--- a/demos/card.html
+++ b/demos/card.html
@@ -238,11 +238,7 @@
         var rtlToggle = document.getElementById('toggle-rtl');
         rtlToggle.addEventListener('change', function() {
           var docEl = document.documentElement;
-          if (rtlToggle.checked) {
-            docEl.setAttribute('dir', 'rtl');
-          } else {
-            docEl.removeAttribute('dir');
-          }
+          docEl.setAttribute('dir', rtlToggle.checked ? 'rtl' : 'ltr');
         });
 
         [].forEach.call(document.querySelectorAll('.mdc-button'), function(surface) {

--- a/demos/top-app-bar.html
+++ b/demos/top-app-bar.html
@@ -199,7 +199,7 @@
         });
 
         rtlCheckbox.addEventListener('change', function()  {
-          document.body[this.checked ? 'setAttribute' : 'removeAttribute']("dir", "rtl");
+          document.body.setAttribute('dir', this.checked ? 'rtl': 'ltr');
           appBarEl.classList.remove('mdc-top-app-bar--short-has-action-item');
 
           appBar.destroy();


### PR DESCRIPTION
* **Problem:** The right-to-left ↔ left-to-right toggling on [the top-app-bar demo](http://material-components-web.appspot.com/top-app-bar.html ) is broken in Safari 11.0.3 (on macOS 10.13.3)
* **Solution:** Don’t remove the `dir` attribute on `body` in the demo: change its value to `ltr` when the “RTL” checkbox is unchecked
* **Testing:**

    1. Get the fix branch set up:
        ```shell
        git clone git@github.com:swashcap/material-components-web.git mcw2
        cd mcw2
        npm install
        npm run dev
        ```
    2. Open http://localhost:8080/top-app-bar.html in Safari
    3. Confirm the “RTL” checkbox works after checked and unchecked