### PR TITLE
style: Order column-count before column-gap

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -78,11 +78,11 @@ rules:
     - resize
 
     - columns
+    - column-count
     - column-gap
     - column-fill
     - column-rule
     - column-span
-    - column-count
     - column-width
 
     - grid-gap


### PR DESCRIPTION
IMO it makes no sense to require `column-count` _after_ other CSS columns properties; column count is the most pertinent bit of information (and sometimes is the rule that makes it evident that something is even using CSS columns to begin with) and putting it first should make other columns properties more readable.