### PR TITLE
chore(infrastructure): Use `Promise.then()` instead of `.catch()`

### DIFF
--- a/test/screenshot/asset-uploader.js
+++ b/test/screenshot/asset-uploader.js
@@ -70,9 +70,12 @@ async function upload() {
     };
 
     promises.push(
-      file.save(fileContents, fileOptions)
-        .then(() => handleUploadSuccess(baseGcsDir, relativeGcsFilePath))
-        .catch((err) => handleUploadFailure(baseGcsDir, relativeGcsFilePath, err))
+      file
+        .save(fileContents, fileOptions)
+        .then(
+          () => handleUploadSuccess(baseGcsDir, relativeGcsFilePath),
+          (err) => handleUploadFailure(baseGcsDir, relativeGcsFilePath, err)
+        )
     );
   });
 

--- a/test/screenshot/run-upload-assets.js
+++ b/test/screenshot/run-upload-assets.js
@@ -18,17 +18,19 @@
 
 const assetUploader = require('./asset-uploader');
 
-assetUploader.upload()
-  .then((files) => {
-    const htmlFileUrls =
-      files
-        .filter((file) => file.relativePath.endsWith('.html'))
-        .map((file) => file.fullUrl)
-        .sort();
-    console.log('\n\nDONE!\n\n');
-    console.log(htmlFileUrls.join('\n'));
-  })
-  .catch((err) => {
-    console.error('\n\nERROR!\n\n');
-    console.error(err);
-  });
+assetUploader.upload().then(handleUploadSuccess, handleUploadFailure);
+
+function handleUploadSuccess(files) {
+  const htmlFileUrls =
+    files
+      .filter((file) => file.relativePath.endsWith('.html'))
+      .map((file) => file.fullUrl)
+      .sort();
+  console.log('\n\nDONE!\n\n');
+  console.log(htmlFileUrls.join('\n'));
+}
+
+function handleUploadFailure(err) {
+  console.error('\n\nERROR!\n\n');
+  console.error(err);
+}


### PR DESCRIPTION
There's a subtle but important difference between these two lines of code:

```js
promise.then(good, bad);
promise.then(good).catch(bad);
```

The first line is probably better, because it only calls `bad` when there's an error in the promise _executor_.

The second line calls `bad` if an error is thrown in the promise executor _or_ the `good` handler, which is a little strange and unexpected.

See https://gist.github.com/kfranqueiro/9ba61be2a71727d75271d336a81a7d72