### PR TITLE
chore(infrastructure): Automatically retry screenshots up to 3 times to reduce flakes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,3 @@
 packages/*/dist
 **/out
 *.pb.js
-**/fixture.js

--- a/test/screenshot/README.md
+++ b/test/screenshot/README.md
@@ -38,8 +38,10 @@ npm run screenshot:test
 You should see something like this in the terminal:
 
 ```
-Found 65 screenshot diffs!
-https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/18/22_57_35_482/report.html
+Changed 1 screenshot:
+  - mdc-fab/classes/baseline.html > desktop_windows_edge@latest
+
+https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/03_37_19_142/report/report.html
 ```
 
 ## Basic usage
@@ -47,7 +49,7 @@ https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/18/22_57
 ### Updating "golden" screenshots
 
 On the
-[report page](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/18/22_57_35_482/report.html),
+[report page](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/03_37_19_142/report/report.html),
 select the checkboxes for all screenshots you want to approve, and click the "Approve" button at the bottom of the page.
 
 This will display a modal dialog containing a CLI command to copy/paste:
@@ -55,7 +57,7 @@ This will display a modal dialog containing a CLI command to copy/paste:
 ```bash
 npm run screenshot:approve -- \
   --all \
-  --report=https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/18/22_57_35_482/report.json
+  --report=https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/03_37_19_142/report/report.json
 ```
 
 **IMPORTANT:** Note the `--` between the script name and its arguments. This is required by `npm`.
@@ -67,7 +69,7 @@ This command will update your local `test/screenshot/golden.json` file with the 
 You can rerun a subset of the tests without running the entire suite, filtering by browser and/or URL.
 
 On the
-[report page](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/06/18/22_57_35_482/report.html),
+[report page](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/03_37_19_142/report/report.html),
 select the checkboxes for all screenshots you want to retry, and click the "Retry" button at the bottom of the page.
 
 This will display a modal dialog containing a CLI command to copy/paste:
@@ -154,9 +156,10 @@ npm run screenshot:test -- \
 **NOTE:** Negative patterns _always_ take precedence over positive patterns, regardless of the order they appear in the
 command line.
 
-### Diffing against a local `golden.json` file
+### Diffing against other git branches and tags
 
 By default, screenshots are diffed against your local `test/screenshot/golden.json` file.
+This enables incremental diff reports, which are typically smaller and easier to review.
 
 You can diff against a local/remote git branch, tag, or commit with the `--diff-base` flag:
 

--- a/test/screenshot/diffing.json
+++ b/test/screenshot/diffing.json
@@ -1,0 +1,10 @@
+{
+  "resemble_config": {
+    "output": {
+      "transparency": 0
+    }
+  },
+  "flaky_tests": {
+    "min_changed_pixel_count": 15
+  }
+}

--- a/test/screenshot/fixture.js
+++ b/test/screenshot/fixture.js
@@ -14,23 +14,28 @@
  * limitations under the License.
  */
 
+/* eslint-disable no-var */
+
 window.mdc = window.mdc || {};
 
 window.mdc.testFixture = {
-  waitForFontsToLoad: function(callback) {
+  attachFontObserver: function() {
     var fontsLoadedPromise = new Promise(function(resolve) {
       var robotoFont = new FontFaceObserver('Roboto');
       var materialIconsFont = new FontFaceObserver('Material Icons');
-      Promise.all([robotoFont.load(), materialIconsFont.load('add')]).then(function() {
+
+      // The `load()` method accepts an optional string of text to ensure that those specific glyphs are available.
+      // For the Material Icons font, we need to pass it one of the icon names.
+      Promise.all([robotoFont.load(), materialIconsFont.load('star_border')]).then(function() {
         resolve();
       });
+
       setTimeout(function() {
         resolve();
       }, 3000); // TODO(acdvorak): Create a constant for font loading timeout values
     });
     fontsLoadedPromise.then(function() {
       document.body.setAttribute('data-fonts-loaded', '');
-      callback();
     });
   },
 };

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -11,10 +11,10 @@
   "mdc-button/classes/baseline-button-without-icons.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/baseline-button-without-icons.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/classes/baseline-button-without-icons.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/classes/baseline-button-without-icons.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/baseline-button-without-icons.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/baseline-button-without-icons.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-button-without-icons.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-button-without-icons.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-button-without-icons.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-button-without-icons.html.windows_ie_11.png"
     }
   },
   "mdc-button/classes/baseline-link-with-icons.html": {
@@ -29,10 +29,10 @@
   "mdc-button/classes/baseline-link-without-icons.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/baseline-link-without-icons.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/classes/baseline-link-without-icons.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/classes/baseline-link-without-icons.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/baseline-link-without-icons.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/baseline-link-without-icons.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-link-without-icons.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-link-without-icons.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-link-without-icons.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/baseline-link-without-icons.html.windows_ie_11.png"
     }
   },
   "mdc-button/classes/dense-button-with-icons.html": {
@@ -47,10 +47,10 @@
   "mdc-button/classes/dense-button-without-icons.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/dense-button-without-icons.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/classes/dense-button-without-icons.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/09_26_36_096/mdc-button/classes/dense-button-without-icons.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/dense-button-without-icons.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/dense-button-without-icons.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-button-without-icons.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-button-without-icons.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-button-without-icons.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-button-without-icons.html.windows_ie_11.png"
     }
   },
   "mdc-button/classes/dense-link-with-icons.html": {
@@ -65,10 +65,10 @@
   "mdc-button/classes/dense-link-without-icons.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/dense-link-without-icons.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/classes/dense-link-without-icons.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/12_02_54_125/mdc-button/classes/dense-link-without-icons.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/dense-link-without-icons.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/classes/dense-link-without-icons.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-link-without-icons.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-link-without-icons.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-link-without-icons.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/classes/dense-link-without-icons.html.windows_ie_11.png"
     }
   },
   "mdc-button/mixins/container-fill-color.html": {
@@ -101,19 +101,19 @@
   "mdc-button/mixins/horizontal-padding-baseline.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-button/mixins/horizontal-padding-baseline.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/mixins/horizontal-padding-baseline.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/mixins/horizontal-padding-baseline.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/mixins/horizontal-padding-baseline.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/mixins/horizontal-padding-baseline.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-baseline.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-baseline.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-baseline.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-baseline.html.windows_ie_11.png"
     }
   },
   "mdc-button/mixins/horizontal-padding-dense.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/05/22/16_23_58_618/af3d7271f/mdc-button/mixins/horizontal-padding-dense.html",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/13/15_50_29_237/mdc-button/mixins/horizontal-padding-dense.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/12_02_54_125/mdc-button/mixins/horizontal-padding-dense.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/mixins/horizontal-padding-dense.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/12/05_44_01_282/mdc-button/mixins/horizontal-padding-dense.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-dense.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-dense.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-dense.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/06_00_21_336/mdc-button/mixins/horizontal-padding-dense.html.windows_ie_11.png"
     }
   },
   "mdc-button/mixins/icon-color.html": {
@@ -180,7 +180,7 @@
     }
   },
   "mdc-fab/mixins/extended-padding.html": {
-    "publicUrl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/13/22_35_48_118/mdc-fab/mixins/extended-padding.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/13/22_35_48_118/mdc-fab/mixins/extended-padding.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/13/22_35_48_118/mdc-fab/mixins/extended-padding.html.windows_chrome_67.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/13/22_35_48_118/mdc-fab/mixins/extended-padding.html.windows_edge_17.png",

--- a/test/screenshot/lib/cbt-api.js
+++ b/test/screenshot/lib/cbt-api.js
@@ -130,7 +130,7 @@ https://crossbrowsertesting.com/account
       // TODO(acdvorak): Implement
       name: undefined,
       // TODO(acdvorak): Figure out why this value is an empty string
-      build: meta.actual_diff_base.input_string,
+      build: meta.snapshot_diff_base.input_string,
 
       // TODO(acdvorak): Expose these as CLI flags
       record_video: true,

--- a/test/screenshot/lib/cli.js
+++ b/test/screenshot/lib/cli.js
@@ -487,8 +487,7 @@ that you know are going to have diffs.
     // E.g.: `--diff-base=/tmp/golden.json`
     const isLocalFile = await fs.exists(rawDiffBase);
     if (isLocalFile) {
-      const fileDB = this.createLocalFileDiffBase_(rawDiffBase);
-      return this.createLocalBranchDiffBase_(await this.gitRepo_.getBranchName(), fileDB.local_file_path);
+      return this.createLocalFileDiffBase_(rawDiffBase);
     }
 
     const [inputGoldenRef, inputGoldenPath] = rawDiffBase.split(':');
@@ -543,6 +542,7 @@ that you know are going to have diffs.
       input_string: localFilePath,
       type: DiffBase.Type.FILE_PATH,
       local_file_path: localFilePath,
+      is_default_local_file: localFilePath === GOLDEN_JSON_RELATIVE_PATH,
     });
   }
 

--- a/test/screenshot/lib/cli.js
+++ b/test/screenshot/lib/cli.js
@@ -274,6 +274,30 @@ Passing this option more than once is equivalent to passing a single comma-separ
 E.g.: '--browser=chrome,-mobile' is the same as '--browser=chrome --browser=-mobile'.
 `,
     });
+
+    this.addArg_(subparser, {
+      optionNames: ['--max-parallels'],
+      type: 'boolean',
+      description: `
+If this option is present, CBT tests will run the maximum number of parallel browser VMs allowed by our plan.
+The default behavior is to start 3 browsers if nobody else is running tests, or 1 browser if other tests are running.
+IMPORTANT: To ensure that other developers can run their tests too, only use this option during off-peak hours when you
+know nobody else is going to be running tests.
+This option is capped by A) our CBT account allowance, and B) the number of available VMs.
+`,
+    });
+
+    this.addArg_(subparser, {
+      optionNames: ['--max-retries'],
+      type: 'integer',
+      defaultValue: 3,
+      description: `
+Number of times to retry a screenshot that comes back with diffs. If you're not expecting any diffs, automatically
+retrying screenshots can help decrease noise from flaky browser rendering. However, if you're making a change that
+intentionally affects the rendered output, there's no point slowing down the test by retrying a bunch of screenshots
+that you know are going to have diffs.
+`,
+    });
   }
 
   /** @return {string} */
@@ -304,6 +328,16 @@ E.g.: '--browser=chrome,-mobile' is the same as '--browser=chrome --browser=-mob
   /** @return {string} */
   get diffBase() {
     return this.args_['--diff-base'];
+  }
+
+  /** @return {boolean} */
+  get maxParallels() {
+    return this.args_['--max-parallels'];
+  }
+
+  /** @return {number} */
+  get maxRetries() {
+    return this.args_['--max-retries'];
   }
 
   /** @return {boolean} */
@@ -437,6 +471,7 @@ E.g.: '--browser=chrome,-mobile' is the same as '--browser=chrome --browser=-mob
   }
 
   /**
+   * TODO(acdvorak): Move this method out of Cli class - it doesn't belong here.
    * @param {string} rawDiffBase
    * @return {!Promise<!mdc.proto.DiffBase>}
    */

--- a/test/screenshot/lib/cli.js
+++ b/test/screenshot/lib/cli.js
@@ -288,7 +288,7 @@ This option is capped by A) our CBT account allowance, and B) the number of avai
     });
 
     this.addArg_(subparser, {
-      optionNames: ['--max-retries'],
+      optionNames: ['--retries'],
       type: 'integer',
       defaultValue: 3,
       description: `
@@ -336,8 +336,8 @@ that you know are going to have diffs.
   }
 
   /** @return {number} */
-  get maxRetries() {
-    return this.args_['--max-retries'];
+  get retries() {
+    return this.args_['--retries'];
   }
 
   /** @return {boolean} */

--- a/test/screenshot/lib/constants.js
+++ b/test/screenshot/lib/constants.js
@@ -47,6 +47,12 @@ module.exports = {
    */
   CBT_CONCURRENCY_MAX_WAIT_MS: 10 * 60 * 1000, // 10 minutes
 
+  /**
+   * Number of milliseconds to wait for fonts to load on a test page in Selenium before giving up.
+   * @type {number}
+   */
+  SELENIUM_FONT_LOAD_WAIT_MS: 3000,
+
   ExitCode: {
     UNKNOWN_ERROR: 11,
     SIGINT: 12, // ctrl-c
@@ -55,5 +61,6 @@ module.exports = {
     HTTP_PORT_ALREADY_IN_USE: 15,
     MISSING_ENV_VAR: 16,
     UNHANDLED_PROMISE_REJECTION: 17,
+    CHANGES_FOUND: 18,
   },
 };

--- a/test/screenshot/lib/controller.js
+++ b/test/screenshot/lib/controller.js
@@ -133,7 +133,7 @@ class Controller {
    * @return {!Promise<!mdc.proto.ReportData>}
    */
   async compareAllScreenshots(reportData) {
-    await this.imageDiffer_.compareAllScreenshots(reportData);
+    await this.reportBuilder_.populateScreenshotMaps(reportData.user_agents, reportData.screenshots);
     await this.cloudStorage_.uploadAllDiffs(reportData);
 
     this.logComparisonResults_(reportData);

--- a/test/screenshot/lib/golden-io.js
+++ b/test/screenshot/lib/golden-io.js
@@ -96,7 +96,10 @@ class GoldenIo {
       return this.gitRepo_.getFileAtRevision(rev.golden_json_file_path, rev.commit);
     }
 
-    throw new Error(`Unable to parse '--diff-base=${rawDiffBase}': Expected a URL, local file path, or git ref`);
+    const serialized = JSON.stringify(parsedDiffBase);
+    throw new Error(
+      `Unable to parse '--diff-base=${rawDiffBase}': Expected a URL, local file path, or git ref. ${serialized}`
+    );
   }
 
   /**

--- a/test/screenshot/lib/image-differ.js
+++ b/test/screenshot/lib/image-differ.js
@@ -23,113 +23,40 @@ const mkdirp = require('mkdirp');
 const path = require('path');
 
 const mdcProto = require('../proto/mdc.pb').mdc.proto;
-const {DiffImageResult, Dimensions, Screenshot, ScreenshotList, TestFile} = mdcProto;
-const {CaptureState} = Screenshot;
+const {DiffImageResult, Dimensions, TestFile} = mdcProto;
 
 /**
  * Computes the difference between two screenshot images and generates an image that highlights the pixels that changed.
  */
 class ImageDiffer {
   /**
-   * @param {!mdc.proto.ReportData} reportData
-   * @return {!Promise<void>}
-   */
-  async compareAllScreenshots(reportData) {
-    const screenshots = reportData.screenshots.comparable_screenshot_list;
-
-    console.log(`Diffing ${screenshots.length} screenshots...`);
-
-    await Promise.all(screenshots.map((screenshot) => {
-      return this.compareOneScreenshot_({reportData, screenshot});
-    }));
-
-    reportData.screenshots.changed_screenshot_browser_map =
-      this.groupByBrowser_(reportData.screenshots.changed_screenshot_list);
-    reportData.screenshots.changed_screenshot_page_map =
-      this.groupByPage_(reportData.screenshots.changed_screenshot_list);
-
-    reportData.screenshots.unchanged_screenshot_browser_map =
-      this.groupByBrowser_(reportData.screenshots.unchanged_screenshot_list);
-    reportData.screenshots.unchanged_screenshot_page_map =
-      this.groupByPage_(reportData.screenshots.unchanged_screenshot_list);
-  }
-
-  /**
-   * @param {!mdc.proto.ReportData} reportData
+   * @param {!mdc.proto.ReportMeta} meta
    * @param {!mdc.proto.Screenshot} screenshot
-   * @return {!Promise<void>}
-   * @private
+   * @return {!Promise<!mdc.proto.DiffImageResult>}
    */
-  async compareOneScreenshot_({reportData, screenshot}) {
-    /** @type {!mdc.proto.DiffImageResult} */
-    const diffImageResult = await this.compareOneImage_({
-      reportData,
+  async compareOneScreenshot({meta, screenshot}) {
+    return await this.compareOneImage_({
+      meta,
       actualImageFile: screenshot.actual_image_file,
       expectedImageFile: screenshot.expected_image_file,
     });
-
-    screenshot.diff_image_result = diffImageResult;
-    screenshot.diff_image_file = diffImageResult.diff_image_file;
-    screenshot.capture_state = CaptureState.DIFFED;
-
-    if (diffImageResult.has_changed) {
-      reportData.screenshots.changed_screenshot_list.push(screenshot);
-    } else {
-      reportData.screenshots.unchanged_screenshot_list.push(screenshot);
-    }
   }
 
   /**
-   * TODO(acdvorak): De-dupe this method with ReportBuilder
-   * @param {!Array<!mdc.proto.Screenshot>} screenshotArray
-   * @return {!Object<string, !mdc.proto.ScreenshotList>}
-   * @private
-   */
-  groupByBrowser_(screenshotArray) {
-    const browserMap = {};
-    screenshotArray.forEach((screenshot) => {
-      const userAgentAlias = screenshot.user_agent.alias;
-      browserMap[userAgentAlias] = browserMap[userAgentAlias] || ScreenshotList.create({screenshots: []});
-      browserMap[userAgentAlias].screenshots.push(screenshot);
-    });
-    return browserMap;
-  }
-
-  /**
-   * TODO(acdvorak): De-dupe this method with ReportBuilder
-   * @param {!Array<!mdc.proto.Screenshot>} screenshotArray
-   * @return {!Object<string, !mdc.proto.ScreenshotList>}
-   * @private
-   */
-  groupByPage_(screenshotArray) {
-    const pageMap = {};
-    screenshotArray.forEach((screenshot) => {
-      const htmlFilePath = screenshot.html_file_path;
-      pageMap[htmlFilePath] = pageMap[htmlFilePath] || ScreenshotList.create({screenshots: []});
-      pageMap[htmlFilePath].screenshots.push(screenshot);
-    });
-    return pageMap;
-  }
-
-  /**
-   * @param {!mdc.proto.ReportData} reportData
+   * @param {!mdc.proto.ReportMeta} meta
    * @param {!mdc.proto.TestFile} actualImageFile
    * @param {!mdc.proto.TestFile} expectedImageFile
    * @return {!Promise<!mdc.proto.DiffImageResult>}
    * @private
    */
-  async compareOneImage_({reportData, actualImageFile, expectedImageFile}) {
-    const reportMeta = reportData.meta;
-
-    // TODO(acdvorak): Fix bug here
-    // TODO(acdvorak): Which bug? Offline comparison? What else? Maybe the paths don't always get set correctly?
+  async compareOneImage_({meta, actualImageFile, expectedImageFile}) {
     const actualImageBuffer = await fs.readFile(actualImageFile.absolute_path);
     const expectedImageBuffer = await fs.readFile(expectedImageFile.absolute_path);
 
     /** @type {!ResembleApiComparisonResult} */
     const resembleComparisonResult = await this.computeDiff_({actualImageBuffer, expectedImageBuffer});
 
-    const diffImageFile = this.createDiffImageFile_({reportMeta, actualImageFile});
+    const diffImageFile = this.createDiffImageFile_({meta, actualImageFile});
     const {diffImageBuffer, diffImageResult} = await this.analyzeComparisonResult_({
       expectedImageBuffer,
       actualImageBuffer,
@@ -141,6 +68,21 @@ class ImageDiffer {
     await fs.writeFile(diffImageFile.absolute_path, diffImageBuffer, {encoding: null});
 
     return diffImageResult;
+  }
+
+  /**
+   * @param {!Buffer} actualImageBuffer
+   * @param {!Buffer} expectedImageBuffer
+   * @return {!Promise<!ResembleApiComparisonResult>}
+   * @private
+   */
+  async computeDiff_({actualImageBuffer, expectedImageBuffer}) {
+    const options = require('../diffing.json').resemble_config;
+    return await compareImages(
+      actualImageBuffer,
+      expectedImageBuffer,
+      options
+    );
   }
 
   /**
@@ -171,6 +113,8 @@ class ImageDiffer {
     const diffPixelRoundPercentage = roundPercentage(diffPixelRawPercentage);
     const diffPixelFraction = diffPixelRawPercentage / 100;
     const diffPixelCount = Math.ceil(diffPixelFraction * diffJimpImage.bitmap.width * diffJimpImage.bitmap.height);
+    const minChangedPixelCount = require('../diffing.json').flaky_tests.min_changed_pixel_count;
+    const hasChanged = diffPixelCount >= minChangedPixelCount;
     const diffImageResult = DiffImageResult.create({
       expected_image_dimensions: Dimensions.create({
         width: expectedJimpImage.bitmap.width,
@@ -187,49 +131,28 @@ class ImageDiffer {
       changed_pixel_count: diffPixelCount,
       changed_pixel_fraction: diffPixelFraction,
       changed_pixel_percentage: diffPixelRoundPercentage,
-      has_changed: diffPixelCount >= require('../resemble.json').mdc_screenshot_test.min_changed_pixel_count,
+      has_changed: hasChanged,
     });
 
     return {diffImageBuffer, diffImageResult};
   }
 
   /**
-   * @param {!mdc.proto.ReportMeta} reportMeta
+   * @param {!mdc.proto.ReportMeta} meta
    * @param {!mdc.proto.TestFile} actualImageFile
    * @return {!mdc.proto.TestFile}
    * @private
    */
-  createDiffImageFile_({reportMeta, actualImageFile}) {
+  createDiffImageFile_({meta, actualImageFile}) {
     const diffImageRelativePath = actualImageFile.relative_path.replace(/\.png$/, '.diff.png');
-    const diffImageAbsolutePath = path.join(
-      reportMeta.local_diff_image_base_dir,
-      diffImageRelativePath
-    );
-    const diffImagePublicUrl =
-      reportMeta.remote_upload_base_url +
-      reportMeta.remote_upload_base_dir +
-      diffImageRelativePath;
+    const diffImageAbsolutePath = path.join(meta.local_diff_image_base_dir, diffImageRelativePath);
+    const diffImagePublicUrl = meta.remote_upload_base_url + meta.remote_upload_base_dir + diffImageRelativePath;
 
     return TestFile.create({
       public_url: diffImagePublicUrl,
       relative_path: diffImageRelativePath,
       absolute_path: diffImageAbsolutePath,
     });
-  }
-
-  /**
-   * @param {!Buffer} actualImageBuffer
-   * @param {!Buffer} expectedImageBuffer
-   * @return {!Promise<!ResembleApiComparisonResult>}
-   * @private
-   */
-  async computeDiff_({actualImageBuffer, expectedImageBuffer}) {
-    const options = require('../resemble.json');
-    return await compareImages(
-      actualImageBuffer,
-      expectedImageBuffer,
-      options
-    );
   }
 }
 

--- a/test/screenshot/lib/image-differ.js
+++ b/test/screenshot/lib/image-differ.js
@@ -45,12 +45,23 @@ class ImageDiffer {
   /**
    * @param {!mdc.proto.ReportMeta} meta
    * @param {!mdc.proto.TestFile} actualImageFile
-   * @param {!mdc.proto.TestFile} expectedImageFile
+   * @param {?mdc.proto.TestFile} expectedImageFile
    * @return {!Promise<!mdc.proto.DiffImageResult>}
    * @private
    */
   async compareOneImage_({meta, actualImageFile, expectedImageFile}) {
     const actualImageBuffer = await fs.readFile(actualImageFile.absolute_path);
+
+    if (!expectedImageFile) {
+      const actualJimpImage = await Jimp.read(actualImageBuffer);
+      return DiffImageResult.create({
+        actual_image_dimensions: Dimensions.create({
+          width: actualJimpImage.bitmap.width,
+          height: actualJimpImage.bitmap.height,
+        }),
+      });
+    }
+
     const expectedImageBuffer = await fs.readFile(expectedImageFile.absolute_path);
 
     /** @type {!ResembleApiComparisonResult} */

--- a/test/screenshot/lib/report-builder.js
+++ b/test/screenshot/lib/report-builder.js
@@ -723,6 +723,7 @@ class ReportBuilder {
       });
 
       if (!actualScreenshot) {
+        // TODO(acdvorak): Add image dimensions here so they can be displayed on the report page
         removedScreenshots.push(expectedScreenshot);
       }
     }

--- a/test/screenshot/lib/report-builder.js
+++ b/test/screenshot/lib/report-builder.js
@@ -397,9 +397,9 @@ class ReportBuilder {
       host_os_icon_url: this.getHostOsIconUrl_(hostOsName),
       cli_invocation: this.getCliInvocation_(),
 
+      git_status: GitStatus.fromObject(await this.gitRepo_.getStatus()),
       golden_diff_base: await this.cli_.parseDiffBase(),
       snapshot_diff_base: await this.cli_.parseDiffBase('HEAD'),
-      git_status: GitStatus.fromObject(await this.gitRepo_.getStatus()),
 
       node_version: LibraryVersion.create({
         version_string: await this.getExecutableVersion_('node'),

--- a/test/screenshot/lib/report-builder.js
+++ b/test/screenshot/lib/report-builder.js
@@ -397,8 +397,8 @@ class ReportBuilder {
       host_os_icon_url: this.getHostOsIconUrl_(hostOsName),
       cli_invocation: this.getCliInvocation_(),
 
-      expected_diff_base: await this.cli_.parseDiffBase(),
-      actual_diff_base: await this.cli_.parseDiffBase('HEAD'),
+      golden_diff_base: await this.cli_.parseDiffBase(),
+      snapshot_diff_base: await this.cli_.parseDiffBase('HEAD'),
       git_status: GitStatus.fromObject(await this.gitRepo_.getStatus()),
 
       node_version: LibraryVersion.create({
@@ -646,6 +646,8 @@ class ReportBuilder {
           expected_html_file: expectedHtmlFile,
           actual_html_file: actualHtmlFile,
           expected_image_file: expectedImageFile,
+          retry_count: 0,
+          max_retries: this.cli_.maxRetries,
         }));
       }
     }
@@ -870,6 +872,14 @@ class ReportBuilder {
       }
     }
     console.log();
+  }
+
+  /**
+   * @return {number}
+   * @private
+   */
+  getMaxRetries_() {
+    return this.cli_.maxRetries;
   }
 }
 

--- a/test/screenshot/lib/report-builder.js
+++ b/test/screenshot/lib/report-builder.js
@@ -873,14 +873,6 @@ class ReportBuilder {
     }
     console.log();
   }
-
-  /**
-   * @return {number}
-   * @private
-   */
-  getMaxRetries_() {
-    return this.cli_.maxRetries;
-  }
 }
 
 module.exports = ReportBuilder;

--- a/test/screenshot/lib/report-builder.js
+++ b/test/screenshot/lib/report-builder.js
@@ -647,7 +647,7 @@ class ReportBuilder {
           actual_html_file: actualHtmlFile,
           expected_image_file: expectedImageFile,
           retry_count: 0,
-          max_retries: this.cli_.maxRetries,
+          max_retries: this.cli_.retries,
         }));
       }
     }

--- a/test/screenshot/lib/selenium-api.js
+++ b/test/screenshot/lib/selenium-api.js
@@ -16,24 +16,29 @@
 
 'use strict';
 
+const Jimp = require('jimp');
+const UserAgentParser = require('useragent');
 const fs = require('mz/fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
-const UserAgentParser = require('useragent');
 
 const mdcProto = require('../proto/mdc.pb').mdc.proto;
 const seleniumProto = require('../proto/selenium.pb').selenium.proto;
 
-const {TestFile, UserAgent} = mdcProto;
+const {Screenshot, TestFile, UserAgent} = mdcProto;
+const {CaptureState} = Screenshot;
 const {BrowserVendorType, FormFactorType, Navigator} = UserAgent;
 const {RawCapabilities} = seleniumProto;
 
 const CbtApi = require('./cbt-api');
 const Cli = require('./cli');
+const Constants = require('./constants');
 const Duration = require('./duration');
 const ImageCropper = require('./image-cropper');
+const ImageDiffer = require('./image-differ');
 const {Browser, Builder, By, until} = require('selenium-webdriver');
-const {CBT_CONCURRENCY_POLL_INTERVAL_MS, CBT_CONCURRENCY_MAX_WAIT_MS} = require('./constants');
+const {CBT_CONCURRENCY_POLL_INTERVAL_MS, CBT_CONCURRENCY_MAX_WAIT_MS} = Constants;
+const {SELENIUM_FONT_LOAD_WAIT_MS} = Constants;
 
 class SeleniumApi {
   constructor() {
@@ -54,6 +59,12 @@ class SeleniumApi {
      * @private
      */
     this.imageCropper_ = new ImageCropper();
+
+    /**
+     * @type {!ImageDiffer}
+     * @private
+     */
+    this.imageDiffer_ = new ImageDiffer();
   }
 
   /**
@@ -80,7 +91,7 @@ class SeleniumApi {
       const queuedUserAgentLoggable = getLoggableAliases(queuedUserAgentAliases);
       console.log('Running user agents:', runningUserAgentLoggable);
       console.log('Queued user agents:', queuedUserAgentLoggable);
-      await this.captureAllPagesInBrowsers_({reportData, userAgents: runningUserAgents});
+      await this.captureAllPagesInAllBrowsers_({reportData, userAgents: runningUserAgents});
     }
 
     return reportData;
@@ -92,10 +103,10 @@ class SeleniumApi {
    * @return {!Promise<void>}
    * @private
    */
-  async captureAllPagesInBrowsers_({reportData, userAgents}) {
+  async captureAllPagesInAllBrowsers_({reportData, userAgents}) {
     const promises = [];
     for (const userAgent of userAgents) {
-      promises.push(this.captureAllPagesInBrowser_({reportData, userAgent}));
+      promises.push(this.captureAllPagesInOneBrowser_({reportData, userAgent}));
     }
     await Promise.all(promises);
   }
@@ -106,7 +117,7 @@ class SeleniumApi {
    * @return {!Promise<void>}
    * @private
    */
-  async captureAllPagesInBrowser_({reportData, userAgent}) {
+  async captureAllPagesInOneBrowser_({reportData, userAgent}) {
     /** @type {!IWebDriver} */
     const driver = await this.createWebDriver_({reportData, userAgent});
 
@@ -156,6 +167,10 @@ class SeleniumApi {
         );
         await this.sleep_(waitTimeMs);
         continue;
+      }
+
+      if (this.cli_.maxParallels) {
+        return max - active;
       }
 
       // If nobody else is running any tests, run half the number of concurrent tests allowed by our CBT account.
@@ -301,19 +316,13 @@ class SeleniumApi {
    * @private
    */
   async driveBrowser_({reportData, userAgent, driver}) {
-    // await driver.get('http://www.google.com/ncr');
-    // await driver.findElement(By.name('q')).sendKeys('webdriver');
-    // await driver.findElement(By.name('btnK')).click();
-    // await driver.wait(until.titleIs('webdriver - Google Search'), 1000);
-    // await driver.sleep(1000 * 10);
-
-    // TODO(acdvorak): Set this value dynamically
-    // TODO(acdvorak): This blows up on mobile browsers
-    // NOTE(acdvorak): Setting smaller window dimensions appears to speed up the tests significantly.
     if (userAgent.form_factor_type === FormFactorType.DESKTOP) {
-      // TODO(acdvorak): Better `catch()` handler
       /** @type {!Window} */
       const window = driver.manage().window();
+
+      // Resize the browser window to roughly match a mobile browser.
+      // This reduces the byte size of the screenshot image, which speeds up the test significantly.
+      // TODO(acdvorak): Set this value dynamically
       await window.setRect({x: 0, y: 0, width: 400, height: 800}).catch(() => undefined);
     }
 
@@ -323,63 +332,127 @@ class SeleniumApi {
     const screenshotQueue = reportData.screenshots.runnable_screenshot_browser_map[userAgent.alias].screenshots;
 
     for (const screenshot of screenshotQueue) {
-      const htmlFilePath = screenshot.html_file_path;
-      const htmlFileUrl = screenshot.actual_html_file.public_url;
+      screenshot.capture_state = CaptureState.RUNNING;
 
-      const imageBuffer = await this.capturePageAsPng_({driver, userAgent, url: htmlFileUrl});
+      const diffImageResult = await this.takeScreenshotWithRetries_({driver, userAgent, screenshot, meta});
 
-      const imageFileNameSuffix = userAgent.image_filename_suffix;
-      const imageFilePathRelative = `${htmlFilePath}.${imageFileNameSuffix}.png`;
-      const imageFilePathAbsolute = path.resolve(meta.local_screenshot_image_base_dir, imageFilePathRelative);
+      screenshot.capture_state = CaptureState.DIFFED;
+      screenshot.diff_image_result = diffImageResult;
+      screenshot.diff_image_file = diffImageResult.diff_image_file;
 
-      mkdirp.sync(path.dirname(imageFilePathAbsolute));
-      await fs.writeFile(imageFilePathAbsolute, imageBuffer, {encoding: null});
-
-      screenshot.actual_image_file = TestFile.create({
-        relative_path: imageFilePathRelative,
-        absolute_path: imageFilePathAbsolute,
-        public_url: meta.remote_upload_base_url + meta.remote_upload_base_dir + imageFilePathRelative,
-      });
+      if (diffImageResult.has_changed) {
+        reportData.screenshots.changed_screenshot_list.push(screenshot);
+      } else {
+        reportData.screenshots.unchanged_screenshot_list.push(screenshot);
+      }
     }
   }
 
   /**
    * @param {!IWebDriver} driver
    * @param {!mdc.proto.UserAgent} userAgent
+   * @param {!mdc.proto.Screenshot} screenshot
+   * @param {!mdc.proto.ReportMeta} meta
+   * @return {!Promise<!mdc.proto.DiffImageResult>}
+   * @private
+   */
+  async takeScreenshotWithRetries_({driver, userAgent, screenshot, meta}) {
+    const htmlFilePath = screenshot.html_file_path;
+    let delayMs = 0;
+
+    /** @type {?mdc.proto.DiffImageResult} */
+    let diffImageResult = null;
+
+    /** @type {?number} */
+    let changedPixelCount = null;
+
+    while (screenshot.retry_count <= screenshot.max_retries) {
+      if (screenshot.retry_count > 0) {
+        const {width, height} = diffImageResult.diff_image_dimensions;
+        const retryMsg = `Retrying ${htmlFilePath} > ${userAgent.alias}`;
+        const countMsg = `attempt ${screenshot.retry_count} of ${screenshot.max_retries}`;
+        const pixelMsg = `${changedPixelCount.toLocaleString()} pixels differed`;
+        const deltaMsg = `${diffImageResult.changed_pixel_percentage}% of ${width}x${height}`;
+        console.warn(`${retryMsg} (${countMsg}). ${pixelMsg} (${deltaMsg})`);
+        delayMs = 1000;
+      }
+
+      screenshot.actual_image_file = await this.takeScreenshotWithoutRetries_({
+        meta, screenshot, userAgent, driver, delayMs,
+      });
+      diffImageResult = await this.imageDiffer_.compareOneScreenshot({meta, screenshot});
+
+      if (!diffImageResult.has_changed) {
+        break;
+      }
+
+      changedPixelCount = diffImageResult.changed_pixel_count;
+      screenshot.retry_count++;
+    }
+
+    return diffImageResult;
+  }
+
+  /**
+   * @param {!mdc.proto.ReportMeta} meta
+   * @param {!mdc.proto.Screenshot} screenshot
+   * @param {!mdc.proto.UserAgent} userAgent
+   * @param {!IWebDriver} driver
+   * @param {number=} delayMs
+   * @return {!Promise<!mdc.proto.TestFile>}
+   * @private
+   */
+  async takeScreenshotWithoutRetries_({meta, screenshot, userAgent, driver, delayMs = 0}) {
+    const htmlFilePath = screenshot.html_file_path;
+    const htmlFileUrl = screenshot.actual_html_file.public_url;
+    const imageBuffer = await this.capturePageAsPng_({driver, userAgent, url: htmlFileUrl, delayMs});
+    const imageFileNameSuffix = userAgent.image_filename_suffix;
+    const imageFilePathRelative = `${htmlFilePath}.${imageFileNameSuffix}.png`;
+    const imageFilePathAbsolute = path.resolve(meta.local_screenshot_image_base_dir, imageFilePathRelative);
+
+    mkdirp.sync(path.dirname(imageFilePathAbsolute));
+    await fs.writeFile(imageFilePathAbsolute, imageBuffer, {encoding: null});
+
+    return TestFile.create({
+      relative_path: imageFilePathRelative,
+      absolute_path: imageFilePathAbsolute,
+      public_url: meta.remote_upload_base_url + meta.remote_upload_base_dir + imageFilePathRelative,
+    });
+  }
+
+  /**
+   * @param {!IWebDriver} driver
+   * @param {!mdc.proto.UserAgent} userAgent
    * @param {string} url
+   * @param {number=} delayMs
    * @return {!Promise<!Buffer>} Buffer containing PNG image data for the cropped screenshot image
    * @private
    */
-  async capturePageAsPng_({driver, userAgent, url}) {
+  async capturePageAsPng_({driver, userAgent, url, delayMs = 0}) {
     console.log(`GET "${url}" > ${userAgent.alias}...`);
 
     await driver.get(url);
-    await driver.executeScript(`
-var timeout;
-var interval;
-var callback = arguments[arguments.length - 1];
+    await driver.executeScript('window.mdc.testFixture.attachFontObserver();');
+    await driver.wait(until.elementLocated(By.css('[data-fonts-loaded]')), SELENIUM_FONT_LOAD_WAIT_MS);
 
-interval = setInterval(function() {
-  if (window.mdc) {
-    window.mdc.testFixture.waitForFontsToLoad(function() { /*callback();*/ });
-    clearInterval(interval);
-    clearTimeout(timeout);
-  }
-}, 100);
+    if (delayMs > 0) {
+      await driver.sleep(delayMs);
+    }
 
-timeout = setTimeout(function() {
-  /*callback();*/
-  clearInterval(interval);
-  clearTimeout(timeout);
-}, 1000);
-`);
-    // TODO(acdvorak): Create a constant for font loading timeout values
-    await driver.wait(until.elementLocated(By.css('[data-fonts-loaded]')), 3000);
+    const uncroppedImageBuffer = Buffer.from(await driver.takeScreenshot(), 'base64');
+    const croppedImageBuffer = await this.imageCropper_.autoCropImage(uncroppedImageBuffer);
 
-    const uncroppedBase64Str = await driver.takeScreenshot();
-    const uncroppedPngBuffer = Buffer.from(uncroppedBase64Str, 'base64');
+    const uncroppedJimpImage = await Jimp.read(uncroppedImageBuffer);
+    const croppedJimpImage = await Jimp.read(croppedImageBuffer);
 
-    return this.imageCropper_.autoCropImage(uncroppedPngBuffer);
+    const {width: uncroppedWidth, height: uncroppedHeight} = uncroppedJimpImage.bitmap;
+    const {width: croppedWidth, height: croppedHeight} = croppedJimpImage.bitmap;
+
+    console.info(`
+Cropped ${url} > ${userAgent.alias} image from ${uncroppedWidth}x${uncroppedHeight} to ${croppedWidth}x${croppedHeight}
+`.trim());
+
+    return croppedImageBuffer;
   }
 
   /**

--- a/test/screenshot/lib/selenium-api.js
+++ b/test/screenshot/lib/selenium-api.js
@@ -429,7 +429,7 @@ class SeleniumApi {
    * @private
    */
   async capturePageAsPng_({driver, userAgent, url, delayMs = 0}) {
-    console.log(`GET "${url}" > ${userAgent.alias}...`);
+    console.log(`GET ${url} > ${userAgent.alias}...`);
 
     await driver.get(url);
     await driver.executeScript('window.mdc.testFixture.attachFontObserver();');

--- a/test/screenshot/lib/user-agent-store.js
+++ b/test/screenshot/lib/user-agent-store.js
@@ -200,11 +200,11 @@ Expected browser vendor to be one of [${validBrowserVendors}], but got '${browse
   getBrowserIconUrl_(browserVendorType) {
     /* eslint-disable max-len */
     const map = {
-      [BrowserVendorType.CHROME]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.8.0/chrome/chrome.svg',
-      [BrowserVendorType.EDGE]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.8.0/edge/edge.svg',
-      [BrowserVendorType.FIREFOX]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.8.0/firefox/firefox.svg',
-      [BrowserVendorType.IE]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.8.0/archive/internet-explorer_9-11/internet-explorer_9-11.svg',
-      [BrowserVendorType.SAFARI]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.8.0/edge/edge.svg',
+      [BrowserVendorType.CHROME]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.10.0/chrome/chrome.svg',
+      [BrowserVendorType.EDGE]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.10.0/edge/edge.svg',
+      [BrowserVendorType.FIREFOX]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.10.0/firefox/firefox.svg',
+      [BrowserVendorType.IE]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.10.0/archive/internet-explorer_9-11/internet-explorer_9-11.svg',
+      [BrowserVendorType.SAFARI]: 'https://cdnjs.cloudflare.com/ajax/libs/browser-logos/45.10.0/safari/safari.png',
     };
     /* eslint-enable max-len */
     return map[browserVendorType];

--- a/test/screenshot/mdc-button/classes/baseline-button-without-icons.html
+++ b/test/screenshot/mdc-button/classes/baseline-button-without-icons.html
@@ -41,16 +41,16 @@
         </div>
 
         <div class="test-cell test-cell--button">
-          <button class="mdc-button">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="mdc-button mdc-button--raised">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--raised">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="mdc-button mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--unelevated">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--outlined">+</button><!-- test min-width -->
         </div>
 
         <div class="test-cell test-cell--button">

--- a/test/screenshot/mdc-button/classes/baseline-link-without-icons.html
+++ b/test/screenshot/mdc-button/classes/baseline-link-without-icons.html
@@ -41,20 +41,16 @@
         </div>
 
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button">是</a>
+          <a href="#" class="mdc-button">+</a><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button mdc-button--raised">是</a>
+          <a href="#" class="mdc-button mdc-button--raised">+</a><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button mdc-button--unelevated">是</a>
+          <a href="#" class="mdc-button mdc-button--unelevated">+</a><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button mdc-button--outlined">是</a>
+          <a href="#" class="mdc-button mdc-button--outlined">+</a><!-- test min-width -->
         </div>
       </div>
     </main>

--- a/test/screenshot/mdc-button/classes/dense-button-without-icons.html
+++ b/test/screenshot/mdc-button/classes/dense-button-without-icons.html
@@ -41,16 +41,16 @@
         </div>
 
         <div class="test-cell test-cell--button">
-          <button class="mdc-button mdc-button--dense">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--dense">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="mdc-button mdc-button--dense mdc-button--raised">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--dense mdc-button--raised">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="mdc-button mdc-button--dense mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--dense mdc-button--unelevated">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
+          <button class="mdc-button mdc-button--dense mdc-button--outlined">+</button><!-- test min-width -->
         </div>
 
         <div class="test-cell test-cell--button">

--- a/test/screenshot/mdc-button/classes/dense-link-without-icons.html
+++ b/test/screenshot/mdc-button/classes/dense-link-without-icons.html
@@ -41,20 +41,16 @@
         </div>
 
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button mdc-button--dense">是</a>
+          <a href="#" class="mdc-button mdc-button--dense">+</a><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button mdc-button--dense mdc-button--raised">是</a>
+          <a href="#" class="mdc-button mdc-button--dense mdc-button--raised">+</a><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button mdc-button--dense mdc-button--unelevated">是</a>
+          <a href="#" class="mdc-button mdc-button--dense mdc-button--unelevated">+</a><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <!-- Short label text to test min-width -->
-          <a href="#" class="mdc-button mdc-button--dense mdc-button--outlined">是</a>
+          <a href="#" class="mdc-button mdc-button--dense mdc-button--outlined">+</a><!-- test min-width -->
         </div>
       </div>
     </main>

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-baseline.html
@@ -55,16 +55,16 @@
         </div>
 
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--raised">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--raised">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--unelevated">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--outlined">+</button><!-- test min-width -->
         </div>
 
         <div class="test-cell test-cell--button">

--- a/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
+++ b/test/screenshot/mdc-button/mixins/horizontal-padding-dense.html
@@ -55,16 +55,16 @@
         </div>
 
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--raised">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--raised">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--unelevated">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--unelevated">+</button><!-- test min-width -->
         </div>
         <div class="test-cell test-cell--button">
-          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">是</button> <!-- Short label text to test min-width -->
+          <button class="custom-button--horizontal-padding mdc-button mdc-button--dense mdc-button--outlined">+</button><!-- test min-width -->
         </div>
 
         <div class="test-cell test-cell--button">

--- a/test/screenshot/proto/mdc.pb.js
+++ b/test/screenshot/proto/mdc.pb.js
@@ -329,6 +329,7 @@ $root.mdc = (function() {
              * @property {mdc.proto.ILibraryVersion|null} [mdc_version] ReportMeta mdc_version
              * @property {mdc.proto.ITestFile|null} [report_html_file] ReportMeta report_html_file
              * @property {mdc.proto.ITestFile|null} [report_json_file] ReportMeta report_json_file
+             * @property {mdc.proto.ITestFile|null} [golden_json_file] ReportMeta golden_json_file
              */
 
             /**
@@ -523,6 +524,14 @@ $root.mdc = (function() {
             ReportMeta.prototype.report_json_file = null;
 
             /**
+             * ReportMeta golden_json_file.
+             * @member {mdc.proto.ITestFile|null|undefined} golden_json_file
+             * @memberof mdc.proto.ReportMeta
+             * @instance
+             */
+            ReportMeta.prototype.golden_json_file = null;
+
+            /**
              * Creates a new ReportMeta instance using the specified properties.
              * @function create
              * @memberof mdc.proto.ReportMeta
@@ -590,6 +599,8 @@ $root.mdc = (function() {
                     $root.mdc.proto.TestFile.encode(message.report_html_file, writer.uint32(/* id 21, wireType 2 =*/170).fork()).ldelim();
                 if (message.report_json_file != null && message.hasOwnProperty("report_json_file"))
                     $root.mdc.proto.TestFile.encode(message.report_json_file, writer.uint32(/* id 22, wireType 2 =*/178).fork()).ldelim();
+                if (message.golden_json_file != null && message.hasOwnProperty("golden_json_file"))
+                    $root.mdc.proto.TestFile.encode(message.golden_json_file, writer.uint32(/* id 23, wireType 2 =*/186).fork()).ldelim();
                 return writer;
             };
 
@@ -689,6 +700,9 @@ $root.mdc = (function() {
                         break;
                     case 22:
                         message.report_json_file = $root.mdc.proto.TestFile.decode(reader, reader.uint32());
+                        break;
+                    case 23:
+                        message.golden_json_file = $root.mdc.proto.TestFile.decode(reader, reader.uint32());
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -809,6 +823,11 @@ $root.mdc = (function() {
                     if (error)
                         return "report_json_file." + error;
                 }
+                if (message.golden_json_file != null && message.hasOwnProperty("golden_json_file")) {
+                    var error = $root.mdc.proto.TestFile.verify(message.golden_json_file);
+                    if (error)
+                        return "golden_json_file." + error;
+                }
                 return null;
             };
 
@@ -902,6 +921,11 @@ $root.mdc = (function() {
                         throw TypeError(".mdc.proto.ReportMeta.report_json_file: object expected");
                     message.report_json_file = $root.mdc.proto.TestFile.fromObject(object.report_json_file);
                 }
+                if (object.golden_json_file != null) {
+                    if (typeof object.golden_json_file !== "object")
+                        throw TypeError(".mdc.proto.ReportMeta.golden_json_file: object expected");
+                    message.golden_json_file = $root.mdc.proto.TestFile.fromObject(object.golden_json_file);
+                }
                 return message;
             };
 
@@ -945,6 +969,7 @@ $root.mdc = (function() {
                     object.mdc_version = null;
                     object.report_html_file = null;
                     object.report_json_file = null;
+                    object.golden_json_file = null;
                 }
                 if (message.start_time_iso_utc != null && message.hasOwnProperty("start_time_iso_utc"))
                     object.start_time_iso_utc = message.start_time_iso_utc;
@@ -993,6 +1018,8 @@ $root.mdc = (function() {
                     object.report_html_file = $root.mdc.proto.TestFile.toObject(message.report_html_file, options);
                 if (message.report_json_file != null && message.hasOwnProperty("report_json_file"))
                     object.report_json_file = $root.mdc.proto.TestFile.toObject(message.report_json_file, options);
+                if (message.golden_json_file != null && message.hasOwnProperty("golden_json_file"))
+                    object.golden_json_file = $root.mdc.proto.TestFile.toObject(message.golden_json_file, options);
                 return object;
             };
 
@@ -1021,6 +1048,7 @@ $root.mdc = (function() {
              * @property {string|null} [local_file_path] DiffBase local_file_path
              * @property {string|null} [public_url] DiffBase public_url
              * @property {mdc.proto.IGitRevision|null} [git_revision] DiffBase git_revision
+             * @property {boolean|null} [is_default_local_file] DiffBase is_default_local_file
              */
 
             /**
@@ -1078,6 +1106,14 @@ $root.mdc = (function() {
              */
             DiffBase.prototype.git_revision = null;
 
+            /**
+             * DiffBase is_default_local_file.
+             * @member {boolean} is_default_local_file
+             * @memberof mdc.proto.DiffBase
+             * @instance
+             */
+            DiffBase.prototype.is_default_local_file = false;
+
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
 
@@ -1126,6 +1162,8 @@ $root.mdc = (function() {
                     writer.uint32(/* id 4, wireType 2 =*/34).string(message.public_url);
                 if (message.git_revision != null && message.hasOwnProperty("git_revision"))
                     $root.mdc.proto.GitRevision.encode(message.git_revision, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                if (message.is_default_local_file != null && message.hasOwnProperty("is_default_local_file"))
+                    writer.uint32(/* id 6, wireType 0 =*/48).bool(message.is_default_local_file);
                 return writer;
             };
 
@@ -1174,6 +1212,9 @@ $root.mdc = (function() {
                         break;
                     case 5:
                         message.git_revision = $root.mdc.proto.GitRevision.decode(reader, reader.uint32());
+                        break;
+                    case 6:
+                        message.is_default_local_file = reader.bool();
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -1246,6 +1287,9 @@ $root.mdc = (function() {
                             return "git_revision." + error;
                     }
                 }
+                if (message.is_default_local_file != null && message.hasOwnProperty("is_default_local_file"))
+                    if (typeof message.is_default_local_file !== "boolean")
+                        return "is_default_local_file: boolean expected";
                 return null;
             };
 
@@ -1290,6 +1334,8 @@ $root.mdc = (function() {
                         throw TypeError(".mdc.proto.DiffBase.git_revision: object expected");
                     message.git_revision = $root.mdc.proto.GitRevision.fromObject(object.git_revision);
                 }
+                if (object.is_default_local_file != null)
+                    message.is_default_local_file = Boolean(object.is_default_local_file);
                 return message;
             };
 
@@ -1309,6 +1355,7 @@ $root.mdc = (function() {
                 if (options.defaults) {
                     object.type = options.enums === String ? "UNKNOWN" : 0;
                     object.input_string = "";
+                    object.is_default_local_file = false;
                 }
                 if (message.type != null && message.hasOwnProperty("type"))
                     object.type = options.enums === String ? $root.mdc.proto.DiffBase.Type[message.type] : message.type;
@@ -1329,6 +1376,8 @@ $root.mdc = (function() {
                     if (options.oneofs)
                         object.value_oneof = "git_revision";
                 }
+                if (message.is_default_local_file != null && message.hasOwnProperty("is_default_local_file"))
+                    object.is_default_local_file = message.is_default_local_file;
                 return object;
             };
 

--- a/test/screenshot/proto/mdc.pb.js
+++ b/test/screenshot/proto/mdc.pb.js
@@ -321,8 +321,8 @@ $root.mdc = (function() {
              * @property {mdc.proto.IUser|null} [user] ReportMeta user
              * @property {string|null} [host_os_name] ReportMeta host_os_name
              * @property {string|null} [cli_invocation] ReportMeta cli_invocation
-             * @property {mdc.proto.IDiffBase|null} [expected_diff_base] ReportMeta expected_diff_base
-             * @property {mdc.proto.IDiffBase|null} [actual_diff_base] ReportMeta actual_diff_base
+             * @property {mdc.proto.IDiffBase|null} [golden_diff_base] ReportMeta golden_diff_base
+             * @property {mdc.proto.IDiffBase|null} [snapshot_diff_base] ReportMeta snapshot_diff_base
              * @property {mdc.proto.IGitStatus|null} [git_status] ReportMeta git_status
              * @property {mdc.proto.ILibraryVersion|null} [node_version] ReportMeta node_version
              * @property {mdc.proto.ILibraryVersion|null} [npm_version] ReportMeta npm_version
@@ -459,20 +459,20 @@ $root.mdc = (function() {
             ReportMeta.prototype.cli_invocation = "";
 
             /**
-             * ReportMeta expected_diff_base.
-             * @member {mdc.proto.IDiffBase|null|undefined} expected_diff_base
+             * ReportMeta golden_diff_base.
+             * @member {mdc.proto.IDiffBase|null|undefined} golden_diff_base
              * @memberof mdc.proto.ReportMeta
              * @instance
              */
-            ReportMeta.prototype.expected_diff_base = null;
+            ReportMeta.prototype.golden_diff_base = null;
 
             /**
-             * ReportMeta actual_diff_base.
-             * @member {mdc.proto.IDiffBase|null|undefined} actual_diff_base
+             * ReportMeta snapshot_diff_base.
+             * @member {mdc.proto.IDiffBase|null|undefined} snapshot_diff_base
              * @memberof mdc.proto.ReportMeta
              * @instance
              */
-            ReportMeta.prototype.actual_diff_base = null;
+            ReportMeta.prototype.snapshot_diff_base = null;
 
             /**
              * ReportMeta git_status.
@@ -574,10 +574,10 @@ $root.mdc = (function() {
                     writer.uint32(/* id 13, wireType 2 =*/106).string(message.host_os_name);
                 if (message.cli_invocation != null && message.hasOwnProperty("cli_invocation"))
                     writer.uint32(/* id 14, wireType 2 =*/114).string(message.cli_invocation);
-                if (message.expected_diff_base != null && message.hasOwnProperty("expected_diff_base"))
-                    $root.mdc.proto.DiffBase.encode(message.expected_diff_base, writer.uint32(/* id 15, wireType 2 =*/122).fork()).ldelim();
-                if (message.actual_diff_base != null && message.hasOwnProperty("actual_diff_base"))
-                    $root.mdc.proto.DiffBase.encode(message.actual_diff_base, writer.uint32(/* id 16, wireType 2 =*/130).fork()).ldelim();
+                if (message.golden_diff_base != null && message.hasOwnProperty("golden_diff_base"))
+                    $root.mdc.proto.DiffBase.encode(message.golden_diff_base, writer.uint32(/* id 15, wireType 2 =*/122).fork()).ldelim();
+                if (message.snapshot_diff_base != null && message.hasOwnProperty("snapshot_diff_base"))
+                    $root.mdc.proto.DiffBase.encode(message.snapshot_diff_base, writer.uint32(/* id 16, wireType 2 =*/130).fork()).ldelim();
                 if (message.git_status != null && message.hasOwnProperty("git_status"))
                     $root.mdc.proto.GitStatus.encode(message.git_status, writer.uint32(/* id 17, wireType 2 =*/138).fork()).ldelim();
                 if (message.node_version != null && message.hasOwnProperty("node_version"))
@@ -667,10 +667,10 @@ $root.mdc = (function() {
                         message.cli_invocation = reader.string();
                         break;
                     case 15:
-                        message.expected_diff_base = $root.mdc.proto.DiffBase.decode(reader, reader.uint32());
+                        message.golden_diff_base = $root.mdc.proto.DiffBase.decode(reader, reader.uint32());
                         break;
                     case 16:
-                        message.actual_diff_base = $root.mdc.proto.DiffBase.decode(reader, reader.uint32());
+                        message.snapshot_diff_base = $root.mdc.proto.DiffBase.decode(reader, reader.uint32());
                         break;
                     case 17:
                         message.git_status = $root.mdc.proto.GitStatus.decode(reader, reader.uint32());
@@ -769,15 +769,15 @@ $root.mdc = (function() {
                 if (message.cli_invocation != null && message.hasOwnProperty("cli_invocation"))
                     if (!$util.isString(message.cli_invocation))
                         return "cli_invocation: string expected";
-                if (message.expected_diff_base != null && message.hasOwnProperty("expected_diff_base")) {
-                    var error = $root.mdc.proto.DiffBase.verify(message.expected_diff_base);
+                if (message.golden_diff_base != null && message.hasOwnProperty("golden_diff_base")) {
+                    var error = $root.mdc.proto.DiffBase.verify(message.golden_diff_base);
                     if (error)
-                        return "expected_diff_base." + error;
+                        return "golden_diff_base." + error;
                 }
-                if (message.actual_diff_base != null && message.hasOwnProperty("actual_diff_base")) {
-                    var error = $root.mdc.proto.DiffBase.verify(message.actual_diff_base);
+                if (message.snapshot_diff_base != null && message.hasOwnProperty("snapshot_diff_base")) {
+                    var error = $root.mdc.proto.DiffBase.verify(message.snapshot_diff_base);
                     if (error)
-                        return "actual_diff_base." + error;
+                        return "snapshot_diff_base." + error;
                 }
                 if (message.git_status != null && message.hasOwnProperty("git_status")) {
                     var error = $root.mdc.proto.GitStatus.verify(message.git_status);
@@ -862,15 +862,15 @@ $root.mdc = (function() {
                     message.host_os_name = String(object.host_os_name);
                 if (object.cli_invocation != null)
                     message.cli_invocation = String(object.cli_invocation);
-                if (object.expected_diff_base != null) {
-                    if (typeof object.expected_diff_base !== "object")
-                        throw TypeError(".mdc.proto.ReportMeta.expected_diff_base: object expected");
-                    message.expected_diff_base = $root.mdc.proto.DiffBase.fromObject(object.expected_diff_base);
+                if (object.golden_diff_base != null) {
+                    if (typeof object.golden_diff_base !== "object")
+                        throw TypeError(".mdc.proto.ReportMeta.golden_diff_base: object expected");
+                    message.golden_diff_base = $root.mdc.proto.DiffBase.fromObject(object.golden_diff_base);
                 }
-                if (object.actual_diff_base != null) {
-                    if (typeof object.actual_diff_base !== "object")
-                        throw TypeError(".mdc.proto.ReportMeta.actual_diff_base: object expected");
-                    message.actual_diff_base = $root.mdc.proto.DiffBase.fromObject(object.actual_diff_base);
+                if (object.snapshot_diff_base != null) {
+                    if (typeof object.snapshot_diff_base !== "object")
+                        throw TypeError(".mdc.proto.ReportMeta.snapshot_diff_base: object expected");
+                    message.snapshot_diff_base = $root.mdc.proto.DiffBase.fromObject(object.snapshot_diff_base);
                 }
                 if (object.git_status != null) {
                     if (typeof object.git_status !== "object")
@@ -937,8 +937,8 @@ $root.mdc = (function() {
                     object.user = null;
                     object.host_os_name = "";
                     object.cli_invocation = "";
-                    object.expected_diff_base = null;
-                    object.actual_diff_base = null;
+                    object.golden_diff_base = null;
+                    object.snapshot_diff_base = null;
                     object.git_status = null;
                     object.node_version = null;
                     object.npm_version = null;
@@ -977,10 +977,10 @@ $root.mdc = (function() {
                     object.host_os_name = message.host_os_name;
                 if (message.cli_invocation != null && message.hasOwnProperty("cli_invocation"))
                     object.cli_invocation = message.cli_invocation;
-                if (message.expected_diff_base != null && message.hasOwnProperty("expected_diff_base"))
-                    object.expected_diff_base = $root.mdc.proto.DiffBase.toObject(message.expected_diff_base, options);
-                if (message.actual_diff_base != null && message.hasOwnProperty("actual_diff_base"))
-                    object.actual_diff_base = $root.mdc.proto.DiffBase.toObject(message.actual_diff_base, options);
+                if (message.golden_diff_base != null && message.hasOwnProperty("golden_diff_base"))
+                    object.golden_diff_base = $root.mdc.proto.DiffBase.toObject(message.golden_diff_base, options);
+                if (message.snapshot_diff_base != null && message.hasOwnProperty("snapshot_diff_base"))
+                    object.snapshot_diff_base = $root.mdc.proto.DiffBase.toObject(message.snapshot_diff_base, options);
                 if (message.git_status != null && message.hasOwnProperty("git_status"))
                     object.git_status = $root.mdc.proto.GitStatus.toObject(message.git_status, options);
                 if (message.node_version != null && message.hasOwnProperty("node_version"))
@@ -5391,6 +5391,8 @@ $root.mdc = (function() {
              * @property {mdc.proto.ITestFile|null} [actual_image_file] Screenshot actual_image_file
              * @property {mdc.proto.ITestFile|null} [diff_image_file] Screenshot diff_image_file
              * @property {mdc.proto.IDiffImageResult|null} [diff_image_result] Screenshot diff_image_result
+             * @property {number|null} [retry_count] Screenshot retry_count
+             * @property {number|null} [max_retries] Screenshot max_retries
              */
 
             /**
@@ -5497,6 +5499,22 @@ $root.mdc = (function() {
             Screenshot.prototype.diff_image_result = null;
 
             /**
+             * Screenshot retry_count.
+             * @member {number} retry_count
+             * @memberof mdc.proto.Screenshot
+             * @instance
+             */
+            Screenshot.prototype.retry_count = 0;
+
+            /**
+             * Screenshot max_retries.
+             * @member {number} max_retries
+             * @memberof mdc.proto.Screenshot
+             * @instance
+             */
+            Screenshot.prototype.max_retries = 0;
+
+            /**
              * Creates a new Screenshot instance using the specified properties.
              * @function create
              * @memberof mdc.proto.Screenshot
@@ -5542,6 +5560,10 @@ $root.mdc = (function() {
                     $root.mdc.proto.TestFile.encode(message.diff_image_file, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
                 if (message.diff_image_result != null && message.hasOwnProperty("diff_image_result"))
                     $root.mdc.proto.DiffImageResult.encode(message.diff_image_result, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+                if (message.retry_count != null && message.hasOwnProperty("retry_count"))
+                    writer.uint32(/* id 12, wireType 0 =*/96).uint32(message.retry_count);
+                if (message.max_retries != null && message.hasOwnProperty("max_retries"))
+                    writer.uint32(/* id 13, wireType 0 =*/104).uint32(message.max_retries);
                 return writer;
             };
 
@@ -5609,6 +5631,12 @@ $root.mdc = (function() {
                     case 11:
                         message.diff_image_result = $root.mdc.proto.DiffImageResult.decode(reader, reader.uint32());
                         break;
+                    case 12:
+                        message.retry_count = reader.uint32();
+                        break;
+                    case 13:
+                        message.max_retries = reader.uint32();
+                        break;
                     default:
                         reader.skipType(tag & 7);
                         break;
@@ -5667,7 +5695,6 @@ $root.mdc = (function() {
                     case 2:
                     case 3:
                     case 4:
-                    case 5:
                         break;
                     }
                 if (message.user_agent != null && message.hasOwnProperty("user_agent")) {
@@ -5708,6 +5735,12 @@ $root.mdc = (function() {
                     if (error)
                         return "diff_image_result." + error;
                 }
+                if (message.retry_count != null && message.hasOwnProperty("retry_count"))
+                    if (!$util.isInteger(message.retry_count))
+                        return "retry_count: integer expected";
+                if (message.max_retries != null && message.hasOwnProperty("max_retries"))
+                    if (!$util.isInteger(message.max_retries))
+                        return "max_retries: integer expected";
                 return null;
             };
 
@@ -5764,13 +5797,9 @@ $root.mdc = (function() {
                 case 3:
                     message.capture_state = 3;
                     break;
-                case "CAPTURED":
+                case "DIFFED":
                 case 4:
                     message.capture_state = 4;
-                    break;
-                case "DIFFED":
-                case 5:
-                    message.capture_state = 5;
                     break;
                 }
                 if (object.user_agent != null) {
@@ -5810,6 +5839,10 @@ $root.mdc = (function() {
                         throw TypeError(".mdc.proto.Screenshot.diff_image_result: object expected");
                     message.diff_image_result = $root.mdc.proto.DiffImageResult.fromObject(object.diff_image_result);
                 }
+                if (object.retry_count != null)
+                    message.retry_count = object.retry_count >>> 0;
+                if (object.max_retries != null)
+                    message.max_retries = object.max_retries >>> 0;
                 return message;
             };
 
@@ -5838,6 +5871,8 @@ $root.mdc = (function() {
                     object.actual_image_file = null;
                     object.diff_image_file = null;
                     object.diff_image_result = null;
+                    object.retry_count = 0;
+                    object.max_retries = 0;
                 }
                 if (message.is_runnable != null && message.hasOwnProperty("is_runnable"))
                     object.is_runnable = message.is_runnable;
@@ -5861,6 +5896,10 @@ $root.mdc = (function() {
                     object.diff_image_file = $root.mdc.proto.TestFile.toObject(message.diff_image_file, options);
                 if (message.diff_image_result != null && message.hasOwnProperty("diff_image_result"))
                     object.diff_image_result = $root.mdc.proto.DiffImageResult.toObject(message.diff_image_result, options);
+                if (message.retry_count != null && message.hasOwnProperty("retry_count"))
+                    object.retry_count = message.retry_count;
+                if (message.max_retries != null && message.hasOwnProperty("max_retries"))
+                    object.max_retries = message.max_retries;
                 return object;
             };
 
@@ -5903,8 +5942,7 @@ $root.mdc = (function() {
              * @property {number} QUEUED=1 QUEUED value
              * @property {number} SKIPPED=2 SKIPPED value
              * @property {number} RUNNING=3 RUNNING value
-             * @property {number} CAPTURED=4 CAPTURED value
-             * @property {number} DIFFED=5 DIFFED value
+             * @property {number} DIFFED=4 DIFFED value
              */
             Screenshot.CaptureState = (function() {
                 var valuesById = {}, values = Object.create(valuesById);
@@ -5912,8 +5950,7 @@ $root.mdc = (function() {
                 values[valuesById[1] = "QUEUED"] = 1;
                 values[valuesById[2] = "SKIPPED"] = 2;
                 values[valuesById[3] = "RUNNING"] = 3;
-                values[valuesById[4] = "CAPTURED"] = 4;
-                values[valuesById[5] = "DIFFED"] = 5;
+                values[valuesById[4] = "DIFFED"] = 4;
                 return values;
             })();
 

--- a/test/screenshot/proto/mdc.proto
+++ b/test/screenshot/proto/mdc.proto
@@ -52,6 +52,7 @@ message ReportMeta {
 
   TestFile report_html_file = 21;
   TestFile report_json_file = 22;
+  TestFile golden_json_file = 23;
 }
 
 message DiffBase {
@@ -70,6 +71,8 @@ message DiffBase {
     string public_url = 4;
     GitRevision git_revision = 5;
   }
+
+  bool is_default_local_file = 6;
 }
 
 message GitRevision {

--- a/test/screenshot/proto/mdc.proto
+++ b/test/screenshot/proto/mdc.proto
@@ -42,8 +42,8 @@ message ReportMeta {
   string host_os_name = 13;
   string cli_invocation = 14;
 
-  DiffBase expected_diff_base = 15;
-  DiffBase actual_diff_base = 16;
+  DiffBase golden_diff_base = 15;
+  DiffBase snapshot_diff_base = 16;
   GitStatus git_status = 17;
 
   LibraryVersion node_version = 18;
@@ -232,8 +232,7 @@ message Screenshot {
     QUEUED = 1;
     SKIPPED = 2;
     RUNNING = 3;
-    CAPTURED = 4;
-    DIFFED = 5;
+    DIFFED = 4;
   }
 
   bool is_runnable = 1;
@@ -248,6 +247,9 @@ message Screenshot {
   TestFile actual_image_file = 9;
   TestFile diff_image_file = 10;
   DiffImageResult diff_image_result = 11;
+
+  uint32 retry_count = 12;
+  uint32 max_retries = 13;
 }
 
 message Dimensions {

--- a/test/screenshot/report/_metadata.hbs
+++ b/test/screenshot/report/_metadata.hbs
@@ -39,13 +39,13 @@
         <tr class="report-metadata__row--top-divider">
           <th class="report-metadata__cell report-metadata__cell--key">Golden:</th>
           <td class="report-metadata__cell report-metadata__cell--val">
-            {{getDiffBaseMarkup meta.expected_diff_base}}
+            {{getDiffBaseMarkup meta.golden_diff_base}}
           </td>
         </tr>
         <tr>
           <th class="report-metadata__cell report-metadata__cell--key">Snapshot:</th>
           <td class="report-metadata__cell report-metadata__cell--val">
-            {{getDiffBaseMarkup meta.actual_diff_base}}
+            {{getDiffBaseMarkup meta.snapshot_diff_base}}
             {{getLocalChangesMarkup meta.git_status}}
           </td>
         </tr>

--- a/test/screenshot/report/_metadata.hbs
+++ b/test/screenshot/report/_metadata.hbs
@@ -39,13 +39,13 @@
         <tr class="report-metadata__row--top-divider">
           <th class="report-metadata__cell report-metadata__cell--key">Golden:</th>
           <td class="report-metadata__cell report-metadata__cell--val">
-            {{getDiffBaseMarkup meta.golden_diff_base}}
+            {{getDiffBaseMarkup meta.golden_diff_base meta}}
           </td>
         </tr>
         <tr>
           <th class="report-metadata__cell report-metadata__cell--key">Snapshot:</th>
           <td class="report-metadata__cell report-metadata__cell--val">
-            {{getDiffBaseMarkup meta.snapshot_diff_base}}
+            {{getDiffBaseMarkup meta.snapshot_diff_base meta}}
             {{getLocalChangesMarkup meta.git_status}}
           </td>
         </tr>

--- a/test/screenshot/resemble.json
+++ b/test/screenshot/resemble.json
@@ -1,8 +1,0 @@
-{
-  "output": {
-    "transparency": 0
-  },
-  "mdc_screenshot_test": {
-    "min_changed_pixel_count": 10
-  }
-}

--- a/test/screenshot/run.js
+++ b/test/screenshot/run.js
@@ -60,10 +60,15 @@ async function run() {
       console.log('Offline mode!');
     }
 
-    cmd().catch((err) => {
-      console.error(err);
-      process.exit(ExitCode.UNKNOWN_ERROR);
-    });
+    cmd()
+      .then(
+        (exitCode = 0) => {
+          process.exit(exitCode);
+        },
+        (err) => {
+          console.error(err);
+          process.exit(ExitCode.UNKNOWN_ERROR);
+        });
   } else {
     console.error(`Error: Unknown command: '${cli.command}'`);
     process.exit(ExitCode.UNSUPPORTED_CLI_COMMAND);


### PR DESCRIPTION
### How to test

Run this command over and over, and scan the console output for lines that start with "Retry":

```bash
npm run screenshot:test -- \
  --url=mdc-button/classes/baseline-button-with-icons.html \
  --browser=desktop_windows_ie@11
```

### What it does

- Automatically retries screenshots that have diffs up to 3 times
    - Minimizes noisy diffs due to flaky browser rendering
    - Significantly reduces noise across all 4 browsers, especially IE 11 💩
- Compares each screenshot to its golden counterpart immediately after capturing it, instead of waiting until all screenshots have been captured
- Adds `--retries` and `--max-parallels` CLI options
- Fixes buggy parsing of `--diff-base` local `golden.json` files
- Increases the minimum pixel diff threshold from 10 pixels to 15 pixels
    - Avoids noisy FAB diffs in Edge
- Changes the `min-width` button label text from `是` to `+`
    - Fixes flaky font rendering in Firefox
- Updates `golden.json` with new `min-width` button screenshots
- Returns a non-zero exit code from the `npm run screenshot:test` if there are any screenshot changes (diffs/added/removed)
    - Necessary for Travis CI (and to be consistent with UNIX conventions)
- Removes `fixture.js` from `.eslintignore`
- Renames `resemble.json` to `diffing.json`
- Updates example report links and console output in README

### Example output

Report page:

- https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/07_08_26_379/report/report.html

Console output:

```
GET https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/07_25_45_444/mdc-button/classes/baseline-button-with-icons.html > desktop_windows_ie@11...
Cropped https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/14/07_25_45_444/mdc-button/classes/baseline-button-with-icons.html > desktop_windows_ie@11 image from 384x687 to 348x628
Retrying mdc-button/classes/baseline-button-with-icons.html > desktop_windows_ie@11 (attempt 1 of 3). 1,873 pixels differed (0.9% of 348x628)
```
