### PR TITLE
fix(chips): Update to guidance

### DIFF
--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -67,7 +67,7 @@
   }
 }
 
-@mixin mdc-chip-stroke($width: 1, $style: solid, $color: black) {
+@mixin mdc-chip-stroke($width: 1, $style: solid, $color: mdc-theme-prop-value(on-surface)) {
   @include mdc-chip-stroke-width($width);
   @include mdc-chip-stroke-style($style);
   @include mdc-chip-stroke-color($color);

--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -29,10 +29,10 @@
 
   @if ($fill-tone == "dark") {
     @include mdc-chip-ink-color(text-primary-on-dark);
-    @include mdc-chip-selected-ink-color(white);
+    @include mdc-chip-selected-ink-color(text-primary-on-dark);
   } @else {
     @include mdc-chip-ink-color(text-primary-on-light);
-    @include mdc-chip-selected-ink-color(black);
+    @include mdc-chip-selected-ink-color(text-primary-on-light);
   }
 }
 

--- a/packages/mdc-chips/_variables.scss
+++ b/packages/mdc-chips/_variables.scss
@@ -17,7 +17,7 @@
 @import "@material/theme/variables";
 
 $mdc-chip-border-radius-default: 16px;
-$mdc-chip-fill-color-default: rgba(mdc-theme-prop-value(on-surface), .12);
+$mdc-chip-fill-color-default: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 12%);
 $mdc-chip-ink-color-default: rgba(mdc-theme-prop-value(on-surface), .87);
 $mdc-chip-horizontal-padding: 12px;
 $mdc-chip-vertical-padding: 7px;

--- a/packages/mdc-chips/chip/mdc-chip.scss
+++ b/packages/mdc-chips/chip/mdc-chip.scss
@@ -20,6 +20,7 @@
 @import "@material/ripple/common";
 @import "@material/ripple/mixins";
 @import "@material/theme/mixins";
+@import "@material/typography/mixins";
 @import "../mixins";
 @import "../variables";
 

--- a/packages/mdc-chips/chip/mdc-chip.scss
+++ b/packages/mdc-chips/chip/mdc-chip.scss
@@ -30,6 +30,7 @@
   @include mdc-chip-fill-color($mdc-chip-fill-color-default);
   @include mdc-chip-ink-color($mdc-chip-ink-color-default);
   @include mdc-chip-selected-ink-color(primary);
+  @include mdc-typography(body2);
 
   display: inline-flex;
   position: relative;
@@ -40,7 +41,7 @@
   overflow: hidden;
 
   &:hover {
-    @include mdc-theme-prop(color, black);
+    @include mdc-theme-prop(color, on-surface);
   }
 }
 

--- a/packages/mdc-chips/package.json
+++ b/packages/mdc-chips/package.json
@@ -19,6 +19,7 @@
     "@material/animation": "^0.34.0",
     "@material/base": "^0.34.0",
     "@material/checkbox": "^0.34.1",
-    "@material/ripple": "^0.34.1"
+    "@material/ripple": "^0.34.1",
+    "@material/typography": "^0.34.0"
   }
 }


### PR DESCRIPTION
Fixes: #2479 
Adds proper typography style.
Changes references to `black` color to use `on-surface`
