### PR TITLE
docs: Add front-matter to importing-js.md to appear in catalog

### DIFF
--- a/docs/importing-js.md
+++ b/docs/importing-js.md
@@ -1,3 +1,11 @@
+<!--docs:
+title: "Importing JS Components"
+navTitle: "Importing JS Components"
+layout: landing
+section: docs
+path: /docs/importing-js/
+-->
+
 # Importing the JS component
 
 Most components ship with Component / Foundation classes which are used to provide a full-fidelity Material Design component. Depending on what technology you use in your stack, there are several ways to import the JavaScript.


### PR DESCRIPTION
Right now this isn't included in the documentation nav on material.io for MDC Web, which causes it to cross-link to github instead. Adding this causes links to it to remain within material.io.