### PR TITLE
docs(image-list): Fix hero section of demo in IE 11

### DIFF
--- a/demos/image-list.scss
+++ b/demos/image-list.scss
@@ -22,7 +22,9 @@
 
 .mdc-image-list.hero-image-list {
   @include mdc-image-list-standard-columns(5);
+
   width: 300px;
+  margin: 0;
 }
 
 .hero-image-list .mdc-image-list__image {
@@ -31,6 +33,7 @@
 
 .mdc-image-list.standard-image-list {
   @include mdc-image-list-standard-columns(5);
+
   max-width: 1000px;
 }
 


### PR DESCRIPTION
Fixes a bug where the Image List in the hero section was right-aligned in IE 11 for some reason. I can only think that for some reason the combination of `auto` side margins when the parent already used flexbox to center its content rubbed IE 11 the wrong way?

The change doesn't cause any visible difference in any other browser.