### PR TITLE
chore: Remove unused extended-fab directory

### DIFF
--- a/packages/mdc-extended-fab/README.md
+++ b/packages/mdc-extended-fab/README.md
@@ -1,4 +1,0 @@
-# Extended Floating Action Button
-
-The [Extended Floating Action Button component](https://material.io/go/design-extended-fab) is yet to be completed, please follow the [tracking issue](https://github.com/material-components/material-components-web/issues/2663) for more information.
-


### PR DESCRIPTION
Removes the `mdc-extended-fab` readme and directory since we're merging extending fab into `mdc-fab`.