### PR TITLE
fix(top-app-bar): Adjust title padding-left

### DIFF
--- a/packages/mdc-top-app-bar/_mixins.scss
+++ b/packages/mdc-top-app-bar/_mixins.scss
@@ -59,10 +59,6 @@
       padding: $mdc-top-app-bar-mobile-section-padding;
     }
 
-    .mdc-top-app-bar__title {
-      @include mdc-rtl-reflexive-box(padding, left, $mdc-top-app-bar-mobile-title-left-padding);
-    }
-
     .mdc-top-app-bar--short {
       transition: width 200ms $mdc-animation-standard-curve-timing-function;
     }

--- a/packages/mdc-top-app-bar/_variables.scss
+++ b/packages/mdc-top-app-bar/_variables.scss
@@ -16,7 +16,7 @@
 
 // Default styles
 $mdc-top-app-bar-row-height: 64px;
-$mdc-top-app-bar-title-left-padding: 10px;
+$mdc-top-app-bar-title-left-padding: 20px;
 $mdc-top-app-bar-section-vertical-padding: 8px;
 $mdc-top-app-bar-section-horizontal-padding: 12px;
 
@@ -27,7 +27,6 @@ $mdc-top-app-bar-mobile-breakpoint: 599px !default;
 
 // Default mobile styles
 $mdc-top-app-bar-mobile-row-height: 56px;
-$mdc-top-app-bar-mobile-title-left-padding: 12px;
 $mdc-top-app-bar-mobile-section-padding: 4px;
 
 // Short top app bar


### PR DESCRIPTION
The padding for mobile/desktop was refactored to apply from the section, so the desktop value is incorrect and the mobile style is no longer needed.