### PR TITLE
chore(package): update google-closure-compiler to version 20180402.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
-    "google-closure-compiler": "^20170521.0.0",
+    "google-closure-compiler": "^20180402.0.0",
     "husky": "^0.14.0",
     "istanbul": "^0.4.4",
     "istanbul-instrumenter-loader": "^3.0.0",

--- a/scripts/closure-test.sh
+++ b/scripts/closure-test.sh
@@ -60,7 +60,6 @@ for pkg in $CLOSURIZED_PKGS; do
   --js $(find $CLOSURE_PKGDIR -type f -name "*.js") \
   --language_out ECMASCRIPT5_STRICT \
   --dependency_mode STRICT \
-  --module_resolution LEGACY \
   --js_module_root $CLOSURE_PKGDIR \
   --entry_point $entry_point \
   --checks_only \


### PR DESCRIPTION
Fixes #2558

Closure Compiler removed the `LEGACY` value for `--module_resolution`. It now defaults to `BROWSER` instead.

That change was made in google/closure-compiler@c2cd433

I ran `npm run test:closure` on this PR and `master` and compared their generated `.closure-tmp` directories. [Beyond Compare](https://www.scootersoftware.com/) found no diffs.