### PR TITLE
fix(text-field): Add error state to trailing icon

### DIFF
--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -153,6 +153,10 @@
   @include mdc-text-field-label-color($mdc-text-field-error);
   @include mdc-text-field-helper-text-validation-color($mdc-text-field-error);
 
+  &.mdc-text-field--with-trailing-icon {
+    @include mdc-text-field-icon-color($mdc-text-field-error);
+  }
+
   + .mdc-text-field-helper-text--validation-msg {
     opacity: 1;
   }


### PR DESCRIPTION
Add error color to invalid trailing icon. 