### PR TITLE
fix(theme): Don't error on CSS variables supplied to mdc-theme-prop

### DIFF
--- a/packages/mdc-theme/_mixins.scss
+++ b/packages/mdc-theme/_mixins.scss
@@ -22,7 +22,7 @@
 // $edgeOptOut controls whether to feature-detect around Edge to avoid emitting CSS variables for it,
 // intended for use in cases where interactions with pseudo-element styles cause problems due to Edge bugs.
 @mixin mdc-theme-prop($property, $style, $important: false, $edgeOptOut: false) {
-  @if type-of($style) == "color" or $style == "currentColor" {
+  @if mdc-theme-is-valid-theme-prop-value_($style) {
     @if $important {
       #{$property}: $style !important;
     } @else {

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -98,8 +98,8 @@ $mdc-theme-property-values: (
   text-icon-on-dark: mdc-theme-ink-color-for-fill_(icon, dark)
 );
 
-// If `$property` is a literal color value (e.g., `blue`, `#fff`), it is returned verbatim. Otherwise, the value of the
-// corresponding theme property (from `$mdc-theme-property-values`) is returned. If `$property` is not a color and no
+// If `$style` is a literal color value (e.g., `blue`, `#fff`), it is returned verbatim. Otherwise, the value of the
+// corresponding theme property (from `$mdc-theme-property-values`) is returned. If `$style` is not a color and no
 // such theme property exists, an error is thrown.
 //
 // This is mainly useful in situations where `mdc-theme-prop` cannot be used directly (e.g., `box-shadow`).
@@ -110,16 +110,16 @@ $mdc-theme-property-values: (
 // 2. mdc-theme-prop-value(blue)    => "blue"
 //
 // NOTE: This function must be defined in _variables.scss instead of _functions.scss to avoid circular imports.
-@function mdc-theme-prop-value($property) {
-  @if type-of($property) == "color" or $property == "currentColor" {
-    @return $property;
+@function mdc-theme-prop-value($style) {
+  @if mdc-theme-is-valid-theme-prop-value_($style) {
+    @return $style;
   }
 
-  @if not map-has-key($mdc-theme-property-values, $property) {
-    @error "Invalid theme property: '#{$property}'. Choose one of: #{map-keys($mdc-theme-property-values)}";
+  @if not map-has-key($mdc-theme-property-values, $style) {
+    @error "Invalid theme property: '#{$style}'. Choose one of: #{map-keys($mdc-theme-property-values)}";
   }
 
-  @return map-get($mdc-theme-property-values, $property);
+  @return map-get($mdc-theme-property-values, $style);
 }
 
 // NOTE: This function must be defined in _variables.scss instead of _functions.scss to avoid circular imports.
@@ -132,4 +132,9 @@ $mdc-theme-property-values: (
   }
 
   @return map-get($color-map-for-tone, $text-style);
+}
+
+// NOTE: This function is depended upon by mdc-theme-prop-value (above) and thus must be defined in this file.
+@function mdc-theme-is-valid-theme-prop-value_($style) {
+  @return type-of($style) == "color" or $style == "currentColor" or str_slice($style, 1, 4) == 'var(';
 }


### PR DESCRIPTION
This allows `mdc-theme-prop` and `mdc-theme-prop-value` to be passed a CSS variable (i.e. `var(--foo)` and treat it the same as a color literal or `currentColor`.

I also noticed we were mistakenly using the wrong variable name in `mdc-theme-prop-value` and fixed it.