### PR TITLE
chore(text-field): Add baseline screenshot test page

### DIFF
--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -268,5 +268,14 @@
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/ink-color.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/ink-color.html.windows_ie_11.png"
     }
+  },
+  "spec/mdc-textfield/classes/baseline-textfield.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/18/20_19_24_759/spec/mdc-textfield/classes/baseline-textfield.html",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/18/20_19_24_759/spec/mdc-textfield/classes/baseline-textfield.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/18/20_19_24_759/spec/mdc-textfield/classes/baseline-textfield.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/18/20_19_24_759/spec/mdc-textfield/classes/baseline-textfield.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/18/20_19_24_759/spec/mdc-textfield/classes/baseline-textfield.html.windows_ie_11.png"
+    }
   }
 }

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-textfield.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-textfield.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Baseline Text Field Element - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.textfield.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-textfield/fixture.css">
+  </head>
+
+  <body class="test-body mdc-typography">
+    <main class="test-main test-main--mobile-viewport">
+      <div class="test-grid">
+        <div class="test-cell test-cell--textfield">
+          <div class="mdc-text-field mdc-text-field--box">
+            <input type="text" id="filled-text-field" class="mdc-text-field__input">
+            <label class="mdc-floating-label" for="filled-text-field">Label</label>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--textfield">
+          <div class="mdc-text-field mdc-text-field--outlined">
+            <input type="text" id="outlined-text-field" class="mdc-text-field__input">
+            <label for="outlined-text-field" class="mdc-floating-label">Label</label>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-textfield/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-textfield/fixture.js
+++ b/test/screenshot/spec/mdc-textfield/fixture.js
@@ -1,0 +1,3 @@
+[].forEach.call(document.querySelectorAll('.mdc-text-field'), function(el) {
+  const textField = new mdc.textField.MDCTextField(el);
+});

--- a/test/screenshot/spec/mdc-textfield/fixture.js
+++ b/test/screenshot/spec/mdc-textfield/fixture.js
@@ -1,3 +1,3 @@
 [].forEach.call(document.querySelectorAll('.mdc-text-field'), function(el) {
-  const textField = new mdc.textField.MDCTextField(el);
+  mdc.textField.MDCTextField.attachTo(el);
 });

--- a/test/screenshot/spec/mdc-textfield/fixture.scss
+++ b/test/screenshot/spec/mdc-textfield/fixture.scss
@@ -1,0 +1,23 @@
+//
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@import "../../../../packages/mdc-textfield/mixins";
+@import "../../../../packages/mdc-theme/color-palette";
+
+.test-cell--textfield {
+  width: 301px;
+  height: 101px;
+}


### PR DESCRIPTION
Does not include textarea, full-width or icon variants, or mixin use.

Intentionally omits the current default since it is being deprecated.

Original report that generated the new goldens: https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/07/18/20_19_24_759/report/report.html