### PR TITLE
refactor(ripple): Add optional width/height params to layout

### DIFF
--- a/packages/mdc-chips/chip/constants.js
+++ b/packages/mdc-chips/chip/constants.js
@@ -18,6 +18,7 @@
 /** @enum {string} */
 const strings = {
   INTERACTION_EVENT: 'MDCChip:interaction',
+  CHECKMARK_SELECTOR: '.mdc-chip__checkmark',
   LEADING_ICON_SELECTOR: '.mdc-chip__icon--leading',
   TRAILING_ICON_INTERACTION_EVENT: 'MDCChip:trailingIconInteraction',
   TRAILING_ICON_SELECTOR: '.mdc-chip__icon--trailing',

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -51,15 +51,15 @@ class MDCChip extends MDCComponent {
     this.leadingIcon_ = this.root_.querySelector(strings.LEADING_ICON_SELECTOR);
     this.ripple_ = new MDCRipple(this.root_);
 
-    // Adjust ripple size for chips with animated growing width.This applies when filter chips without
+    // Adjust ripple size for chips with animated growing width. This applies when filter chips without
     // a leading icon are selected, and a leading checkmark will cause the chip width to expand.
     const checkmarkEl = this.root_.querySelector(strings.CHECKMARK_SELECTOR);
     if (!!checkmarkEl && !this.leadingIcon_) {
-      // The checkmark width is initially set to 0, so use the chip's height as a proxy, since the
+      const height = this.root_.getBoundingClientRect().height;
+      // The checkmark width is initially set to 0, so use the chip's height as a proxy since the
       // checkmark should always be square.
-      const checkmarkWidthProxy = this.root_.getBoundingClientRect().height;
-      const width = this.root_.getBoundingClientRect().width + checkmarkWidthProxy;
-      this.ripple_.layout(width);
+      const width = this.root_.getBoundingClientRect().width + height;
+      this.ripple_.layout({height: height, width: width});
     }
   }
 

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -34,9 +34,9 @@ class MDCChip extends MDCComponent {
     super(...args);
 
     /** @private {?Element} */
-    this.leadingIcon_ = this.root_.querySelector(strings.LEADING_ICON_SELECTOR);
+    this.leadingIcon_;
     /** @private {!MDCRipple} */
-    this.ripple_ = new MDCRipple(this.root_);
+    this.ripple_;
   }
 
   /**
@@ -45,6 +45,22 @@ class MDCChip extends MDCComponent {
    */
   static attachTo(root) {
     return new MDCChip(root);
+  }
+
+  initialize() {
+    this.leadingIcon_ = this.root_.querySelector(strings.LEADING_ICON_SELECTOR);
+    this.ripple_ = new MDCRipple(this.root_);
+
+    // Adjust ripple size for chips with animated growing width.This applies when filter chips without
+    // a leading icon are selected, and a leading checkmark will cause the chip width to expand.
+    const checkmarkEl = this.root_.querySelector(strings.CHECKMARK_SELECTOR);
+    if (!!checkmarkEl && !this.leadingIcon_) {
+      // The checkmark width is initially set to 0, so use the chip's height as a proxy, since the
+      // checkmark should always be square.
+      const checkmarkWidthProxy = this.root_.getBoundingClientRect().height;
+      const width = this.root_.getBoundingClientRect().width + checkmarkWidthProxy;
+      this.ripple_.layout(width);
+    }
   }
 
   destroy() {

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -143,7 +143,7 @@ Method Signature | Description
 --- | ---
 `activate() => void` | Proxies to the foundation's `activate` method
 `deactivate() => void` | Proxies to the foundation's `deactivate` method
-`layout(width, height) => void` | Proxies to the foundation's `layout` method
+`layout(dimensions: {height: number, width: number}) => void` | Proxies to the foundation's `layout` method
 
 ### `MDCRippleAdapter`
 
@@ -174,7 +174,7 @@ Method Signature | Description
 --- | ---
 `activate() => void` | Triggers an activation of the ripple (the first stage, which happens when the ripple surface is engaged via interaction, such as a `mousedown` or a `pointerdown` event). It expands from the center.
 `deactivate() => void` | Triggers a deactivation of the ripple (the second stage, which happens when the ripple surface is engaged via interaction, such as a `mouseup` or a `pointerup` event). It expands from the center.
-`layout(width, height) => void` | Recomputes all dimensions and positions for the ripple element. Useful if a ripple surface's position or dimension is changed programmatically.
+`layout(dimensions: {height: number, width: number}) => void` | Recomputes all dimensions and positions for the ripple element. Useful if a ripple surface's position or dimension is changed programmatically. `dimensions` are optional and only required when the size is expected to change during the ripple.
 `setUnbounded(unbounded: boolean) => void` | Sets the ripple to be unbounded or not, based on the given boolean.
 
 ## Tips/Tricks

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -143,7 +143,7 @@ Method Signature | Description
 --- | ---
 `activate() => void` | Proxies to the foundation's `activate` method
 `deactivate() => void` | Proxies to the foundation's `deactivate` method
-`layout() => void` | Proxies to the foundation's `layout` method
+`layout(width, height) => void` | Proxies to the foundation's `layout` method
 
 ### `MDCRippleAdapter`
 
@@ -174,7 +174,7 @@ Method Signature | Description
 --- | ---
 `activate() => void` | Triggers an activation of the ripple (the first stage, which happens when the ripple surface is engaged via interaction, such as a `mousedown` or a `pointerdown` event). It expands from the center.
 `deactivate() => void` | Triggers a deactivation of the ripple (the second stage, which happens when the ripple surface is engaged via interaction, such as a `mouseup` or a `pointerup` event). It expands from the center.
-`layout() => void` | Recomputes all dimensions and positions for the ripple element. Useful if a ripple surface's position or dimension is changed programmatically.
+`layout(width, height) => void` | Recomputes all dimensions and positions for the ripple element. Useful if a ripple surface's position or dimension is changed programmatically.
 `setUnbounded(unbounded: boolean) => void` | Sets the ripple to be unbounded or not, based on the given boolean.
 
 ## Tips/Tricks

--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -212,11 +212,6 @@
     width: var(--mdc-ripple-fg-size, $radius);
     height: var(--mdc-ripple-fg-size, $radius);
   }
-
-  &.mdc-ripple-upgraded::after {
-    width: var(--mdc-ripple-fg-size, $radius);
-    height: var(--mdc-ripple-fg-size, $radius);
-  }
 }
 
 //

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -490,29 +490,26 @@ class MDCRippleFoundation extends MDCFoundation {
 
   /**
    * Recomputes all dimensions and positions for the ripple element.
-   * Optionally include width and height for ripple surfaces that change size during runtime.
-   * @param {number=} width
-   * @param {number=} height
+   * Optionally include dimensions for ripple surfaces that change size during animation.
+   * @param {{height:number, width: number}=} dimensions
    */
-  layout(width, height) {
+  layout(dimensions) {
     if (this.layoutFrame_) {
       cancelAnimationFrame(this.layoutFrame_);
     }
     this.layoutFrame_ = requestAnimationFrame(() => {
-      this.layoutInternal_(width, height);
+      this.layoutInternal_(dimensions);
       this.layoutFrame_ = 0;
     });
   }
 
   /**
-   * @param {number=} width
-   * @param {number=} height
+   * @param {{height:number, width: number}=} dimensions
    * @private
    */
-  layoutInternal_(width, height) {
-    this.frame_ = this.adapter_.computeBoundingRect();
-    width = width || this.frame_.width;
-    height = height || this.frame_.height;
+  layoutInternal_(dimensions) {
+    this.frame_ = /** @type {!ClientRect} */ (dimensions) || this.adapter_.computeBoundingRect();
+    const maxDim = Math.max(this.frame_.height, this.frame_.width);
 
     // Surface diameter is treated differently for unbounded vs. bounded ripples.
     // Unbounded ripple diameter is calculated smaller since the surface is expected to already be padded appropriately
@@ -521,11 +518,10 @@ class MDCRippleFoundation extends MDCFoundation {
     // (calculated based on the diagonal plus a constant padding), and are clipped at the surface's border via
     // `overflow: hidden`.
     const getBoundedRadius = () => {
-      const hypotenuse = Math.sqrt(Math.pow(width, 2) + Math.pow(height, 2));
+      const hypotenuse = Math.sqrt(Math.pow(this.frame_.width, 2) + Math.pow(this.frame_.height, 2));
       return hypotenuse + MDCRippleFoundation.numbers.PADDING;
     };
 
-    const maxDim = Math.max(height, width);
     this.maxRadius_ = this.adapter_.isUnbounded() ? maxDim : getBoundedRadius();
 
     // Ripple is sized as a fraction of the largest dimension of the surface, then scales up using a CSS scale transform

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -488,20 +488,31 @@ class MDCRippleFoundation extends MDCFoundation {
     }
   }
 
-  layout() {
+  /**
+   * Recomputes all dimensions and positions for the ripple element.
+   * Optionally include width and height for ripple surfaces that change size during runtime.
+   * @param {number=} width
+   * @param {number=} height
+   */
+  layout(width, height) {
     if (this.layoutFrame_) {
       cancelAnimationFrame(this.layoutFrame_);
     }
     this.layoutFrame_ = requestAnimationFrame(() => {
-      this.layoutInternal_();
+      this.layoutInternal_(width, height);
       this.layoutFrame_ = 0;
     });
   }
 
-  /** @private */
-  layoutInternal_() {
+  /** 
+   * @param {number=} width
+   * @param {number=} height
+   * @private
+   */
+  layoutInternal_(width, height) {
     this.frame_ = this.adapter_.computeBoundingRect();
-    const maxDim = Math.max(this.frame_.height, this.frame_.width);
+    width = width || this.frame_.width;
+    height = height || this.frame_.height;
 
     // Surface diameter is treated differently for unbounded vs. bounded ripples.
     // Unbounded ripple diameter is calculated smaller since the surface is expected to already be padded appropriately
@@ -510,10 +521,11 @@ class MDCRippleFoundation extends MDCFoundation {
     // (calculated based on the diagonal plus a constant padding), and are clipped at the surface's border via
     // `overflow: hidden`.
     const getBoundedRadius = () => {
-      const hypotenuse = Math.sqrt(Math.pow(this.frame_.width, 2) + Math.pow(this.frame_.height, 2));
+      const hypotenuse = Math.sqrt(Math.pow(width, 2) + Math.pow(height, 2));
       return hypotenuse + MDCRippleFoundation.numbers.PADDING;
     };
 
+    const maxDim = Math.max(height, width);
     this.maxRadius_ = this.adapter_.isUnbounded() ? maxDim : getBoundedRadius();
 
     // Ripple is sized as a fraction of the largest dimension of the surface, then scales up using a CSS scale transform

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -504,7 +504,7 @@ class MDCRippleFoundation extends MDCFoundation {
     });
   }
 
-  /** 
+  /**
    * @param {number=} width
    * @param {number=} height
    * @private

--- a/packages/mdc-ripple/index.js
+++ b/packages/mdc-ripple/index.js
@@ -110,8 +110,14 @@ class MDCRipple extends MDCComponent {
     this.foundation_.deactivate();
   }
 
-  layout() {
-    this.foundation_.layout();
+  /**
+   * Updates the dimensions of the ripple.
+   * Optionally include width and height for surfaces that change size during runtime.
+   * @param {number=} width
+   * @param {number=} height
+   */
+  layout(width, height) {
+    this.foundation_.layout(width, height);
   }
 
   /** @return {!MDCRippleFoundation} */

--- a/packages/mdc-ripple/index.js
+++ b/packages/mdc-ripple/index.js
@@ -112,12 +112,11 @@ class MDCRipple extends MDCComponent {
 
   /**
    * Updates the dimensions of the ripple.
-   * Optionally include width and height for surfaces that change size during runtime.
-   * @param {number=} width
-   * @param {number=} height
+   * Optionally include dimensions for surfaces that change size during animation.
+   * @param {{height:number, width: number}=} dimensions
    */
-  layout(width, height) {
-    this.foundation_.layout(width, height);
+  layout(dimensions) {
+    this.foundation_.layout(dimensions);
   }
 
   /** @return {!MDCRippleFoundation} */

--- a/test/unit/mdc-ripple/foundation.test.js
+++ b/test/unit/mdc-ripple/foundation.test.js
@@ -202,6 +202,19 @@ testFoundation(`#layout sets ${strings.VAR_FG_SIZE} to the circumscribing circle
     td.verify(adapter.updateCssVariable(strings.VAR_FG_SIZE, `${initialSize}px`));
   });
 
+testFoundation(`#layout sets ${strings.VAR_FG_SIZE} to the circumscribing circle's diameter when called with` +
+               'dimensions', ({foundation, adapter, mockRaf}) => {
+  const width = 200;
+  const height = 100;
+  const maxSize = Math.max(width, height);
+  const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
+
+  foundation.layout({width, height});
+  mockRaf.flush();
+
+  td.verify(adapter.updateCssVariable(strings.VAR_FG_SIZE, `${initialSize}px`));
+});
+
 testFoundation(`#layout sets ${strings.VAR_FG_SCALE} based on the difference between the ` +
                'proportion of the max radius and the initial size', ({foundation, adapter, mockRaf}) => {
   const width = 200;

--- a/test/unit/mdc-ripple/mdc-ripple.test.js
+++ b/test/unit/mdc-ripple/mdc-ripple.test.js
@@ -92,7 +92,7 @@ test('layout() delegates to the foundation', () => {
   const {component} = setupTest();
   component.foundation_.layout = td.function();
   component.layout();
-  td.verify(component.foundation_.layout());
+  td.verify(component.foundation_.layout(undefined, undefined));
 });
 
 test('adapter#browserSupportsCssVars delegates to util', () => {

--- a/test/unit/mdc-ripple/mdc-ripple.test.js
+++ b/test/unit/mdc-ripple/mdc-ripple.test.js
@@ -92,7 +92,14 @@ test('layout() delegates to the foundation', () => {
   const {component} = setupTest();
   component.foundation_.layout = td.function();
   component.layout();
-  td.verify(component.foundation_.layout(undefined, undefined));
+  td.verify(component.foundation_.layout(undefined));
+});
+
+test('layout() passes value of dimensions to the foundation when set', () => {
+  const {component} = setupTest();
+  component.foundation_.layout = td.function();
+  component.layout({height: '10px', width: '10px'});
+  td.verify(component.foundation_.layout({height: '10px', width: '10px'}));
 });
 
 test('adapter#browserSupportsCssVars delegates to util', () => {


### PR DESCRIPTION
Pass in width and/or height to `layout()` for ripple surfaces that are JS-upgraded and change size during runtime, so we can update `--mdc-ripple-fg-size` in JS. 

The specific use case this is needed for is in filter chips, but I could extract that out into a separate PR.

Fixes #2334.