### PR TITLE
chore(infrastructure): Remove retry limit for parallel executions on CBT

### DIFF
--- a/test/screenshot/lib/screenshot.js
+++ b/test/screenshot/lib/screenshot.js
@@ -85,7 +85,7 @@ async function sendCaptureRequest(testPageUrl, retryCount = 0) {
       if (reachedParallelExecutionLimit(err)) {
         console.warn(`Parallel execution limit reached - waiting for ${waitInSeconds} seconds before retrying...`);
         await sleep(API_POLL_INTERVAL_MS);
-        return sendCaptureRequest(testPageUrl, retryCount + 1);
+        return sendCaptureRequest(testPageUrl, retryCount); // don't increment the retry count for parallel execution
       }
 
       // TODO(acdvorak): Abstract this logic into CbtApi for every HTTP request?

--- a/test/screenshot/lib/screenshot.js
+++ b/test/screenshot/lib/screenshot.js
@@ -74,7 +74,7 @@ async function captureOneUrl(testPageUrl) {
 
 async function sendCaptureRequest(testPageUrl, retryCount = 0) {
   if (retryCount > API_MAX_RETRIES) {
-    throw new Error(`Capture request failed after ${retryCount} retry attempts - ${testPageUrl}`);
+    throw new Error(`Capture request failed after ${API_MAX_RETRIES} retry attempts - ${testPageUrl}`);
   }
 
   const userAgents = await CbtUserAgent.fetchBrowsersToRun();
@@ -101,7 +101,7 @@ async function sendCaptureRequest(testPageUrl, retryCount = 0) {
 
 async function handleCaptureResponse(testPageUrl, captureResponseBody, retryCount = 0) {
   if (retryCount > API_MAX_RETRIES) {
-    throw new Error(`Capture response failed after ${retryCount} retry attempts - ${testPageUrl}`);
+    throw new Error(`Capture response failed after ${API_MAX_RETRIES} retry attempts - ${testPageUrl}`);
   }
 
   let infoResponseBody;

--- a/test/screenshot/lib/storage.js
+++ b/test/screenshot/lib/storage.js
@@ -66,7 +66,7 @@ class Storage {
 
     if (retryCount > API_MAX_RETRIES) {
       throw new Error(
-        `Failed to upload file ${queuePosition} after ${retryCount} retry attempts - ${gcsAbsoluteFilePath}`
+        `Failed to upload file ${queuePosition} after ${API_MAX_RETRIES} retry attempts - ${gcsAbsoluteFilePath}`
       );
     }
 


### PR DESCRIPTION
### How to test

```bash
export CBT_USERNAME='...'
export CBT_AUTHKEY='...'
export MDC_GCLOUD_SERVICE_ACCOUNT_KEY_FILE_PATH='...'
```

Open two or more terminals and run the tests in both terminals at the same time:

```bash
npm run screenshot:test
```

### What it does

CBT allows us to test up to 5 pages concurrently.

If two developers run their tests at the same time, we hit that limit:

```
Parallel execution limit reached - waiting for 5 seconds before retrying...
```

Currently, the tests will fail after 5 failed retry attempts:

```
Error: Capture request failed after 5 retry attempts - https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/16_43_43_944/704147ef0/mdc-button/classes/dense.html
    at sendCaptureRequest (/Users/advorak/dev/mdc-web/test/screenshot/lib/screenshot.js:77:11)
    at cbtApi.sendCaptureRequest.catch (/Users/advorak/dev/mdc-web/test/screenshot/lib/screenshot.js:88:16)
    at <anonymous>
```

This is to prevent infinite loops on requests that we know are going to keep failing, like HTTP 500 server errors.

However, it probably doesn't make sense to limit parallel executions to 5 retry attempts, because eventually the other developers' tests will finish and your tests will get a chance to run.

So this PR just removes the retry limit for parallel executions (but leaves all other retry limits intact).