### PR TITLE
chore(infrastructure): Reduce noisy Travis job log output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,11 @@ cache:
   directories:
   - $HOME/.npm
   - $HOME/google-cloud-sdk
-  - node_modules
 before_install:
   # Source the script to run it in the same shell process. This ensures that any environment variables set by the
   # script are visible to subsequent Travis CLI commands.
   # https://superuser.com/a/176788/62792
   - source test/screenshot/infra/commands/travis.sh
+install:
+  - npm ci # Deletes `node_modules` before installing packages
+  #- npm ls # Noisy output, but useful for debugging npm package dependency version issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,5 @@ before_install:
   # https://superuser.com/a/176788/62792
   - source test/screenshot/infra/commands/travis.sh
 install:
-  - npm install # Slower than `npm ci`, but it actually works
-  #- npm ci # Deletes `node_modules` before installing packages. Requires npm@latest (v6.x?)
+  - npm install
   #- npm ls # Noisy output, but useful for debugging npm package dependency version issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,6 @@ before_install:
   # https://superuser.com/a/176788/62792
   - source test/screenshot/infra/commands/travis.sh
 install:
-  - npm ci # Deletes `node_modules` before installing packages
+  - npm install # Slower than `npm ci`, but it actually works
+  #- npm ci # Deletes `node_modules` before installing packages. Requires npm@latest (v6.x?)
   #- npm ls # Noisy output, but useful for debugging npm package dependency version issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,27 +8,27 @@ branches:
   - master
 matrix:
   include:
-#  - node_js: 8
-#    env:
-#    - TEST_SUITE=lint
-#    script: npm run lint
-#  - node_js: 8
-#    env:
-#    - TEST_SUITE=unit
-#    addons:
-#      sauce_connect: true
-#    script: npm run test:unit && npm run posttest
-#    after_success:
-#    - codecov
-#  - node_js: 8
-#    env:
-#    - TEST_SUITE=closure
-#    - CLOSURE=1
-#    script: npm run test:closure
-#  - node_js: 8
-#    env:
-#    - TEST_SUITE=site-generator
-#    script: npm run test:site
+  - node_js: 8
+    env:
+    - TEST_SUITE=lint
+    script: npm run lint
+  - node_js: 8
+    env:
+    - TEST_SUITE=unit
+    addons:
+      sauce_connect: true
+    script: npm run test:unit && npm run posttest
+    after_success:
+    - codecov
+  - node_js: 8
+    env:
+    - TEST_SUITE=closure
+    - CLOSURE=1
+    script: npm run test:closure
+  - node_js: 8
+    env:
+    - TEST_SUITE=site-generator
+    script: npm run test:site
   - node_js: 8
     env:
     - TEST_SUITE=screenshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,12 @@ matrix:
     env:
     - TEST_SUITE=screenshot
     script: npm run screenshot:test -- --no-fetch
-cache:
-  directories:
-  - $HOME/.npm
-  - $HOME/google-cloud-sdk
 before_install:
   # Source the script to run it in the same shell process. This ensures that any environment variables set by the
   # script are visible to subsequent Travis CLI commands.
   # https://superuser.com/a/176788/62792
   - source test/screenshot/infra/commands/travis.sh
 install:
+  - rm -rf node_modules
   - npm install
   #- npm ls # Noisy output, but useful for debugging npm package dependency version issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,36 @@ branches:
   - master
 matrix:
   include:
-  - node_js: 8
-    env:
-    - TEST_SUITE=lint
-    script: npm run lint
-  - node_js: 8
-    env:
-    - TEST_SUITE=unit
-    addons:
-      sauce_connect: true
-    script: npm run test:unit && npm run posttest
-    after_success:
-    - codecov
-  - node_js: 8
-    env:
-    - TEST_SUITE=closure
-    - CLOSURE=1
-    script: npm run test:closure
-  - node_js: 8
-    env:
-    - TEST_SUITE=site-generator
-    script: npm run test:site
+#  - node_js: 8
+#    env:
+#    - TEST_SUITE=lint
+#    script: npm run lint
+#  - node_js: 8
+#    env:
+#    - TEST_SUITE=unit
+#    addons:
+#      sauce_connect: true
+#    script: npm run test:unit && npm run posttest
+#    after_success:
+#    - codecov
+#  - node_js: 8
+#    env:
+#    - TEST_SUITE=closure
+#    - CLOSURE=1
+#    script: npm run test:closure
+#  - node_js: 8
+#    env:
+#    - TEST_SUITE=site-generator
+#    script: npm run test:site
   - node_js: 8
     env:
     - TEST_SUITE=screenshot
     script: npm run screenshot:test -- --no-fetch
+cache:
+  directories:
+  - $HOME/.npm
+  - $HOME/google-cloud-sdk
+  - node_modules
 before_install:
   # Source the script to run it in the same shell process. This ensures that any environment variables set by the
   # script are visible to subsequent Travis CLI commands.

--- a/test/screenshot/infra/commands/build.js
+++ b/test/screenshot/infra/commands/build.js
@@ -63,9 +63,11 @@ module.exports = {
    * @private
    */
   buildProtoFiles_(shouldWatch) {
-    const compile = debounce(() => ProtoCommand.runAsync(), 1000);
+    const buildRightNow = () => ProtoCommand.runAsync();
+    const buildDelayed = debounce(buildRightNow, 1000);
+
     if (!shouldWatch) {
-      compile();
+      buildRightNow();
       return;
     }
 
@@ -74,10 +76,8 @@ module.exports = {
       awaitWriteFinish: true,
     });
 
-    /* eslint-disable no-unused-vars */
-    watcher.on('add', (filePath) => compile());
-    watcher.on('change', (filePath) => compile());
-    /* eslint-enable no-unused-vars */
+    watcher.on('add', buildDelayed);
+    watcher.on('change', buildDelayed);
   },
 
   /**
@@ -85,9 +85,11 @@ module.exports = {
    * @private
    */
   buildHtmlFiles_(shouldWatch) {
-    const compile = debounce(() => IndexCommand.runAsync(), 1000);
+    const buildRightNow = () => IndexCommand.runAsync();
+    const buildDelayed = debounce(buildRightNow, 1000);
+
     if (!shouldWatch) {
-      compile();
+      buildRightNow();
       return;
     }
 
@@ -97,10 +99,8 @@ module.exports = {
       ignored: ['**/report/report.html', '**/index.html'],
     });
 
-    /* eslint-disable no-unused-vars */
-    watcher.on('add', (filePath) => compile());
-    watcher.on('unlink', (filePath) => compile());
-    /* eslint-enable no-unused-vars */
+    watcher.on('add', buildDelayed);
+    watcher.on('unlink', buildDelayed);
   },
 
   /**

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -44,6 +44,10 @@ function install_google_cloud_sdk() {
   gcloud components update gsutil
 }
 
+function set_npm_loglevel() {
+  npm config set --global loglevel warn
+}
+
 if [[ "$TEST_SUITE" == 'screenshot' ]] || [[ "$TEST_SUITE" == 'unit' ]]; then
   exit_if_external_pr
 fi
@@ -51,6 +55,7 @@ fi
 if [[ "$TEST_SUITE" == 'screenshot' ]]; then
   extract_api_credentials
   install_google_cloud_sdk
+  set_npm_loglevel
 fi
 
 echo

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -19,6 +19,10 @@ function print_travis_env_vars() {
   echo
 }
 
+function install_latest_npm() {
+  npm i -g npm@latest
+}
+
 function extract_api_credentials() {
   openssl aes-256-cbc -K $encrypted_eead2343bb54_key -iv $encrypted_eead2343bb54_iv \
     -in test/screenshot/infra/auth/travis.tar.enc -out test/screenshot/infra/auth/travis.tar -d
@@ -54,12 +58,15 @@ function install_google_cloud_sdk() {
   gcloud components update gsutil
 }
 
-if [[ "$TEST_SUITE" == 'screenshot' ]] || [[ "$TEST_SUITE" == 'unit' ]]; then
+if [[ "$TEST_SUITE" == 'unit' ]]; then
   exit_if_external_pr
-fi
-
-if [[ "$TEST_SUITE" == 'screenshot' ]]; then
+  install_latest_npm
+elif [[ "$TEST_SUITE" == 'screenshot' ]]; then
+  exit_if_external_pr
+  install_latest_npm
   print_travis_env_vars
   extract_api_credentials
   install_google_cloud_sdk
+else
+  install_latest_npm
 fi

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -60,13 +60,9 @@ function install_google_cloud_sdk() {
 
 if [[ "$TEST_SUITE" == 'unit' ]]; then
   exit_if_external_pr
-  install_latest_npm
 elif [[ "$TEST_SUITE" == 'screenshot' ]]; then
   exit_if_external_pr
-  install_latest_npm
   print_travis_env_vars
   extract_api_credentials
   install_google_cloud_sdk
-else
-  install_latest_npm
 fi

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -41,6 +41,7 @@ function install_google_cloud_sdk() {
     echo 'gcloud already installed'
   else
     echo 'gcloud not installed'
+    rm -rf $HOME/google-cloud-sdk
     curl -o /tmp/gcp-sdk.bash https://sdk.cloud.google.com
     chmod +x /tmp/gcp-sdk.bash
     /tmp/gcp-sdk.bash --disable-prompts | grep -v -E '^google-cloud-sdk/'

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -29,7 +29,15 @@ function extract_api_credentials() {
 }
 
 function install_google_cloud_sdk() {
-  if [[ ! -d $HOME/google-cloud-sdk ]]; then
+  echo ls $HOME/google-cloud-sdk
+  ls $HOME/google-cloud-sdk
+
+  which gcloud 2>&1 > /dev/null
+
+  if [[ $? == 0 ]]; then
+    echo 'gcloud already installed'
+  else
+    echo 'gcloud not installed'
     curl -o /tmp/gcp-sdk.bash https://sdk.cloud.google.com
     chmod +x /tmp/gcp-sdk.bash
     /tmp/gcp-sdk.bash --disable-prompts | grep -v -E '^google-cloud-sdk/'

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -56,10 +56,6 @@ function install_google_cloud_sdk() {
   gcloud components update gsutil
 }
 
-function set_npm_loglevel() {
-  npm config set --global loglevel warn
-}
-
 if [[ "$TEST_SUITE" == 'screenshot' ]] || [[ "$TEST_SUITE" == 'unit' ]]; then
   exit_if_external_pr
 fi
@@ -67,5 +63,4 @@ fi
 if [[ "$TEST_SUITE" == 'screenshot' ]]; then
   extract_api_credentials
   install_google_cloud_sdk
-  set_npm_loglevel
 fi

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -32,19 +32,22 @@ function install_google_cloud_sdk() {
   export PATH=$PATH:$HOME/google-cloud-sdk/bin
   export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
-  echo ls $HOME/google-cloud-sdk
-  ls $HOME/google-cloud-sdk
-
   which gcloud 2>&1 > /dev/null
 
   if [[ $? == 0 ]]; then
     echo 'gcloud already installed'
+    echo
   else
     echo 'gcloud not installed'
+    echo
+
     rm -rf $HOME/google-cloud-sdk
     curl -o /tmp/gcp-sdk.bash https://sdk.cloud.google.com
     chmod +x /tmp/gcp-sdk.bash
-    /tmp/gcp-sdk.bash --disable-prompts | grep -v -E '^google-cloud-sdk/'
+
+    # The gcloud installer runs `tar -C "$install_dir" -zxvf "$download_dst"`, which generates a lot of noisy output.
+    # Filter out all lines from `tar`.
+    /tmp/gcp-sdk.bash | grep -v -E '^google-cloud-sdk/'
   fi
 
   gcloud auth activate-service-account --key-file test/screenshot/infra/auth/gcs.json
@@ -66,8 +69,3 @@ if [[ "$TEST_SUITE" == 'screenshot' ]]; then
   install_google_cloud_sdk
   set_npm_loglevel
 fi
-
-echo
-echo 'advorak - exiting early'
-echo
-exit 1

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -29,6 +29,9 @@ function extract_api_credentials() {
 }
 
 function install_google_cloud_sdk() {
+  export PATH=$PATH:$HOME/google-cloud-sdk/bin
+  export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
   echo ls $HOME/google-cloud-sdk
   ls $HOME/google-cloud-sdk
 
@@ -42,9 +45,6 @@ function install_google_cloud_sdk() {
     chmod +x /tmp/gcp-sdk.bash
     /tmp/gcp-sdk.bash --disable-prompts | grep -v -E '^google-cloud-sdk/'
   fi
-
-  export PATH=$PATH:$HOME/google-cloud-sdk/bin
-  export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
   gcloud auth activate-service-account --key-file test/screenshot/infra/auth/gcs.json
   gcloud config set project material-components-web

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -19,10 +19,6 @@ function print_travis_env_vars() {
   echo
 }
 
-function install_latest_npm() {
-  npm i -g npm@latest
-}
-
 function extract_api_credentials() {
   openssl aes-256-cbc -K $encrypted_eead2343bb54_key -iv $encrypted_eead2343bb54_iv \
     -in test/screenshot/infra/auth/travis.tar.enc -out test/screenshot/infra/auth/travis.tar -d

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -32,7 +32,7 @@ function install_google_cloud_sdk() {
   if [[ ! -d $HOME/google-cloud-sdk ]]; then
     curl -o /tmp/gcp-sdk.bash https://sdk.cloud.google.com
     chmod +x /tmp/gcp-sdk.bash
-    /tmp/gcp-sdk.bash --disable-prompts
+    /tmp/gcp-sdk.bash --disable-prompts | grep -v -E '^google-cloud-sdk/'
   fi
 
   export PATH=$PATH:$HOME/google-cloud-sdk/bin
@@ -41,12 +41,7 @@ function install_google_cloud_sdk() {
   gcloud auth activate-service-account --key-file test/screenshot/infra/auth/gcs.json
   gcloud config set project material-components-web
   gcloud components install gsutil
-
-  which gsutil 2>&1 > /dev/null
-  if [[ $? != 0 ]]; then
-    pip install --upgrade pip
-    pip install gsutil
-  fi
+  gcloud components update gsutil
 }
 
 if [[ "$TEST_SUITE" == 'screenshot' ]] || [[ "$TEST_SUITE" == 'unit' ]]; then
@@ -57,3 +52,8 @@ if [[ "$TEST_SUITE" == 'screenshot' ]]; then
   extract_api_credentials
   install_google_cloud_sdk
 fi
+
+echo
+echo 'advorak - exiting early'
+echo
+exit 1

--- a/test/screenshot/infra/commands/travis.sh
+++ b/test/screenshot/infra/commands/travis.sh
@@ -13,19 +13,17 @@ function exit_if_external_pr() {
   fi
 }
 
+function print_travis_env_vars() {
+  echo
+  env | grep TRAVIS
+  echo
+}
+
 function extract_api_credentials() {
   openssl aes-256-cbc -K $encrypted_eead2343bb54_key -iv $encrypted_eead2343bb54_iv \
     -in test/screenshot/infra/auth/travis.tar.enc -out test/screenshot/infra/auth/travis.tar -d
 
   tar -xf test/screenshot/infra/auth/travis.tar -C test/screenshot/infra/auth/
-
-  echo
-  echo 'git status:'
-  echo
-  git status
-  echo
-  env | grep TRAVIS
-  echo
 }
 
 function install_google_cloud_sdk() {
@@ -61,6 +59,7 @@ if [[ "$TEST_SUITE" == 'screenshot' ]] || [[ "$TEST_SUITE" == 'unit' ]]; then
 fi
 
 if [[ "$TEST_SUITE" == 'screenshot' ]]; then
+  print_travis_env_vars
   extract_api_credentials
   install_google_cloud_sdk
 fi

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -49,6 +49,7 @@ const {SELENIUM_FONT_LOAD_WAIT_MS} = Constants;
 const CliStatuses = {
   ACTIVE: {name: 'Active', color: colors.bold.cyan},
   QUEUED: {name: 'Queued', color: colors.cyan},
+  WAITING: {name: 'Waiting', color: colors.magenta},
   STARTING: {name: 'Starting', color: colors.green},
   STARTED: {name: 'Started', color: colors.bold.green},
   GET: {name: 'Get', color: colors.bold.white},
@@ -202,7 +203,8 @@ class SeleniumApi {
 
         const waitTimeMs = CBT_CONCURRENCY_POLL_INTERVAL_MS;
         const waitTimeHuman = Duration.millis(waitTimeMs).toHumanShort();
-        console.warn(
+        this.logStatus_(
+          CliStatuses.WAITING,
           `Parallel execution limit reached. ${max} tests are already running on CBT. Will retry in ${waitTimeHuman}...`
         );
         await this.sleep_(waitTimeMs);


### PR DESCRIPTION
### What it does

A few recent Travis jobs have had their job logs truncated for being too long. Let's fix that.

- Reduces Travis job log output from ~8k lines to ~2k lines
    - Suppresses noisy log output from `install` step
        - Only runs `npm install` (but not `npm ls`)
        - Travis runs `npm ls` by default, which produces about 4k log lines. This makes the log output harder to read and slower to load in the UI, and it doesn't seem terribly useful.
    - Suppresses noisy log output from gcloud installer's `tar` command
        - Makes the log output easier to read and faster to load in the Travis job log UI
- Colorizes log output for "parallel execution limit reached" warning messages
