### PR TITLE
docs(fab): Fix broken link

### DIFF
--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -114,7 +114,7 @@ The ripple effect for the FAB component is styled using [MDC Ripple](../mdc-ripp
 
 #### Caveat: Edge and CSS Variables
 
-In browsers that fully support CSS custom properties, the above mixins will work if you pass in a [MDC Theme](mdc-theme) property (e.g. `primary`) as an argument. However, Edge does not fully support CSS custom properties. If you are using the `mdc-fab-container-color` mixin, you must pass in an actual color value for support in Edge.
+In browsers that fully support CSS custom properties, the above mixins will work if you pass in a [MDC Theme](../mdc-theme) property (e.g. `primary`) as an argument. However, Edge does not fully support CSS custom properties. If you are using the `mdc-fab-container-color` mixin, you must pass in an actual color value for support in Edge.
 
 ### Additional Information
 


### PR DESCRIPTION
This was presumably carried over from Button which we only realized we missed a few hours ago.