### PR TITLE
fix(button): Rename stroke to outline

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -194,29 +194,29 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--headline6">Stroked Button (Experimental)</legend>
+          <legend class="mdc-typography--headline6">Outlined Button (Experimental)</legend>
           <div>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               Baseline
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--dense">
+            <button class="mdc-button mdc-button--outlined mdc-button--dense">
               Dense
             </button>
-            <button class="mdc-button mdc-button--stroked secondary-stroked-button">
+            <button class="mdc-button mdc-button--outlined secondary-outlined-button">
               Secondary
             </button>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon
             </button>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
                 <path fill="none" d="M0 0h24v24H0z"/>
                 <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
               </svg>
               SVG Icon
             </button>
-            <a href="javascript:void(0)" class="mdc-button mdc-button--stroked">
+            <a href="javascript:void(0)" class="mdc-button mdc-button--outlined">
               Link
             </a>
           </div>
@@ -228,8 +228,8 @@
             <button class="mdc-button mdc-button--unelevated big-round-corner-button">
               Corner Radius
             </button>
-            <button class="mdc-button mdc-button--stroked thick-stroke-button">
-              Thick Stroke Width
+            <button class="mdc-button mdc-button--outlined thick-outline-button">
+              Thick Outline Width
             </button>
           </div>
         </fieldset>
@@ -241,7 +241,7 @@
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Ink Color
             </button>
-            <button class="mdc-button mdc-button--stroked demo-icon-color">
+            <button class="mdc-button mdc-button--outlined demo-icon-color">
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon Color
             </button>
@@ -338,29 +338,29 @@
         </fieldset>
 
         <fieldset>
-          <legend class="mdc-typography--headline6">Stroked Button (Experimental)</legend>
+          <legend class="mdc-typography--headline6">Outlined Button (Experimental)</legend>
           <div>
-            <button class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined" data-demo-no-js>
               Baseline
             </button>
-            <button class="mdc-button mdc-button--stroked mdc-button--dense" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined mdc-button--dense" data-demo-no-js>
               Dense
             </button>
-            <button class="mdc-button mdc-button--stroked secondary-stroked-button" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined secondary-outlined-button" data-demo-no-js>
               Secondary
             </button>
-            <button class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined" data-demo-no-js>
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon
             </button>
-            <button class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined" data-demo-no-js>
               <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
                 <path fill="none" d="M0 0h24v24H0z"/>
                 <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
               </svg>
               SVG Icon
             </button>
-            <a href="javascript:void(0)" class="mdc-button mdc-button--stroked" data-demo-no-js>
+            <a href="javascript:void(0)" class="mdc-button mdc-button--outlined" data-demo-no-js>
               Link
             </a>
           </div>
@@ -372,8 +372,8 @@
             <button class="mdc-button mdc-button--unelevated big-round-corner-button" data-demo-no-js>
               Big Corner Radius
             </button>
-            <button class="mdc-button mdc-button--stroked thick-stroke-button" data-demo-no-js>
-              Thick Stroke Width
+            <button class="mdc-button mdc-button--outlined thick-outline-button" data-demo-no-js>
+              Thick Outline Width
             </button>
           </div>
         </fieldset>
@@ -385,7 +385,7 @@
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Ink Color
             </button>
-            <button class="mdc-button mdc-button--stroked demo-icon-color" data-demo-no-js>
+            <button class="mdc-button mdc-button--outlined demo-icon-color" data-demo-no-js>
               <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
               Icon Color
             </button>

--- a/demos/button.scss
+++ b/demos/button.scss
@@ -31,9 +31,9 @@
   @include mdc-button-filled-accessible($mdc-theme-secondary);
 }
 
-.mdc-button.secondary-stroked-button {
+.mdc-button.secondary-outlined-button {
   @include mdc-button-ink-color($mdc-theme-secondary);
-  @include mdc-button-stroke-color($mdc-theme-secondary);
+  @include mdc-button-outline-color($mdc-theme-secondary);
 
 }
 
@@ -41,8 +41,8 @@
   @include mdc-button-corner-radius(8px);
 }
 
-.mdc-button.thick-stroke-button {
-  @include mdc-button-stroke-width(4px);
+.mdc-button.thick-outline-button {
+  @include mdc-button-outline-width(4px);
 }
 
 .demo-ink-color {

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -98,10 +98,10 @@
             <label for="basic-checkbox">Default checkbox</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked" onclick="this.parentElement.parentElement.hasAttribute('dir') ? this.parentElement.parentElement.removeAttribute('dir') : this.parentElement.parentElement.setAttribute('dir', 'rtl');">
+            <button type="button" class="mdc-button mdc-button--outlined" onclick="this.parentElement.parentElement.hasAttribute('dir') ? this.parentElement.parentElement.removeAttribute('dir') : this.parentElement.parentElement.setAttribute('dir', 'rtl');">
               Toggle RTL
             </button>
-            <button type="button" class="mdc-button mdc-button--stroked" onclick="document.querySelector('.mdc-form-field').classList.toggle('mdc-form-field--align-end');">
+            <button type="button" class="mdc-button mdc-button--outlined" onclick="document.querySelector('.mdc-form-field').classList.toggle('mdc-form-field--align-end');">
               <span>Toggle <code>--align-end</code></span>
             </button>
           </div>
@@ -214,8 +214,8 @@
             <label for="native-js-checkbox">Default checkbox</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
         </div>
         <div>
@@ -239,8 +239,8 @@
             <label for="native-js-checkbox-indeterminate">Indeterminate checkbox</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
           <script>
             document.getElementById('native-js-checkbox-indeterminate').indeterminate = true;
@@ -266,8 +266,8 @@
             <label for="native-js-checkbox-custom-all">Custom colored checkbox (stroke, fill, ripple, and focus)</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
         </div>
         <div>
@@ -290,8 +290,8 @@
             <label for="native-js-checkbox-custom-stroke-and-fill">Custom colored checkbox (stroke and fill only)</label>
           </div>
           <div class="demo-toggle-group">
-            <button type="button" class="mdc-button mdc-button--stroked toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
-            <button type="button" class="mdc-button mdc-button--stroked toggle-disabled"><span>Toggle <code>disabled</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-indeterminate"><span>Toggle <code>indeterminate</code></span></button>
+            <button type="button" class="mdc-button mdc-button--outlined toggle-disabled"><span>Toggle <code>disabled</code></span></button>
           </div>
         </div>
       </section>

--- a/demos/drawer/permanent-drawer-above-toolbar.html
+++ b/demos/drawer/permanent-drawer-above-toolbar.html
@@ -151,14 +151,14 @@
         </div>
 
         <div class="extra-content-wrapper">
-          <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+          <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-wide" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-wide content</button>
+          <button id="toggle-wide" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-wide content</button>
           <div id="extra-wide-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-tall" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-tall content</button>
+          <button id="toggle-tall" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-tall content</button>
           <div id="extra-tall-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
       </main>

--- a/demos/drawer/permanent-drawer-below-toolbar.html
+++ b/demos/drawer/permanent-drawer-below-toolbar.html
@@ -143,14 +143,14 @@
         </div>
 
         <div class="extra-content-wrapper">
-          <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+          <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-wide" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-wide content</button>
+          <button id="toggle-wide" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-wide content</button>
           <div id="extra-wide-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
         <div class="extra-content-wrapper">
-          <button id="toggle-tall" class="mdc-button mdc-button--stroked mdc-button--dense">Toggle extra-tall content</button>
+          <button id="toggle-tall" class="mdc-button mdc-button--outlined mdc-button--dense">Toggle extra-tall content</button>
           <div id="extra-tall-content" class="mdc-elevation--z2">&nbsp;</div>
         </div>
       </main>

--- a/demos/drawer/persistent-drawer.html
+++ b/demos/drawer/persistent-drawer.html
@@ -138,7 +138,7 @@
             <label for="theme-radio-accessible">Accessible Theme</label>
           </div>
         </div>
-        <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+        <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
       </main>
 
       <script src="/assets/material-components-web.js" async></script>

--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -126,7 +126,7 @@
         </div>
       </div>
       <div class="extra-content-wrapper">
-        <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
+        <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button>
       </div>
     </main>
 

--- a/demos/shape.html
+++ b/demos/shape.html
@@ -46,7 +46,7 @@
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-left"></div>
         </div>
         <div class="mdc-shape-container four-corner-container four-corner-container--stroked">
-          <button class="mdc-button mdc-button--stroked">Stroked Button</button>
+          <button class="mdc-button mdc-button--outlined">Stroked Button</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-right"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
@@ -73,12 +73,12 @@
 
         <h2 class="mdc-typography--headline4">Stroked</h2>
         <div class="mdc-shape-container two-corner-container two-corner-container--stroked">
-          <button class="mdc-button mdc-button--stroked">Skip</button>
+          <button class="mdc-button mdc-button--outlined">Skip</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
         </div>
         <div class="mdc-shape-container four-corner-container four-corner-container--stroked">
-          <button class="mdc-button mdc-button--stroked">Finish</button>
+          <button class="mdc-button mdc-button--outlined">Finish</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-right"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -285,7 +285,7 @@
             <button class="mdc-button mdc-button--unelevated">
               Unelevated
             </button>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               Stroked
             </button>
           </div>
@@ -304,7 +304,7 @@
             <button class="mdc-button mdc-button--unelevated">
               Unelevated
             </button>
-            <button class="mdc-button mdc-button--stroked">
+            <button class="mdc-button mdc-button--outlined">
               Stroked
             </button>
           </div>
@@ -419,10 +419,10 @@
             <label for="disabled-checkbox" id="disabled-checkbox-label">Disabled</label>
           </div>
 
-          <button type="button" class="mdc-button mdc-button--stroked demo-checkbox-toggle-button" id="checkbox-toggle--indeterminate">
+          <button type="button" class="mdc-button mdc-button--outlined demo-checkbox-toggle-button" id="checkbox-toggle--indeterminate">
             <span>Toggle <code class="demo-button__code">indeterminate</code></span>
           </button>
-          <button type="button" class="mdc-button mdc-button--stroked demo-checkbox-toggle-button" id="checkbox-toggle--align-end">
+          <button type="button" class="mdc-button mdc-button--outlined demo-checkbox-toggle-button" id="checkbox-toggle--align-end">
             <span>Toggle <code class="demo-button__code">--align-end</code></span>
           </button>
         </div>

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -286,7 +286,7 @@
               Unelevated
             </button>
             <button class="mdc-button mdc-button--outlined">
-              Stroked
+              Outlined
             </button>
           </div>
         </fieldset>
@@ -305,7 +305,7 @@
               Unelevated
             </button>
             <button class="mdc-button mdc-button--outlined">
-              Stroked
+              Outlined
             </button>
           </div>
         </fieldset>

--- a/demos/toolbar/index.html
+++ b/demos/toolbar/index.html
@@ -118,7 +118,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Normal Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./default-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./default-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -126,7 +126,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Fixed Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./fixed-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./fixed-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -134,7 +134,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Fixed Toolbar with Menu</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./menu-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./menu-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -142,7 +142,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -150,7 +150,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Default Flexible Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./default-flexible-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./default-flexible-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -158,7 +158,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Flexible Toolbar</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-flexible-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-flexible-toolbar.html" width="320" height="600"></iframe>
         </div>
@@ -166,7 +166,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Toolbar Fix Last Row</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-toolbar-fix-last-row.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-toolbar-fix-last-row.html" width="320" height="600"></iframe>
         </div>
@@ -174,7 +174,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Waterfall Flexible Toolbar with Custom Style</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./waterfall-flexible-toolbar-custom-style.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./waterfall-flexible-toolbar-custom-style.html" width="320" height="600"></iframe>
         </div>
@@ -182,7 +182,7 @@
         <div class="example">
           <h2 class="demo-toolbar-example-heading">
             <span class="demo-toolbar-example-heading__text">Custom Colored Toolbar and Icons</span>
-            <button type="button" class="mdc-button mdc-button--stroked mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
+            <button type="button" class="mdc-button mdc-button--outlined mdc-button--dense demo-toolbar-example-heading__rtl-toggle-button">Toggle RTL</button></h2>
           <p><a href="./custom-toolbar.html" target="_blank">View in separate window</a></p>
           <iframe class="demo-container" src="./custom-toolbar.html" width="320" height="600"></iframe>
         </div>

--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -90,7 +90,7 @@ CSS Class | Description
 `mdc-button__icon`    | Optional, for the icon element
 `mdc-button--raised` | Optional, a contained button that is elevated upon the surface
 `mdc-button--unelevated` | Optional, a contained button that is flush with the surface
-`mdc-button--stroked` | Optional, a contained button that is flush with the surface and has a visible border
+`mdc-button--outlined` | Optional, a contained button that is flush with the surface and has a visible border
 `mdc-button--dense` | Optional, compresses the button text to make it slightly smaller
 
 ### Disabled Button
@@ -135,7 +135,7 @@ container color to the given color, and updates the Button's ink and ripple colo
 
 ### Advanced Sass Mixins
 
-> **A note about advanced mixins**, The following mixins are intended for advanced users. These mixins will override the color of the container, ink, stroke or ripple. You can use all of them if you want to completely customize a Button. Or you can use only one of them, e.g. if you only need to override the ripple color. **It is up to you to pick container, ink, stroke and ripple colors that work together, and meet accessibility standards.**
+> **A note about advanced mixins**, The following mixins are intended for advanced users. These mixins will override the color of the container, ink, outline or ripple. You can use all of them if you want to completely customize a Button. Or you can use only one of them, e.g. if you only need to override the ripple color. **It is up to you to pick container, ink, outline and ripple colors that work together, and meet accessibility standards.**
 
 Mixin | Description
 --- | ---
@@ -144,12 +144,12 @@ Mixin | Description
 `mdc-button-ink-color($color)` | Sets the ink color to the given color. This affects both text and icon, unless `mdc-button-icon-color` is also used.
 `mdc-button-corner-radius($corner-radius)` | Sets the corner radius to the given number (defaults to 2px).
 `mdc-button-horizontal-padding($padding)` | Sets horizontal padding to the given number.
-`mdc-button-stroke-color($color)` | Sets the stroke color to the given color.
-`mdc-button-stroke-width($width, $padding)` | Sets the stroke width to the given number (defaults to 2px) and adjusts padding accordingly. `$padding` is only required in cases where `mdc-button-horizontal-padding` is also included with a custom value.
+`mdc-button-outline-color($color)` | Sets the outline color to the given color.
+`mdc-button-outline-width($width, $padding)` | Sets the outline width to the given number (defaults to 2px) and adjusts padding accordingly. `$padding` is only required in cases where `mdc-button-horizontal-padding` is also included with a custom value.
 
 The ripple effect for the Button component is styled using [MDC Ripple](../mdc-ripple) mixins.
 
-> **Note:** If you want to customize both horizontal padding and stroke width, simply include the `mdc-button-stroke-width` mixin with both arguments. It will include `mdc-button-horizontal-padding` for you.
+> **Note:** If you want to customize both horizontal padding and the outline width, simply include the `mdc-button-outline-width` mixin with both arguments. It will include `mdc-button-horizontal-padding` for you.
 
 #### Caveat: Edge and CSS Variables
 

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -44,7 +44,7 @@
   }
 }
 
-@mixin mdc-button-stroke-color($color) {
+@mixin mdc-button-outline-color($color) {
   &:not(:disabled) {
     @include mdc-theme-prop(border-color, $color);
   }
@@ -71,21 +71,21 @@
   padding: 0 $padding 0 $padding;
 }
 
-@mixin mdc-button-stroke-width($stroke-width, $padding: $mdc-button-contained-horizontal-padding) {
-  // Note: Adjust padding to maintain consistent width with non-stroked buttons
-  $padding-value: max($padding - $stroke-width, 0);
+@mixin mdc-button-outline-width($outline-width, $padding: $mdc-button-contained-horizontal-padding) {
+  // Note: Adjust padding to maintain consistent width with non-outlined buttons
+  $padding-value: max($padding - $outline-width, 0);
 
   @include mdc-button-horizontal-padding($padding-value);
 
-  border-width: $stroke-width;
-  // Note: line height is adjusted for stroke button because borders are not
+  border-width: $outline-width;
+  // Note: line height is adjusted for outline button because borders are not
   // considered as space available to text on the Web
-  line-height: $mdc-button-height - $stroke-width * 2;
+  line-height: $mdc-button-height - $outline-width * 2;
 
   // postcss-bem-linter: ignore
   &.mdc-button--dense {
     // Minus extra 1 to accommodate odd font size of dense button
-    line-height: $mdc-dense-button-height - $stroke-width * 2 - 1;
+    line-height: $mdc-dense-button-height - $outline-width * 2 - 1;
   }
 }
 
@@ -153,7 +153,7 @@
   @include mdc-rtl-reflexive-property(margin, -4px, 8px);
 }
 
-@mixin mdc-button--stroked_() {
+@mixin mdc-button--outlined_() {
   border-style: solid;
 
   &:disabled {

--- a/packages/mdc-button/mdc-button.scss
+++ b/packages/mdc-button/mdc-button.scss
@@ -43,7 +43,7 @@
 
 .mdc-button--raised,
 .mdc-button--unelevated,
-.mdc-button--stroked {
+.mdc-button--outlined {
   .mdc-button__icon {
     // Icons inside contained buttons have different styles due to increased button padding
     @include mdc-button__icon-contained_;
@@ -62,10 +62,10 @@
   @include mdc-button--raised_;
 }
 
-.mdc-button--stroked {
-  @include mdc-button--stroked_;
-  @include mdc-button-stroke-width(2px);
-  @include mdc-button-stroke-color(primary);
+.mdc-button--outlined {
+  @include mdc-button--outlined_;
+  @include mdc-button-outline-width(2px);
+  @include mdc-button-outline-color(primary);
 }
 
 .mdc-button--dense {

--- a/test/screenshot/README.md
+++ b/test/screenshot/README.md
@@ -42,7 +42,7 @@ Guidelines:
 
 4.  Do not test _combinations_ of mixins and modifier classes unless:
     1. It's necessary to prevent a regression; or
-    2. We explicitly support the combination, and the implementation is likely to have bugs (e.g., `mdc-button--dense` and `mdc-button-stroke-width` both set `line-height`)
+    2. We explicitly support the combination, and the implementation is likely to have bugs (e.g., `mdc-button--dense` and `mdc-button-outline-width` both set `line-height`)
 
 ## Example test page
 

--- a/test/screenshot/mdc-button/classes/baseline.html
+++ b/test/screenshot/mdc-button/classes/baseline.html
@@ -150,22 +150,22 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">Button</button>
+          <button class="mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">
+          <button class="mdc-button mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked">
+          <button class="mdc-button mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -174,13 +174,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>

--- a/test/screenshot/mdc-button/classes/dense.html
+++ b/test/screenshot/mdc-button/classes/dense.html
@@ -150,22 +150,22 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">Button</button>
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="mdc-button mdc-button--dense mdc-button--stroked" href="#">Link</a>
+          <a class="mdc-button mdc-button--dense mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked">
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -174,13 +174,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--dense mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="mdc-button mdc-button--dense mdc-button--stroked" disabled>
+          <button class="mdc-button mdc-button--dense mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>

--- a/test/screenshot/mdc-button/mixins/corner-radius.html
+++ b/test/screenshot/mdc-button/mixins/corner-radius.html
@@ -52,10 +52,10 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--stroked" disabled>Disabled</button>
+          <button class="custom-button custom-button--corner-radius mdc-button mdc-button--outlined" disabled>Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/custom.scss
+++ b/test/screenshot/mdc-button/mixins/custom.scss
@@ -19,7 +19,7 @@
 
 $custom-button-color: $material-color-red-300;
 $custom-button-custom-corner-radius: 8px;
-$custom-button-custom-stroke-width: 4px;
+$custom-button-custom-outline-width: 4px;
 $custom-button-custom-horizontal-padding: 36px;
 
 .custom-button--ink-color {
@@ -34,12 +34,12 @@ $custom-button-custom-horizontal-padding: 36px;
   @include mdc-button-filled-accessible($custom-button-color);
 }
 
-.custom-button--stroke-color {
-  @include mdc-button-stroke-color($custom-button-color);
+.custom-button--outline-color {
+  @include mdc-button-outline-color($custom-button-color);
 }
 
-.custom-button--stroke-width {
-  @include mdc-button-stroke-width($custom-button-custom-stroke-width);
+.custom-button--outline-width {
+  @include mdc-button-outline-width($custom-button-custom-outline-width);
 }
 
 .custom-button--corner-radius {

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
@@ -79,19 +79,19 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button--horizontal-padding mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button--horizontal-padding mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--stroked" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
@@ -79,19 +79,19 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked">Button</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
         </span>
         <span class="test-cell">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--stroked" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/stroke-color.html
+++ b/test/screenshot/mdc-button/mixins/stroke-color.html
@@ -17,7 +17,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>stroke-color Button Mixin - MDC Web Screenshot Test</title>
+    <title>outline-color Button Mixin - MDC Web Screenshot Test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
@@ -28,13 +28,13 @@
     <main class="test-main">
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-color mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button custom-button--outline-color mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button custom-button--stroke-color mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button custom-button--outline-color mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-color mdc-button mdc-button--stroked" disabled>Disabled</button>
+          <button class="custom-button custom-button--outline-color mdc-button mdc-button--outlined" disabled>Disabled</button>
         </span>
       </p>
     </main>

--- a/test/screenshot/mdc-button/mixins/stroke-width.html
+++ b/test/screenshot/mdc-button/mixins/stroke-width.html
@@ -17,7 +17,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>stroke-width Button Mixin - MDC Web Screenshot Test</title>
+    <title>outline-width Button Mixin - MDC Web Screenshot Test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
@@ -28,19 +28,19 @@
     <main class="test-main">
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked">Button</button>
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked" href="#">Link</a>
+          <a class="custom-button custom-button--outline-width mdc-button mdc-button--outlined" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked">
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked">
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -49,13 +49,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked" disabled>
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked" disabled>
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -66,19 +66,19 @@
       </p>
       <p class="test-row">
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense">Button</button>
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense">Button</button>
         </span>
         <span class="test-cell">
-          <a class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense" href="#">Link</a>
+          <a class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense" href="#">Link</a>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense">
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense">
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
@@ -87,13 +87,13 @@
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense" disabled>
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
         </span>
         <span class="test-cell">
-          <button class="custom-button custom-button--stroke-width mdc-button mdc-button--stroked mdc-button--dense" disabled>
+          <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>


### PR DESCRIPTION
BREAKING CHANGE: Renames variant, classes and mixins containing `stroke` to use `outline`. 