### PR TITLE
docs: A few more links

### DIFF
--- a/packages/mdc-animation/README.md
+++ b/packages/mdc-animation/README.md
@@ -15,7 +15,7 @@ Material in motion is responsive and natural. Use these easing curves and durati
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec">
-    <a href="https://material.io/go/design-motion">Material Design guidelines: Duration & easing</a>
+    <a href="https://material.io/go/design-motion">Material Design guidelines: Motion</a>
   </li>
 </ul>
 

--- a/packages/mdc-layout-grid/README.md
+++ b/packages/mdc-layout-grid/README.md
@@ -22,6 +22,9 @@ Material design’s responsive UI is based on a column-variate grid layout. It h
 ## Design & API Documentation
 
 <ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-grid">Material Design guidelines: Layout grid</a>
+  </li>
   <li class="icon-list-item icon-list-item--link">
     <a href="https://material-components.github.io/material-components-web-catalog/#/component/layout-grid">Demo</a>
   </li>

--- a/packages/mdc-shape/README.md
+++ b/packages/mdc-shape/README.md
@@ -26,6 +26,9 @@ applying angled corners to unelevated surfaces.
   <li class="icon-list-item icon-list-item--spec">
     <a href="https://material.io/go/design-shape">Material Design guidelines: Shape</a>
   </li>
+  <li class="icon-list-item icon-list-item--link">
+    <a href="https://material-components.github.io/material-components-web-catalog/#/component/shape">Demo</a>
+  </li>
 </ul>
 
 ## Installation

--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -24,7 +24,7 @@ It requires JavaScript to show and hide itself.
 
 <ul class="icon-list">
   <li class="icon-list-item icon-list-item--spec">
-    <a href="https://material.io/go/design-snackbars">Material Design guidelines: Snackbars & toasts</a>
+    <a href="https://material.io/go/design-snackbar">Material Design guidelines: Snackbars & toasts</a>
   </li>
   <li class="icon-list-item icon-list-item--link">
     <a href="https://material-components.github.io/material-components-web-catalog/#/component/snackbar">Demo</a>


### PR DESCRIPTION
NOTE: This is pending https://github.com/material-components/material-components-web-catalog/pull/131 being merged and the catalog being redeployed, for the new shape demo to exist.