### PR TITLE
fix(typography): Update letter-spacing units from em to rem

### DIFF
--- a/packages/mdc-typography/_functions.scss
+++ b/packages/mdc-typography/_functions.scss
@@ -66,5 +66,5 @@
 }
 
 @function mdc-typography-get-letter-spacing_($tracking, $font-size) {
-  @return $tracking / ($font-size * 16) * 1em;
+  @return $tracking / ($font-size * 16) * 1rem;
 }


### PR DESCRIPTION
All other sizes for typography are in `rem`, so the letter-spacing function should also return a `rem` value.