### PR TITLE
feat(typography): make it compatible with upcoming sass 4

### DIFF
--- a/packages/mdc-typography/_functions.scss
+++ b/packages/mdc-typography/_functions.scss
@@ -54,7 +54,7 @@
     $style-props: map-merge($base-styles, $style-props);
 
     // Merge global overrides onto each style.
-    @if global_variable_exists(mdc-typography-styles-#{$style}) {
+    @if global_variable_exists(unquote("mdc-typography-styles-#{$style}")) {
       $style-props: map-merge($style-props, mdc-typography-get-global-variable_(#{$style}));
     }
 


### PR DESCRIPTION
The following is the deprecation warning you get by running typography
with SASS 3.5.6:

```
$ sass -v
Ruby Sass 3.5.6
$ sass --check packages/mdc-typography/mdc-typography.scss
DEPRECATION WARNING on line 57 of packages/mdc-typography/_functions.scss:
To preserve the current behavior, use quotes:

  unquote("mdc-typography-styles-#{$style}")
```