### PR TITLE
docs: Add more info to release process; update next steps output

### DIFF
--- a/docs/open_source/release-process.md
+++ b/docs/open_source/release-process.md
@@ -42,19 +42,27 @@ Run the following script to automatically cherry-pick new bugfixes on top of the
 node scripts/cherry-pick-patch-commits
 ```
 
+> Note: After running the script, you are in a detached HEAD state. You can create a temporary local branch if desired,
+> but all that needs to be pushed is the tag produced at the end of the release process.
+
 Read the output carefully:
 
 * You may need to cherry-pick commits that the script could not cherry-pick cleanly without conflict
 * The script may have cherry-picked fixes that rely on breaking changes or new features; these need to be removed.
   This is especially likely if the script reports that either the build or the unit tests failed.
 * Examine `git log` to ensure there are no unexpected commits beyond the previous tag (in case any breaking changes
-  weren't flagged properly)
+  weren't flagged properly, or features were mislabeled as fixes, etc.)
 
-After running the script, you are in a detached HEAD state. You can create a temporary local branch if desired, but all
-that should need to be pushed is the tag produced at the end of the release process.
+If you find you need to remove commits that should not have been cherry-picked, perform the following steps:
 
-> Note: In the rare event that zero commits were skipped, you can simply cut the release from master as you would
-> normally do for a minor release, and skip all of the cherry-picking back and forth.
+1. Find the base tag that the cherry-pick script identified and used (find the "Checking out v0.x.y" line in the output)
+1. Run `git rebase -i <base tag>` - this will open the sequence of cherry-picked commits in an editor (probably vim)
+1. Find and delete lines for commits that should not have been included (in vim, type `dd` on the line in question)
+1. Save and exit (`:x` in vim)
+1. Re-check `git log` to confirm that the commits are no longer present
+
+> Note: In the rare event that zero commits were skipped, you can simply checkout master and cut the release as you
+> would normally do for a minor release, and skip all of the cherry-picking back and forth.
 
 ## Preparation
 

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -43,4 +43,6 @@ log "Tagging repo using semver tag $SEMVER_TAG"
 git tag $SEMVER_TAG -m "Material Components for the web release $SEMVER_TAG"
 echo ""
 
-log "Done! You should now git push to master and git push --tags"
+log "Post-release steps done! Next, continue with the Push step in the Release Process documentation:"
+echo "https://github.com/material-components/material-components-web/blob/master/docs/open_source/release-process.md#push"
+echo ""

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -58,6 +58,6 @@ log "Moving built assets to package directories..."
 node scripts/cp-pkgs.js
 echo ""
 
-log "Pre-release steps done! Next, you should run:" \
-    "\$(npm bin)/lerna publish --skip-git"
+log "Pre-release steps done! Next, continue with the Release step in the Release Process documentation:"
+echo "https://github.com/material-components/material-components-web/blob/master/docs/open_source/release-process.md#release"
 echo ""


### PR DESCRIPTION
* Adds info on how to remove cherry-picked commits that don't belong in a patch release
* Changes output at end of pre and post-release scripts to point to docs, since the next command depends on the type of release