### PR TITLE
fix: Rename stroke to outline

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -194,29 +194,29 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--headline6">Stroked Button (Experimental)</legend>
+          <legend class="mdc-typography--headline6">Outlined Button (Experimental)</legend>
           <div>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               Baseline
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--dense">
+            <button class="mdc-button mdc-button--outlined mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button mdc-button--stroked secondary-stroked-button">
+            <button class="mdc-button mdc-button--outlined secondary-outlined-button">
               Secondary
             </button>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon
             </button>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
                 <path fill="none" d="M0 0h24v24H0z"/>
                 <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
               </svg>
               SVG Icon
             </button>
-            <a href="javascript:void(0)" class="mdc-button mdc-button--stroked">
+            <a href="javascript:void(0)" class="mdc-button mdc-button--outlined">
               Link
             </a>
           </div>
@@ -228,8 +228,8 @@
             <button class="mdc-button mdc-button--unelevated big-round-corner-button">
               Corner Radius
             </button>
-            <button class="mdc-button mdc-button--stroked thick-stroke-button">
-              Thick Stroke Width
+            <button class="mdc-button mdc-button--outlined thick-outline-button">
+              Thick Outline Width
             </button>
           </div>
         </fieldset>
@@ -241,7 +241,7 @@
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Ink Color
             </button>
-            <button class="mdc-button mdc-button--stroked demo-icon-color">
+            <button class="mdc-button mdc-button--outlined demo-icon-color">
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon Color
             </button>
@@ -338,29 +338,29 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--headline6">Stroked Button (Experimental)</legend>
+          <legend class="mdc-typography--headline6">Outlined Button (Experimental)</legend>
           <div>
-            <button class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined" data-demo-no-js>
               Baseline
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--dense" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button mdc-button--stroked secondary-stroked-button" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined secondary-outlined-button" data-demo-no-js>
               Secondary
             </button>
-            <button class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined" data-demo-no-js>
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon
             </button>
-            <button class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined" data-demo-no-js>
               <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
                 <path fill="none" d="M0 0h24v24H0z"/>
                 <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
               </svg>
               SVG Icon
             </button>
-            <a href="javascript:void(0)" class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <a href="javascript:void(0)" class="mdc-button mdc-button--outlined" data-demo-no-js>
               Link
             </a>
           </div>
@@ -372,8 +372,8 @@
             <button class="mdc-button mdc-button--unelevated big-round-corner-button" data-demo-no-js>
               Big Corner Radius
             </button>
-            <button class="mdc-button mdc-button--stroked thick-stroke-button" data-demo-no-js>
-              Thick Stroke Width
+            <button class="mdc-button mdc-button--outlined thick-outline-button" data-demo-no-js>
+              Thick Outline Width
             </button>
           </div>
         </fieldset>
@@ -385,7 +385,7 @@
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Ink Color
             </button>
-            <button class="mdc-button mdc-button--stroked demo-icon-color" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined demo-icon-color" data-demo-no-js>
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon Color
             </button>

--- a/demos/button.scss
+++ b/demos/button.scss
@@ -31,9 +31,9 @@
   @include mdc-button-filled-accessible($mdc-theme-secondary);
 }
 
-.mdc-button.secondary-stroked-button {
+.mdc-button.secondary-outlined-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
-  @include mdc-button-stroke-color($mdc-theme-secondary);
+  @include mdc-button-outline-color($mdc-theme-secondary);
 
 }
 
@@ -41,8 +41,8 @@
   @include mdc-button-corner-radius(8px);
 }
 
-.mdc-button.thick-stroke-button {
-  @include mdc-button-stroke-width(4px);
+.mdc-button.thick-outline-button {
+  @include mdc-button-outline-width(4px);
 }
 
 .demo-ink-color {

--- a/demos/card.html
+++ b/demos/card.html
@@ -99,7 +99,7 @@
       </section>
 
       <section class="demo-card-collection">
-        <div class="mdc-card mdc-card--stroked demo-card">
+        <div class="mdc-card mdc-card--outlined demo-card">
           <div class="demo-card-article-group-heading mdc-typography--subtitle2">Headlines</div>
 
           <hr class="mdc-list-divider">

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -98,10 +98,10 @@
             <label for="basic-checkbox">Default checkbox</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked" onclick="this.parentElement.parentElement.hasAttribute('dir') ? this.parentElement.parentElement.removeAttribute('dir') : this.parentElement.parentElement.setAttribute('dir', 'rtl');">
+            <button type="button" class="mdc-button mdc-button--outlined" onclick="this.parentElement.parentElement.hasAttribute('dir') ? this.parentElement.parentElement.removeAttribute('dir') : this.parentElement.parentElement.setAttribute('dir', 'rtl');">
               Toggle RTL
             </button>
-            <button type="button" class="mdc-button mdc-button--stroked" onclick="document.querySelector('.mdc-form-field').classList.toggle('mdc-form-field--align-end');">
+            <button type="button" class="mdc-button mdc-button--outlined" onclick="document.querySelector('.mdc-form-field').classList.toggle('mdc-form-field--align-end');">
               <span>Toggle <code>--align-end</code></span>
             </button>
           </div>
@@ -214,8 +214,8 @@
             <label for="native-js-checkbox">Default checkbox</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
         </div>
         <div>
@@ -239,8 +239,8 @@
             <label for="native-js-checkbox-indeterminate">Indeterminate checkbox</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
           <script>
             document.getElementById('native-js-checkbox-indeterminate').indeterminate = true;
@@ -266,8 +266,8 @@
             <label for="native-js-checkbox-custom-all">Custom colored checkbox (stroke, fill, ripple, and focus)</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
         </div>
         <div>
@@ -290,8 +290,8 @@
             <label for="native-js-checkbox-custom-stroke-and-fill">Custom colored checkbox (stroke and fill only)</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
         </div>
       </section>

--- a/demos/chips.scss
+++ b/demos/chips.scss
@@ -30,5 +30,5 @@
   @include mdc-chip-fill-color(white);
   @include mdc-chip-ink-color($mdc-theme-secondary);
   @include mdc-chip-selected-ink-color($mdc-theme-secondary);
-  @include mdc-chip-stroke(2px, solid, $mdc-theme-secondary);
+  @include mdc-chip-outline(2px, solid, $mdc-theme-secondary);
 }

--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -151,14 +151,14 @@
         </div>
 
         <div class="extra-content-wrapper">
-          <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+          <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-wide" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-wide content</button>
+          <button id="toggle-wide" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-wide content</button>
           <div id="extra-wide-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-tall" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-tall content</button>
+          <button id="toggle-tall" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-tall content</button>
           <div id="extra-tall-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
       </main>

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -143,14 +143,14 @@
         </div>
 
         <div class="extra-content-wrapper">
-          <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+          <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-wide" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-wide content</button>
+          <button id="toggle-wide" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-wide content</button>
           <div id="extra-wide-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-tall" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-tall content</button>
+          <button id="toggle-tall" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-tall content</button>
           <div id="extra-tall-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
       </main>

--- a/demos/drawer/persistent-drawer.html
+++ b/demos/drawer/persistent-drawer.html
@@ -138,7 +138,7 @@
             <label for="theme-radio-accessible">Accessible Theme</label>
           </div>
         </div>
-        <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+        <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
       </main>
 
       <script src="/assets/material-components-web.js" async></script>

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -126,7 +126,7 @@
         </div>
       </div>
       <div class="extra-content-wrapper">
-        <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+        <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
       </div>
     </main>
 

--- a/demos/shape.html
+++ b/demos/shape.html
@@ -46,7 +46,7 @@
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-left"></div>
         </div>
         <div class="mdc-shape-container four-corner-container four-corner-container--stroked">
-          <button class="mdc-button mdc-button--stroked">Stroked Button</button>
+          <button class="mdc-button mdc-button--outlined">Stroked Button</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-right"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
@@ -73,12 +73,12 @@
 
         <h2 class="mdc-typography--headline4">Stroked</h2>
         <div class="mdc-shape-container two-corner-container two-corner-container--stroked">
-          <button class="mdc-button mdc-button--stroked">Skip</button>
+          <button class="mdc-button mdc-button--outlined">Skip</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
         </div>
         <div class="mdc-shape-container four-corner-container four-corner-container--stroked">
-          <button class="mdc-button mdc-button--stroked">Finish</button>
+          <button class="mdc-button mdc-button--outlined">Finish</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-right"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
@@ -88,7 +88,7 @@
         <h1 class="mdc-typography--headline3">Card</h1>
 
         <div class="mdc-shape-container card-container">
-          <div class="mdc-card mdc-card--stroked demo-card">
+          <div class="mdc-card mdc-card--outlined demo-card">
             <a class="mdc-card__primary-action demo-card__primary-action" href="#">
               <div class="demo-card__row">
                 <div class="mdc-card__media mdc-card__media--square demo-card__media"></div>

--- a/demos/shape.scss
+++ b/demos/shape.scss
@@ -61,7 +61,7 @@
 
 .card-container {
   @include mdc-shape-angled-corner($mdc-theme-background, 24px, 4px);
-  @include mdc-shape-angled-corner-stroke($mdc-card-stroke-width, $mdc-card-stroke-color);
+  @include mdc-shape-angled-corner-stroke($mdc-card-outline-width, $mdc-card-outline-color);
 }
 
 .demo-card {

--- a/demos/text-field.scss
+++ b/demos/text-field.scss
@@ -33,7 +33,7 @@
   @include mdc-text-field-hover-outline-color($hover-border);
   @include mdc-text-field-focused-outline-color($focused-border);
   @include mdc-text-field-helper-text-color($idle-border);
-  @include mdc-text-field-textarea-stroke-color($idle-border);
+  @include mdc-text-field-textarea-outline-color($idle-border);
   @include mdc-text-field-icon-color($hover-border);
 
   &.mdc-text-field--focused {
@@ -49,22 +49,22 @@
 
   @include mdc-text-field-ink-color(black);
   @include mdc-text-field-label-color(rgba(blue, .5));
-  @include mdc-text-field-textarea-stroke-color($idle-border);
+  @include mdc-text-field-textarea-outline-color($idle-border);
 
   &.mdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(blue, .87));
-    @include mdc-text-field-textarea-stroke-color($focused-border);
+    @include mdc-text-field-textarea-outline-color($focused-border);
   }
 }
 
 .demo-textarea.mdc-text-field--invalid {
   @include mdc-text-field-ink-color(orange);
   @include mdc-text-field-label-color(rgba(orange, .5));
-  @include mdc-text-field-textarea-stroke-color(rgba(orange, .38));
+  @include mdc-text-field-textarea-outline-color(rgba(orange, .38));
 
   &.mdc-text-field--focused {
     @include mdc-text-field-label-color(rgba(orange, .87));
-    @include mdc-text-field-textarea-stroke-color(orange);
+    @include mdc-text-field-textarea-outline-color(orange);
   }
 }
 
@@ -105,7 +105,7 @@
   @include mdc-text-field-hover-outline-color($hover-border);
   @include mdc-text-field-focused-outline-color($focused-border);
   @include mdc-text-field-helper-text-validation-color($hover-border);
-  @include mdc-text-field-textarea-stroke-color($idle-border);
+  @include mdc-text-field-textarea-outline-color($idle-border);
 
   @include mdc-text-field-icon-color($focused-border);
 

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -285,8 +285,8 @@
             <button class="mdc-button mdc-button--unelevated">
               Unelevated
             </button>
-            <button class="mdc-button mdc-button--stroked">
-              Stroked
+            <button class="mdc-button mdc-button--outlined">
+              Outlined
             </button>
           </div>
         </fieldset>
@@ -304,8 +304,8 @@
             <button class="mdc-button mdc-button--unelevated">
               Unelevated
             </button>
-            <button class="mdc-button mdc-button--stroked">
-              Stroked
+            <button class="mdc-button mdc-button--outlined">
+              Outlined
             </button>
           </div>
         </fieldset>
@@ -419,10 +419,10 @@
             <label for="disabled-checkbox" id="disabled-checkbox-label">Disabled</label>
           </div>
 
-          <button type="button" class="mdc-button mdc-button--stroked demo-checkbox-toggle-button" id="checkbox-toggle--indeterminate">
+          <button type="button" class="mdc-button mdc-button--outlined demo-checkbox-toggle-button" id="checkbox-toggle--indeterminate">
             <span>Toggle <code class="demo-button__code">indeterminate</code></span>
           </button>
-          <button type="button" class="mdc-button mdc-button--stroked demo-checkbox-toggle-button" id="checkbox-toggle--align-end">
+          <button type="button" class="mdc-button mdc-button--outlined demo-checkbox-toggle-button" id="checkbox-toggle--align-end">
             <span>Toggle <code class="demo-button__code">--align-end</code></span>
           </button>
         </div>

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -118,7 +118,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Normal Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./default-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./default-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -126,7 +126,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Fixed Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./fixed-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./fixed-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -134,7 +134,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Fixed Toolbar with Menu</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./menu-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./menu-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -142,7 +142,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -150,7 +150,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Default Flexible Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./default-flexible-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./default-flexible-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -158,7 +158,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Flexible Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-flexible-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-flexible-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -166,7 +166,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Toolbar Fix Last Row</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-toolbar-fix-last-row.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-toolbar-fix-last-row.html" width="320" height="600"></iframe>
         </div>
@@ -174,7 +174,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Flexible Toolbar with Custom Style</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-flexible-toolbar-custom-style.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-flexible-toolbar-custom-style.html" width="320" height="600"></iframe>
         </div>
@@ -182,7 +182,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Custom Colored Toolbar and Icons</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./custom-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./custom-toolbar.html" width="320" height="600"></iframe>
         </div>

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -90,7 +90,7 @@ CSS Class | Description
 `mdc-button__icon`    | Optional, for the icon element
 `mdc-button--raised` | Optional, a contained button that is elevated upon the surface
 `mdc-button--unelevated` | Optional, a contained button that is flush with the surface
-`mdc-button--stroked` | Optional, a contained button that is flush with the surface and has a visible border
+`mdc-button--outlined` | Optional, a contained button that is flush with the surface and has a visible border
 `mdc-button--dense` | Optional, compresses the button text to make it slightly smaller
 
 ### Disabled Button
@@ -144,12 +144,12 @@ Mixin | Description
 `mdc-button-ink-color($color)` | Sets the ink color to the given color. This affects both text and icon, unless `mdc-button-icon-color` is also used.
 `mdc-button-corner-radius($corner-radius)` | Sets the corner radius to the given number (defaults to 2px).
 `mdc-button-horizontal-padding($padding)` | Sets horizontal padding to the given number.
-`mdc-button-stroke-color($color)` | Sets the stroke color to the given color.
-`mdc-button-stroke-width($width, $padding)` | Sets the stroke width to the given number (defaults to 2px) and adjusts padding accordingly. `$padding` is only required in cases where `mdc-button-horizontal-padding` is also included with a custom value.
+`mdc-button-outline-color($color)` | Sets the stroke color to the given color.
+`mdc-button-outline-width($width, $padding)` | Sets the stroke width to the given number (defaults to 2px) and adjusts padding accordingly. `$padding` is only required in cases where `mdc-button-horizontal-padding` is also included with a custom value.
 
 The ripple effect for the Button component is styled using [MDC Ripple](../mdc-ripple) mixins.
 
-> **Note:** If you want to customize both horizontal padding and stroke width, simply include the `mdc-button-stroke-width` mixin with both arguments. It will include `mdc-button-horizontal-padding` for you.
+> **Note:** If you want to customize both horizontal padding and stroke width, simply include the `mdc-button-outline-width` mixin with both arguments. It will include `mdc-button-horizontal-padding` for you.
 
 #### Caveat: Edge and CSS Variables
 

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -44,7 +44,7 @@
   }
 }
 
-@mixin mdc-button-stroke-color($color) {
+@mixin mdc-button-outline-color($color) {
   &:not(:disabled) {
     @include mdc-theme-prop(border-color, $color);
   }
@@ -71,21 +71,21 @@
   padding: 0 $padding 0 $padding;
 }
 
-@mixin mdc-button-stroke-width($stroke-width, $padding: $mdc-button-contained-horizontal-padding) {
-  // Note: Adjust padding to maintain consistent width with non-stroked buttons
-  $padding-value: max($padding - $stroke-width, 0);
+@mixin mdc-button-outline-width($outline-width, $padding: $mdc-button-contained-horizontal-padding) {
+  // Note: Adjust padding to maintain consistent width with non-outlined buttons
+  $padding-value: max($padding - $outline-width, 0);
 
   @include mdc-button-horizontal-padding($padding-value);
 
-  border-width: $stroke-width;
-  // Note: line height is adjusted for stroke button because borders are not
+  border-width: $outline-width;
+  // Note: line height is adjusted for outline button because borders are not
   // considered as space available to text on the Web
-  line-height: $mdc-button-height - $stroke-width * 2;
+  line-height: $mdc-button-height - $outline-width * 2;
 
   // postcss-bem-linter: ignore
   &.mdc-button--dense {
     // Minus extra 1 to accommodate odd font size of dense button
-    line-height: $mdc-dense-button-height - $stroke-width * 2 - 1;
+    line-height: $mdc-dense-button-height - $outline-width * 2 - 1;
   }
 }
 
@@ -153,7 +153,7 @@
   @include mdc-rtl-reflexive-property(margin, -4px, 8px);
 }
 
-@mixin mdc-button--stroked_() {
+@mixin mdc-button--outlined_() {
   border-style: solid;
 
   &:disabled {

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -43,7 +43,7 @@
 
 .mdc-button--raised,
 .mdc-button--unelevated,
-.mdc-button--stroked {
+.mdc-button--outlined {
   .mdc-button__icon {
     // Icons inside contained buttons have different styles due to increased button padding
     @include mdc-button__icon-contained_;
@@ -62,10 +62,10 @@
   @include mdc-button--raised_;
 }
 
-.mdc-button--stroked {
-  @include mdc-button--stroked_;
-  @include mdc-button-stroke-width(2px);
-  @include mdc-button-stroke-color(primary);
+.mdc-button--outlined {
+  @include mdc-button--outlined_;
+  @include mdc-button-outline-width(2px);
+  @include mdc-button-outline-color(primary);
 }
 
 .mdc-button--dense {

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -171,7 +171,7 @@ elements:
 CSS Class | Description
 --- | ---
 `mdc-card` | Mandatory, for the card element
-`mdc-card--stroked` | Removes the shadow and displays a hairline stroke instead
+`mdc-card--outline` | Removes the shadow and displays a hairline outline instead
 `mdc-card__primary-action` | The main tappable area of the card. Typically contains most (or all) card content _except_ `mdc-card__actions`. Only applicable to cards that have a primary action that the main surface should trigger.
 `mdc-card__media` | Media area that displays a custom `background-image` with `background-size: cover`
 `mdc-card__media--square` | Automatically scales the media area's height to equal its width
@@ -190,6 +190,6 @@ CSS Class | Description
 Mixin | Description
 --- | ---
 `mdc-card-fill-color($color)` | Sets the fill color of a card
-`mdc-card-stroke($color, $thickness)` | Sets the color and thickness of a card's stroke (but does _not_ remove its shadow)
+`mdc-card-outline($color, $thickness)` | Sets the color and thickness of a card's outline (but does _not_ remove its shadow)
 `mdc-card-corner-radius($radius)` | Sets the corner radius of a card
 `mdc-card-media-aspect-ratio($x, $y)` | Maintains the given aspect ratio on a `mdc-card__media` subelement by dynamically scaling its height relative to its width

--- a/packages/mdc-card/_mixins.scss
+++ b/packages/mdc-card/_mixins.scss
@@ -24,7 +24,7 @@
   @include mdc-theme-prop(background-color, $color);
 }
 
-@mixin mdc-card-stroke($color, $thickness: $mdc-card-stroke-width) {
+@mixin mdc-card-outline($color, $thickness: $mdc-card-outline-width) {
   border: $thickness solid mdc-theme-prop-value($color);
 }
 

--- a/packages/mdc-card/_variables.scss
+++ b/packages/mdc-card/_variables.scss
@@ -16,5 +16,5 @@
 
 @import "@material/theme/mixins";
 
-$mdc-card-stroke-color: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 12%);
-$mdc-card-stroke-width: 1px;
+$mdc-card-outline-color: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 12%);
+$mdc-card-outline-width: 1px;

--- a/packages/mdc-card/mdc-card.scss
+++ b/packages/mdc-card/mdc-card.scss
@@ -30,9 +30,9 @@
   @include mdc-card-container-layout_;
 }
 
-.mdc-card--stroked {
+.mdc-card--outlined {
   @include mdc-elevation(0);
-  @include mdc-card-stroke($mdc-card-stroke-color);
+  @include mdc-card-outline($mdc-card-outline-color);
 }
 
 //

--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -163,10 +163,10 @@ Mixin | Description
 `mdc-chip-fill-color($color)` | Customizes the background fill color for a chip
 `mdc-chip-ink-color($color)` | Customizes the text ink color for a chip, and updates the chip's ripple color to match
 `mdc-chip-selected-ink-color($color)` | Customizes text ink and ripple color of a chip in the _selected_ state
-`mdc-chip-stroke($width, $style, $color)` | Customizes the border stroke properties for a chip
-`mdc-chip-stroke-width($width)` | Customizes the border stroke width for a chip
-`mdc-chip-stroke-style($style)` | Customizes the border stroke style for a chip
-`mdc-chip-stroke-color($color)` | Customizes the border stroke color for a chip
+`mdc-chip-outline($width, $style, $color)` | Customizes the border outline properties for a chip
+`mdc-chip-outline-width($width)` | Customizes the border outline width for a chip
+`mdc-chip-outline-style($style)` | Customizes the border outline style for a chip
+`mdc-chip-outline-color($color)` | Customizes the border outline color for a chip
 `mdc-chip-leading-icon-color($color, $opacity)` | Customizes the color of a leading icon in a chip, optionally customizes opacity
 `mdc-chip-trailing-icon-color($color, $opacity, $hover-opacity, $focus-opacity)` | Customizes the color of a trailing icon in a chip, optionally customizes regular/hover/focus opacities
 `mdc-chip-leading-icon-size($size)` | Customizes the size of a leading icon in a chip

--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -71,22 +71,22 @@
   }
 }
 
-@mixin mdc-chip-stroke($width: 1, $style: solid, $color: mdc-theme-prop-value(on-surface)) {
-  @include mdc-chip-stroke-width($width);
-  @include mdc-chip-stroke-style($style);
-  @include mdc-chip-stroke-color($color);
+@mixin mdc-chip-outline($width: 1, $style: solid, $color: mdc-theme-prop-value(on-surface)) {
+  @include mdc-chip-outline-width($width);
+  @include mdc-chip-outline-style($style);
+  @include mdc-chip-outline-color($color);
 }
 
-@mixin mdc-chip-stroke-color($color) {
+@mixin mdc-chip-outline-color($color) {
   @include mdc-theme-prop(border-color, $color);
 }
 
-@mixin mdc-chip-stroke-style($style) {
+@mixin mdc-chip-outline-style($style) {
   border-style: $style;
 }
 
-@mixin mdc-chip-stroke-width($width) {
-  // Note: Adjust padding to maintain consistent width with non-stroked chips
+@mixin mdc-chip-outline-width($width) {
+  // Note: Adjust padding to maintain consistent width with non-outlined chips
   $horizontal-padding-value: max($mdc-chip-horizontal-padding - $width, 0);
   $vertical-padding-value: max($mdc-chip-vertical-padding - $width, 0);
 

--- a/packages/mdc-notched-outline/README.md
+++ b/packages/mdc-notched-outline/README.md
@@ -49,7 +49,7 @@ Mixin | Description
 --- | ---
 `mdc-notched-outline-color($color)` | Customizes the border color of the notched outlined.
 `mdc-notched-outline-idle-color($color)` | Customizes the border color of the idle outline.
-`mdc-notched-outline-stroke-width($width)` | Changes notched outline width to a specified pixel value.
+`mdc-notched-outline-width($width)` | Changes notched outline width to a specified pixel value.
 `mdc-notched-outline-corner-radius($radius)` | Sets the corner radius of the notched outline element to the given number.
 `mdc-notched-outline-idle-corner-radius($radius)` | Sets the corner radius of the notched outline element in idle state.
 

--- a/packages/mdc-notched-outline/_mixins.scss
+++ b/packages/mdc-notched-outline/_mixins.scss
@@ -28,7 +28,7 @@
   }
 }
 
-@mixin mdc-notched-outline-stroke-width($width) {
+@mixin mdc-notched-outline-width($width) {
   .mdc-notched-outline__path {
     stroke-width: $width;
   }

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -200,7 +200,7 @@ Mixin | Description
 --- | ---
 `mdc-text-field-textarea-corner-radius($radius)` | Customizes the border radius for a `<textarea>` variant.
 `mdc-text-field-textarea-fill-color($color)` | Customizes the color of the background of the textarea.
-`mdc-text-field-textarea-stroke-color($color)` | Customizes the color of the border of the textarea.
+`mdc-text-field-textarea-outline-color($color)` | Customizes the color of the border of the textarea.
 
 
 #### Mixins for Text Field Fullwidth

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -57,9 +57,9 @@
   }
 }
 
-@mixin mdc-text-field-textarea-stroke-color($color) {
+@mixin mdc-text-field-textarea-outline-color($color) {
   &:not(.mdc-text-field--disabled) {
-    @include mdc-text-field-textarea-stroke-color_($color);
+    @include mdc-text-field-textarea-outline-color_($color);
   }
 }
 
@@ -224,7 +224,7 @@
 }
 
 @mixin mdc-text-field-outlined-focused_ {
-  @include mdc-notched-outline-stroke-width(2px);
+  @include mdc-notched-outline-width(2px);
 }
 
 @mixin mdc-text-field-outlined-dense_ {
@@ -446,7 +446,7 @@
 // Textarea
 
 @mixin mdc-text-field-textarea-disabled_ {
-  @include mdc-text-field-textarea-stroke-color_($mdc-text-field-disabled-border);
+  @include mdc-text-field-textarea-outline-color_($mdc-text-field-disabled-border);
   @include mdc-text-field-textarea-fill-color_($mdc-textarea-disabled-background);
 
   border-style: solid;
@@ -461,12 +461,12 @@
 }
 
 @mixin mdc-text-field-textarea-invalid_ {
-  @include mdc-text-field-textarea-stroke-color($mdc-text-field-error);
+  @include mdc-text-field-textarea-outline-color($mdc-text-field-error);
 }
 
 @mixin mdc-text-field-textarea_ {
   @include mdc-text-field-textarea-corner-radius($mdc-text-field-border-radius);
-  @include mdc-text-field-textarea-stroke-color($mdc-textarea-border);
+  @include mdc-text-field-textarea-outline-color($mdc-textarea-border);
 
   // Translate above the top of the input, and compensate for the amount of offset needed
   // to position the label within the bounds of the inset padding.
@@ -516,7 +516,7 @@
   @include mdc-theme-prop(background-color, $color);
 }
 
-@mixin mdc-text-field-textarea-stroke-color_($color) {
+@mixin mdc-text-field-textarea-outline-color_($color) {
   @include mdc-theme-prop(border-color, $color);
 
   .mdc-text-field__input:focus {

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -209,7 +209,7 @@
 }
 
 .mdc-text-field--textarea.mdc-text-field--focused {
-  @include mdc-text-field-textarea-stroke-color(primary);
+  @include mdc-text-field-textarea-outline-color(primary);
 }
 
 .mdc-text-field--invalid {

--- a/test/screenshot/README.md
+++ b/test/screenshot/README.md
@@ -42,7 +42,7 @@ Guidelines:
 
 4.  Do not test _combinations_ of mixins and modifier classes unless:
     1. It's necessary to prevent a regression; or
-    2. We explicitly support the combination, and the implementation is likely to have bugs (e.g., `mdc-button--dense` and `mdc-button-stroke-width` both set `line-height`)
+    2. We explicitly support the combination, and the implementation is likely to have bugs (e.g., `mdc-button--dense` and `mdc-button-outline-width` both set `line-height`)
 
 ## Example test page
 

--- a/test/screenshot/mdc-button/classes/baseline.html
+++ b/test/screenshot/mdc-button/classes/baseline.html
@@ -150,22 +150,22 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">Button</button>
+          <button class="mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">
+          <button class="mdc-button mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">
+          <button class="mdc-button mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -174,13 +174,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>

--- a/test/screenshot/mdc-button/classes/dense.html
+++ b/test/screenshot/mdc-button/classes/dense.html
@@ -150,22 +150,22 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">Button</button>
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="mdc-button mdc-button--dense mdc-button--stroked" href="#">Link</a>
+          <a class="mdc-button mdc-button--dense mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -174,13 +174,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--dense mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--dense mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>

--- a/test/screenshot/mdc-button/mixins/corner-radius.html
+++ b/test/screenshot/mdc-button/mixins/corner-radius.html
@@ -52,10 +52,10 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--stroked" disabled>Disabled</button>
+          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--outlined" disabled>Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/custom.scss
+++ b/test/screenshot/mdc-button/mixins/custom.scss
@@ -35,11 +35,11 @@ $custom-button-custom-horizontal-padding: 36px;
 }
 
 .custom-button--stroke-color {
-  @include mdc-button-stroke-color($custom-button-color);
+  @include mdc-button-outline-color($custom-button-color);
 }
 
 .custom-button--stroke-width {
-  @include mdc-button-stroke-width($custom-button-custom-stroke-width);
+  @include mdc-button-outline-width($custom-button-custom-stroke-width);
 }
 
 .custom-button--corner-radius {

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
@@ -79,19 +79,19 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button--horizontal-padding mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button--horizontal-padding mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
@@ -79,19 +79,19 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked">Button</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/stroke-color.html
+++ b/test/screenshot/mdc-button/mixins/stroke-color.html
@@ -28,13 +28,13 @@
     <main class="test-main">
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-color mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button custom-button--stroke-color mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button custom-button--stroke-color mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button custom-button--stroke-color mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-color mdc-button mdc-button--stroked" disabled>Disabled</button>
+          <button class="custom-button custom-button--stroke-color mdc-button mdc-button--outlined" disabled>Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/stroke-width.html
+++ b/test/screenshot/mdc-button/mixins/stroke-width.html
@@ -28,19 +28,19 @@
     <main class="test-main">
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked">
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked">
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -49,13 +49,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked" disabled>
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked" disabled>
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -66,19 +66,19 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense">Button</button>
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined mdc-button--dense">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense" href="#">Link</a>
+          <a class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined mdc-button--dense" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense">
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined mdc-button--dense">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense">
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined mdc-button--dense">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -87,13 +87,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense" disabled>
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined mdc-button--dense" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense" disabled>
+          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--outlined mdc-button--dense" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>


### PR DESCRIPTION
Renames `stroke` to `outline` for card, chip, button, notched outline and text field. 