### PR TITLE
fix(chips): Add nowrap to chip text

### DIFF
--- a/packages/mdc-chips/chip/mdc-chip.scss
+++ b/packages/mdc-chips/chip/mdc-chip.scss
@@ -66,6 +66,7 @@
 .mdc-chip__text {
   // Set line-height to be <18px to force the content height of mdc-chip to be 18px.
   line-height: 17px;
+  white-space: nowrap;
 }
 
 .mdc-chip__icon {


### PR DESCRIPTION
fixes: #2667 
Chips with spaces in the text are wrapping when the exit animation is occurring, causing the chip to increase in height. 