### PR TITLE
chore(infrastructure): Show "added", "removed", and "unchanged" screenshots in report

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "npm run test:unit && npm run test:closure && npm run test:dependency && npm run build && npm run clean",
     "posttest": "istanbul report --root coverage text-summary && istanbul check-coverage --lines 95 --statements 95 --branches 95 --functions 95",
     "screenshot:build": "npm run screenshot:clean && mkdirp test/screenshot/out/ && webpack --config=test/screenshot/webpack.config.js --progress",
-    "screenshot:clean": "del-cli test/screenshot/out/",
+    "screenshot:clean": "del-cli test/screenshot/{out,report.html,report.json,snapshot.json}",
     "screenshot:serve": "node test/screenshot/bin/run-static-server.js",
     "screenshot:test": "node test/screenshot/bin/run-screenshot-test.js",
     "screenshot:update-goldens": "node test/screenshot/bin/run-update-goldens.js",

--- a/test/screenshot/.gitignore
+++ b/test/screenshot/.gitignore
@@ -1,0 +1,3 @@
+report.html
+report.json
+snapshot.json

--- a/test/screenshot/lib/snapshot-store.js
+++ b/test/screenshot/lib/snapshot-store.js
@@ -46,14 +46,21 @@ class SnapshotStore {
   }
 
   /**
-   * Writes the data to the given `golden.json` file path.
+   * @param {!ReportData} reportData
+   * @return {!Promise<string>}
+   */
+  async getSnapshotJsonString(reportData) {
+    const jsonData = await this.getJsonData_(reportData);
+    return stringify(jsonData, {space: '  '}) + '\n';
+  }
+
+  /**
    * @param {!ReportData} reportData
    * @return {!Promise<void>}
    */
   async writeToDisk(reportData) {
-    const jsonData = await this.getJsonData_(reportData);
+    const jsonFileContent = await this.getSnapshotJsonString(reportData);
     const jsonFilePath = this.cliArgs_.goldenPath;
-    const jsonFileContent = stringify(jsonData, {space: '  '}) + '\n';
 
     await fs.writeFile(jsonFilePath, jsonFileContent);
 
@@ -156,11 +163,12 @@ class SnapshotStore {
     diffs.forEach((diff) => {
       const htmlFilePath = diff.htmlFilePath;
       const browserKey = diff.browserKey;
+      const newPage = newJsonData[htmlFilePath];
       if (jsonData[htmlFilePath]) {
-        jsonData[htmlFilePath].publicUrl = newJsonData[htmlFilePath].publicUrl;
-        jsonData[htmlFilePath].screenshots[browserKey] = newJsonData[htmlFilePath].screenshots[browserKey];
+        jsonData[htmlFilePath].publicUrl = newPage.publicUrl;
+        jsonData[htmlFilePath].screenshots[browserKey] = newPage.screenshots[browserKey];
       } else {
-        jsonData[htmlFilePath] = this.deepCloneJson_(newJsonData[htmlFilePath]);
+        jsonData[htmlFilePath] = this.deepCloneJson_(newPage);
       }
     });
 

--- a/test/screenshot/lib/types.js
+++ b/test/screenshot/lib/types.js
@@ -80,6 +80,9 @@ let ImageDiffJson;
 /**
  * @typedef {{
  *   diffs: !Array<!ImageDiffJson>,
+ *   added: !Array<!ImageDiffJson>,
+ *   removed: !Array<!ImageDiffJson>,
+ *   unchanged: !Array<!ImageDiffJson>,
  *   testCases: !Array<!UploadableTestCase>,
  * }}
  */


### PR DESCRIPTION
### How to test

Env vars:
```bash
export CBT_USERNAME='...'
export CBT_AUTHKEY='...'
export MDC_GCLOUD_SERVICE_ACCOUNT_KEY_FILE_PATH='...'
```

Test:
```bash
mv test/screenshot/mdc-button/classes/{baseline,default}.html
npm run screenshot:test
```

### What it does

- Adds three new sections to the diff report page:
    * Added (new pages and/or browsers)
    * Removed (deleted pages and/or browsers)
    * Unchanged (no diffs)
- Writes `report.html` to local disk (in addition to uploading it to GCS)
- Writes `report.json` and `snapshot.json` to local disk and uploads them to GCS
- Updates `npm run screenshot:clean` to delete `report.html`, `report.json`, and `snapshot.json`
- Updates `.gitignore` to ignore `report.html`, `report.json`, and `snapshot.json`
- **NOTE**: At the moment, screenshots that get filtered out by the CLI flags (e.g., `--mdc-include-url`) are incorrectly displayed as "removed" rather than "skipped". This will be fixed in an upcoming PR.