### PR TITLE
docs(notched-outline): Fix front-matter for site generation

### DIFF
--- a/packages/mdc-notched-outline/README.md
+++ b/packages/mdc-notched-outline/README.md
@@ -4,7 +4,7 @@ layout: detail
 section: components
 excerpt: "The notched outline is a border around either a text field or select element"
 iconId: text_field
-path: /catalog/input-controls/notched-outline
+path: /catalog/input-controls/notched-outline/
 -->
 
 # Notched Outline


### PR DESCRIPTION
This was breaking our site generation scripts because the lack of trailing slash leads to generation of invalid navigation tree data.