### PR TITLE
build: Remove grid property from autoprefixer

### DIFF
--- a/scripts/webpack/css-bundle-factory.js
+++ b/scripts/webpack/css-bundle-factory.js
@@ -195,7 +195,7 @@ class CssBundleFactory {
           loader: 'postcss-loader',
           options: {
             sourceMap: true,
-            plugins: () => [this.autoprefixerLib_({grid: false})],
+            plugins: () => [this.autoprefixerLib_()],
           },
         },
         {


### PR DESCRIPTION
`grid: false` is the default property for `autoprefixer`, so we should remove it from our webpack config.