### PR TITLE
chore(infrastructure): Add method to fetch browsers skipped by user's CLI flags

### DIFF
--- a/test/screenshot/lib/cli-arg-parser.js
+++ b/test/screenshot/lib/cli-arg-parser.js
@@ -25,11 +25,22 @@ const HTTP_URL_REGEX = new RegExp('^https?://');
 
 class CliArgParser {
   constructor() {
+    /**
+     * @type {!GitRepo}
+     * @private
+     */
     this.gitRepo_ = new GitRepo();
 
+    /**
+     * @type {!ArgumentParser}
+     * @private
+     */
     this.parser_ = new ArgumentParser({
       addHelp: true,
       description: 'Run screenshot tests and display diffs.',
+
+      // argparse throws an error if `process.argv[1]` is undefined, which happens when you run `node --interactive`.
+      prog: process.argv[1] || '--interactive',
     });
 
     this.parser_.addArgument(


### PR DESCRIPTION
### How to test

```bash
node - --mdc-include-browser=chrome
```

Copy and paste these lines of JS into the `node` console:

```js
const CbtUserAgent = require('./test/screenshot/lib/cbt-user-agent');
CbtUserAgent.fetchBrowsersToRun().then((uas) => console.log(uas.map((ua) => ua.alias)), (err) => console.error(err));
CbtUserAgent.fetchSkippedBrowsers().then((uas) => console.log(uas.map((ua) => ua.alias)), (err) => console.error(err));
```

### What it does

* Adds a `fetchSkippedBrowsers()` method to `cbt-user-agent.js`
    - This will be needed by a future PR to display skipped tests on the report page
* Fixes a debugging issue that occurs when you run `node` interactively