### PR TITLE
fix(button): Remove dense/stroked line-height tweaks to improve alignment

### DIFF
--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -78,15 +78,6 @@
   @include mdc-button-horizontal-padding($padding-value);
 
   border-width: $outline-width;
-  // Note: line height is adjusted for outline button because borders are not
-  // considered as space available to text on the Web
-  line-height: $mdc-button-height - $outline-width * 2;
-
-  // postcss-bem-linter: ignore
-  &.mdc-button--dense {
-    // Minus extra 1 to accommodate odd font size of dense button
-    line-height: $mdc-dense-button-height - $outline-width * 2 - 1;
-  }
 }
 
 @mixin mdc-button-base_() {
@@ -192,5 +183,4 @@
 @mixin mdc-button--dense_() {
   height: $mdc-dense-button-height;
   font-size: .8125rem; // 13sp
-  line-height: $mdc-dense-button-height;
 }


### PR DESCRIPTION
Fixes #3026.

Screenshot test report: https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/03/21_45_26_756/report.html

Vertical differences on dense and outlined buttons are expected. Horizontal diffs are...curious, and I'm pretty sure I wasn't seeing those when I tested this in June. FAB diffs are noise, I didn't touch that code at all.