### PR TITLE
fix(fab): Change fab to inline-block. Move material-icons class to icon

### DIFF
--- a/demos/fab.html
+++ b/demos/fab.html
@@ -103,8 +103,8 @@
     <main>
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
-        <button class="mdc-fab material-icons" aria-label="Favorite">
-          <span class="mdc-fab__icon">
+        <button class="mdc-fab " aria-label="Favorite">
+          <span class="material-icons mdc-fab__icon">
             favorite_border
           </span>
         </button>
@@ -122,8 +122,8 @@
         <legend>FABs with Ripple</legend>
         <div class="demo-fabs">
           <figure>
-            <button class="mdc-fab material-icons" aria-label="Favorite">
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab" aria-label="Favorite">
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
@@ -132,8 +132,8 @@
             </figcaption>
           </figure>
           <figure>
-            <button class="mdc-fab mdc-fab--mini material-icons" aria-label="Favorite">
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
@@ -143,8 +143,8 @@
             </figcaption>
           </figure>
           <figure>
-            <button class="mdc-fab material-icons" aria-label="Favorite">
-              <svg xmlns="http://www.w3.org/2000/svg" class="mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
+            <button class="mdc-fab" aria-label="Favorite">
+              <svg xmlns="http://www.w3.org/2000/svg" class="material-icons mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
                 <path fill="none" d="M0 0h24v24H0z"/>
                 <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
               </svg>
@@ -154,8 +154,8 @@
             </figcaption>
           </figure>
           <figure>
-            <button class="mdc-fab mdc-fab--mini material-icons" aria-label="Favorite">
-              <svg xmlns="http://www.w3.org/2000/svg" class="mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
+            <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
+              <svg xmlns="http://www.w3.org/2000/svg" class="material-icons mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
                 <path fill="none" d="M0 0h24v24H0z"/>
                 <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
               </svg>
@@ -166,8 +166,8 @@
             </figcaption>
           </figure>
           <figure>
-            <button class="mdc-fab lightGreen800Fab material-icons" aria-label="Favorite">
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab lightGreen800Fab" aria-label="Favorite">
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
@@ -177,8 +177,8 @@
             </figcaption>
           </figure>
           <figure>
-            <button class="mdc-fab lightGreen800Fab mdc-fab--mini material-icons" aria-label="Favorite">
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab lightGreen800Fab mdc-fab--mini" aria-label="Favorite">
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
@@ -193,8 +193,8 @@
         <legend>FABs with Larger Icons</legend>
         <div class="demo-fabs">
           <figure>
-            <button class="mdc-fab material-icons demo-fab-icon-size" aria-label="Favorite">
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab demo-fab-icon-size" aria-label="Favorite">
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
@@ -203,8 +203,8 @@
             </figcaption>
           </figure>
           <figure>
-            <button class="mdc-fab mdc-fab--mini material-icons demo-fab-icon-size" aria-label="Favorite">
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab mdc-fab--mini demo-fab-icon-size" aria-label="Favorite">
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
@@ -214,8 +214,8 @@
             </figcaption>
           </figure>
           <figure>
-            <button class="mdc-fab material-icons demo-fab-icon-size" aria-label="Favorite">
-              <svg xmlns="http://www.w3.org/2000/svg" class="mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
+            <button class="mdc-fab demo-fab-icon-size" aria-label="Favorite">
+              <svg xmlns="http://www.w3.org/2000/svg" class="material-icons mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
                 <path fill="none" d="M0 0h24v24H0z"/>
                 <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
               </svg>
@@ -231,29 +231,29 @@
         <legend>CSS Only FABs</legend>
         <div class="demo-fabs">
           <figure>
-            <button class="mdc-fab material-icons" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab" aria-label="Favorite" data-demo-no-js>
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
           </figure>
           <figure>
-            <button class="mdc-fab mdc-fab--mini material-icons" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab mdc-fab--mini" aria-label="Favorite" data-demo-no-js>
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
           </figure>
           <figure>
-            <button class="mdc-fab lightGreen800Fab material-icons" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab lightGreen800Fab" aria-label="Favorite" data-demo-no-js>
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
           </figure>
           <figure>
-            <button class="mdc-fab lightGreen800Fab mdc-fab--mini material-icons" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon">
+            <button class="mdc-fab lightGreen800Fab mdc-fab--mini" aria-label="Favorite" data-demo-no-js>
+              <span class="material-icons mdc-fab__icon">
                 favorite_border
               </span>
             </button>
@@ -270,8 +270,8 @@
             <p>View two (without FAB)</p>
             <p><button type="button" disabled id="enter-exit-back">Go back</button></p>
           </div>
-          <button id="enter-exit-add" class="mdc-fab demo-absolute-fab material-icons" aria-label="Add">
-            <span class="mdc-fab__icon">
+          <button id="enter-exit-add" class="mdc-fab demo-absolute-fab" aria-label="Add">
+            <span class="material-icons mdc-fab__icon">
               add
             </span>
           </button>

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -50,8 +50,8 @@ We recommend you load [Material Icons](https://material.io/icons/) from Google F
 ### HTML Structure
 
 ```html
-<button class="mdc-fab material-icons" aria-label="Favorite">
-  <span class="mdc-fab__icon">
+<button class="mdc-fab" aria-label="Favorite">
+  <span class="material-icons mdc-fab__icon">
     favorite
   </span>
 </button>
@@ -141,8 +141,8 @@ Developers must position MDC FAB as needed within their application's design.
   }
 }
 </style>
-<button class="mdc-fab material-icons app-fab--absolute" aria-label="Favorite">
-  <span class="mdc-fab__icon">
+<button class="mdc-fab app-fab--absolute" aria-label="Favorite">
+  <span class="material-icons mdc-fab__icon">
     favorite
   </span>
 </button>

--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -58,7 +58,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
   @include mdc-ripple-radius-bounded;
   @include mdc-elevation(6);
 
-  display: inline-flex;
+  display: inline-block;
   position: relative;
   justify-content: center;
   box-sizing: border-box;


### PR DESCRIPTION
Fixes icon alignment issues with IE11. The icon was rendered on the right side of the fab. 

Also, the demos were putting the `material-icons` class on the button instead of on the icon class, which causes IE11 to align the icons higher than it should be. 