### PR TITLE
chore(infrastructure): Faster, more reliable asset file uploads to GCS

### DIFF
--- a/test/screenshot/lib/git-repo.js
+++ b/test/screenshot/lib/git-repo.js
@@ -111,6 +111,14 @@ class GitRepo {
   }
 
   /**
+   * @param {!Array<string>} filePaths
+   * @return {!Promise<!Array<string>>}
+   */
+  async getIgnoredPaths(filePaths) {
+    return this.repo_.checkIgnore(filePaths);
+  }
+
+  /**
    * @param {string} cmd
    * @param {!Array<string>=} argList
    * @return {!Promise<string>}

--- a/test/screenshot/lib/screenshot.js
+++ b/test/screenshot/lib/screenshot.js
@@ -88,6 +88,10 @@ async function sendCaptureRequest(testPageUrl, retryCount = 0) {
         return sendCaptureRequest(testPageUrl, retryCount); // don't increment the retry count for parallel execution
       }
 
+      if (isBadUrl(err)) {
+        return rejectWithError('sendCaptureRequest', testPageUrl, new Error(err.response.body.message));
+      }
+
       // TODO(acdvorak): Abstract this logic into CbtApi for every HTTP request?
       if (isServerError(err)) {
         logServerError(err);
@@ -187,7 +191,16 @@ function computeTestSuiteProgress() {
 function reachedParallelExecutionLimit(requestError) {
   try {
     // The try/catch is necessary because some of these properties might not exist.
-    return requestError.response.body.message.indexOf('maximum number of parallel');
+    return requestError.response.body.message.includes('maximum number of parallel');
+  } catch (e) {
+    return false;
+  }
+}
+
+function isBadUrl(requestError) {
+  try {
+    // The try/catch is necessary because some of these properties might not exist.
+    return requestError.response.body.message.includes('URL check failed');
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
### How to test

```bash
export CBT_USERNAME='...'
export CBT_AUTHKEY='...'
export MDC_GCLOUD_SERVICE_ACCOUNT_KEY_FILE_PATH='...'

npm run screenshot:test
```

### What it does

- Uses the `gsutil` CLI command to upload asset files instead of the Node API (`@google-cloud/storage`)
  - Speeds up asset file uploads from ~2 minutes to ~45 seconds
  - Improves reliability of asset file uploads by letting `gsutil` handle retries and parallelism
- Skips top-level files/directories that are ignored by git
- Displays which HTML files are being tested and which ones are being skipped due to CLI filters
- Displays an error message if no page URLs match the CLI filters
- Adds a more specific error message for bad URLs sent to CBT (HTTP 404, 403, etc.)