### PR TITLE
docs(tabs): Update metadata and synopses

### DIFF
--- a/docs/docsite-tabs.md
+++ b/docs/docsite-tabs.md
@@ -1,0 +1,13 @@
+---
+# This file exists describes the directory housing the tab components. If the
+# URL is visited, it will immediately redirect to the Tab component.
+title: "Tabs"
+layout: detail
+section: components
+excerpt: "Components for tabbed navigation."
+iconId: tabs
+path: /catalog/tabs/
+redirect_path: /catalog/tabs/tab/
+---
+
+{% include redirect-page.html %}

--- a/packages/mdc-tab-indicator/README.md
+++ b/packages/mdc-tab-indicator/README.md
@@ -2,21 +2,14 @@
 title: "Tab Indicator"
 layout: detail
 section: components
-excerpt: "Tab Indicator is a visual guide that shows which Tab is active"
-iconId: tab
-path: /catalog/tab/
+excerpt: "A visual guide that shows which Tab is active."
+iconId: tabs
+path: /catalog/tabs/indicator/
 -->
 
 # Tab Indicator
 
-<!--<div class="article__asset">
-  <a class="article__asset-link"
-     href="https://material-components-web.appspot.com/tab-indicator.html">
-    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/tab-indicator.png" width="363" alt="Tab indicator screenshot">
-  </a>
-</div>-->
-
-Tab Indicator is a visual guide that shows which Tab is active
+A Tab Indicator is a visual guide that shows which Tab is active.
 
 ## Design & API Documentation
 

--- a/packages/mdc-tab-scroller/README.md
+++ b/packages/mdc-tab-scroller/README.md
@@ -2,21 +2,14 @@
 title: "Tab Scroller"
 layout: detail
 section: components
-excerpt: "Tab Scroller allows for smoothing animated scrolling of tab content"
-iconId: tab
-path: /catalog/tab-scroller/
+excerpt: "Allows for smooth native and animated scrolling of tabs."
+iconId: tabs
+path: /catalog/tabs/scroller/
 -->
 
 # Tab Scroller
 
-<!--<div class="article__asset">
-  <a class="article__asset-link"
-     href="https://material-components-web.appspot.com/tab-scroller.html">
-    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/tab-scroller.png" width="363" alt="Tab scroller screenshot">
-  </a>
-</div>-->
-
-Tab Scroller allows for smooth animated scrolling of tab content.
+A Tab Scroller allows for smooth native and animated scrolling of tabs.
 
 ## Installation
 ```

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -1,13 +1,16 @@
+<!--docs:
+title: "Tab"
+layout: detail
+section: components
+excerpt: "Governs the visibility of one of several groups of content."
+iconId: tabs
+path: /catalog/tabs/tab/
+-->
+
 # Tab
 
-<!--<div class="article__asset">
-  <a class="article__asset-link"
-     href="https://material-components.github.io/material-components-web-catalog/#/component/tabs">
-    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/tab.png" width="363" alt="Tab screenshot">
-  </a>
-</div>-->
-
-Tab is a selectable element with an active state
+Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy.
+Each Tab governs the visibility of one group of content.
 
 ## Design & API Documentation
 

--- a/packages/mdc-tabs/README.md
+++ b/packages/mdc-tabs/README.md
@@ -1,11 +1,18 @@
 <!--docs:
-title: "Tabs"
+title: "Tabs (Deprecated)"
 layout: detail
 section: components
 excerpt: "A tabbed navigation component."
 iconId: tabs
-path: /catalog/tabs/
+path: /catalog/tabs/legacy/
 -->
+
+## Important - Deprecation Notice
+
+The `mdc-tabs` package is deprecated and no longer maintained. Improved functionality is available across the
+`mdc-tab-bar`, `mdc-tab-scroller`, `mdc-tab-indicator`, and `mdc-tab` packages. Bugs and feature requests
+will no longer be accepted for this package. It is recommended that you migrate to the new packages to continue to
+receive new features and updates.
 
 # MDC Tabs
 


### PR DESCRIPTION
Fixes #3056.

For now, the top-level "Tabs" navigation entry redirects to Tab. We should redirect it to Tab Bar instead once that exists (just update `docs/docsite-tabs.md`).