### PR TITLE
docs(top-app-bar): Add metadata for catalog site

### DIFF
--- a/packages/mdc-toolbar/README.md
+++ b/packages/mdc-toolbar/README.md
@@ -10,7 +10,7 @@ path: /catalog/toolbar/
 ## Important - Deprecation Notice
 
 The existing `MDCToolbar` component and styles will be removed in a future release. Some of its functionality
-will be available in the `mdc-top-app-bar` package instead. Bugs and feature requests
+will be available in the [MDC Top App Bar](../mdc-top-app-bar) package instead. Bugs and feature requests
 will no longer be accepted for the `mdc-toolbar` package. It is recommended that you migrate to the
 `mdc-top-app-bar` package to continue to receive new features and updates.
 

--- a/packages/mdc-top-app-bar/README.md
+++ b/packages/mdc-top-app-bar/README.md
@@ -11,7 +11,7 @@ path: /catalog/top-app-bar/
 
 <!--<div class="article__asset">
   <a class="article__asset-link"
-     href="https://material-components-web.appspot.com/top-app-bar/index.html">
+     href="https://material-components-web.appspot.com/top-app-bar.html">
     <img src="{{ site.rootpath }}/images/mdc_web_screenshots/top-app-bar.png" width="494" alt="Top App Bar screenshot">
   </a>
 </div>-->

--- a/packages/mdc-top-app-bar/README.md
+++ b/packages/mdc-top-app-bar/README.md
@@ -1,4 +1,20 @@
+<!--docs:
+title: "Top App Bar"
+layout: detail
+section: components
+excerpt: "A container for items such as application title, navigation icon, and action items."
+iconId: toolbar
+path: /catalog/top-app-bar/
+-->
+
 # Top App Bar
+
+<!--<div class="article__asset">
+  <a class="article__asset-link"
+     href="https://material-components-web.appspot.com/top-app-bar/index.html">
+    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/top-app-bar.png" width="494" alt="Top App Bar screenshot">
+  </a>
+</div>-->
 
 MDC Top App Bar acts as a container for items such as application title, navigation icon, and action items. Top app bars scroll with content by default.
 


### PR DESCRIPTION
We held off adding this until several features of Top App Bar were fleshed out. Now that we've added the deprecation notice to Toolbar, it makes sense to make this visible in the catalog.