### PR TITLE
fix(select): Fix SassC compilation error

### DIFF
--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -98,5 +98,5 @@
 }
 
 @mixin mdc-select-dd-arrow-svg-bg_($fill-hex-number: 000000, $opacity: .54) {
-  background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%23#{$fill-hex-number}%22%20fill-rule%3D%22evenodd%22%20opacity%3D%22#{$opacity}%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E);
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%23#{$fill-hex-number}%22%20fill-rule%3D%22evenodd%22%20opacity%3D%22#{$opacity}%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
 }


### PR DESCRIPTION
SassC::SyntaxError compilation error is caused by unquoted backround-image url:

```
SassC::SyntaxError: Error: expected a variable name (e.g. $x) or ')' for the parameter list for url
        on line 17987 of stdin
>>   background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20heigh
   -----------------------^
stdin:17987
/home/lex/.gem/ruby/2.3.0/gems/sassc-1.11.4/lib/sassc/engine.rb:47:in `render'
/home/lex/.gem/ruby/2.3.0/gems/sassc-rails-1.3.0/lib/sassc/rails/compressor.rb:16:in `call'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/sass_compressor.rb:28:in `call'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/processor_utils.rb:75:in `call_processor'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/processor_utils.rb:57:in `block in call_processors'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/processor_utils.rb:56:in `reverse_each'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/processor_utils.rb:56:in `call_processors'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/loader.rb:134:in `load_from_unloaded'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/loader.rb:60:in `block in load'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/loader.rb:317:in `fetch_asset_from_dependency_cache'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/loader.rb:44:in `load'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/cached_environment.rb:20:in `block in initialize'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/cached_environment.rb:47:in `load'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/base.rb:66:in `find_asset'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/base.rb:73:in `find_all_linked_assets'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/manifest.rb:142:in `block in find'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/legacy.rb:114:in `block (2 levels) in logical_paths'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/path_utils.rb:228:in `block in stat_tree'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/path_utils.rb:212:in `block in stat_directory'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/path_utils.rb:209:in `each'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/path_utils.rb:209:in `stat_directory'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/path_utils.rb:227:in `stat_tree'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/legacy.rb:105:in `each'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/legacy.rb:105:in `block in logical_paths'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/legacy.rb:104:in `each'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/legacy.rb:104:in `logical_paths'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/manifest.rb:140:in `find'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/sprockets/manifest.rb:185:in `compile'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-rails-3.2.1/lib/sprockets/rails/task.rb:68:in `block (3 levels) in define'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-3.7.1/lib/rake/sprocketstask.rb:147:in `with_logger'
/home/lex/.gem/ruby/2.3.0/gems/sprockets-rails-3.2.1/lib/sprockets/rails/task.rb:67:in `block (2 levels) in define'
/home/lex/.gem/ruby/2.3.0/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => assets:precompile
```