### PR TITLE
fix(text-field): Restore icon tabindex according to its initial value

### DIFF
--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -105,6 +105,7 @@ This allows the parent `MDCTextField` component to access the public methods on 
 
 Method Signature | Description
 --- | ---
+`getAttr(attr: string) => string` | Gets the value of an attribute on the icon element
 `setAttr(attr: string, value: string) => void` | Sets an attribute with a given value on the icon element
 `removeAttr(attr: string) => void` | Removes an attribute from the icon element
 `registerInteractionHandler(evtType: string, handler: EventListener) => void` | Registers an event listener for a given event

--- a/packages/mdc-textfield/icon/adapter.js
+++ b/packages/mdc-textfield/icon/adapter.js
@@ -29,6 +29,13 @@
  */
 class MDCTextFieldIconAdapter {
   /**
+   * Gets the value of an attribute on the icon element.
+   * @param {string} attr
+   * @return {string}
+   */
+  getAttr(attr) {}
+
+  /**
    * Sets an attribute on the icon element.
    * @param {string} attr
    * @param {string} value

--- a/packages/mdc-textfield/icon/foundation.js
+++ b/packages/mdc-textfield/icon/foundation.js
@@ -52,7 +52,7 @@ class MDCTextFieldIconFoundation extends MDCFoundation {
   constructor(adapter) {
     super(Object.assign(MDCTextFieldIconFoundation.defaultAdapter, adapter));
 
-    /** @private {number?} */
+    /** @private {string?} */
     this.savedTabIndex_ = null;
 
     /** @private {function(!Event): undefined} */

--- a/packages/mdc-textfield/icon/foundation.js
+++ b/packages/mdc-textfield/icon/foundation.js
@@ -37,6 +37,7 @@ class MDCTextFieldIconFoundation extends MDCFoundation {
    */
   static get defaultAdapter() {
     return /** @type {!MDCTextFieldIconAdapter} */ ({
+      getAttr: () => {},
       setAttr: () => {},
       removeAttr: () => {},
       registerInteractionHandler: () => {},
@@ -51,11 +52,16 @@ class MDCTextFieldIconFoundation extends MDCFoundation {
   constructor(adapter) {
     super(Object.assign(MDCTextFieldIconFoundation.defaultAdapter, adapter));
 
+    /** @private {number?} */
+    this.savedTabIndex_ = null;
+
     /** @private {function(!Event): undefined} */
     this.interactionHandler_ = (evt) => this.handleInteraction(evt);
   }
 
   init() {
+    this.savedTabIndex_ = this.adapter_.getAttr('tabindex');
+
     ['click', 'keydown'].forEach((evtType) => {
       this.adapter_.registerInteractionHandler(evtType, this.interactionHandler_);
     });
@@ -73,10 +79,14 @@ class MDCTextFieldIconFoundation extends MDCFoundation {
    */
   setDisabled(disabled) {
     if (disabled) {
-      this.adapter_.setAttr('tabindex', '-1');
+      if (this.savedTabIndex_) {
+        this.adapter_.setAttr('tabindex', '-1');
+      }
       this.adapter_.removeAttr('role');
     } else {
-      this.adapter_.setAttr('tabindex', '0');
+      if (this.savedTabIndex_) {
+        this.adapter_.setAttr('tabindex', this.savedTabIndex_);
+      }
       this.adapter_.setAttr('role', strings.ICON_ROLE);
     }
   }

--- a/packages/mdc-textfield/icon/foundation.js
+++ b/packages/mdc-textfield/icon/foundation.js
@@ -78,15 +78,15 @@ class MDCTextFieldIconFoundation extends MDCFoundation {
    * @param {boolean} disabled
    */
   setDisabled(disabled) {
+    if (!this.savedTabIndex_) {
+      return;
+    }
+
     if (disabled) {
-      if (this.savedTabIndex_) {
-        this.adapter_.setAttr('tabindex', '-1');
-      }
+      this.adapter_.setAttr('tabindex', '-1');
       this.adapter_.removeAttr('role');
     } else {
-      if (this.savedTabIndex_) {
-        this.adapter_.setAttr('tabindex', this.savedTabIndex_);
-      }
+      this.adapter_.setAttr('tabindex', this.savedTabIndex_);
       this.adapter_.setAttr('role', strings.ICON_ROLE);
     }
   }

--- a/packages/mdc-textfield/icon/index.js
+++ b/packages/mdc-textfield/icon/index.js
@@ -45,6 +45,7 @@ class MDCTextFieldIcon extends MDCComponent {
    */
   getDefaultFoundation() {
     return new MDCTextFieldIconFoundation(/** @type {!MDCTextFieldIconAdapter} */ (Object.assign({
+      getAttr: (attr) => this.root_.getAttribute(attr),
       setAttr: (attr, value) => this.root_.setAttribute(attr, value),
       removeAttr: (attr) => this.root_.removeAttribute(attr),
       registerInteractionHandler: (evtType, handler) => this.root_.addEventListener(evtType, handler),

--- a/test/unit/mdc-textfield/mdc-text-field-icon-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-icon-foundation.test.js
@@ -30,7 +30,7 @@ test('exports strings', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTextFieldIconFoundation, [
-    'setAttr', 'removeAttr', 'registerInteractionHandler', 'deregisterInteractionHandler',
+    'getAttr', 'setAttr', 'removeAttr', 'registerInteractionHandler', 'deregisterInteractionHandler',
     'notifyIconAction',
   ]);
 });
@@ -53,10 +53,22 @@ test('#destroy removes event listeners', () => {
   td.verify(mockAdapter.deregisterInteractionHandler('keydown', td.matchers.isA(Function)));
 });
 
-test('#setDisabled sets icon tabindex to -1 when set to true', () => {
+test('#setDisabled sets icon tabindex to -1 when set to true if icon initially had a tabindex', () => {
   const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn('1');
+  foundation.init();
+
   foundation.setDisabled(true);
   td.verify(mockAdapter.setAttr('tabindex', '-1'));
+});
+
+test('#setDisabled does not set icon tabindex when set to true if icon initially had no tabindex', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn(null);
+  foundation.init();
+
+  foundation.setDisabled(true);
+  td.verify(mockAdapter.setAttr('tabindex', td.matchers.isA(String)), {times: 0});
 });
 
 test('#setDisabled removes icon role when set to true', () => {
@@ -65,10 +77,23 @@ test('#setDisabled removes icon role when set to true', () => {
   td.verify(mockAdapter.removeAttr('role'));
 });
 
-test('#setDisabled sets icon tabindex to 0 when set to false', () => {
+test('#setDisabled restores icon tabindex when set to false if icon initially had a tabindex', () => {
   const {foundation, mockAdapter} = setupTest();
+  const expectedTabIndex = '1';
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn(expectedTabIndex);
+  foundation.init();
+
   foundation.setDisabled(false);
-  td.verify(mockAdapter.setAttr('tabindex', '0'));
+  td.verify(mockAdapter.setAttr('tabindex', expectedTabIndex));
+});
+
+test('#setDisabled does not set icon tabindex when set to false if icon initially had no tabindex', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn(null);
+  foundation.init();
+
+  foundation.setDisabled(false);
+  td.verify(mockAdapter.setAttr('tabindex', td.matchers.isA(String)), {times: 0});
 });
 
 test(`#setDisabled sets icon role to ${strings.ICON_ROLE} when set to false`, () => {

--- a/test/unit/mdc-textfield/mdc-text-field-icon-foundation.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-icon-foundation.test.js
@@ -53,31 +53,27 @@ test('#destroy removes event listeners', () => {
   td.verify(mockAdapter.deregisterInteractionHandler('keydown', td.matchers.isA(Function)));
 });
 
-test('#setDisabled sets icon tabindex to -1 when set to true if icon initially had a tabindex', () => {
+test('#setDisabled sets icon tabindex to -1 and removes role when set to true if icon initially had a tabindex', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.getAttr('tabindex')).thenReturn('1');
   foundation.init();
 
   foundation.setDisabled(true);
   td.verify(mockAdapter.setAttr('tabindex', '-1'));
+  td.verify(mockAdapter.removeAttr('role'));
 });
 
-test('#setDisabled does not set icon tabindex when set to true if icon initially had no tabindex', () => {
+test('#setDisabled does not change icon tabindex or role when set to true if icon initially had no tabindex', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.getAttr('tabindex')).thenReturn(null);
   foundation.init();
 
   foundation.setDisabled(true);
   td.verify(mockAdapter.setAttr('tabindex', td.matchers.isA(String)), {times: 0});
+  td.verify(mockAdapter.removeAttr('role'), {times: 0});
 });
 
-test('#setDisabled removes icon role when set to true', () => {
-  const {foundation, mockAdapter} = setupTest();
-  foundation.setDisabled(true);
-  td.verify(mockAdapter.removeAttr('role'));
-});
-
-test('#setDisabled restores icon tabindex when set to false if icon initially had a tabindex', () => {
+test('#setDisabled restores icon tabindex and role when set to false if icon initially had a tabindex', () => {
   const {foundation, mockAdapter} = setupTest();
   const expectedTabIndex = '1';
   td.when(mockAdapter.getAttr('tabindex')).thenReturn(expectedTabIndex);
@@ -85,21 +81,17 @@ test('#setDisabled restores icon tabindex when set to false if icon initially ha
 
   foundation.setDisabled(false);
   td.verify(mockAdapter.setAttr('tabindex', expectedTabIndex));
+  td.verify(mockAdapter.setAttr('role', strings.ICON_ROLE));
 });
 
-test('#setDisabled does not set icon tabindex when set to false if icon initially had no tabindex', () => {
+test('#setDisabled does not change icon tabindex or role when set to false if icon initially had no tabindex', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.getAttr('tabindex')).thenReturn(null);
   foundation.init();
 
   foundation.setDisabled(false);
   td.verify(mockAdapter.setAttr('tabindex', td.matchers.isA(String)), {times: 0});
-});
-
-test(`#setDisabled sets icon role to ${strings.ICON_ROLE} when set to false`, () => {
-  const {foundation, mockAdapter} = setupTest();
-  foundation.setDisabled(false);
-  td.verify(mockAdapter.setAttr('role', strings.ICON_ROLE));
+  td.verify(mockAdapter.setAttr('role', td.matchers.isA(String)), {times: 0});
 });
 
 test('on click notifies custom icon event', () => {

--- a/test/unit/mdc-textfield/mdc-text-field-icon.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-icon.test.js
@@ -37,6 +37,14 @@ function setupTest() {
   return {root, component};
 }
 
+test('#adapter.getAttr returns the value of a given attribute on the element', () => {
+  const {root, component} = setupTest();
+  const expectedAttr = 'tabindex';
+  const expectedValue = '0';
+  root.setAttribute(expectedAttr, expectedValue);
+  assert.equal(component.getDefaultFoundation().adapter_.getAttr(expectedAttr), expectedValue);
+});
+
 test('#adapter.setAttr adds a given attribute to the element', () => {
   const {root, component} = setupTest();
   component.getDefaultFoundation().adapter_.setAttr('aria-label', 'foo');


### PR DESCRIPTION
h/t to @MrChriZ for originally giving this a shot in #2441. This is effectively a review of that with fewer overall changes, but I figured it'd be easier to re-apply the changes since that PR had conflicts with master at this point.

Fixes #2156.

BREAKING CHANGE: Adds getAttr adapter API to text field icon