### PR TITLE
fix(card): updated demo to have separate block element

### DIFF
--- a/demos/card.html
+++ b/demos/card.html
@@ -151,32 +151,34 @@
               </div>
             </div>
           </a>
-          <div class="mdc-card__actions mdc-card__action-icons">
-            <i class="mdc-icon-toggle material-icons mdc-card__action mdc-card__action--icon"
-               tabindex="0"
-               role="button"
-               aria-pressed="false"
-               aria-label="Add to favorites"
-               title="Add to favorites"
-               data-toggle-on='{"content": "favorite", "label": "Remove from favorites"}'
-               data-toggle-off='{"content": "favorite_border", "label": "Add to favorites"}'>
-              favorite_border
-            </i>
-            <i class="mdc-icon-toggle material-icons mdc-card__action mdc-card__action--icon"
-               tabindex="0"
-               role="button"
-               aria-pressed="false"
-               aria-label="Add bookmark"
-               title="Add bookmark"
-               data-toggle-on='{"content": "bookmark", "label": "Remove bookmark"}'
-               data-toggle-off='{"content": "bookmark_border", "label": "Add bookmark"}'>
-              bookmark_border
-            </i>
-            <i class="material-icons mdc-card__action mdc-card__action--icon mdc-ripple-surface"
-               tabindex="0"
-               role="button"
-               data-mdc-ripple-is-unbounded
-               title="Share">share</i>
+          <div class="mdc-card__actions">
+            <div class="mdc-card__action-icons">
+              <i class="mdc-icon-toggle material-icons mdc-card__action mdc-card__action--icon"
+                 tabindex="0"
+                 role="button"
+                 aria-pressed="false"
+                 aria-label="Add to favorites"
+                 title="Add to favorites"
+                 data-toggle-on='{"content": "favorite", "label": "Remove from favorites"}'
+                 data-toggle-off='{"content": "favorite_border", "label": "Add to favorites"}'>
+                favorite_border
+              </i>
+              <i class="mdc-icon-toggle material-icons mdc-card__action mdc-card__action--icon"
+                 tabindex="0"
+                 role="button"
+                 aria-pressed="false"
+                 aria-label="Add bookmark"
+                 title="Add bookmark"
+                 data-toggle-on='{"content": "bookmark", "label": "Remove bookmark"}'
+                 data-toggle-off='{"content": "bookmark_border", "label": "Add bookmark"}'>
+                bookmark_border
+              </i>
+              <i class="material-icons mdc-card__action mdc-card__action--icon mdc-ripple-surface"
+                 tabindex="0"
+                 role="button"
+                 data-mdc-ripple-is-unbounded
+                 title="Share">share</i>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
Moved `mdc-card__action-icons` to a separate block element, since it breaks the rules of BEM, which states you shouldn't have 2 block selectors on the same element.