### PR TITLE
fix(shape): Rename stroke to outline

### DIFF
--- a/demos/shape.html
+++ b/demos/shape.html
@@ -45,8 +45,8 @@
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-left"></div>
         </div>
-        <div class="mdc-shape-container four-corner-container four-corner-container--stroked">
-          <button class="mdc-button mdc-button--outlined">Stroked Button</button>
+        <div class="mdc-shape-container four-corner-container four-corner-container--outlined">
+          <button class="mdc-button mdc-button--outlined">Outlined Button</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-right"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
@@ -71,13 +71,13 @@
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-left"></div>
         </div>
 
-        <h2 class="mdc-typography--headline4">Stroked</h2>
-        <div class="mdc-shape-container two-corner-container two-corner-container--stroked">
+        <h2 class="mdc-typography--headline4">Outlined</h2>
+        <div class="mdc-shape-container two-corner-container two-corner-container--outlined">
           <button class="mdc-button mdc-button--outlined">Skip</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--bottom-right"></div>
         </div>
-        <div class="mdc-shape-container four-corner-container four-corner-container--stroked">
+        <div class="mdc-shape-container four-corner-container four-corner-container--outlined">
           <button class="mdc-button mdc-button--outlined">Finish</button>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-left"></div>
           <div class="mdc-shape-container__corner mdc-shape-container__corner--top-right"></div>

--- a/demos/shape.scss
+++ b/demos/shape.scss
@@ -61,7 +61,7 @@
 
 .card-container {
   @include mdc-shape-angled-corner($mdc-theme-background, 24px, 4px);
-  @include mdc-shape-angled-corner-stroke($mdc-card-outline-width, $mdc-card-outline-color);
+  @include mdc-shape-angled-corner-outline($mdc-card-outline-width, $mdc-card-outline-color);
 }
 
 .demo-card {

--- a/demos/shape.scss
+++ b/demos/shape.scss
@@ -39,9 +39,9 @@
   @include mdc-shape-angled-corner($mdc-theme-background, $mdc-button-height / 4 + 1);
 }
 
-.two-corner-container--stroked,
-.four-corner-container--stroked {
-  @include mdc-shape-angled-corner-stroke(2px, $mdc-theme-primary);
+.two-corner-container--outlined,
+.four-corner-container--outlined {
+  @include mdc-shape-angled-corner-outline(2px, $mdc-theme-primary);
 }
 
 .hero {

--- a/packages/mdc-shape/README.md
+++ b/packages/mdc-shape/README.md
@@ -77,7 +77,7 @@ Stroked angled corners involve the same markup and styles as above, with the add
 
 .my-shape-container {
   @include mdc-shape-angled-corner(#fff, 10px);
-  @include mdc-shape-angled-corner-stroke(2px, blue);
+  @include mdc-shape-angled-corner-outline(2px, blue);
 }
 ```
 
@@ -100,7 +100,7 @@ Mixin | Description
 --- | ---
 `mdc-shape-angled-corner($background-color, $top-left-size[, $top-right-size, $bottom-right-size, $bottom-left-size])` | Applies styles for masking angled corners, using the given background color and corner sizes. If fewer than 4 corner sizes are specified, the mixin automatically determines the other corners similarly to CSS `border-radius`.
 `mdc-shape-angled-corner-background($background-color)` | Sets the background color used to mask angled corners. Useful for styling a subset of components in a section with a different background color.
-`mdc-shape-angled-corner-stroke($stroke-width, $stroke-color[, $stroke-style])` | Applies stroke styles to angled corners. `$stroke-style` defaults to `solid`.
+`mdc-shape-angled-corner-outline($stroke-width, $stroke-color[, $stroke-style])` | Applies stroke styles to angled corners. `$stroke-style` defaults to `solid`.
 
 > **Note:** When mentioned above, "background color" specifically refers to the color of the background behind the surface (_not_ the fill color of the surface). These mixins operate by masking the corners of the surface to match the background.
 

--- a/packages/mdc-shape/README.md
+++ b/packages/mdc-shape/README.md
@@ -68,9 +68,9 @@ unelevated component.
 
 ## Variants
 
-### Stroked Angled Corners
+### Outlined Angled Corners
 
-Stroked angled corners involve the same markup and styles as above, with the addition of including a mixin for stroke:
+Outlined angled corners involve the same markup and styles as above, with the addition of including a mixin for outline:
 
 ```scss
 @import "@material/shape/mixins";
@@ -100,7 +100,7 @@ Mixin | Description
 --- | ---
 `mdc-shape-angled-corner($background-color, $top-left-size[, $top-right-size, $bottom-right-size, $bottom-left-size])` | Applies styles for masking angled corners, using the given background color and corner sizes. If fewer than 4 corner sizes are specified, the mixin automatically determines the other corners similarly to CSS `border-radius`.
 `mdc-shape-angled-corner-background($background-color)` | Sets the background color used to mask angled corners. Useful for styling a subset of components in a section with a different background color.
-`mdc-shape-angled-corner-outline($stroke-width, $stroke-color[, $stroke-style])` | Applies stroke styles to angled corners. `$stroke-style` defaults to `solid`.
+`mdc-shape-angled-corner-outline($outline-width, $outline-color[, $outline-style])` | Applies outline styles to angled corners. `$outline-style` defaults to `solid`.
 
 > **Note:** When mentioned above, "background color" specifically refers to the color of the background behind the surface (_not_ the fill color of the surface). These mixins operate by masking the corners of the surface to match the background.
 

--- a/packages/mdc-shape/_mixins.scss
+++ b/packages/mdc-shape/_mixins.scss
@@ -50,9 +50,9 @@
   }
 }
 
-@mixin mdc-shape-angled-corner-stroke($stroke-width, $stroke-color, $stroke-style: solid) {
+@mixin mdc-shape-angled-corner-outline($outline-width, $outline-color, $outline-style: solid) {
   .mdc-shape-container__corner::before {
-    top: $stroke-width;
-    border-bottom: $stroke-width $stroke-style $stroke-color;
+    top: $outline-width;
+    border-bottom: $outline-width $outline-style $outline-color;
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Renames variant, classes and mixins containing the word stroke to use the word outline.