### PR TITLE
chore(infrastructure): Show "skipped" screenshots on report page

### DIFF
--- a/test/screenshot/lib/controller.js
+++ b/test/screenshot/lib/controller.js
@@ -311,6 +311,7 @@ class Controller {
 
     /** @type {!Array<!ImageDiffJson>} */
     const {diffs, added, removed, unchanged, skipped} = await this.imageDiffer_.compareAllPages({
+      runReport,
       actualSuite: await this.snapshotStore_.fromTestCases(runnableTestCases),
       expectedSuite: await this.snapshotStore_.fromDiffBase(),
     });

--- a/test/screenshot/lib/image-differ.js
+++ b/test/screenshot/lib/image-differ.js
@@ -153,6 +153,14 @@ class ImageDiffer {
     return removed;
   }
 
+  /**
+   * @param {!RunReport} runReport
+   * @param {?SnapshotPageJson} actualPage
+   * @param {string} userAgentAlias
+   * @param {string} htmlFilePath
+   * @return {boolean}
+   * @private
+   */
   isRemovedFromPage_({
     runReport,
     actualPage,

--- a/test/screenshot/lib/types.js
+++ b/test/screenshot/lib/types.js
@@ -57,13 +57,13 @@ let RunResult;
 /**
  * @typedef {{
  *   htmlFilePath: string,
- *   goldenPageUrl: string,
- *   snapshotPageUrl: string,
  *   userAgentAlias: string,
- *   actualImageUrl: string,
- *   expectedImageUrl: string,
+ *   goldenPageUrl: ?string,
+ *   snapshotPageUrl: ?string,
+ *   actualImageUrl: ?string,
+ *   expectedImageUrl: ?string,
  *   diffImageBuffer ?Buffer,
- *   diffImageUrl: string,
+ *   diffImageUrl: ?string,
  * }}
  */
 let ImageDiffJson;
@@ -125,7 +125,7 @@ class UploadableFile {
     /** @type {?Buffer} */
     this.fileContent = fileContent;
 
-    /** @type {?Object} */
+    /** @type {?CbtUserAgent} */
     this.userAgent = userAgent;
 
     /** @type {number} */


### PR DESCRIPTION
### How to test

Env vars:
```bash
export CBT_USERNAME='...'
export CBT_AUTHKEY='...'
export MDC_GCLOUD_SERVICE_ACCOUNT_KEY_FILE_PATH='...'
```

Test with filters:
```bash
npm run screenshot:test -- --mdc-include-url=fab/classes/mini --mdc-include-browser=chrome
```

Test without filters:
```bash
npm run screenshot:test
```

### What it does

- Fixes #2806
- Adds a "skipped" section to the report page (instead of incorrectly displaying skipped screenshots as "removed")

### Example output

- [67 skipped, 0 diffs](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/14/22_54_11_534/report.html)
- [64 skipped, 1 diff](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/14/22_51_54_901/report.html)
- [0 skipped, 1 diff](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/14/22_57_28_534/report.html)

![report-screenshot](https://user-images.githubusercontent.com/409245/41442947-ccb73594-6fee-11e8-80fd-9b3807f23aea.png)
