### PR TITLE
chore(text-field): Remove redundant font-size

### DIFF
--- a/packages/mdc-textfield/helper-text/mdc-text-field-helper-text.scss
+++ b/packages/mdc-textfield/helper-text/mdc-text-field-helper-text.scss
@@ -26,7 +26,6 @@
   margin: 0;
   transition: mdc-text-field-transition(opacity);
   opacity: 0;
-  font-size: .75rem;
   will-change: opacity;
 
   // stylelint-disable plugin/selector-bem-pattern


### PR DESCRIPTION
Remove the redundant font-size from textfield helper text. The font-size is already specified in the typography settings and this line is redundant.