### PR TITLE
fix(chips): Add delay to filter chip checkmark

### DIFF
--- a/packages/mdc-chips/chip/mdc-chip.scss
+++ b/packages/mdc-chips/chip/mdc-chip.scss
@@ -118,10 +118,12 @@
 .mdc-chip__icon--leading {
   transition: opacity $mdc-chip-opacity-animation-duration linear;
   opacity: 1;
+  transition-delay: -50ms; 
 
   + .mdc-chip__checkmark {
     transition: opacity $mdc-chip-opacity-animation-duration linear;
     opacity: 0;
+    transition-delay: 80ms;
 
     .mdc-chip__checkmark-svg {
       transition: width 0ms;


### PR DESCRIPTION
Add delay to transition animation so checkmark does not appear behind text. Add speed up to leading icon to brige gap between icons.