### PR TITLE
fix(top-app-bar): Update short collapsed border-radius to match baseline

### DIFF
--- a/packages/mdc-top-app-bar/_variables.scss
+++ b/packages/mdc-top-app-bar/_variables.scss
@@ -30,7 +30,7 @@ $mdc-top-app-bar-mobile-row-height: 56px;
 $mdc-top-app-bar-mobile-section-padding: 4px;
 
 // Short top app bar
-$mdc-top-app-bar-short-collapsed-border-radius: 10px;
+$mdc-top-app-bar-short-collapsed-border-radius: 4px;
 $mdc-top-app-bar-short-collapsed-width: 56px;
 $mdc-top-app-bar-short-collapsed-right-icon-padding: 12px;
 


### PR DESCRIPTION
Updated this value to align with the baseline spec. 