### PR TITLE
docs(layout-grid): update README.md

### DIFF
--- a/packages/mdc-layout-grid/README.md
+++ b/packages/mdc-layout-grid/README.md
@@ -81,7 +81,7 @@ CSS Class | Description
 `mdc-layout-grid__inner` | Mandatory, for wrapping grid cell
 `mdc-layout-grid__cell` | Mandatory, for the layout grid cell
 `mdc-layout-grid__cell--span-<NUMBER_OF_COLUMNS>` | Optional, specifies the number of columns the cell spans
-`mdc-layout-grid__cell--span-<NUMBER_OF_COLUMNS>-<TYPE_OF_DEVICE>` | Optional, specifies the number of columns the cell spans on a type of device (desktop, tablet, mobile)
+`mdc-layout-grid__cell--span-<NUMBER_OF_COLUMNS>-<TYPE_OF_DEVICE>` | Optional, specifies the number of columns the cell spans on a type of device (desktop, tablet, phone)
 `mdc-layout-grid__cell--order-<INDEX>` | Optional, specifies the order of the cell
 `mdc-layout-grid__cell--align-<POSITION>` | Optional, specifies the alignment of cell
 `mdc-layout-grid--fixed-column-width` | Optional, specifies the grid should have fixed column width


### PR DESCRIPTION
Rename 'mobile' to 'phone' for consistency.

Fixes #2836.