### PR TITLE
docs(fab): Remove trailing whitespace from material icons

### DIFF
--- a/demos/fab.html
+++ b/demos/fab.html
@@ -104,9 +104,7 @@
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <button class="mdc-fab" aria-label="Favorite">
-          <span class="mdc-fab__icon material-icons">
-            favorite_border
-          </span>
+          <span class="mdc-fab__icon material-icons">favorite_border</span>
         </button>
       </section>
 
@@ -123,9 +121,7 @@
         <div class="demo-fabs">
           <figure>
             <button class="mdc-fab" aria-label="Favorite">
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
             <figcaption>
               <div>Themed FAB</div>
@@ -133,9 +129,7 @@
           </figure>
           <figure>
             <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
             <figcaption>
               <div>Mini FAB</div>
@@ -167,9 +161,7 @@
           </figure>
           <figure>
             <button class="mdc-fab lightGreen800Fab" aria-label="Favorite">
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
             <figcaption>
               <div>Customized Accessible FAB</div>
@@ -178,9 +170,7 @@
           </figure>
           <figure>
             <button class="mdc-fab lightGreen800Fab mdc-fab--mini" aria-label="Favorite">
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
             <figcaption>
               <div>Customized Accessible Mini FAB</div>
@@ -194,9 +184,7 @@
         <div class="demo-fabs">
           <figure>
             <button class="mdc-fab demo-fab-icon-size" aria-label="Favorite">
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
             <figcaption>
               <div>Themed FAB</div>
@@ -204,9 +192,7 @@
           </figure>
           <figure>
             <button class="mdc-fab mdc-fab--mini demo-fab-icon-size" aria-label="Favorite">
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
             <figcaption>
               <div>Mini FAB</div>
@@ -232,30 +218,22 @@
         <div class="demo-fabs">
           <figure>
             <button class="mdc-fab" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
           </figure>
           <figure>
             <button class="mdc-fab mdc-fab--mini" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
           </figure>
           <figure>
             <button class="mdc-fab lightGreen800Fab" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
           </figure>
           <figure>
             <button class="mdc-fab lightGreen800Fab mdc-fab--mini" aria-label="Favorite" data-demo-no-js>
-              <span class="mdc-fab__icon material-icons">
-                favorite_border
-              </span>
+              <span class="mdc-fab__icon material-icons">favorite_border</span>
             </button>
           </figure>
         </div>
@@ -271,9 +249,7 @@
             <p><button type="button" disabled id="enter-exit-back">Go back</button></p>
           </div>
           <button id="enter-exit-add" class="mdc-fab demo-absolute-fab" aria-label="Add">
-            <span class="mdc-fab__icon material-icons">
-              add
-            </span>
+            <span class="mdc-fab__icon material-icons">add</span>
           </button>
         </div>
       </section>

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -472,9 +472,7 @@
                 <div class="demo-fab-tile__snippet mdc-typography--body1">Secondary theme color</div>
               </figcaption>
               <button class="mdc-fab demo-fab" aria-label="Favorite">
-                <span class="mdc-fab__icon material-icons">
-                  favorite_border
-                </span>
+                <span class="mdc-fab__icon material-icons">favorite_border</span>
               </button>
             </figure>
             <figure class="demo-fab-tile">
@@ -483,9 +481,7 @@
                 <div class="demo-fab-tile__snippet mdc-typography--body1"><code>mdc-fab--mini</code></div>
               </figcaption>
               <button class="mdc-fab mdc-fab--mini demo-fab" aria-label="Favorite">
-                <span class="mdc-fab__icon material-icons">
-                  favorite_border
-                </span>
+                <span class="mdc-fab__icon material-icons">favorite_border</span>
               </button>
             </figure>
           </div>

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -129,9 +129,7 @@ Here's the markup:
       </div>
     </div>
     <button class="mdc-fab" id="demo-absolute-fab" aria-label="Favorite">
-      <span class="mdc-fab__icon material-icons">
-        favorite
-      </span>
+      <span class="mdc-fab__icon material-icons">favorite</span>
     </button>
   </body>
 </html>

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -51,13 +51,13 @@ We recommend you load [Material Icons](https://material.io/icons/) from Google F
 
 ```html
 <button class="mdc-fab" aria-label="Favorite">
-  <span class="mdc-fab__icon material-icons">
-    favorite
-  </span>
+  <span class="mdc-fab__icon material-icons">favorite</span>
 </button>
 ```
 
 > _NOTE:_ The floating action button icon can be used with a `span`, `i`, `img`, or `svg` element.
+
+> _NOTE:_ IE 11 will not center the icon properly if there is a newline or space after the material icon text.
 
 ### Styles
 
@@ -142,8 +142,6 @@ Developers must position MDC FAB as needed within their application's design.
 }
 </style>
 <button class="mdc-fab app-fab--absolute" aria-label="Favorite">
-  <span class="mdc-fab__icon material-icons">
-    favorite
-  </span>
+  <span class="mdc-fab__icon material-icons">favorite</span>
 </button>
 ```

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -110,22 +110,22 @@
     }
   },
   "mdc-fab/classes/baseline.html": {
-    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html",
+    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/05/25/21_14_58_299/6b0f3e00/mdc-fab/classes/baseline.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_chrome66x64.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_edge17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_ff59x64.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.win10_ie11.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/05/25/21_14_58_299/6b0f3e00/mdc-fab/classes/baseline.html.win10_ie11.png",
       "mobile_android_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/baseline.html.galaxys7and70_mblchrome64.png"
     }
   },
   "mdc-fab/classes/mini.html": {
-    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html",
+    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/05/25/21_14_58_299/6b0f3e00/mdc-fab/classes/mini.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_chrome66x64.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_edge17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_ff59x64.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.win10_ie11.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/05/25/21_14_58_299/6b0f3e00/mdc-fab/classes/mini.html.win10_ie11.png",
       "mobile_android_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/24/19_19_57_797/3ac00277f/mdc-fab/classes/mini.html.galaxys7and70_mblchrome64.png"
     }
   }

--- a/test/screenshot/mdc-fab/classes/baseline.html
+++ b/test/screenshot/mdc-fab/classes/baseline.html
@@ -29,9 +29,7 @@
       <div class="test-grid">
         <div class="test-cell test-cell--fab">
           <button class="mdc-fab" aria-label="Favorite">
-            <span class="mdc-fab__icon material-icons">
-              favorite_border
-            </span>
+            <span class="mdc-fab__icon material-icons">favorite_border</span>
           </button>
         </div>
         <div class="test-cell test-cell--fab">

--- a/test/screenshot/mdc-fab/classes/mini.html
+++ b/test/screenshot/mdc-fab/classes/mini.html
@@ -29,9 +29,7 @@
       <div class="test-grid">
         <div class="test-cell test-cell--fab">
           <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
-            <span class="mdc-fab__icon material-icons">
-              favorite_border
-            </span>
+            <span class="mdc-fab__icon material-icons">favorite_border</span>
           </button>
         </div>
         <div class="test-cell test-cell--fab">


### PR DESCRIPTION
IE vertically displaces icons from the Material Icons font if there is trailing whitespace after the text content intended to render the icon.

This fixes all instances of `mdc-fab__icon material-icons` to put the entire element on one line, in docs and demos and screenshot tests.

Fixes #2752.