### PR TITLE
fix(chips): Rename stroke to outline

### DIFF
--- a/demos/chips.scss
+++ b/demos/chips.scss
@@ -30,5 +30,5 @@
   @include mdc-chip-fill-color(white);
   @include mdc-chip-ink-color($mdc-theme-secondary);
   @include mdc-chip-selected-ink-color($mdc-theme-secondary);
-  @include mdc-chip-stroke(2px, solid, $mdc-theme-secondary);
+  @include mdc-chip-outline(2px, solid, $mdc-theme-secondary);
 }

--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -163,10 +163,10 @@ Mixin | Description
 `mdc-chip-fill-color($color)` | Customizes the background fill color for a chip
 `mdc-chip-ink-color($color)` | Customizes the text ink color for a chip, and updates the chip's ripple color to match
 `mdc-chip-selected-ink-color($color)` | Customizes text ink and ripple color of a chip in the _selected_ state
-`mdc-chip-outline($width, $style, $color)` | Customizes the border outline properties for a chip
-`mdc-chip-outline-width($width)` | Customizes the border outline width for a chip
-`mdc-chip-outline-style($style)` | Customizes the border outline style for a chip
-`mdc-chip-outline-color($color)` | Customizes the border outline color for a chip
+`mdc-chip-outline($width, $style, $color)` | Customizes the outline properties for a chip
+`mdc-chip-outline-width($width)` | Customizes the outline width for a chip
+`mdc-chip-outline-style($style)` | Customizes the outline style for a chip
+`mdc-chip-outline-color($color)` | Customizes the outline color for a chip
 `mdc-chip-leading-icon-color($color, $opacity)` | Customizes the color of a leading icon in a chip, optionally customizes opacity
 `mdc-chip-trailing-icon-color($color, $opacity, $hover-opacity, $focus-opacity)` | Customizes the color of a trailing icon in a chip, optionally customizes regular/hover/focus opacities
 `mdc-chip-leading-icon-size($size)` | Customizes the size of a leading icon in a chip

--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -163,10 +163,10 @@ Mixin | Description
 `mdc-chip-fill-color($color)` | Customizes the background fill color for a chip
 `mdc-chip-ink-color($color)` | Customizes the text ink color for a chip, and updates the chip's ripple color to match
 `mdc-chip-selected-ink-color($color)` | Customizes text ink and ripple color of a chip in the _selected_ state
-`mdc-chip-stroke($width, $style, $color)` | Customizes the border stroke properties for a chip
-`mdc-chip-stroke-width($width)` | Customizes the border stroke width for a chip
-`mdc-chip-stroke-style($style)` | Customizes the border stroke style for a chip
-`mdc-chip-stroke-color($color)` | Customizes the border stroke color for a chip
+`mdc-chip-outline($width, $style, $color)` | Customizes the border outline properties for a chip
+`mdc-chip-outline-width($width)` | Customizes the border outline width for a chip
+`mdc-chip-outline-style($style)` | Customizes the border outline style for a chip
+`mdc-chip-outline-color($color)` | Customizes the border outline color for a chip
 `mdc-chip-leading-icon-color($color, $opacity)` | Customizes the color of a leading icon in a chip, optionally customizes opacity
 `mdc-chip-trailing-icon-color($color, $opacity, $hover-opacity, $focus-opacity)` | Customizes the color of a trailing icon in a chip, optionally customizes regular/hover/focus opacities
 `mdc-chip-leading-icon-size($size)` | Customizes the size of a leading icon in a chip

--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -71,22 +71,22 @@
   }
 }
 
-@mixin mdc-chip-stroke($width: 1, $style: solid, $color: mdc-theme-prop-value(on-surface)) {
-  @include mdc-chip-stroke-width($width);
-  @include mdc-chip-stroke-style($style);
-  @include mdc-chip-stroke-color($color);
+@mixin mdc-chip-outline($width: 1, $style: solid, $color: mdc-theme-prop-value(on-surface)) {
+  @include mdc-chip-outline-width($width);
+  @include mdc-chip-outline-style($style);
+  @include mdc-chip-outline-color($color);
 }
 
-@mixin mdc-chip-stroke-color($color) {
+@mixin mdc-chip-outline-color($color) {
   @include mdc-theme-prop(border-color, $color);
 }
 
-@mixin mdc-chip-stroke-style($style) {
+@mixin mdc-chip-outline-style($style) {
   border-style: $style;
 }
 
-@mixin mdc-chip-stroke-width($width) {
-  // Note: Adjust padding to maintain consistent width with non-stroked chips
+@mixin mdc-chip-outline-width($width) {
+  // Note: Adjust padding to maintain consistent width with non-outlined chips
   $horizontal-padding-value: max($mdc-chip-horizontal-padding - $width, 0);
   $vertical-padding-value: max($mdc-chip-vertical-padding - $width, 0);
 


### PR DESCRIPTION
BREAKING CHANGE: Renames variant, classes and mixins containing the word stroke to use the word outline.