### PR TITLE
chore(elevation): Update to use latest theme version

### DIFF
--- a/packages/mdc-elevation/_mixins.scss
+++ b/packages/mdc-elevation/_mixins.scss
@@ -30,13 +30,7 @@
     @error "$z-value must be between 0 and 24, but received '#{$z-value}'";
   }
 
-  @if map-has-key($mdc-theme-property-values, $color) {
-    $color: map-get($mdc-theme-property-values, $color);
-  }
-
-  @if type-of($color) != color {
-    @error "$color must be a valid color, but '#{$color}' is of type #{type-of($color)}";
-  }
+  $color: mdc-theme-prop-value($color);
 
   $umbra-z-value: map-get($mdc-elevation-umbra-map, $z-value);
   $penumbra-z-value: map-get($mdc-elevation-penumbra-map, $z-value);

--- a/packages/mdc-elevation/package.json
+++ b/packages/mdc-elevation/package.json
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "@material/animation": "^0.34.0",
-    "@material/theme": "^0.4.0"
+    "@material/theme": "^0.35.0"
   }
 }


### PR DESCRIPTION
I noticed while testing installing 0.36.0 that elevation ends up with a nested `node_modules/@material/theme` because it is still depending on a really old version. This fixes that, and takes advantage of the `mdc-theme-prop-value` function that now exists, which elevation was pretty much repeating code from (with a potentially less-helpful error message).