### PR TITLE
docs(mdc-icon-button): Fix event description

### DIFF
--- a/packages/mdc-icon-button/README.md
+++ b/packages/mdc-icon-button/README.md
@@ -143,7 +143,7 @@ Property | Value Type | Description
 
 Event Name | Event Data Structure | Description
 --- | --- | ---
-`MDCIconButtonToggle` | `{"detail": {"isOn": boolean}}` | Emits when the icon is toggled.
+`MDCIconButtonToggle:change` | `{"detail": {"isOn": boolean}}` | Emits when the icon is toggled.
 
 ## Usage within Web Frameworks
 


### PR DESCRIPTION
The docs are just missing the right event.