### PR TITLE
chore: Remove abstract function bodies in closure rewriting

### DIFF
--- a/scripts/rewrite-decl-statements-for-closure-test.js
+++ b/scripts/rewrite-decl-statements-for-closure-test.js
@@ -182,6 +182,14 @@ function transform(srcFile, rootDir) {
       }
       path.replaceWith(variableDeclaration);
     },
+
+    ClassMethod(path) {
+      // Remove any statements from abstract function bodies.
+      // Closure doesn't like seeing this, but we like to include a throw statement for non-closure clients.
+      if (path.node.comments && path.node.comments.some((comment) => comment.value.includes('@abstract'))) {
+        path.node.body.body = [];
+      }
+    }
   });
 
   let {code: outputCode} = recast.print(ast, {


### PR DESCRIPTION
This allows us to throw informative errors in abstract methods for non-closure clients, while still including the `@abstract` annotation and not having closure throw a fit about an abstract method having a non-empty function body.