### PR TITLE
chore(infrastructure): Use component-specific test page dimensions

### DIFF
--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -122,7 +122,7 @@
   }
 }
 
-.mdc-dialog__action {
+.mdc-dialog__action:not(:disabled) {
   @include mdc-theme-prop(color, secondary);
 }
 

--- a/test/screenshot/fixture.scss
+++ b/test/screenshot/fixture.scss
@@ -19,11 +19,6 @@
 
 $test-trim-color: #abc123; // Value must match `TRIM_COLOR_CSS_VALUE` in `image-cropper.js`
 $test-grid-color: #dddddd;
-$test-fixture-width: 348px;
-$test-button-cell-padding: 10px;
-$test-button-cell-width: 171px;
-$test-button-cell-height: 71px;
-$test-button-columns: 2;
 
 .test-body {
   display: flex;
@@ -34,7 +29,6 @@ $test-button-columns: 2;
 
 .test-main {
   box-sizing: border-box;
-  width: $test-fixture-width;
   border: 1px solid $test-trim-color;
 }
 
@@ -46,12 +40,10 @@ $test-button-columns: 2;
 
 .test-cell {
   box-sizing: border-box;
-  width: $test-button-cell-width;
-  height: $test-button-cell-height;
   margin: 1px;
 
   // Ensure that shadows from adjacent components don't overlap
-  padding: $test-button-cell-padding;
+  padding: 10px;
 
   // Ruler grid pattern
   // https://stackoverflow.com/a/32861765/467582
@@ -59,5 +51,5 @@ $test-button-columns: 2;
     linear-gradient(to right, #{$test-grid-color} 1px, transparent 1.01px),  // fraction for IE 11
     linear-gradient(to bottom, #{$test-grid-color} 1px, transparent 1.01px); // fraction for IE 11
 
-  background-size: #{$test-button-cell-padding} #{$test-button-cell-padding};
+  background-size: 10px 10px;
 }

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -110,23 +110,23 @@
     }
   },
   "mdc-fab/classes/baseline.html": {
-    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/baseline.html",
+    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/baseline.html.win10e15_chrome66x64.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/baseline.html.win10e17_edge17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/baseline.html.win10e14_ff59x64.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/baseline.html.win10e14_ie11.png",
-      "mobile_android_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/baseline.html.galaxys7and70_mblchrome64.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_chrome66x64.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_edge17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_ff59x64.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_ie11.png",
+      "mobile_android_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.galaxys7and70_mblchrome64.png"
     }
   },
   "mdc-fab/classes/mini.html": {
-    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/mini.html",
+    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/mini.html.win10e15_chrome66x64.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/mini.html.win10e17_edge17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/mini.html.win10e14_ff59x64.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/mini.html.win10e14_ie11.png",
-      "mobile_android_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-fab/classes/mini.html.galaxys7and70_mblchrome64.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_chrome66x64.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_edge17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_ff59x64.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_ie11.png",
+      "mobile_android_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.galaxys7and70_mblchrome64.png"
     }
   }
 }

--- a/test/screenshot/mdc-button/classes/baseline.html
+++ b/test/screenshot/mdc-button/classes/baseline.html
@@ -21,24 +21,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="mdc-button">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -46,8 +47,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -55,26 +56,26 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button mdc-button--raised" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--raised">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--raised">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -82,8 +83,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--raised" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -91,26 +92,26 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--raised" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--unelevated">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button mdc-button--unelevated" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--unelevated">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--unelevated">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -118,8 +119,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--unelevated" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -127,26 +128,26 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--unelevated" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--outlined">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button mdc-button--outlined" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -154,8 +155,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -163,25 +164,25 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--raised">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/classes/dense.html
+++ b/test/screenshot/mdc-button/classes/dense.html
@@ -21,24 +21,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button mdc-button--dense" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -46,8 +47,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -55,26 +56,26 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button mdc-button--dense mdc-button--raised" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--raised">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--raised">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -82,8 +83,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--raised" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -91,26 +92,26 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--raised" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--unelevated">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button mdc-button--dense mdc-button--unelevated" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--unelevated">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--unelevated">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -118,8 +119,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--unelevated" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -127,26 +128,26 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--unelevated" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--outlined">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="mdc-button mdc-button--dense mdc-button--outlined" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -154,8 +155,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -163,25 +164,25 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--raised">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/custom.scss
+++ b/test/screenshot/mdc-button/custom.scss
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-@import "../../../../packages/mdc-button/mixins";
-@import "../../../../packages/mdc-theme/color-palette";
+@import "../../../packages/mdc-button/mixins";
+@import "../../../packages/mdc-theme/color-palette";
 
 $custom-button-color: $material-color-red-300;
 $custom-button-custom-corner-radius: 8px;

--- a/test/screenshot/mdc-button/fixture.scss
+++ b/test/screenshot/mdc-button/fixture.scss
@@ -1,0 +1,24 @@
+//
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+.test-main--button {
+  width: 348px; // fits 2 columns of buttons within a Galaxy S7 viewport
+}
+
+.test-cell--button {
+  width: 171px;
+  height: 71px;
+}

--- a/test/screenshot/mdc-button/mixins/container-fill-color.html
+++ b/test/screenshot/mdc-button/mixins/container-fill-color.html
@@ -21,21 +21,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--container-fill-color mdc-button mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button custom-button--container-fill-color mdc-button mdc-button--raised" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--container-fill-color mdc-button mdc-button--raised" disabled>Disabled</button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/corner-radius.html
+++ b/test/screenshot/mdc-button/mixins/corner-radius.html
@@ -21,36 +21,37 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button" disabled>Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button mdc-button--raised" disabled>Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button mdc-button--unelevated">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button mdc-button--unelevated" disabled>Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button mdc-button--outlined">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button mdc-button--outlined" disabled>Disabled</button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/filled-accessible.html
+++ b/test/screenshot/mdc-button/mixins/filled-accessible.html
@@ -21,25 +21,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--filled-accessible mdc-button mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button custom-button--filled-accessible mdc-button mdc-button--raised" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--filled-accessible mdc-button mdc-button--raised">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--filled-accessible mdc-button mdc-button--raised">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -47,8 +48,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--filled-accessible mdc-button mdc-button--raised" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -56,13 +57,13 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--filled-accessible mdc-button mdc-button--raised" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
@@ -21,72 +21,73 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button mdc-button--raised" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--raised"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--raised" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--unelevated">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button mdc-button--unelevated" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--unelevated"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--unelevated" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button mdc-button--outlined" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--raised">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
@@ -21,72 +21,73 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button mdc-button--dense" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--raised" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--raised"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--raised" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--unelevated">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--unelevated" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--unelevated"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--unelevated" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined"><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Icon</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined" disabled><i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i> Disabled</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--raised">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/icon-color.html
+++ b/test/screenshot/mdc-button/mixins/icon-color.html
@@ -21,19 +21,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -41,8 +42,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -50,20 +51,20 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button mdc-button--raised">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button mdc-button--raised">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -71,8 +72,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button mdc-button--raised" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -80,13 +81,13 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button mdc-button--raised" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/ink-color.html
+++ b/test/screenshot/mdc-button/mixins/ink-color.html
@@ -21,25 +21,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button custom-button--ink-color mdc-button" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -47,14 +48,14 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -62,20 +63,20 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button mdc-button--raised">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button custom-button--ink-color mdc-button mdc-button--raised" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button mdc-button--raised">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button mdc-button--raised">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -83,14 +84,14 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button mdc-button--raised" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button mdc-button--raised" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -98,7 +99,7 @@
             </svg>
             SVG Icon
           </button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/stroke-color.html
+++ b/test/screenshot/mdc-button/mixins/stroke-color.html
@@ -21,21 +21,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-color mdc-button mdc-button--outlined">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button custom-button--outline-color mdc-button mdc-button--outlined" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-color mdc-button mdc-button--outlined" disabled>Disabled</button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-button/mixins/stroke-width.html
+++ b/test/screenshot/mdc-button/mixins/stroke-width.html
@@ -12,7 +12,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License
+  limitations under the License.
 -->
 <html lang="en">
   <head>
@@ -21,25 +21,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.button.css">
-    <link rel="stylesheet" href="../../out/mdc-button/mixins/custom.css">
+    <link rel="stylesheet" href="../../out/mdc-button/fixture.css">
+    <link rel="stylesheet" href="../../out/mdc-button/custom.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--button">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button custom-button--outline-width mdc-button mdc-button--outlined" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -47,8 +48,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -56,26 +57,26 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense">Button</button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <a class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense" href="#">Link</a>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense">
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -83,8 +84,8 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense" disabled>
             <svg class="mdc-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
@@ -92,13 +93,13 @@
             </svg>
             SVG Icon
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined mdc-button--dense" disabled>
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
             Font Icon
           </button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-fab/classes/baseline.html
+++ b/test/screenshot/mdc-fab/classes/baseline.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright 2018 Google Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+  Copyright 2018 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -21,26 +21,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.fab.css">
+    <link rel="stylesheet" href="../../out/mdc-fab/fixture.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--fab">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--fab">
           <button class="mdc-fab" aria-label="Favorite">
             <span class="mdc-fab__icon material-icons">
               favorite_border
             </span>
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--fab">
           <button class="mdc-fab" aria-label="Favorite">
             <svg xmlns="http://www.w3.org/2000/svg" class="mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
             </svg>
           </button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-fab/classes/baseline.html
+++ b/test/screenshot/mdc-fab/classes/baseline.html
@@ -12,7 +12,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
+  limitations under the License
 -->
 <html lang="en">
   <head>

--- a/test/screenshot/mdc-fab/classes/mini.html
+++ b/test/screenshot/mdc-fab/classes/mini.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright 2018 Google Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+  Copyright 2018 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -21,26 +21,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../out/fixture.css">
     <link rel="stylesheet" href="../../out/mdc.fab.css">
+    <link rel="stylesheet" href="../../out/mdc-fab/fixture.css">
   </head>
 
   <body class="test-body mdc-typography">
-    <main class="test-main">
+    <main class="test-main test-main--fab">
       <div class="test-grid">
-        <span class="test-cell">
+        <div class="test-cell test-cell--fab">
           <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
             <span class="mdc-fab__icon material-icons">
               favorite_border
             </span>
           </button>
-        </span>
-        <span class="test-cell">
+        </div>
+        <div class="test-cell test-cell--fab">
           <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
             <svg xmlns="http://www.w3.org/2000/svg" class="mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
               <path fill="none" d="M0 0h24v24H0z"/>
               <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
             </svg>
           </button>
-        </span>
+        </div>
       </div>
     </main>
   </body>

--- a/test/screenshot/mdc-fab/classes/mini.html
+++ b/test/screenshot/mdc-fab/classes/mini.html
@@ -12,7 +12,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
+  limitations under the License
 -->
 <html lang="en">
   <head>

--- a/test/screenshot/mdc-fab/fixture.scss
+++ b/test/screenshot/mdc-fab/fixture.scss
@@ -1,0 +1,24 @@
+//
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+.test-main--fab {
+  width: 334px; // fits 4 columns of FABs within a Galaxy S7 viewport
+}
+
+.test-cell--fab {
+  width: 81px;
+  height: 81px;
+}


### PR DESCRIPTION
Fixes #2805

### How to test

```bash
export CBT_USERNAME='...'
export CBT_AUTHKEY='...'
export MDC_GCLOUD_SERVICE_ACCOUNT_KEY_FILE_PATH='...'

npm run screenshot:test
```

### What it does

- Sets button-specific widths/heights with new `test-main--button` and `test-cell--button` classes
- Sets FAB-specific widths/heights with new `test-main--fab` and `test-cell--fab` classes
- Moves `mdc-button/mixins/custom.scss` to `mdc-button/custom.scss`
- Changes `<span class="test-cell">` to `<div class="test-cell">`
- Removes and inlines some Sass variables

### Example output

[Diff report](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/report.html) (**NOTE:** the first diff on the report is flaky - it is NOT included in this PR's `golden.json`)