### PR TITLE
chore(infrastructure): Fix browser alias lookup bug

### DIFF
--- a/test/screenshot/lib/cbt-user-agent.js
+++ b/test/screenshot/lib/cbt-user-agent.js
@@ -67,7 +67,7 @@ const CBT_FILTERS = {
   },
 };
 
-let userAgentsPromise;
+let allUserAgentsPromise;
 
 module.exports = {
   fetchBrowsersToRun,
@@ -76,15 +76,15 @@ module.exports = {
 };
 
 /**
- * Resolves aliases in `browser.json` and returns their corresponding CBT API representations.
- * @param {!Array<string>=} aliases
+ * Resolves all aliases in `browser.json` and returns their corresponding CBT API representations.
  * @return {!Promise<!Array<!CbtUserAgent>>}
  */
-async function fetchBrowsersToRun(aliases = getFilteredAliases()) {
-  return userAgentsPromise || (userAgentsPromise = new Promise((resolve, reject) => {
+async function fetchBrowsersToRun() {
+  return allUserAgentsPromise || (allUserAgentsPromise = new Promise((resolve, reject) => {
     cbtApi.fetchAvailableDevices()
       .then(
         (cbtDevices) => {
+          const aliases = getFilteredAliases();
           const userAgents = findAllMatchingUAs(aliases, cbtDevices);
           console.log(userAgents.map((config) => `${config.alias}: ${config.fullCbtApiName}`));
           console.log('\n');
@@ -117,7 +117,10 @@ async function fetchBrowserByApiName(cbtDeviceApiName, cbtBrowserApiName) {
  * @return {!Promise<?CbtUserAgent>}
  */
 async function fetchBrowserByAlias(userAgentAlias) {
-  return (await fetchBrowsersToRun([userAgentAlias]))[0];
+  const userAgents = await fetchBrowsersToRun();
+  return userAgents.find((userAgent) => {
+    return userAgent.alias === userAgentAlias;
+  });
 }
 
 /**

--- a/test/screenshot/lib/storage.js
+++ b/test/screenshot/lib/storage.js
@@ -90,6 +90,17 @@ class Storage {
 
 
     const cloudFile = this.storageBucket_.file(gcsAbsoluteFilePath);
+    const [cloudFileExists] = await cloudFile.exists();
+
+    if (cloudFileExists) {
+      console.warn([
+        `WARNING: GCS file ${queuePosition} already exists - ${gcsAbsoluteFilePath}`,
+        'This is a bug in the screenshot testing logic. Tell acdvorak to fix it.',
+        'The file will NOT be overwritten. Continuing.',
+      ].join('\n'));
+      return this.handleUploadSuccess_(uploadableFile);
+    }
+
     const uploadPromise = new Promise(((resolve, reject) => {
       console.log(`➡ Uploading file ${queuePosition} - ${gcsAbsoluteFilePath}`);
 


### PR DESCRIPTION
### How to test

```bash
export CBT_USERNAME='...'
export CBT_AUTHKEY='...'
export MDC_GCLOUD_SERVICE_ACCOUNT_KEY_FILE_PATH='...'

npm run screenshot:test
```

### What it does

- Fixes a bug in which all diff images get uploaded to the same URL (which throws an error and crashes the test run)
- Prints a warning message to the console if a file already exists, but continues uploading remaining files
- Removes the argument from `fetchBrowsersToRun()`, because it uses a promise to memoize the result (which means the result needs to be invariant between calls)
- Refactors `fetchBrowserByAlias()`