### PR TITLE
style: Use single-line `//` comments in Sass

### DIFF
--- a/packages/mdc-drawer/_mixins.scss
+++ b/packages/mdc-drawer/_mixins.scss
@@ -32,7 +32,7 @@
     padding: 16px;
     border-bottom: 1px solid rgba(0, 0, 0, .12);
 
-    /* TODO(sgomes): replace with global breakpoints when we have them */
+    // TODO(sgomes): replace with global breakpoints when we have them
     @media (min-width: 600px) {
       height: 64px;
     }
@@ -40,7 +40,7 @@
 }
 
 @mixin mdc-drawer-header_() {
-  /* Use aspect ratio trick to maintain 16:9 aspect ratio on the header */
+  // Use aspect ratio trick to maintain 16:9 aspect ratio on the header
   // styline things header is a type
   // stylelint-disable selector-max-type
   .mdc-drawer__header {

--- a/packages/mdc-drawer/temporary/mdc-temporary-drawer.scss
+++ b/packages/mdc-drawer/temporary/mdc-temporary-drawer.scss
@@ -39,7 +39,7 @@
   contain: strict;
   z-index: 5;
 
-  /* Shaded background */
+  // Shaded background
   &::before {
     display: block;
     position: absolute;
@@ -68,7 +68,7 @@
     overflow: hidden;
     touch-action: none;
 
-    /* TODO(sgomes): replace with global breakpoints when we have them */
+    // TODO(sgomes): replace with global breakpoints when we have them
     @media (min-width: 600px) {
       width: calc(100% - 64px);
       max-width: 320px;

--- a/packages/mdc-elevation/_mixins.scss
+++ b/packages/mdc-elevation/_mixins.scss
@@ -17,12 +17,10 @@
 @import "@material/theme/variables";
 @import "./variables";
 
-/**
- * Applies the correct CSS rules to an element to give it the elevation specified by $z-value.
- * The $z-value must be between 0 and 24.
- * If $color has an alpha channel, it will be ignored and overridden. To increase the opacity of the shadow, use
- * $opacity-boost.
- */
+// Applies the correct CSS rules to an element to give it the elevation specified by $z-value.
+// The $z-value must be between 0 and 24.
+// If $color has an alpha channel, it will be ignored and overridden. To increase the opacity of the shadow, use
+// $opacity-boost.
 @mixin mdc-elevation($z-value, $color: $mdc-elevation-baseline-color, $opacity-boost: 0) {
   @if type-of($z-value) != number or not unitless($z-value) {
     @error "$z-value must be a unitless number, but received '#{$z-value}'";
@@ -54,18 +52,16 @@
     #{$ambient-z-value} $ambient-color;
 }
 
-/**
- * Returns a string that can be used as the value for a `transition` property for elevation.
- * Calling this function directly is useful in situations where a component needs to transition
- * more than one property.
- *
- * ```scss
- * .foo {
- *   transition: mdc-elevation-transition-value(), opacity 100ms ease;
- *   will-change: $mdc-elevation-property, opacity;
- * }
- * ```
- */
+// Returns a string that can be used as the value for a `transition` property for elevation.
+// Calling this function directly is useful in situations where a component needs to transition
+// more than one property.
+//
+// ```scss
+// .foo {
+//   transition: mdc-elevation-transition-value(), opacity 100ms ease;
+//   will-change: $mdc-elevation-property, opacity;
+// }
+// ```
 @function mdc-elevation-transition-value(
   $duration: $mdc-elevation-transition-duration,
   $easing: $mdc-elevation-transition-timing-function) {

--- a/packages/mdc-elevation/_variables.scss
+++ b/packages/mdc-elevation/_variables.scss
@@ -105,19 +105,13 @@ $mdc-elevation-ambient-map: (
   24: "0px 9px 46px 8px"
 );
 
-/**
- * The css property used for elevation. In most cases this should not be changed. It is exposed
- * as a variable for abstraction / easy use when needing to reference the property directly, for
- * example in a `will-change` rule.
- */
+// The css property used for elevation. In most cases this should not be changed. It is exposed
+// as a variable for abstraction / easy use when needing to reference the property directly, for
+// example in a `will-change` rule.
 $mdc-elevation-property: box-shadow !default;
 
-/**
- * The default duration value for elevation transitions.
- */
+// The default duration value for elevation transitions.
 $mdc-elevation-transition-duration: 280ms !default;
 
-/**
- * The default easing value for elevation transitions.
- */
+// The default easing value for elevation transitions.
 $mdc-elevation-transition-timing-function: $mdc-animation-standard-curve-timing-function !default;

--- a/packages/mdc-form-field/mdc-form-field.scss
+++ b/packages/mdc-form-field/mdc-form-field.scss
@@ -20,7 +20,7 @@
 
 $mdc-form-field-item-spacing: 4px;
 
-/* stylelint-disable selector-max-type */
+// stylelint-disable selector-max-type
 .mdc-form-field {
   @include mdc-typography(body2);
   @include mdc-theme-prop(color, text-primary-on-background);
@@ -57,4 +57,4 @@ $mdc-form-field-item-spacing: 4px;
     }
   }
 }
-/* stylelint-enable selector-max-type */
+// stylelint-enable selector-max-type

--- a/packages/mdc-icon-toggle/mdc-icon-toggle.scss
+++ b/packages/mdc-icon-toggle/mdc-icon-toggle.scss
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-/** postcss-bem-linter: define icon-toggle */
+// postcss-bem-linter: define icon-toggle
 
 @import "@material/animation/functions";
 @import "@material/ripple/common";
@@ -60,4 +60,4 @@
   pointer-events: none;
 }
 
-/** postcss-bem-linter: end */
+// postcss-bem-linter: end

--- a/packages/mdc-rtl/_mixins.scss
+++ b/packages/mdc-rtl/_mixins.scss
@@ -14,53 +14,51 @@
 // limitations under the License.
 //
 
-/**
- * Creates a rule that will be applied when an MDC Web component is within the context of an RTL layout.
- *
- * Usage Example:
- * ```scss
- * .mdc-foo {
- *   position: absolute;
- *   left: 0;
- *
- *   @include mdc-rtl {
- *     left: auto;
- *     right: 0;
- *   }
- *
- *   &__bar {
- *     margin-left: 4px;
- *     @include mdc-rtl(".mdc-foo") {
- *       margin-left: auto;
- *       margin-right: 4px;
- *     }
- *   }
- * }
- *
- * .mdc-foo--mod {
- *   padding-left: 4px;
- *
- *   @include mdc-rtl {
- *     padding-left: auto;
- *     padding-right: 4px;
- *   }
- * }
- * ```
- *
- * Note that this works by checking for [dir="rtl"] on an ancestor element. While this will work
- * in most cases, it will in some cases lead to false negatives, e.g.
- *
- * ```html
- * <html dir="rtl">
- *   <!-- ... -->
- *   <div dir="ltr">
- *     <div class="mdc-foo">Styled incorrectly as RTL!</div>
- *   </div>
- * </html>
- * ```
- *
- * In the future, selectors such as :dir (http://mdn.io/:dir) will help us mitigate this.
- */
+// Creates a rule that will be applied when an MDC Web component is within the context of an RTL layout.
+//
+// Usage Example:
+// ```scss
+// .mdc-foo {
+//   position: absolute;
+//   left: 0;
+//
+//   @include mdc-rtl {
+//     left: auto;
+//     right: 0;
+//   }
+//
+//   &__bar {
+//     margin-left: 4px;
+//     @include mdc-rtl(".mdc-foo") {
+//       margin-left: auto;
+//       margin-right: 4px;
+//     }
+//   }
+// }
+//
+// .mdc-foo--mod {
+//   padding-left: 4px;
+//
+//   @include mdc-rtl {
+//     padding-left: auto;
+//     padding-right: 4px;
+//   }
+// }
+// ```
+//
+// Note that this works by checking for [dir="rtl"] on an ancestor element. While this will work
+// in most cases, it will in some cases lead to false negatives, e.g.
+//
+// ```html
+// <html dir="rtl">
+//   <!-- ... -->
+//   <div dir="ltr">
+//     <div class="mdc-foo">Styled incorrectly as RTL!</div>
+//   </div>
+// </html>
+// ```
+//
+// In the future, selectors such as :dir (http://mdn.io/:dir) will help us mitigate this.
 @mixin mdc-rtl($root-selector: null) {
   @if ($root-selector) {
     @at-root {
@@ -77,57 +75,55 @@
   }
 }
 
-/**
- * Takes a base box-model property - e.g. margin / border / padding - along with a default
- * direction and value, and emits rules which apply the value to the
- * "<base-property>-<default-direction>" property by default, but flips the direction
- * when within an RTL context.
- *
- * For example:
- *
- * ```scss
- * .mdc-foo {
- *   @include mdc-rtl-reflexive-box(margin, left, 8px);
- * }
- * ```
- * is equivalent to:
- *
- * ```scss
- * .mdc-foo {
- *   margin-left: 8px;
- *
- *   @include mdc-rtl {
- *     margin-right: 8px;
- *     margin-left: 0;
- *   }
- * }
- * ```
- * whereas:
- *
- * ```scss
- * .mdc-foo {
- *   @include mdc-rtl-reflexive-box(margin, right, 8px);
- * }
- * ```
- * is equivalent to:
- *
- * ```scss
- * .mdc-foo {
- *   margin-right: 8px;
- *
- *   @include mdc-rtl {
- *     margin-right: 0;
- *     margin-left: 8px;
- *   }
- * }
- * ```
- *
- * You can also pass a 4th optional $root-selector argument which will be forwarded to `mdc-rtl`,
- * e.g. `@include mdc-rtl-reflexive-box(margin, left, 8px, ".mdc-component")`.
- *
- * Note that this function will always zero out the original value in an RTL context. If you're
- * trying to flip the values, use mdc-rtl-reflexive-property().
- */
+// Takes a base box-model property - e.g. margin / border / padding - along with a default
+// direction and value, and emits rules which apply the value to the
+// "<base-property>-<default-direction>" property by default, but flips the direction
+// when within an RTL context.
+//
+// For example:
+//
+// ```scss
+// .mdc-foo {
+//   @include mdc-rtl-reflexive-box(margin, left, 8px);
+// }
+// ```
+// is equivalent to:
+//
+// ```scss
+// .mdc-foo {
+//   margin-left: 8px;
+//
+//   @include mdc-rtl {
+//     margin-right: 8px;
+//     margin-left: 0;
+//   }
+// }
+// ```
+// whereas:
+//
+// ```scss
+// .mdc-foo {
+//   @include mdc-rtl-reflexive-box(margin, right, 8px);
+// }
+// ```
+// is equivalent to:
+//
+// ```scss
+// .mdc-foo {
+//   margin-right: 8px;
+//
+//   @include mdc-rtl {
+//     margin-right: 0;
+//     margin-left: 8px;
+//   }
+// }
+// ```
+//
+// You can also pass a 4th optional $root-selector argument which will be forwarded to `mdc-rtl`,
+// e.g. `@include mdc-rtl-reflexive-box(margin, left, 8px, ".mdc-component")`.
+//
+// Note that this function will always zero out the original value in an RTL context. If you're
+// trying to flip the values, use mdc-rtl-reflexive-property().
 @mixin mdc-rtl-reflexive-box($base-property, $default-direction, $value, $root-selector: null) {
   @if (index((right, left), $default-direction) == null) {
     @error "Invalid default direction: '#{$default-direction}'. Please specifiy either 'right' or 'left'.";
@@ -144,32 +140,30 @@
   @include mdc-rtl-reflexive-property($base-property, $left-value, $right-value, $root-selector);
 }
 
-/**
- * Takes a base property and emits rules that assign <base-property>-left to <left-value> and
- * <base-property>-right to <right-value> in a LTR context, and vice versa in a RTL context.
- * For example:
- *
- * ```scss
- * .mdc-foo {
- *   @include mdc-rtl-reflexive-property(margin, auto, 12px);
- * }
- * ```
- * is equivalent to:
- *
- * ```scss
- * .mdc-foo {
- *   margin-left: auto;
- *   margin-right: 12px;
- *
- *   @include mdc-rtl {
- *     margin-left: 12px;
- *     margin-right: auto;
- *   }
- * }
- * ```
- *
- * A 4th optional $root-selector argument can be given, which will be passed to `mdc-rtl`.
- */
+// Takes a base property and emits rules that assign <base-property>-left to <left-value> and
+// <base-property>-right to <right-value> in a LTR context, and vice versa in a RTL context.
+// For example:
+//
+// ```scss
+// .mdc-foo {
+//   @include mdc-rtl-reflexive-property(margin, auto, 12px);
+// }
+// ```
+// is equivalent to:
+//
+// ```scss
+// .mdc-foo {
+//   margin-left: auto;
+//   margin-right: 12px;
+//
+//   @include mdc-rtl {
+//     margin-left: 12px;
+//     margin-right: auto;
+//   }
+// }
+// ```
+//
+// A 4th optional $root-selector argument can be given, which will be passed to `mdc-rtl`.
 @mixin mdc-rtl-reflexive-property($base-property, $left-value, $right-value, $root-selector: null) {
   $prop-left: #{$base-property}-left;
   $prop-right: #{$base-property}-right;
@@ -177,33 +171,31 @@
   @include mdc-rtl-reflexive_($prop-left, $left-value, $prop-right, $right-value, $root-selector);
 }
 
-/**
- * Takes an argument specifying a horizontal position property (either "left" or "right") as well
- * as a value, and applies that value to the specified position in a LTR context, and flips it in a
- * RTL context. For example:
- *
- * ```scss
- * .mdc-foo {
- *   @include mdc-rtl-reflexive-position(left, 0);
- *   position: absolute;
- * }
- * ```
- * is equivalent to:
- *
- * ```scss
- *  .mdc-foo {
- *    position: absolute;
- *    left: 0;
- *    right: initial;
- *
- *    @include mdc-rtl {
- *      right: 0;
- *      left: initial;
- *    }
- *  }
- * ```
- * An optional third $root-selector argument may also be given, which is passed to `mdc-rtl`.
- */
+// Takes an argument specifying a horizontal position property (either "left" or "right") as well
+// as a value, and applies that value to the specified position in a LTR context, and flips it in a
+// RTL context. For example:
+//
+// ```scss
+// .mdc-foo {
+//   @include mdc-rtl-reflexive-position(left, 0);
+//   position: absolute;
+// }
+// ```
+// is equivalent to:
+//
+// ```scss
+//  .mdc-foo {
+//    position: absolute;
+//    left: 0;
+//    right: initial;
+//
+//    @include mdc-rtl {
+//      right: 0;
+//      left: initial;
+//    }
+//  }
+// ```
+// An optional third $root-selector argument may also be given, which is passed to `mdc-rtl`.
 @mixin mdc-rtl-reflexive-position($position-property, $value, $root-selector: null) {
   @if (index((right, left), $position-property) == null) {
     @error "Invalid position #{position-property}. Please specifiy either right or left";

--- a/packages/mdc-slider/mdc-slider.scss
+++ b/packages/mdc-slider/mdc-slider.scss
@@ -147,10 +147,8 @@
     transition: transform 100ms ease-out;
     border-radius: 50% 50% 50% 0%;
 
-    /**
-     * Ensuring that the pin is higher than the thumb in the stacking order
-     * removes some rendering jank observed in Chrome.
-     */
+    // Ensuring that the pin is higher than the thumb in the stacking order
+    // removes some rendering jank observed in Chrome.
     z-index: 1;
   }
 

--- a/packages/mdc-snackbar/mdc-snackbar.scss
+++ b/packages/mdc-snackbar/mdc-snackbar.scss
@@ -20,7 +20,7 @@
 @import "@material/typography/mixins";
 @import "./variables";
 
-/* postcss-bem-linter: define snackbar */
+// postcss-bem-linter: define snackbar
 .mdc-snackbar {
   display: flex;
   position: fixed;
@@ -157,10 +157,10 @@
   opacity: 1;
 }
 
-/* stylelint-disable plugin/selector-bem-pattern */
+// stylelint-disable plugin/selector-bem-pattern
 .mdc-snackbar--multiline.mdc-snackbar--action-on-bottom .mdc-snackbar__text {
   margin: 0;
 }
-/* stylelint-enable plugin/selector-bem-pattern */
+// stylelint-enable plugin/selector-bem-pattern
 
-/* postcss-bem-linter: end */
+// postcss-bem-linter: end

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -75,9 +75,7 @@
   @include mdc-rtl-reflexive-box(padding, left, 8px);
 }
 
-/**
- * The [de]activation animation affects color for text label and icon
- */
+// The [de]activation animation affects color for text label and icon
 .mdc-tab--animating-activate .mdc-tab__text-label,
 .mdc-tab--animating-activate .mdc-tab__icon,
 .mdc-tab--animating-deactivate .mdc-tab__text-label,
@@ -85,9 +83,7 @@
   transition: 150ms color linear;
 }
 
-/**
- * The activation animation has a delay of 100ms
- */
+// The activation animation has a delay of 100ms
 .mdc-tab--animating-activate .mdc-tab__text-label,
 .mdc-tab--animating-activate .mdc-tab__icon {
   transition-delay: 100ms;

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -67,13 +67,13 @@ $mdc-theme-text-colors: (
 //
 
 $mdc-theme-property-values: (
-  /* Primary */
+  // Primary
   primary: $mdc-theme-primary,
-  /* Secondary */
+  // Secondary
   secondary: $mdc-theme-secondary,
-  /* Background */
+  // Background
   background: $mdc-theme-background,
-  /* Surface */
+  // Surface
   surface: $mdc-theme-surface,
   on-primary: $mdc-theme-on-primary,
   on-secondary: $mdc-theme-on-secondary,

--- a/packages/mdc-typography/_variables.scss
+++ b/packages/mdc-typography/_variables.scss
@@ -37,7 +37,7 @@ $mdc-typography-styles: mdc-typography-set-styles_(
   $mdc-typography-base,
   (
     headline1: (
-      font-size: 6rem, /* 96sp */
+      font-size: 6rem, // 96sp
       line-height: 6rem,
       font-weight: map-get($mdc-typography-font-weight-values, light),
       letter-spacing: mdc-typography-get-letter-spacing_(-1.5, 6),
@@ -45,7 +45,7 @@ $mdc-typography-styles: mdc-typography-set-styles_(
       text-transform: inherit
     ),
     headline2: (
-      font-size: 3.75rem, /* 60sp */
+      font-size: 3.75rem, // 60sp
       line-height: 3.75rem,
       font-weight: map-get($mdc-typography-font-weight-values, light),
       letter-spacing: mdc-typography-get-letter-spacing_(-.5, 3.75),
@@ -53,88 +53,88 @@ $mdc-typography-styles: mdc-typography-set-styles_(
       text-transform: inherit
     ),
     headline3: (
-      font-size: 3rem, /* 48px */
-      line-height: 3.125rem, /* 50px */
+      font-size: 3rem, // 48px
+      line-height: 3.125rem, // 50px
       font-weight: map-get($mdc-typography-font-weight-values, regular),
       letter-spacing: normal,
       text-decoration: inherit,
       text-transform: inherit
     ),
     headline4: (
-      font-size: 2.125rem, /* 34sp */
-      line-height: 2.5rem, /* 40sp */
+      font-size: 2.125rem, // 34sp
+      line-height: 2.5rem, // 40sp
       font-weight: map-get($mdc-typography-font-weight-values, regular),
       letter-spacing: mdc-typography-get-letter-spacing_(.25, 2.125),
       text-decoration: inherit,
       text-transform: inherit
     ),
     headline5: (
-      font-size: 1.5rem, /* 24sp */
-      line-height: 2rem, /* 32sp */
+      font-size: 1.5rem, // 24sp
+      line-height: 2rem, // 32sp
       font-weight: map-get($mdc-typography-font-weight-values, regular),
       letter-spacing: normal,
       text-decoration: inherit,
       text-transform: inherit
     ),
     headline6: (
-      font-size: 1.25rem, /* 20sp */
-      line-height: 2rem, /* 32sp */
+      font-size: 1.25rem, // 20sp
+      line-height: 2rem, // 32sp
       font-weight: map-get($mdc-typography-font-weight-values, medium),
       letter-spacing: mdc-typography-get-letter-spacing_(.25, 1.25),
       text-decoration: inherit,
       text-transform: inherit
     ),
     subtitle1: (
-      font-size: 1rem, /* 16sp */
-      line-height: 1.75rem, /* 28sp */
+      font-size: 1rem, // 16sp
+      line-height: 1.75rem, // 28sp
       font-weight: map-get($mdc-typography-font-weight-values, regular),
       letter-spacing: mdc-typography-get-letter-spacing_(.15, 1),
       text-decoration: inherit,
       text-transform: inherit
     ),
     subtitle2: (
-      font-size: .875rem, /* 14sp */
-      line-height: 1.375rem, /* 22sp */
+      font-size: .875rem, // 14sp
+      line-height: 1.375rem, // 22sp
       font-weight: map-get($mdc-typography-font-weight-values, medium),
       letter-spacing: mdc-typography-get-letter-spacing_(.1, .875),
       text-decoration: inherit,
       text-transform: inherit
     ),
     body1: (
-      font-size: 1rem, /* 16sp */
-      line-height: 1.5rem, /* 24sp */
+      font-size: 1rem, // 16sp
+      line-height: 1.5rem, // 24sp
       font-weight: map-get($mdc-typography-font-weight-values, regular),
       letter-spacing: mdc-typography-get-letter-spacing_(.5, 1),
       text-decoration: inherit,
       text-transform: inherit
     ),
     body2: (
-      font-size: .875rem, /* 14sp */
-      line-height: 1.25rem, /* 20sp */
+      font-size: .875rem, // 14sp
+      line-height: 1.25rem, // 20sp
       font-weight: map-get($mdc-typography-font-weight-values, regular),
       letter-spacing: mdc-typography-get-letter-spacing_(.25, .875),
       text-decoration: inherit,
       text-transform: inherit
     ),
     caption: (
-      font-size: .75rem, /* 12sp */
-      line-height: 1.25rem, /* 20sp */
+      font-size: .75rem, // 12sp
+      line-height: 1.25rem, // 20sp
       font-weight: map-get($mdc-typography-font-weight-values, regular),
       letter-spacing: mdc-typography-get-letter-spacing_(.4, .75),
       text-decoration: inherit,
       text-transform: inherit
     ),
     button: (
-      font-size: .875rem, /* 14sp */
-      line-height: 2.25rem, /* 36sp */
+      font-size: .875rem, // 14sp
+      line-height: 2.25rem, // 36sp
       font-weight: map-get($mdc-typography-font-weight-values, medium),
       letter-spacing: mdc-typography-get-letter-spacing_(1.25, .875),
       text-decoration: none,
       text-transform: uppercase
     ),
     overline: (
-      font-size: .75rem, /* 12sp */
-      line-height: 2rem, /* 32sp */
+      font-size: .75rem, // 12sp
+      line-height: 2rem, // 32sp
       font-weight: map-get($mdc-typography-font-weight-values, medium),
       letter-spacing: mdc-typography-get-letter-spacing_(2, .75),
       text-decoration: none,


### PR DESCRIPTION
Multi-line `/* ... */` comments get emitted verbatim in the CSS output,
whereas single-line `//` comments do not.

To test, run `npm run build` and compare
`build/material-components-web.css` against the same file generated by
`master`.

You'll notice a bunch of seemingly random orphaned CSS comments are no
longer emitted.