### PR TITLE
docs(toolbar): Only use h1 on the main heading to fix catalog site

### DIFF
--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -7,11 +7,11 @@ iconId: toolbar
 path: /catalog/toolbar/
 -->
 
-# Important - Deprecation Notice
+## Important - Deprecation Notice
 
 The existing `MDCToolbar` component and styles will be removed in a future release. Some of its functionality
 will be available in the `mdc-top-app-bar` package instead. Bugs and feature requests
-will no longer be accepted for the `mdc-toolbar` package. It is recommended that you migrate to the 
+will no longer be accepted for the `mdc-toolbar` package. It is recommended that you migrate to the
 `mdc-top-app-bar` package to continue to receive new features and updates.
 
 # Toolbars


### PR DESCRIPTION
The site catalog currently uses `h1::before` for the icon at the top of each catalog page, so having multiple h1 elements causes multiple icons. It should probably not do that, but in the interim, this will make the page look normal again.