### PR TITLE
docs(tab): Remove front-matter since package isn't public yet

### DIFF
--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -1,12 +1,3 @@
-<!--docs:
-title: "Tab"
-layout: detail
-section: components
-excerpt: "Tab is a selectable element with an active state"
-iconId: tab
-path: /catalog/tab/
--->
-
 # Tab
 
 <!--<div class="article__asset">
@@ -61,7 +52,7 @@ CSS Class | Description
 
 ### Sass Mixins
 
-To customize the colors of any part of the tab, use the following mixins. 
+To customize the colors of any part of the tab, use the following mixins.
 
 Mixin | Description
 --- | ---


### PR DESCRIPTION
This falls under the same category as #2499. We don't want this listed on the component catalog until all of the pieces of the tab redesign are done.

Also, when we do add it, we should probably use nested paths e.g. `/catalog/tabs/tab` so that there is one top-level item on the catalog listing and the rest appear under it in the nav when you navigate to it.