### PR TITLE
feat(infrastructure): Add golden/snapshot links to report page

### DIFF
--- a/test/screenshot/fixture.scss
+++ b/test/screenshot/fixture.scss
@@ -57,7 +57,7 @@ $test-button-columns: 2;
   // Ruler grid pattern
   // https://stackoverflow.com/a/32861765/467582
   background-image:
-    linear-gradient(to right, #{$test-ruler-color} 1px, transparent 1px),
+    linear-gradient(to right, #{$test-ruler-color} 1px, transparent 1.01px),  // fraction for IE 11
     linear-gradient(to bottom, #{$test-ruler-color} 1px, transparent 1.01px); // fraction for IE 11
 
   background-size: #{$test-ruler-granularity} #{$test-ruler-granularity};

--- a/test/screenshot/lib/controller.js
+++ b/test/screenshot/lib/controller.js
@@ -22,12 +22,12 @@ const path = require('path');
 
 const CbtUserAgent = require('./cbt-user-agent');
 const CliArgParser = require('./cli-arg-parser');
-const GoldenStore = require('./golden-store');
 const ImageCache = require('./image-cache');
 const ImageCropper = require('./image-cropper');
 const ImageDiffer = require('./image-differ');
 const ReportGenerator = require('./report-generator');
 const Screenshot = require('./screenshot');
+const SnapshotStore = require('./snapshot-store');
 const {Storage, UploadableFile, UploadableTestCase} = require('./storage');
 
 /**
@@ -279,8 +279,8 @@ class Controller {
    * @return {!Promise<!Array<!UploadableTestCase>>}
    */
   async updateGoldenJson({testCases, diffReportUrl}) {
-    const goldenStore = await GoldenStore.fromTestCases(testCases);
-    await goldenStore.writeToDisk({jsonFilePath: this.goldenJsonFilePath_, diffReportUrl});
+    const snapshotStore = await SnapshotStore.fromTestCases(testCases);
+    await snapshotStore.writeToDisk({jsonFilePath: this.goldenJsonFilePath_, diffReportUrl});
     return testCases;
   }
 
@@ -291,8 +291,8 @@ class Controller {
   async diffGoldenJson(testCases) {
     /** @type {!Array<!ImageDiffJson>} */
     const diffs = await this.imageDiffer_.compareAllPages({
-      actualStore: await GoldenStore.fromTestCases(testCases),
-      expectedStore: await GoldenStore.fromMaster(this.goldenJsonFilePath_),
+      actualStore: await SnapshotStore.fromTestCases(testCases),
+      expectedStore: await SnapshotStore.fromMaster(this.goldenJsonFilePath_),
     });
 
     return Promise.all(diffs.map((diff) => this.uploadOneDiffImage_(diff)))

--- a/test/screenshot/lib/git-repo.js
+++ b/test/screenshot/lib/git-repo.js
@@ -40,8 +40,8 @@ class GitRepo {
   /**
    * @return {!Promise<void>}
    */
-  async fetchMasterShallow() {
-    return this.repo_.fetch(['--depth=1', 'origin', 'master']);
+  async fetch(branch = 'master', remote = 'origin') {
+    return this.repo_.fetch([remote, branch]);
   }
 
   /**

--- a/test/screenshot/lib/git-repo.js
+++ b/test/screenshot/lib/git-repo.js
@@ -38,13 +38,16 @@ class GitRepo {
   }
 
   /**
+   * @param {string} branch
+   * @param {string=} remote
    * @return {!Promise<void>}
    */
-  async fetch(branch = 'master', remote = 'origin') {
+  async fetch(branch, remote = 'origin') {
     return this.repo_.fetch([remote, branch]);
   }
 
   /**
+   * @param {string=} ref
    * @return {!Promise<string>}
    */
   async getShortCommitHash(ref = 'HEAD') {
@@ -52,6 +55,7 @@ class GitRepo {
   }
 
   /**
+   * @param {string=} ref
    * @return {!Promise<string>}
    */
   async getBranchName(ref = 'HEAD') {

--- a/test/screenshot/lib/golden-store.js
+++ b/test/screenshot/lib/golden-store.js
@@ -54,7 +54,7 @@ class GoldenStore {
    */
   static async fromMaster(jsonFilePath) {
     const mdcGitRepo = new GitRepo();
-    await mdcGitRepo.fetchMasterShallow();
+    await mdcGitRepo.fetch();
 
     const getFrom = (rev) => mdcGitRepo.getFileAtRevision(jsonFilePath, rev);
 

--- a/test/screenshot/lib/image-differ.js
+++ b/test/screenshot/lib/image-differ.js
@@ -29,8 +29,8 @@ class ImageDiffer {
   }
 
   /**
-   * @param {!GoldenStore} actualStore
-   * @param {!GoldenStore} expectedStore
+   * @param {!SnapshotStore} actualStore
+   * @param {!SnapshotStore} expectedStore
    * @return {!Promise<!Array<!ImageDiffJson>>}
    */
   async compareAllPages({

--- a/test/screenshot/lib/image-differ.js
+++ b/test/screenshot/lib/image-differ.js
@@ -53,6 +53,8 @@ class ImageDiffer {
       pagePromises.push(
         this.compareOnePage_({
           htmlFilePath,
+          goldenPageUrl: expectedCapture.publicUrl,
+          snapshotPageUrl: actualCapture.publicUrl,
           actualCapture,
           expectedCapture,
         })
@@ -68,6 +70,8 @@ class ImageDiffer {
 
   /**
    * @param {string} htmlFilePath
+   * @param {string} goldenPageUrl
+   * @param {string} snapshotPageUrl
    * @param {!CaptureJson} actualCapture
    * @param {!CaptureJson} expectedCapture
    * @return {!Promise<!Array<!ImageDiffJson>>}
@@ -75,6 +79,8 @@ class ImageDiffer {
    */
   async compareOnePage_({
     htmlFilePath,
+    goldenPageUrl,
+    snapshotPageUrl,
     actualCapture,
     expectedCapture,
   }) {
@@ -96,6 +102,8 @@ class ImageDiffer {
           .then(
             (diffImageBuffer) => ({
               htmlFilePath,
+              goldenPageUrl,
+              snapshotPageUrl,
               browserKey,
               expectedImageUrl,
               actualImageUrl,

--- a/test/screenshot/lib/report-generator.js
+++ b/test/screenshot/lib/report-generator.js
@@ -149,24 +149,20 @@ class ReportGenerator {
           <td class="report-metadata__cell report-metadata__cell--val">${numTestCases}</td>
         </tr>
         <tr>
-          <th class="report-metadata__cell report-metadata__cell--key">Git User:</th>
+          <th class="report-metadata__cell report-metadata__cell--key">User:</th>
           <td class="report-metadata__cell report-metadata__cell--val">${gitUser}</td>
         </tr>
         <tr>
-          <th class="report-metadata__cell report-metadata__cell--key">Git HEAD Branch:</th>
-          <td class="report-metadata__cell report-metadata__cell--val">${gitHeadBranch}</td>
+          <th class="report-metadata__cell report-metadata__cell--key">Golden Commit:</th>
+          <td class="report-metadata__cell report-metadata__cell--val">
+            ${this.getCommitLinkMarkup_(gitGoldenCommit, gitGoldenBranch}
+          </td>
         </tr>
         <tr>
-          <th class="report-metadata__cell report-metadata__cell--key">Git HEAD Commit:</th>
-          <td class="report-metadata__cell report-metadata__cell--val">${gitHeadCommit}</td>
-        </tr>
-        <tr>
-          <th class="report-metadata__cell report-metadata__cell--key">Git Golden Branch:</th>
-          <td class="report-metadata__cell report-metadata__cell--val">${gitGoldenBranch}</td>
-        </tr>
-        <tr>
-          <th class="report-metadata__cell report-metadata__cell--key">Git Golden Commit:</th>
-          <td class="report-metadata__cell report-metadata__cell--val">${gitGoldenCommit}</td>
+          <th class="report-metadata__cell report-metadata__cell--key">Snapshot Commit:</th>
+          <td class="report-metadata__cell report-metadata__cell--val">
+            ${this.getCommitLinkMarkup_(gitHeadCommit, gitHeadBranch}
+          </td>
         </tr>
         <tr>
           <th class="report-metadata__cell report-metadata__cell--key">Node Version:</th>
@@ -184,6 +180,14 @@ class ReportGenerator {
     </table>
   </div>
 </details>
+`;
+  }
+
+  getCommitLinkMarkup_(commit, branch) {
+    return `
+<a href="https://github.com/material-components/material-components-web/commit/${commit}">${commit}</a>
+on
+<a href="https://github.com/material-components/material-components-web/tree/${branch.replace('origin/', '')}">${branch}</a>
 `;
   }
 

--- a/test/screenshot/lib/snapshot-store.js
+++ b/test/screenshot/lib/snapshot-store.js
@@ -54,7 +54,7 @@ class SnapshotStore {
    */
   static async fromMaster(jsonFilePath) {
     const mdcGitRepo = new GitRepo();
-    await mdcGitRepo.fetch();
+    await mdcGitRepo.fetch('master');
 
     const cliArgParser = new CliArgParser();
     const goldenJsonStr = await mdcGitRepo.getFileAtRevision(jsonFilePath, cliArgParser.diffBase);

--- a/test/screenshot/lib/snapshot-store.js
+++ b/test/screenshot/lib/snapshot-store.js
@@ -21,9 +21,9 @@ const GitRepo = require('./git-repo');
 const CliArgParser = require('./cli-arg-parser');
 
 /**
- * Reads and writes a `golden.json` file.
+ * Reads and writes a `golden.json` or `snapshot.json` file.
  */
-class GoldenStore {
+class SnapshotStore {
   /**
    * @param {!GoldenJson} jsonData
    */
@@ -50,25 +50,23 @@ class GoldenStore {
   /**
    * Parses the `golden.json` file from the `master` Git branch.
    * @param {string} jsonFilePath
-   * @return {!Promise<!GoldenStore>}
+   * @return {!Promise<!SnapshotStore>}
    */
   static async fromMaster(jsonFilePath) {
     const mdcGitRepo = new GitRepo();
     await mdcGitRepo.fetch();
 
-    const getFrom = (rev) => mdcGitRepo.getFileAtRevision(jsonFilePath, rev);
-
     const cliArgParser = new CliArgParser();
-    const masterJsonStr = await getFrom(cliArgParser.diffBase);
-    return new GoldenStore({
-      jsonData: JSON.parse(masterJsonStr),
+    const goldenJsonStr = await mdcGitRepo.getFileAtRevision(jsonFilePath, cliArgParser.diffBase);
+    return new SnapshotStore({
+      jsonData: JSON.parse(goldenJsonStr),
     });
   }
 
   /**
    * Transforms the given test cases into `golden.json` format.
    * @param {!Array<!UploadableTestCase>} testCases
-   * @return {!Promise<!GoldenStore>}
+   * @return {!Promise<!SnapshotStore>}
    */
   static async fromTestCases(testCases) {
     const jsonData = {};
@@ -90,8 +88,8 @@ class GoldenStore {
       });
     });
 
-    return new GoldenStore({jsonData});
+    return new SnapshotStore({jsonData});
   }
 }
 
-module.exports = GoldenStore;
+module.exports = SnapshotStore;

--- a/test/screenshot/lib/types.js
+++ b/test/screenshot/lib/types.js
@@ -66,6 +66,8 @@ let ScreenshotDictionaryJson;
 /**
  * @typedef {{
  *   htmlFilePath: string,
+ *   goldenPageUrl: string,
+ *   snapshotPageUrl: string,
  *   browserKey: string,
  *   actualImageUrl: string,
  *   expectedImageUrl: string,


### PR DESCRIPTION
### How to test

```bash
export CBT_USERNAME='...'
export CBT_AUTHKEY='...'
export MDC_GCLOUD_SERVICE_ACCOUNT_KEY_FILE_PATH='...'

# 0 diffs
npm run screenshot:build
npm run screenshot:test

# 2 diffs
echo '.mdc-button:not(:disabled){color:red}' >> packages/mdc-button/mdc-button.scss
echo '.mdc-button:disabled{margin-left:10px}' >> packages/mdc-button/mdc-button.scss
npm run screenshot:build
npm run screenshot:test -- --mdc-include-url=button/classes/ --mdc-include-browser=ie@11
```

### What it does

- Adds "golden" and "snapshot" links to every HTML file listed in `report.html`
- Adds links to golden/snapshot commits and branches on GitHub
- Replaces shallow `git fetch` with a full fetch
    * Shallow fetch seems to break future git fetch/pull/merge commands: `fatal: refusing to merge unrelated histories`
    * Can be fixed with `git fetch --unshallow`
- Fixes ruler grid in IE 11
- Renames `GoldenStore` to `SnapshotStore`
- Replaces `$HOME` and `$PWD` with `~` and `.` instead of empty strings
- "collapse all" button now collapses browsers as well as pages

### Example output

[Report page](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/10/21_40_28_358/8a5bffda2/report.html):

![button-report](https://user-images.githubusercontent.com/409245/39895858-bffac446-5460-11e8-9ab6-72f9d88c1a13.png)