### PR TITLE
fix(switch): Fix switch styling in IE and Firefox

### DIFF
--- a/packages/mdc-switch/_variables.scss
+++ b/packages/mdc-switch/_variables.scss
@@ -18,16 +18,10 @@
 
 $mdc-switch-track-width: 32px;
 $mdc-switch-track-height: 14px;
-
-$mdc-switch-tap-target-size: 48px;
-
 $mdc-switch-thumb-diameter: 20px;
-$mdc-switch-thumb-active-margin: $mdc-switch-track-width - $mdc-switch-thumb-diameter;
-$mdc-switch-thumb-border: $mdc-switch-thumb-diameter / 2;
-$mdc-switch-thumb-offset: ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter) / 2;
-
-$mdc-switch-native-control-offset: -($mdc-switch-thumb-offset + $mdc-switch-thumb-border);
+$mdc-switch-tap-target-size: 48px;
 $mdc-switch-native-control-width: $mdc-switch-track-width + ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter);
+$mdc-switch-thumb-active-margin: $mdc-switch-track-width - $mdc-switch-thumb-diameter;
 
 $mdc-switch-toggled-off-thumb-color: mdc-theme-prop-value(surface);
 $mdc-switch-toggled-off-track-color: mdc-theme-prop-value(on-surface);

--- a/packages/mdc-switch/_variables.scss
+++ b/packages/mdc-switch/_variables.scss
@@ -18,10 +18,16 @@
 
 $mdc-switch-track-width: 32px;
 $mdc-switch-track-height: 14px;
-$mdc-switch-thumb-diameter: 20px;
+
 $mdc-switch-tap-target-size: 48px;
-$mdc-switch-native-control-width: $mdc-switch-track-width + ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter);
+
+$mdc-switch-thumb-diameter: 20px;
 $mdc-switch-thumb-active-margin: $mdc-switch-track-width - $mdc-switch-thumb-diameter;
+$mdc-switch-thumb-border: $mdc-switch-thumb-diameter / 2;
+$mdc-switch-thumb-offset: ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter) / 2;
+
+$mdc-switch-native-control-offset: -($mdc-switch-thumb-offset + $mdc-switch-thumb-border);
+$mdc-switch-native-control-width: $mdc-switch-track-width + ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter);
 
 $mdc-switch-toggled-off-thumb-color: mdc-theme-prop-value(surface);
 $mdc-switch-toggled-off-track-color: mdc-theme-prop-value(on-surface);

--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -36,10 +36,11 @@
 }
 
 .mdc-switch__native-control {
-  @include mdc-rtl-reflexive-position(left, $mdc-switch-native-control-offset);
-
   position: absolute;
-  top: $mdc-switch-native-control-offset;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   width: $mdc-switch-native-control-width;
   height: $mdc-switch-tap-target-size;
   margin: 0;
@@ -68,9 +69,12 @@
     $mdc-switch-baseline-theme-color,
     $has-nested-focusable-element: true);
 
+  display: flex;
   position: absolute;
   // Ensures the knob is centered on the track.
   top: -($mdc-switch-track-height / 2 + $mdc-switch-thumb-diameter / 2);
+  align-items: center;
+  justify-content: center;
   width: $mdc-switch-tap-target-size;
   height: $mdc-switch-tap-target-size;
   transform: translateX(0);
@@ -83,13 +87,10 @@
 .mdc-switch__thumb {
   @include mdc-elevation(2);
 
-  position: absolute;
-  top: $mdc-switch-thumb-offset;
-  left: $mdc-switch-thumb-offset;
   box-sizing: border-box;
   width: $mdc-switch-thumb-diameter;
   height: $mdc-switch-thumb-diameter;
-  border: $mdc-switch-thumb-border solid;
+  border: $mdc-switch-thumb-diameter / 2 solid;
   border-radius: 50%;
   z-index: 1;
 }

--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -36,11 +36,10 @@
 }
 
 .mdc-switch__native-control {
+  @include mdc-rtl-reflexive-position(left, 0);
+
   position: absolute;
   top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   width: $mdc-switch-native-control-width;
   height: $mdc-switch-tap-target-size;
   margin: 0;

--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -89,7 +89,7 @@
   box-sizing: border-box;
   width: $mdc-switch-thumb-diameter;
   height: $mdc-switch-thumb-diameter;
-  border: $mdc-switch-thumb-diameter / 2 solid;
+  border: $mdc-switch-thumb-border solid;
   border-radius: 50%;
   z-index: 1;
 }

--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -36,11 +36,13 @@
 }
 
 .mdc-switch__native-control {
-  @include mdc-rtl-reflexive-position(left, -24px);
+  @include mdc-rtl-reflexive-position(left, $mdc-switch-native-control-offset);
 
   position: absolute;
+  top: $mdc-switch-native-control-offset;
   width: $mdc-switch-native-control-width;
   height: $mdc-switch-tap-target-size;
+  margin: 0;
   opacity: 0;
   cursor: pointer;
 }
@@ -66,12 +68,9 @@
     $mdc-switch-baseline-theme-color,
     $has-nested-focusable-element: true);
 
-  display: flex;
   position: absolute;
   // Ensures the knob is centered on the track.
   top: -($mdc-switch-track-height / 2 + $mdc-switch-thumb-diameter / 2);
-  align-items: center;
-  justify-content: center;
   width: $mdc-switch-tap-target-size;
   height: $mdc-switch-tap-target-size;
   transform: translateX(0);
@@ -84,9 +83,9 @@
 .mdc-switch__thumb {
   @include mdc-elevation(2);
 
-  display: flex;
   position: absolute;
-  align-items: center;
+  top: $mdc-switch-thumb-offset;
+  left: $mdc-switch-thumb-offset;
   box-sizing: border-box;
   width: $mdc-switch-thumb-diameter;
   height: $mdc-switch-thumb-diameter;


### PR DESCRIPTION
Discovered through screenshot tests that IE and Firefox have issues with absolutely positioned elements inside elements that are display: flex (although it was working in Chrome).