### PR TITLE
chore(infrastructure): Skip screenshot tests on external PRs

### DIFF
--- a/test/screenshot/commands/test.js
+++ b/test/screenshot/commands/test.js
@@ -19,9 +19,17 @@
 const BuildCommand = require('./build');
 const Controller = require('../lib/controller');
 const GitHubApi = require('../lib/github-api');
+const {ExitCode} = require('../lib/constants');
 
 module.exports = {
   async runAsync() {
+    const travisPrSlug = process.env.TRAVIS_PULL_REQUEST_SLUG;
+    if (travisPrSlug && !travisPrSlug.startsWith('material-components/')) {
+      console.log('Screenshot tests are not supported on external PRs.');
+      console.log('Skipping screenshot tests.');
+      return ExitCode.OK;
+    }
+
     await BuildCommand.runAsync();
     const controller = new Controller();
     const gitHubApi = new GitHubApi();
@@ -31,7 +39,8 @@ module.exports = {
 
     const {isTestable, prNumber} = controller.checkIsTestable(reportData);
     if (!isTestable) {
-      console.log(`PR #${prNumber} does not contain any testable source file changes.\nSkipping screenshot tests.`);
+      console.log(`PR #${prNumber} does not contain any testable source file changes.`);
+      console.log('Skipping screenshot tests.');
       return;
     }
 

--- a/test/screenshot/commands/travis.sh
+++ b/test/screenshot/commands/travis.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+function exit_if_external_pr() {
+  if [[ -n "$TRAVIS_PULL_REQUEST_SLUG" ]] && [[ ! "$TRAVIS_PULL_REQUEST_SLUG" =~ ^material-components/ ]]; then
+    echo 'Screenshot tests are not supported on external PRs.'
+    echo 'Skipping screenshot tests.'
+    exit
+  fi
+}
+
 function extract_api_credentials() {
   openssl aes-256-cbc -K $encrypted_eead2343bb54_key -iv $encrypted_eead2343bb54_iv \
     -in test/screenshot/auth/travis.tar.enc -out test/screenshot/auth/travis.tar -d
@@ -16,7 +24,7 @@ function extract_api_credentials() {
 }
 
 function install_google_cloud_sdk() {
-  if [ ! -d $HOME/google-cloud-sdk ]; then
+  if [[ ! -d $HOME/google-cloud-sdk ]]; then
     curl -o /tmp/gcp-sdk.bash https://sdk.cloud.google.com
     chmod +x /tmp/gcp-sdk.bash
     /tmp/gcp-sdk.bash --disable-prompts
@@ -30,13 +38,14 @@ function install_google_cloud_sdk() {
   gcloud components install gsutil
 
   which gsutil 2>&1 > /dev/null
-  if [ $? != 0 ]; then
+  if [[ $? != 0 ]]; then
     pip install --upgrade pip
     pip install gsutil
   fi
 }
 
 if [ "$TEST_SUITE" == 'screenshot' ]; then
+  exit_if_external_pr
   extract_api_credentials
   install_google_cloud_sdk
 fi


### PR DESCRIPTION
Avoids spurious Travis test failures.

External PRs are a security risk because they contain untrusted code. Therefore, Travis does not pass env vars to them, which means we don't have access to CBT/GCS credentials.

We might as well check for this condition and exit early instead of waiting 2 minutes to throw an error.