### PR TITLE
fix(button): Fix vertical alignment of contents

### DIFF
--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -149,6 +149,8 @@ Mixin | Description
 
 The ripple effect for the Button component is styled using [MDC Ripple](../mdc-ripple) mixins.
 
+> **Note:** If you want to customize both horizontal padding and stroke width, simply include the `mdc-button-stroke-width` mixin with both arguments. It will include `mdc-button-horizontal-padding` for you.
+
 #### Caveat: Edge and CSS Variables
 
 In browsers that fully support CSS variables, the above mixins will hook up styles using CSS variables if a theme property is passed.

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -67,16 +67,16 @@
 }
 
 @mixin mdc-button-horizontal-padding($padding) {
-  padding-right: $padding;
-  padding-left: $padding;
+  // $padding should be a single value; enforce it by specifying all 4 sides in the output
+  padding: 0 $padding 0 $padding;
 }
 
 @mixin mdc-button-stroke-width($stroke-width, $padding: $mdc-button-contained-horizontal-padding) {
   // Note: Adjust padding to maintain consistent width with non-stroked buttons
   $padding-value: max($padding - $stroke-width, 0);
 
-  padding-right: $padding-value;
-  padding-left: $padding-value;
+  @include mdc-button-horizontal-padding($padding-value);
+
   border-width: $stroke-width;
   // Note: line height is adjusted for stroke button because borders are not
   // considered as space available to text on the Web
@@ -104,6 +104,7 @@
   height: $mdc-button-height;
   border: none;
   outline: none;
+  line-height: inherit;
   user-select: none;
   -webkit-appearance: none;
   overflow: hidden;


### PR DESCRIPTION
When creating the horizontal-padding mixin, we unwittingly removed styles that set 0 top and bottom padding, which is important for overriding UA stylesheets. I also didn't need to remove the line-height style when switching to inline-flex.

Also added a note to the readme to clarify the case of customizing padding when stroke is used.