### PR TITLE
fix(dialog): Fix Typography version

### DIFF
--- a/packages/mdc-dialog/package.json
+++ b/packages/mdc-dialog/package.json
@@ -21,7 +21,7 @@
     "@material/ripple": "^0.35.0",
     "@material/rtl": "^0.35.0",
     "@material/theme": "^0.35.0",
-    "@material/typography": "^0.1.1",
+    "@material/typography": "^0.35.0",
     "focus-trap": "^2.3.0"
   },
   "publishConfig": {


### PR DESCRIPTION
It uses legacy @material/typography which is incompatible with
other material components.

#2820