### PR TITLE
Adding prefix for appearance

### DIFF
--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -75,7 +75,9 @@
     background-color: transparent;
     white-space: nowrap;
     cursor: pointer;
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
   }
 
   // stylelint-disable-next-line plugin/selector-bem-pattern

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -76,8 +76,8 @@
     white-space: nowrap;
     cursor: pointer;
     -webkit-appearance: none;
-       -moz-appearance: none;
-            appearance: none;
+    -moz-appearance: none;
+    appearance: none;
   }
 
   // stylelint-disable-next-line plugin/selector-bem-pattern


### PR DESCRIPTION
In Chrome, the propery appearance is not working.
The result is a select displaying two arrows: 
![image](https://user-images.githubusercontent.com/15799533/41724780-ada9e506-7544-11e8-8d0b-b51444eeaaaa.png)

It's necessary to add -webkit- to the property.