### PR TITLE
chore(infrastructure): Post-merge Travis runs should fail w/ diffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 branches:
+  # Only run Travis on:
+  #   A) Commits made directly to the `master` branch (i.e., merged PRs); and
+  #   B) PRs that will eventually be merged into `master`.
+  # This prevents excessive resource usage and CI slowness.
   only:
   - master
 matrix:

--- a/test/screenshot/lib/controller.js
+++ b/test/screenshot/lib/controller.js
@@ -208,8 +208,9 @@ class Controller {
    * @return {!Promise<number>}
    */
   async getTestExitCode(reportData) {
-    // Don't fail Travis builds when screenshots change. The diffs are reported in GitHub instead.
-    if (process.env.TRAVIS === 'true') {
+    // Pull requests display screenshot diffs as a separate "status check" in the GitHub UI, so we don't want to mark
+    // the Travis run as "failed".
+    if (Number(process.env.TRAVIS_PULL_REQUEST)) {
       return ExitCode.OK;
     }
 
@@ -247,6 +248,7 @@ class Controller {
   }
 
   /**
+   * @param {string} title
    * @param {!Array<!mdc.proto.Screenshot>} screenshots
    * @private
    */


### PR DESCRIPTION
PRs have a separate "status check" for screenshot diffs in the GitHub UI, so we don't want to fail the Travis job if a PR has diffs.

However, once the PR has been merged into `master`, we absolutely _should_ fail the Travis job if there are any diffs.