### PR TITLE
Fix typo of generating app.js in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -232,17 +232,28 @@ Then configure webpack to convert `app.js` into `bundle.js` by adding the follow
 module.exports.push({
   entry: './app.js',
   output: {
-    filename: 'bundle.js'
+    filename: 'javascript-bundle.js'
   },
-  rules: {
-    loaders: [{
+  module: {
+    rules: [{
       test: /\.js$/,
-      loader: 'babel-loader',
-      query: {
-        presets: ['es2015']
-      }
+      use: [
+        {
+          loader: 'file-loader',
+          options: 
+            {
+              name: 'bundle.js',
+            },
+        },
+        {
+          loader: 'babel-loader',
+          query: {
+            presets: ['es2015']
+          }
+        }
+      ]
     }]
-  },
+  }
 });
 ```
 


### PR DESCRIPTION
Hi there,

It looks the typo of generating app.js in Webpack.config.js not working as follows. I changed the code and executed it on my computer successfully so would like to commit the code into the master.
![screen shot 2018-06-30 at 3 50 44 am](https://user-images.githubusercontent.com/4927815/42103246-980beaa8-7c1c-11e8-9557-76720fe9af95.png)

My change:
![screen shot 2018-06-30 at 4 01 25 am](https://user-images.githubusercontent.com/4927815/42103369-f44f06a6-7c1c-11e8-8f53-f7401871026e.png)
