### PR TITLE
feat(tab): Update tab color and typography

### DIFF
--- a/packages/mdc-tab/_variables.scss
+++ b/packages/mdc-tab/_variables.scss
@@ -14,4 +14,6 @@
 // limitations under the License.
 //
 
-$mdc-tab-baseline-color: rgba(25, 25, 25, .6);
+$mdc-tab-icon-size: 24px;
+$mdc-tab-height: 48px;
+$mdc-tab-stacked-height: 72px;

--- a/packages/mdc-tab/_variables.scss
+++ b/packages/mdc-tab/_variables.scss
@@ -17,3 +17,5 @@
 $mdc-tab-icon-size: 24px;
 $mdc-tab-height: 48px;
 $mdc-tab-stacked-height: 72px;
+$mdc-tab-text-label-opacity: .6;
+$mdc-tab-icon-opacity: .54;

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -73,14 +73,14 @@
   display: inline-block;
   padding: 16px 0 20px;
   line-height: 1;
-  opacity: 0.6;
+  opacity: $mdc-tab-text-label-opacity;
 }
 
 .mdc-tab__icon {
   width: $mdc-tab-icon-size;
   height: $mdc-tab-icon-size;
   padding: 12px 0;
-  opacity: 0.54;
+  opacity: $mdc-tab-icon-opacity;
 }
 
 .mdc-tab--stacked {

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -23,15 +23,16 @@
 @import "./variables";
 
 .mdc-tab {
-  @include mdc-tab-text-label-color($mdc-tab-baseline-color);
-  @include mdc-tab-icon-color($mdc-tab-baseline-color);
+  @include mdc-tab-text-label-color(on-surface);
+  @include mdc-tab-icon-color(on-surface);
   @include mdc-tab-indicator-surface;
+  @include mdc-typography(button);
 
   display: flex;
   flex: 1 0 auto;
   justify-content: center;
   box-sizing: border-box;
-  height: 48px;
+  height: $mdc-tab-height;
   padding: 0 24px;
   border: none;
   outline: none;
@@ -69,22 +70,21 @@
 }
 
 .mdc-tab__text-label {
-  @include mdc-typography-base;
-
   display: inline-block;
   padding: 16px 0 20px;
-  font-size: 14px;
-  font-weight: 500;
+  line-height: 1;
+  opacity: 0.6;
 }
 
 .mdc-tab__icon {
-  width: 24px;
-  height: 24px;
+  width: $mdc-tab-icon-size;
+  height: $mdc-tab-icon-size;
   padding: 12px 0;
+  opacity: 0.54;
 }
 
 .mdc-tab--stacked {
-  height: 72px;
+  height: $mdc-tab-stacked-height;
 }
 
 .mdc-tab--stacked .mdc-tab__content {
@@ -98,7 +98,6 @@
 
 .mdc-tab--stacked .mdc-tab__text-label {
   padding: 0 0 16px;
-  line-height: 12px;
 }
 
 // The [de]activation animation affects color for text label and icon
@@ -106,7 +105,7 @@
 .mdc-tab--animating-activate .mdc-tab__icon,
 .mdc-tab--animating-deactivate .mdc-tab__text-label,
 .mdc-tab--animating-deactivate .mdc-tab__icon {
-  transition: 150ms color linear;
+  transition: 150ms color linear, 150ms opacity linear;
 }
 
 // The activation animation has a delay of 100ms
@@ -118,6 +117,11 @@
 .mdc-tab--active {
   @include mdc-tab-text-label-color(primary);
   @include mdc-tab-icon-color(primary);
+
+  .mdc-tab__text-label,
+  .mdc-tab__icon {
+    opacity: 1;
+  }
 }
 
 .mdc-tab .mdc-tab__icon + .mdc-tab__text-label {

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -72,8 +72,8 @@
 .mdc-tab__text-label {
   display: inline-block;
   padding: 16px 0 20px;
-  line-height: 1;
   opacity: $mdc-tab-text-label-opacity;
+  line-height: 1;
 }
 
 .mdc-tab__icon {

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -73,6 +73,10 @@
   display: inline-block;
   padding: 16px 0 20px;
   opacity: $mdc-tab-text-label-opacity;
+  // Setting line-height here overrides the line-height from the typography
+  // mixin above. The line-height needs to be overridden so that the spacing
+  // between the text label and the icon as well as the text label and the
+  // bottom of the tab remain the same.
   line-height: 1;
 }
 


### PR DESCRIPTION
Update the use of color and typography in MDCTab to use the most-recent mixins. Add variables for icon size, tab height, text label opacity, and icon opacity. Closes #3058 