### PR TITLE
chore: Support manually modifying changelog before post-release

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -22,9 +22,17 @@ function log() {
   echo '\033[36m[post-release]\033[0m' "$@"
 }
 
-log "Generating and committing changelog"
-npm run changelog
-git add CHANGELOG.md
+if [[ $(git diff --cached CHANGELOG.md) ]]; then
+  log "Found modified CHANGELOG; committing as-is"
+else
+  if [[ $(git diff CHANGELOG.md) ]]; then
+    log "Found modified CHANGELOG; committing as-is"
+  else
+    log "Generating changelog"
+    npm run changelog
+  fi
+  git add CHANGELOG.md
+fi
 git commit -m "docs: Update CHANGELOG.md"
 echo ""
 


### PR DESCRIPTION
This will allow us to manually run `npm run changelog` and tweak the output ourselves before running `post-release.sh` if we want (e.g. to combine changelogs from pre-releases for a minor release).

To test:

* I would suggest commenting out the latter half of the file to avoid creating spurious tags (i.e. beyond line 37)
* Make a dummy modification to CHANGELOG.md and leave it unstaged in your local repo
* Run `post-release.sh`
* It should detect the existing change and forego running `npm run changelog` itself
* Make another dummy modification, then `git add CHANGELOG.md` so it is staged but not committed
* Run `post-release.sh`
* Again, it should detect the existing change and forego running `npm run changelog` itself
* Run `post-release.sh` without any local changes to CHANGELOG.md
* The script should run `npm run changelog` itself