### PR TITLE
chore: Skip both package and webpack checks for private packages

### DIFF
--- a/scripts/check-pkg-for-release.js
+++ b/scripts/check-pkg-for-release.js
@@ -51,8 +51,12 @@ function main() {
   checkPublicConfigForNewComponent();
   if (pkg.name !== MASTER_PKG.name) {
     checkNameIsPresentInAllowedScope();
-    checkDependencyAddedInWebpackConfig();
-    checkDependencyAddedInMDCPackage();
+    if (pkg.private) {
+      console.log('Skipping private component', pkg.name);
+    } else {
+      checkDependencyAddedInWebpackConfig();
+      checkDependencyAddedInMDCPackage();
+    }
   }
 }
 
@@ -112,10 +116,6 @@ function checkCSSDependencyAddedInWebpackConfig() {
 }
 
 function checkDependencyAddedInMDCPackage() {
-  if (pkg.private) {
-    console.log('Skipping private component', pkg.name);
-    return;
-  }
   // Package is added to package.json
   checkPkgDependencyAddedInMDCPackage();
 


### PR DESCRIPTION
Follow-up to #2499. We missed part of the check-pkg-for-release script that needed to be revised.