### PR TITLE
fix(text-field): Update typography

### DIFF
--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -27,7 +27,6 @@
 
 // postcss-bem-linter: define select
 .mdc-select {
-  @include mdc-typography-base;
   @include mdc-select-container-fill-color(transparent);
   @include mdc-select-dd-arrow-svg-bg_;
   @include mdc-select-ink-color(text-primary-on-light);
@@ -55,7 +54,7 @@
 
   &__native-control {
     @include mdc-rtl-reflexive-property(padding, 0, $mdc-select-arrow-padding);
-    @include mdc-typography-base;
+    @include mdc-typography(subtitle1);
 
     &::-ms-expand {
       display: none;
@@ -74,6 +73,7 @@
     border-radius: 0;
     outline: none;
     background-color: transparent;
+    line-height: 1.15rem;
     white-space: nowrap;
     cursor: pointer;
     appearance: none;
@@ -120,7 +120,6 @@
   }
 
   .mdc-select__native-control {
-    @include mdc-typography(subtitle1);
     @include mdc-rtl-reflexive-property(padding, $mdc-select-label-padding, $mdc-select-arrow-padding);
 
     height: 56px;

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -43,7 +43,7 @@
   display: inline-flex;
   position: relative;
   box-sizing: border-box;
-  height: 48px;
+  height: 52px;
   background-repeat: no-repeat;
   background-position: right 8px bottom 12px;
   overflow: hidden;
@@ -67,13 +67,12 @@
 
     width: 100%;
     padding-top: 20px;
-    padding-bottom: 6px;
+    padding-bottom: 4px;
     border: none;
     border-bottom: 1px solid;
     border-radius: 0;
     outline: none;
     background-color: transparent;
-    line-height: 1.15rem;
     white-space: nowrap;
     cursor: pointer;
     appearance: none;

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -27,6 +27,7 @@
 
 // postcss-bem-linter: define select
 .mdc-select {
+  @include mdc-typography-base;
   @include mdc-select-container-fill-color(transparent);
   @include mdc-select-dd-arrow-svg-bg_;
   @include mdc-select-ink-color(text-primary-on-light);
@@ -43,7 +44,7 @@
   display: inline-flex;
   position: relative;
   box-sizing: border-box;
-  height: 52px;
+  height: 48px;
   background-repeat: no-repeat;
   background-position: right 8px bottom 12px;
   overflow: hidden;
@@ -54,7 +55,7 @@
 
   &__native-control {
     @include mdc-rtl-reflexive-property(padding, 0, $mdc-select-arrow-padding);
-    @include mdc-typography(subtitle1);
+    @include mdc-typography-base;
 
     &::-ms-expand {
       display: none;
@@ -67,7 +68,7 @@
 
     width: 100%;
     padding-top: 20px;
-    padding-bottom: 4px;
+    padding-bottom: 6px;
     border: none;
     border-bottom: 1px solid;
     border-radius: 0;
@@ -119,6 +120,7 @@
   }
 
   .mdc-select__native-control {
+    @include mdc-typography(subtitle1);
     @include mdc-rtl-reflexive-property(padding, $mdc-select-label-padding, $mdc-select-arrow-padding);
 
     height: 56px;

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -255,7 +255,6 @@
 
   .mdc-text-field__input {
     display: flex;
-    height: 30px;
     padding: 12px;
     border: none;
     background-color: transparent;

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -52,13 +52,13 @@
   @include mdc-typography(subtitle1);
 
   width: 100%;
-  padding: 20px 0 8px;
+  height: 30px;
+  padding: 20px 0 1px;
   transition: mdc-text-field-transition(opacity);
   border: none;
   border-bottom: 1px solid;
   border-radius: 0;
   background: none;
-  line-height: 1.15rem;
   appearance: none;
 
   &::placeholder {

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -49,15 +49,7 @@
 }
 
 .mdc-text-field__input {
-  @include mdc-typography-base;
-  // We use only a subset of the MDC typography values here as changing things such as line-height
-  // affects how the labels are transformed.
-  // TODO: Re-add setting the font-size from mdc-typography-styles (currently
-  // setting it here has no effect because it is overriden by the font-size
-  // given below).
-  @each $prop in (letter-spacing) {
-    #{$prop}: map-get(map-get($mdc-typography-styles, subtitle1), $prop);
-  }
+  @include mdc-typography(subtitle1);
 
   width: 100%;
   padding: 20px 0 8px;
@@ -66,7 +58,7 @@
   border-bottom: 1px solid;
   border-radius: 0;
   background: none;
-  font-size: inherit;
+  line-height: 1.15rem;
   appearance: none;
 
   &::placeholder {


### PR DESCRIPTION
Fixes: #2538 
Updates the typography for select and text-field. Explicitly declares line-height instead of implicitly depending on normalize.css