### PR TITLE
chore: Upgrade to node-sass 4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10927,9 +10927,9 @@
       }
     },
     "node-sass": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.8.3.tgz",
-      "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^5.0.0",
     "mz": "^2.7.0",
-    "node-sass": "^4.8.3",
+    "node-sass": "^4.9.0",
     "npm-run-all": "^4.1.1",
     "postcss-loader": "^2.0.3",
     "query-ast": "^1.0.1",


### PR DESCRIPTION
Similar in nature to https://github.com/material-components/material-components-web-codelabs/pull/30. Enables `npm install` to work on platforms without python installed.

The only difference I saw in CSS output is `transparent` -> `rgba(0, 0, 0, 0)` due to a change propagated from the core Sass repo.