### PR TITLE
fix: Compile demo CSS/JS during `npm run build`

### DIFF
--- a/demos/webpack.config.js
+++ b/demos/webpack.config.js
@@ -36,6 +36,7 @@ const jsBundleFactory = new JsBundleFactory({env, pathResolver, globber, pluginF
 const DEMO_BASE_DIR_ABSOLUTE_PATH = pathResolver.getAbsolutePath('/demos');
 
 const OUTPUT = {
+  fsDirAbsolutePath: pathResolver.getAbsolutePath('/build'),
   httpDirAbsolutePath: '/assets/',
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Material Components Web",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "npm run clean && mkdirp build && webpack --progress --colors",
+    "build": "npm run clean && mkdirp build && webpack --progress --colors && webpack --config=demos/webpack.config.js --progress --colors",
     "build:min": "mkdirp build && cross-env MDC_ENV=production webpack -p --progress --colors",
     "changelog": "standard-changelog -i CHANGELOG.md -k packages/material-components-web/package.json -w",
     "clean": "del-cli build/** build .closure-tmp/** .closure-tmp",

--- a/test/build/goldens/build-config-dev-env.golden.json
+++ b/test/build/goldens/build-config-dev-env.golden.json
@@ -3,6 +3,7 @@
     "name": "main-js-combined",
     "entry": "/packages/material-components-web/index.js",
     "output": {
+      "path": "/build",
       "publicPath": "/assets/",
       "filename": "material-components-web.js",
       "libraryTarget": "umd",
@@ -74,6 +75,7 @@
       "typography": "/demos/typography.scss"
     },
     "output": {
+      "path": "/build",
       "publicPath": "/assets/",
       "filename": "[name].css.js"
     },
@@ -123,6 +125,9 @@
         "options": {}
       },
       {
+        "cleanupDirRelativePath": "/build"
+      },
+      {
         "options": {
           "banner": "/*!\n Material Components for the Web\n Copyright (c) 2018 Google Inc.\n License: Apache-2.0\n*/",
           "raw": true,
@@ -139,6 +144,7 @@
       "theme/index": "/demos/theme/index.js"
     },
     "output": {
+      "path": "/build",
       "publicPath": "/assets/",
       "filename": "[name].js",
       "libraryTarget": "umd",


### PR DESCRIPTION
Fixes a regression introduced by #2325.

Supersedes #2433.

To verify:

1. Build and deploy to staging server:
    ```bash
    MDC_ENV=development npm run build && gcloud app deploy app.yaml --project google.com:mdc-web-dev --version $USER
    ```
2. View the staging server:
    ```
    http://$USER.material-components-web.appspot.com
    ```