### PR TITLE
fix(ripple): Expose focus/blur handlers 

### DIFF
--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -150,6 +150,8 @@ Method Signature | Description
 `activate() => void` | Proxies to the foundation's `activate` method
 `deactivate() => void` | Proxies to the foundation's `deactivate` method
 `layout() => void` | Proxies to the foundation's `layout` method
+`handleFocus() => void` | Adds `BG_FOCUSED` class to the ripple surface
+`handleBlur() => void` | Removes `BG_FOCUSED` class from the ripple surface
 
 ### `MDCRippleAdapter`
 

--- a/packages/mdc-ripple/README.md
+++ b/packages/mdc-ripple/README.md
@@ -150,8 +150,8 @@ Method Signature | Description
 `activate() => void` | Proxies to the foundation's `activate` method
 `deactivate() => void` | Proxies to the foundation's `deactivate` method
 `layout() => void` | Proxies to the foundation's `layout` method
-`handleFocus() => void` | Adds `BG_FOCUSED` class to the ripple surface
-`handleBlur() => void` | Removes `BG_FOCUSED` class from the ripple surface
+`handleFocus() => void` | Handles focus event on the ripple surface
+`handleBlur() => void` | Handles blur event on the ripple surface
 
 ### `MDCRippleAdapter`
 

--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -132,14 +132,10 @@ class MDCRippleFoundation extends MDCFoundation {
     this.deactivateHandler_ = (e) => this.deactivate_(e);
 
     /** @private {function(?Event=)} */
-    this.focusHandler_ = () => requestAnimationFrame(
-      () => this.adapter_.addClass(MDCRippleFoundation.cssClasses.BG_FOCUSED)
-    );
+    this.focusHandler_ = () => this.handleFocus();
 
     /** @private {function(?Event=)} */
-    this.blurHandler_ = () => requestAnimationFrame(
-      () => this.adapter_.removeClass(MDCRippleFoundation.cssClasses.BG_FOCUSED)
-    );
+    this.blurHandler_ = () => this.handleBlur();
 
     /** @private {!Function} */
     this.resizeHandler_ = () => this.layout();
@@ -586,6 +582,16 @@ class MDCRippleFoundation extends MDCFoundation {
     } else {
       this.adapter_.removeClass(UNBOUNDED);
     }
+  }
+
+  handleFocus() {
+    requestAnimationFrame(() =>
+      this.adapter_.addClass(MDCRippleFoundation.cssClasses.BG_FOCUSED));
+  }
+
+  handleBlur() {
+    requestAnimationFrame(() =>
+      this.adapter_.removeClass(MDCRippleFoundation.cssClasses.BG_FOCUSED));
   }
 }
 

--- a/test/unit/mdc-ripple/mdc-ripple.test.js
+++ b/test/unit/mdc-ripple/mdc-ripple.test.js
@@ -222,3 +222,16 @@ test('adapter#getWindowPageOffset returns page{X,Y}Offset as {x,y} respectively'
     y: window.pageYOffset,
   });
 });
+
+test(`handleFocus() adds class ${cssClasses.BG_FOCUSED}`, () => {
+  const {root, component} = setupTest();
+  component.handleFocus();
+  assert.isTrue(root.classList.contains(cssClasses.BG_FOCUSED));
+});
+
+test(`handleBlur() removes class ${cssClasses.BG_FOCUSED}`, () => {
+  const {root, component} = setupTest();
+  root.classList.add(cssClasses.BG_FOCUSED);
+  component.blurFocus();
+  assert.isFalse(root.classList.contains(cssClasses.BG_FOCUSED));
+});

--- a/test/unit/mdc-ripple/mdc-ripple.test.js
+++ b/test/unit/mdc-ripple/mdc-ripple.test.js
@@ -22,6 +22,7 @@ import td from 'testdouble';
 import {MDCRipple} from '../../../packages/mdc-ripple';
 import {cssClasses} from '../../../packages/mdc-ripple/constants';
 import * as util from '../../../packages/mdc-ripple/util';
+import {createMockRaf} from '../helpers/raf';
 
 suite('MDCRipple');
 
@@ -224,14 +225,20 @@ test('adapter#getWindowPageOffset returns page{X,Y}Offset as {x,y} respectively'
 });
 
 test(`handleFocus() adds class ${cssClasses.BG_FOCUSED}`, () => {
+  const raf = createMockRaf();
   const {root, component} = setupTest();
-  component.handleFocus();
+  component.foundation_.handleFocus();
+  raf.flush();
   assert.isTrue(root.classList.contains(cssClasses.BG_FOCUSED));
+  raf.restore();
 });
 
 test(`handleBlur() removes class ${cssClasses.BG_FOCUSED}`, () => {
+  const raf = createMockRaf();
   const {root, component} = setupTest();
   root.classList.add(cssClasses.BG_FOCUSED);
-  component.blurFocus();
+  component.foundation_.handleBlur();
+  raf.flush();
   assert.isFalse(root.classList.contains(cssClasses.BG_FOCUSED));
+  raf.restore();
 });


### PR DESCRIPTION
This change adds two new public methods to MDC Ripple Foundation - including `handleFocus` and `handleBlur` to be used by other frameworks on focus and blur.

Fixes #2838 