### PR TITLE
fix(text-field): Clicking label should focus textfield

### DIFF
--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -60,7 +60,7 @@
   }
 
   width: 100%;
-  padding: 0 0 8px;
+  padding: 20px 0 8px;
   transition: mdc-text-field-transition(opacity);
   border: none;
   border-bottom: 1px solid;

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -163,10 +163,6 @@
   &:not(.mdc-text-field--textarea):not(.mdc-text-field--outlined) {
     height: 48px;
   }
-
-  .mdc-floating-label {
-    pointer-events: none;
-  }
 }
 
 .mdc-text-field--dense {


### PR DESCRIPTION
Fixes : #2015 
Makes the label work like a standard label. If the `for` attribute is specified, clicking the label will focus the corresponding `input`.  