### PR TITLE
chore(dialog): Remove ripple layout & layoutFooterRipples adapter API

### DIFF
--- a/packages/mdc-dialog/foundation.js
+++ b/packages/mdc-dialog/foundation.js
@@ -46,7 +46,6 @@ export default class MDCDialogFoundation extends MDCFoundation {
       trapFocusOnSurface: () => {},
       untrapFocusOnSurface: () => {},
       isDialog: (/* el: Element */) => /* boolean */ false,
-      layoutFooterRipples: () => {},
     };
   }
 
@@ -138,7 +137,6 @@ export default class MDCDialogFoundation extends MDCFoundation {
       this.adapter_.removeClass(MDCDialogFoundation.cssClasses.ANIMATING);
       if (this.isOpen_) {
         this.adapter_.trapFocusOnSurface();
-        this.adapter_.layoutFooterRipples();
       } else {
         this.enableScroll_();
       };

--- a/packages/mdc-dialog/index.js
+++ b/packages/mdc-dialog/index.js
@@ -83,7 +83,6 @@ export class MDCDialog extends MDCComponent {
       trapFocusOnSurface: () => this.focusTrap_.activate(),
       untrapFocusOnSurface: () => this.focusTrap_.deactivate(),
       isDialog: (el) => el === this.dialogSurface_,
-      layoutFooterRipples: () => this.footerBtnRipples_.forEach((ripple) => ripple.layout()),
     });
   }
 }

--- a/test/unit/mdc-dialog/foundation.test.js
+++ b/test/unit/mdc-dialog/foundation.test.js
@@ -40,7 +40,6 @@ test('default adapter returns a complete adapter implementation', () => {
     'registerDocumentKeydownHandler', 'deregisterDocumentKeydownHandler',
     'registerTransitionEndHandler', 'deregisterTransitionEndHandler',
     'notifyAccept', 'notifyCancel', 'trapFocusOnSurface', 'untrapFocusOnSurface', 'isDialog',
-    'layoutFooterRipples',
   ]);
 });
 
@@ -156,16 +155,6 @@ test('#close deactivates focus trapping on the dialog surface', () => {
   foundation.close();
 
   td.verify(mockAdapter.untrapFocusOnSurface());
-});
-
-test('#open calls adapter method to re-layout footer ripples', () => {
-  const {foundation, mockAdapter} = setupTest();
-
-  td.when(mockAdapter.registerTransitionEndHandler(td.callback)).thenCallback({target: {}});
-  td.when(mockAdapter.isDialog(td.matchers.isA(Object))).thenReturn(true);
-  foundation.open();
-
-  td.verify(mockAdapter.layoutFooterRipples());
 });
 
 test('#accept closes the dialog', () => {

--- a/test/unit/mdc-dialog/mdc-dialog.test.js
+++ b/test/unit/mdc-dialog/mdc-dialog.test.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-// This suite requires hooks to stub (and clean up) MDCRipple#layout.
-/* eslint mocha/no-hooks: "off" */
-
 import {assert} from 'chai';
 import bel from 'bel';
 import domEvents from 'dom-events';
@@ -72,22 +69,6 @@ function hasClassMatcher(className) {
 }
 
 suite('MDCDialog');
-
-const originalLayout = MDCRipple.prototype.layout;
-const stubbedLayout = td.func('MDCRipple#layout');
-
-before(() => {
-  MDCRipple.prototype.layout = stubbedLayout;
-});
-
-afterEach(() => {
-  // Ensure that stubbedLayout's call count resets between tests
-  td.reset();
-});
-
-after(() => {
-  MDCRipple.prototype.layout = originalLayout;
-});
 
 test('attachTo returns a component instance', () => {
   assert.isOk(MDCDialog.attachTo(getFixture().querySelector('.mdc-dialog')) instanceof MDCDialog);
@@ -331,10 +312,4 @@ test('adapter#isDialog returns true for the dialog surface element', () => {
 test('adapter#isDialog returns false for a non-dialog surface element', () => {
   const {root, component} = setupTest();
   assert.isNotOk(component.getDefaultFoundation().adapter_.isDialog(root));
-});
-
-test('adapter#layoutFooterRipples calls layout on each footer button\'s ripple instance', () => {
-  const {component} = setupTest();
-  component.getDefaultFoundation().adapter_.layoutFooterRipples();
-  td.verify(stubbedLayout(), {times: 2});
 });


### PR DESCRIPTION
Ripple now calls layout upon activation.

The layoutFooterRipples adapter API is no longer used and can be removed.

Requires #2567 (which this PR is based on).