### PR TITLE
docs: Update issue template codepen to include icons/roboto

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,29 +1,8 @@
 ** PLEASE READ THIS BEFORE FILING AN ISSUE **
 
-## Feature Requests
-
-> If you're interested in requesting a new component or proposing UX changes to an existing
-> component, please read our [Component Request Policy](https://github.com/material-components/material-components/blob/develop/COMPONENTS_REQUEST_POLICY.md) before opening an issue.
-
-If you have an idea for a new feature, we'd love to hear about it! Please provide enough
-information regarding the feature such that we'll be able to evaluate the appropriateness and
-feasibility of your request. Try to be as specific as possible regarding your motivation, use-case,
-and potential API or affects on other APIs (where applicable). The more detailed your proposal is,
-the easier it will be for us to understand and evaluate it. [This Meta.SE answer](http://meta.stackexchange.com/a/259196) also contains great general guidelines for writing
-feature requests.
-
-If you'd like to work on a component, please ensure that you *submit an Engineering Outline before
-submitting a pull request*. You can read more about this in our [contributing docs](https://github.com/material-components/material-components-web/blob/master/CONTRIBUTING.md#building-components).
-
-MDC Web is still under active development. You can see our current progress on [master](https://github.com/material-components/material-components-web/tree/master) as well as an overview of our [architecture and practices](https://github.com/material-components/material-components-web/blob/master/docs/code).
-
-If you're interested in information for a specific component, check out our [component issues](https://github.com/material-components/material-components-web/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Av2-component) to see which milestone it's associated with and subscribe to updates to it. If an issue has the `in-tracker` label, you can also take a look at our [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1664011) for a rough estimate of when we'll get to it.
-
-Our team prioritizes responding to as many engineering and user experience questions as possible. We do not support responses to questions outside of these areas at this time.
-
 ## Bugs
 
-Follow the template below to ensure the quickest and most accurate response to your issue.
+Follow the template below **and include a codepen** to ensure the quickest and most accurate response to your issue.
 
 ### What MDC Web Version are you using?
 
@@ -47,7 +26,7 @@ Follow the template below to ensure the quickest and most accurate response to y
 > 3. Tab-focus on the first text field
 > 4. Observe the component's behavior
 >
-> We also have a [template on CodePen](http://codepen.io/traviskaufman/pen/pNQmRp) which we encourage you to use to create a reproduction of
+> We also have a [template on CodePen](https://codepen.io/williamernest/pen/deyxyp) which we encourage you to use to create a reproduction of
 > the issue. The less time it takes for us to reproduce the issue, the less time it takes to verify and
 > fix it!
 
@@ -61,3 +40,24 @@ Follow the template below to ensure the quickest and most accurate response to y
 doing.
 
 ### Any other information you believe would be useful?
+
+## Feature Requests
+
+> If you're interested in requesting a new component or proposing UX changes to an existing
+> component, please read our [Component Request Policy](https://github.com/material-components/material-components/blob/develop/COMPONENTS_REQUEST_POLICY.md) before opening an issue.
+
+If you have an idea for a new feature, we'd love to hear about it! Please provide enough
+information regarding the feature such that we'll be able to evaluate the appropriateness and
+feasibility of your request. Try to be as specific as possible regarding your motivation, use-case,
+and potential API or affects on other APIs (where applicable). The more detailed your proposal is,
+the easier it will be for us to understand and evaluate it. [This Meta.SE answer](http://meta.stackexchange.com/a/259196) also contains great general guidelines for writing
+feature requests.
+
+If you'd like to work on a component, please ensure that you *submit an Engineering Outline before
+submitting a pull request*. You can read more about this in our [contributing docs](https://github.com/material-components/material-components-web/blob/master/CONTRIBUTING.md#building-components).
+
+MDC Web is still under active development. You can see our current progress on [master](https://github.com/material-components/material-components-web/tree/master) as well as an overview of our [architecture and practices](https://github.com/material-components/material-components-web/blob/master/docs/code).
+
+If you're interested in information for a specific component, check out our [component issues](https://github.com/material-components/material-components-web/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Av2-component) to see which milestone it's associated with and subscribe to updates to it. If an issue has the `in-tracker` label, you can also take a look at our [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1664011) for a rough estimate of when we'll get to it.
+
+Our team prioritizes responding to as many engineering and user experience questions as possible. We do not support responses to questions outside of these areas at this time.


### PR DESCRIPTION
Update issue template to move bug reporting steps and codepen to the top. Also updates the codepen link to a codepen template that include material icons and the roboto font. 