### PR TITLE
fix(checkbox): support high contrast mode in Firefox on Windows

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -97,7 +97,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-disabled" aria-labelledby="toggle-disabled-label">
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59">
+                <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59">
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>

--- a/demos/button.html
+++ b/demos/button.html
@@ -97,7 +97,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-disabled" aria-labelledby="toggle-disabled-label">
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59">
+                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59">
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>

--- a/demos/card.html
+++ b/demos/card.html
@@ -83,7 +83,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>

--- a/demos/card.html
+++ b/demos/card.html
@@ -83,7 +83,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -67,7 +67,6 @@
                  viewBox="0 0 24 24">
               <path class="mdc-checkbox__checkmark-path"
                     fill="none"
-                    stroke="currentColor"
                     d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
             </svg>
             <div class="mdc-checkbox__mixedmark"></div>
@@ -89,7 +88,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -118,7 +116,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -137,7 +134,6 @@
                        viewBox="0 0 24 24">
                     <path class="mdc-checkbox__checkmark-path"
                           fill="none"
-                          stroke="currentColor"
                           d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
@@ -160,7 +156,6 @@
                        viewBox="0 0 24 24">
                     <path class="mdc-checkbox__checkmark-path"
                           fill="none"
-                          stroke="currentColor"
                           d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
@@ -180,7 +175,6 @@
                        viewBox="0 0 24 24">
                     <path class="mdc-checkbox__checkmark-path"
                           fill="none"
-                          stroke="currentColor"
                           d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
@@ -205,7 +199,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -230,7 +223,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -257,7 +249,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -281,7 +272,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -67,7 +67,7 @@
                  viewBox="0 0 24 24">
               <path class="mdc-checkbox__checkmark-path"
                     fill="none"
-                    stroke="white"
+                    stroke="currentColor"
                     d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
             </svg>
             <div class="mdc-checkbox__mixedmark"></div>
@@ -89,7 +89,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -118,7 +118,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -137,7 +137,7 @@
                        viewBox="0 0 24 24">
                     <path class="mdc-checkbox__checkmark-path"
                           fill="none"
-                          stroke="white"
+                          stroke="currentColor"
                           d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
@@ -160,7 +160,7 @@
                        viewBox="0 0 24 24">
                     <path class="mdc-checkbox__checkmark-path"
                           fill="none"
-                          stroke="white"
+                          stroke="currentColor"
                           d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
@@ -180,7 +180,7 @@
                        viewBox="0 0 24 24">
                     <path class="mdc-checkbox__checkmark-path"
                           fill="none"
-                          stroke="white"
+                          stroke="currentColor"
                           d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
@@ -205,7 +205,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -230,7 +230,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -257,7 +257,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -281,7 +281,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -178,7 +178,6 @@
                   viewBox="0 0 24 24">
                 <path class="mdc-checkbox__checkmark-path"
                       fill="none"
-                      stroke="currentColor"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/dialog.html
+++ b/demos/dialog.html
@@ -178,7 +178,7 @@
                   viewBox="0 0 24 24">
                 <path class="mdc-checkbox__checkmark-path"
                       fill="none"
-                      stroke="white"
+                      stroke="currentColor"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -92,7 +92,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>

--- a/demos/grid-list.html
+++ b/demos/grid-list.html
@@ -92,7 +92,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>

--- a/demos/image-list.html
+++ b/demos/image-list.html
@@ -125,7 +125,7 @@
                 <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
                 <div class="mdc-checkbox__background">
                   <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                    <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                    <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
                 </div>
@@ -139,7 +139,7 @@
                 <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-radius" aria-labelledby="toggle-radius-label" />
                 <div class="mdc-checkbox__background">
                   <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                    <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                    <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
                 </div>

--- a/demos/image-list.html
+++ b/demos/image-list.html
@@ -125,7 +125,7 @@
                 <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-rtl" aria-labelledby="toggle-rtl-label" />
                 <div class="mdc-checkbox__background">
                   <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                    <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                    <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
                 </div>
@@ -139,7 +139,7 @@
                 <input type="checkbox" class="mdc-checkbox__native-control" id="toggle-radius" aria-labelledby="toggle-radius-label" />
                 <div class="mdc-checkbox__background">
                   <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                    <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                    <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
                   </svg>
                   <div class="mdc-checkbox__mixedmark"></div>
                 </div>

--- a/demos/list.html
+++ b/demos/list.html
@@ -101,7 +101,7 @@
                    aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white"
+                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/list.html
+++ b/demos/list.html
@@ -101,7 +101,7 @@
                    aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
+                <path class="mdc-checkbox__checkmark-path" fill="none"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -83,7 +83,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="multiline" aria-labelledby="multiline-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>
@@ -97,7 +97,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="action-on-bottom" aria-labelledby="action-on-bottom-label" />
             <div class="mdc-checkbox__background">
                 <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                  <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white"
+                  <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
               <div class="mdc-checkbox__mixedmark"></div>
@@ -112,7 +112,7 @@
               <input type="checkbox" checked class="mdc-checkbox__native-control" id="dismiss-on-action" aria-labelledby="dismiss-on-action-label" />
               <div class="mdc-checkbox__background">
                 <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                  <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white"
+                  <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -83,7 +83,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="multiline" aria-labelledby="multiline-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>
             </div>
@@ -97,7 +97,7 @@
             <input type="checkbox" class="mdc-checkbox__native-control" id="action-on-bottom" aria-labelledby="action-on-bottom-label" />
             <div class="mdc-checkbox__background">
                 <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                  <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
+                  <path class="mdc-checkbox__checkmark-path" fill="none"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
               <div class="mdc-checkbox__mixedmark"></div>
@@ -112,7 +112,7 @@
               <input type="checkbox" checked class="mdc-checkbox__native-control" id="dismiss-on-action" aria-labelledby="dismiss-on-action-label" />
               <div class="mdc-checkbox__background">
                 <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                  <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
+                  <path class="mdc-checkbox__checkmark-path" fill="none"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/switch.html
+++ b/demos/switch.html
@@ -83,9 +83,9 @@
           </div>
           <div class="demo-switch-wrapper">
             <div class="mdc-switch demo-switch--custom">
-              <input type="checkbox" 
-                    id="basic-switch-custom" 
-                    class="mdc-switch__native-control" 
+              <input type="checkbox"
+                    id="basic-switch-custom"
+                    class="mdc-switch__native-control"
                     role="switch" checked>
               <div class="mdc-switch__background">
                 <div class="mdc-switch__knob"></div>
@@ -121,7 +121,7 @@
                   aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
+                <path class="mdc-checkbox__checkmark-path" fill="none"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/switch.html
+++ b/demos/switch.html
@@ -121,7 +121,7 @@
                   aria-labelledby="toggle-rtl-label" />
             <div class="mdc-checkbox__background">
               <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="white"
+                <path class="mdc-checkbox__checkmark-path" fill="none" stroke="currentColor"
                       d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
               </svg>
               <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -365,7 +365,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -384,7 +383,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -404,7 +402,6 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -365,7 +365,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -384,7 +384,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>
@@ -404,7 +404,7 @@
                      viewBox="0 0 24 24">
                   <path class="mdc-checkbox__checkmark-path"
                         fill="none"
-                        stroke="white"
+                        stroke="currentColor"
                         d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
                 </svg>
                 <div class="mdc-checkbox__mixedmark"></div>

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -102,7 +102,7 @@ Note that `mdc-checkbox--disabled` is necessary on the root element of CSS-only 
          viewBox="0 0 24 24">
       <path class="mdc-checkbox__checkmark-path"
             fill="none"
-            stroke="white"
+            stroke="currentColor"
             d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
     </svg>
     <div class="mdc-checkbox__mixedmark"></div>
@@ -149,7 +149,7 @@ Property Name | Type | Description
 `checked` | Boolean | Setter/getter for the checkbox's checked state
 `indeterminate` | Boolean | Setter/getter for the checkbox's indeterminate state
 `disabled` | Boolean | Setter/getter for the checkbox's disabled state
-`value` | String | Setter/getter for the checkbox's 
+`value` | String | Setter/getter for the checkbox's
 
 ## Usage within Web Frameworks
 

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -51,7 +51,6 @@ We recommend using MDC Checkbox with [MDC Form Field](../mdc-form-field) for enh
            viewBox="0 0 24 24">
         <path class="mdc-checkbox__checkmark-path"
               fill="none"
-              stroke="currentColor"
               d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
       </svg>
       <div class="mdc-checkbox__mixedmark"></div>
@@ -102,7 +101,6 @@ Note that `mdc-checkbox--disabled` is necessary on the root element of CSS-only 
          viewBox="0 0 24 24">
       <path class="mdc-checkbox__checkmark-path"
             fill="none"
-            stroke="currentColor"
             d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
     </svg>
     <div class="mdc-checkbox__mixedmark"></div>

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -51,7 +51,7 @@ We recommend using MDC Checkbox with [MDC Form Field](../mdc-form-field) for enh
            viewBox="0 0 24 24">
         <path class="mdc-checkbox__checkmark-path"
               fill="none"
-              stroke="white"
+              stroke="currentColor"
               d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
       </svg>
       <div class="mdc-checkbox__mixedmark"></div>

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -322,6 +322,7 @@
   width: 100%;
   transition: mdc-checkbox-transition-exit(opacity, 0ms, $mdc-checkbox-transition-duration * 2);
   opacity: 0;
+  stroke: currentColor;
 
   .mdc-checkbox--upgraded & {
     opacity: 1;

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -69,10 +69,8 @@
 }
 
 @mixin mdc-checkbox-ink-color($color) {
-  .mdc-checkbox__checkmark-path {
-    // !important is needed here because a stroke must be set as an attribute on the SVG in order
-    // for line animation to work properly.
-    @include mdc-theme-prop(stroke, $color, $important: true);
+  .mdc-checkbox__checkmark {
+    @include mdc-theme-prop(color, $color);
   }
 
   .mdc-checkbox__mixedmark {

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -320,7 +320,6 @@
   width: 100%;
   transition: mdc-checkbox-transition-exit(opacity, 0ms, $mdc-checkbox-transition-duration * 2);
   opacity: 0;
-  stroke: currentColor;
 
   .mdc-checkbox--upgraded & {
     opacity: 1;

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -350,6 +350,7 @@
       0ms,
       $mdc-checkbox-transition-duration * 2
     );
+  stroke: currentColor;
   stroke-width: $mdc-checkbox-mark-stroke-size * 1.3;
   stroke-dashoffset: $mdc-checkbox-mark-path-length_;
   stroke-dasharray: $mdc-checkbox-mark-path-length_;

--- a/packages/mdc-checkbox/_variables.scss
+++ b/packages/mdc-checkbox/_variables.scss
@@ -17,7 +17,6 @@
 @import "@material/theme/variables";
 
 $mdc-checkbox-mark-color: mdc-theme-prop-value(on-primary);
-$mdc-checkbox-mark-color-high-contrast-black-on-white: black !default;
 $mdc-checkbox-border-color: rgba(mdc-theme-prop-value(on-surface), .54);
 $mdc-checkbox-disabled-color: rgba(mdc-theme-prop-value(on-surface), .26);
 $mdc-checkbox-baseline-theme-color: secondary;

--- a/packages/mdc-checkbox/mdc-checkbox.scss
+++ b/packages/mdc-checkbox/mdc-checkbox.scss
@@ -41,12 +41,6 @@
   }
 }
 
-@media screen and (-ms-high-contrast: black-on-white) {
-  @at-root {
-    @include mdc-checkbox-ink-color($mdc-checkbox-mark-color-high-contrast-black-on-white);
-  }
-}
-
 // Needed to disable hover effects on CSS-only (non-JS) checkboxes
 .mdc-checkbox--disabled {
   @include mdc-checkbox--disabled_;

--- a/test/unit/mdc-checkbox/mdc-checkbox.test.js
+++ b/test/unit/mdc-checkbox/mdc-checkbox.test.js
@@ -40,7 +40,7 @@ function getFixture() {
              viewBox="0 0 24 24">
           <path class="mdc-checkbox__checkmark-path"
                 fill="none"
-                stroke="white"
+                stroke="currentColor"
                 d="M4.1,12.7 9,17.6 20.3,6.3"/>
         </svg>
         <div class="mdc-checkbox__mixedmark"></div>

--- a/test/unit/mdc-checkbox/mdc-checkbox.test.js
+++ b/test/unit/mdc-checkbox/mdc-checkbox.test.js
@@ -40,7 +40,6 @@ function getFixture() {
              viewBox="0 0 24 24">
           <path class="mdc-checkbox__checkmark-path"
                 fill="none"
-                stroke="currentColor"
                 d="M4.1,12.7 9,17.6 20.3,6.3"/>
         </svg>
         <div class="mdc-checkbox__mixedmark"></div>


### PR DESCRIPTION
**NOTE:** The `stroke="white"` SVG attribute has been removed as it is no longer needed.