### PR TITLE
docs: Update list of officially supported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,8 @@ This will produce a Material Design ripple on the button!
 
 We officially support the last two versions of every major browser. Specifically, we test on the following browsers:
 
-- Chrome
-- Safari
-- Firefox
-- IE 11/Edge
-- Opera
-- Mobile Safari
-- Chrome on Android
+- **Chrome** on Android, Windows, macOS, and Linux
+- **Firefox** on Windows, macOS, and Linux
+- **Safari** on iOS and macOS
+- **Edge** on Windows
+- **IE 11** on Windows


### PR DESCRIPTION
- Remove "Opera". We don't test in it, and it uses the same rendering engine as Chrome (Blink)
- Reorganize list into a map of browsers to OSes (I find it easier to read)