### PR TITLE
feat(tab): Emit selection and activation events

### DIFF
--- a/demos/tab.html
+++ b/demos/tab.html
@@ -332,10 +332,10 @@
               activeTab = tab;
             }
 
-            tabEl.addEventListener('click', function() {
+            tabEl.addEventListener('MDCTab:selected', function(evt) {
               activeTab.deactivate();
-              tab.activate(activeTab.computeIndicatorClientRect());
-              activeTab = tab;
+              evt.detail.tab.activate(activeTab.computeIndicatorClientRect());
+              activeTab = evt.detail.tab;
             });
           });
         }

--- a/demos/tab.html
+++ b/demos/tab.html
@@ -332,7 +332,12 @@
               activeTab = tab;
             }
 
-            tabEl.addEventListener('MDCTab:selected', function(evt) {
+            tabEl.addEventListener('MDCTab:interacted', function(evt) {
+              // Early exit if the interacted tab is the currently active tab
+              if (activeTab === evt.detail.tab) {
+                return;
+              }
+
               activeTab.deactivate();
               evt.detail.tab.activate(activeTab.computeIndicatorClientRect());
               activeTab = evt.detail.tab;

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -98,7 +98,7 @@ Method Signature | Description
 
 Event Name | Event Data Structure | Description
 --- | --- | ---
-`MDCTab:interacted` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is interacted with but not active. Used by parent components.
+`MDCTab:interacted` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is interacted with, regardless of it's active state. Used by parent components to know which Tab to activate.
 `MDCTab:activated` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is activated. Listen for this to update content when a Tab becomes active.
 
 

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -122,6 +122,7 @@ Method Signature | Description
 Method Signature | Description
 --- | ---
 `handleTransitionEnd(evt: Event) => void` | Handles the logic for the `"transitionend"` event.
+`handleClick() => void` | Handles the logic for the `"click"` event.
 `isActive() => boolean` | Returns whether the tab is active.
 `activate(previousIndicatorClientRect: ClientRect=) => void` | Activates the tab. `previousIndicatorClientRect` is an optional argument.
 `deactivate() => void` | Deactivates the tab.

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -96,6 +96,11 @@ Method Signature | Description
 `computeIndicatorClientRect() => ClientRect` | Returns the bounding client rect of the indicator.
 `computeDimensions() => MDCTabDimensions` | Returns the dimensions of the Tab.
 
+Event Name | Event Data Structure | Description
+--- | --- | ---
+`MDCTab:interacted` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is interacted with but not active. Used by parent components.
+`MDCTab:activated` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is activated. Listen for this to update content when a Tab becomes active.
+
 
 ### `MDCTabAdapter`
 
@@ -114,7 +119,7 @@ Method Signature | Description
 `getOffsetWidth() => number` | Returns the `offsetWidth` value of the root element
 `getContentOffsetLeft() => number` | Returns the `offsetLeft` value of the content element
 `getContentOffsetWidth() => number` | Returns the `offsetWidth` value of the content element
-`notifySelected() => void` | Emits the `MDCTab:selected` event
+`notifyInteracted() => void` | Emits the `MDCTab:interacted` event
 `notifyActivated() => void` | Emits the `MDCTab:activated` event
 
 ### `MDCTabFoundation`

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -98,7 +98,7 @@ Method Signature | Description
 
 Event Name | Event Data Structure | Description
 --- | --- | ---
-`MDCTab:interacted` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is interacted with, regardless of it's active state. Used by parent components to know which Tab to activate.
+`MDCTab:interacted` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is interacted with, regardless of its active state. Used by parent components to know which Tab to activate.
 `MDCTab:activated` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is activated. Listen for this to update content when a Tab becomes active.
 
 

--- a/packages/mdc-tab/adapter.js
+++ b/packages/mdc-tab/adapter.js
@@ -92,9 +92,9 @@ class MDCTabAdapter {
   computeIndicatorClientRect() {}
 
   /**
-   * Emits the MDCTab:selected event for use by parent components
+   * Emits the MDCTab:interacted event for use by parent components
    */
-  notifySelected() {}
+  notifyInteracted() {}
 
   /**
    * Emits the MDCTab:activated event for use by parent components

--- a/packages/mdc-tab/adapter.js
+++ b/packages/mdc-tab/adapter.js
@@ -82,6 +82,16 @@ class MDCTabAdapter {
    * @return {!ClientRect}
    */
   computeIndicatorClientRect() {}
+
+  /**
+   * Emits the MDCTab:selected event for use by parent components
+   */
+  notifySelected() {}
+
+  /**
+   * Emits the MDCTab:activated event for use by parent components
+   */
+  notifyActivated() {}
 }
 
 export default MDCTabAdapter;

--- a/packages/mdc-tab/constants.js
+++ b/packages/mdc-tab/constants.js
@@ -29,7 +29,7 @@ const strings = {
   CONTENT_SELECTOR: '.mdc-tab__content',
   TAB_INDICATOR_SELECTOR: '.mdc-tab-indicator',
   TABINDEX: 'tabIndex',
-  SELECTED_EVENT: 'MDCTab:selected',
+  INTERACTED_EVENT: 'MDCTab:interacted',
   ACTIVATED_EVENT: 'MDCTab:activated',
 };
 

--- a/packages/mdc-tab/constants.js
+++ b/packages/mdc-tab/constants.js
@@ -28,6 +28,8 @@ const strings = {
   RIPPLE_SELECTOR: '.mdc-tab__ripple',
   TAB_INDICATOR_SELECTOR: '.mdc-tab-indicator',
   TABINDEX: 'tabIndex',
+  SELECTED_EVENT: 'MDCTab:selected',
+  ACTIVATED_EVENT: 'MDCTab:activated',
 };
 
 export {

--- a/packages/mdc-tab/foundation.js
+++ b/packages/mdc-tab/foundation.js
@@ -98,12 +98,8 @@ class MDCTabFoundation extends MDCFoundation {
    * Handles the "click" event
    */
   handleClick() {
-    // Early exit if the tab is already active. We don't want to emit an
-    // interacted event that tries to interact with a tab that's already active.
-    if (this.isActive()) {
-      return;
-    }
-
+    // It's up to the parent component to keep track of the active Tab and
+    // ensure we don't activate a Tab that's already active.
     this.adapter_.notifyInteracted();
   }
 

--- a/packages/mdc-tab/foundation.js
+++ b/packages/mdc-tab/foundation.js
@@ -56,7 +56,7 @@ class MDCTabFoundation extends MDCFoundation {
       activateIndicator: () => {},
       deactivateIndicator: () => {},
       computeIndicatorClientRect: () => {},
-      notifySelected: () => {},
+      notifyInteracted: () => {},
       notifyActivated: () => {},
       getOffsetLeft: () => {},
       getOffsetWidth: () => {},
@@ -98,13 +98,13 @@ class MDCTabFoundation extends MDCFoundation {
    * Handles the "click" event
    */
   handleClick() {
-    // Early exit if the tab is already active. We don't want to emit a selected
-    // event that tries to select a tab that's already active.
+    // Early exit if the tab is already active. We don't want to emit an
+    // interacted event that tries to interact with a tab that's already active.
     if (this.isActive()) {
       return;
     }
 
-    this.adapter_.notifySelected();
+    this.adapter_.notifyInteracted();
   }
 
   /**

--- a/packages/mdc-tab/foundation.js
+++ b/packages/mdc-tab/foundation.js
@@ -52,6 +52,8 @@ class MDCTabFoundation extends MDCFoundation {
       activateIndicator: () => {},
       deactivateIndicator: () => {},
       computeIndicatorClientRect: () => {},
+      notifySelected: () => {},
+      notifyActivated: () => {},
     });
   }
 
@@ -61,6 +63,13 @@ class MDCTabFoundation extends MDCFoundation {
 
     /** @private {function(!Event): undefined} */
     this.handleTransitionEnd_ = (evt) => this.handleTransitionEnd(evt);
+
+    /** @private {function(?Event): undefined} */
+    this.handleClick_ = () => this.handleClick();
+  }
+
+  init() {
+    this.adapter_.registerEventHandler('click', this.handleClick_);
   }
 
   /**
@@ -75,6 +84,19 @@ class MDCTabFoundation extends MDCFoundation {
     this.adapter_.deregisterEventHandler('transitionend', this.handleTransitionEnd_);
     this.adapter_.removeClass(cssClasses.ANIMATING_ACTIVATE);
     this.adapter_.removeClass(cssClasses.ANIMATING_DEACTIVATE);
+  }
+
+  /**
+   * Handles the "click" event
+   */
+  handleClick() {
+    // Early exit if the tab is already active. We don't want to emit a selected
+    // event that tries to select a tab that's already active.
+    if (this.isActive()) {
+      return;
+    }
+
+    this.adapter_.notifySelected();
   }
 
   /**
@@ -101,6 +123,7 @@ class MDCTabFoundation extends MDCFoundation {
     this.adapter_.setAttr(strings.ARIA_SELECTED, 'true');
     this.adapter_.setAttr(strings.TABINDEX, '0');
     this.adapter_.activateIndicator(previousIndicatorClientRect);
+    this.adapter_.notifyActivated();
   }
 
   /**

--- a/packages/mdc-tab/index.js
+++ b/packages/mdc-tab/index.js
@@ -89,7 +89,7 @@ class MDCTab extends MDCComponent {
         activateIndicator: (previousIndicatorClientRect) => this.tabIndicator_.activate(previousIndicatorClientRect),
         deactivateIndicator: () => this.tabIndicator_.deactivate(),
         computeIndicatorClientRect: () => this.tabIndicator_.computeContentClientRect(),
-        notifySelected: () => this.emit(MDCTabFoundation.strings.SELECTED_EVENT, {tab: this}, true /* bubble */),
+        notifyInteracted: () => this.emit(MDCTabFoundation.strings.INTERACTED_EVENT, {tab: this}, true /* bubble */),
         notifyActivated: () => this.emit(MDCTabFoundation.strings.ACTIVATED_EVENT, {tab: this}, true /* bubble */),
         getOffsetLeft: () => this.root_.offsetLeft,
         getOffsetWidth: () => this.root_.offsetWidth,

--- a/packages/mdc-tab/index.js
+++ b/packages/mdc-tab/index.js
@@ -85,6 +85,8 @@ class MDCTab extends MDCComponent {
         activateIndicator: (previousIndicatorClientRect) => this.tabIndicator_.activate(previousIndicatorClientRect),
         deactivateIndicator: () => this.tabIndicator_.deactivate(),
         computeIndicatorClientRect: () => this.tabIndicator_.computeContentClientRect(),
+        notifySelected: () => this.emit(MDCTabFoundation.strings.SELECTED_EVENT, {tab: this}, true /* should bubble */),
+        notifyActivated: () => this.emit(MDCTabFoundation.strings.ACTIVATED_EVENT, {tab: this}, true /* should bubble */),
       }));
   }
 

--- a/test/unit/mdc-tab/foundation.test.js
+++ b/test/unit/mdc-tab/foundation.test.js
@@ -88,6 +88,12 @@ test('#activate activates the indicator', () => {
   td.verify(mockAdapter.activateIndicator({width: 100, left: 200}));
 });
 
+test(`#activate emits the ${MDCTabFoundation.strings.ACTIVATED_EVENT} event`, () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.activate();
+  td.verify(mockAdapter.notifyActivated());
+});
+
 test('#computeIndicatorClientRect calls computeIndicatorClientRect on the adapter', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.computeIndicatorClientRect();
@@ -178,16 +184,8 @@ test('on transitionend, call #handleTransitionEnd', () => {
   td.verify(foundation.handleTransitionEnd(td.matchers.anything()), {times: 1});
 });
 
-test('#handleClick does nothing if the tab is already active', () => {
+test(`#handleClick emits the ${MDCTabFoundation.strings.INTERACTED_EVENT} event`, () => {
   const {foundation, mockAdapter} = setupTest();
-  td.when(mockAdapter.hasClass(MDCTabFoundation.cssClasses.ACTIVE)).thenReturn(true);
-  foundation.handleClick();
-  td.verify(mockAdapter.notifyInteracted(td.matchers.anything()), {times: 0});
-});
-
-test('#handleClick emits the selected event if it is not active', () => {
-  const {foundation, mockAdapter} = setupTest();
-  td.when(mockAdapter.hasClass(MDCTabFoundation.cssClasses.ACTIVE)).thenReturn(false);
   foundation.handleClick();
   td.verify(mockAdapter.notifyInteracted(), {times: 1});
 });

--- a/test/unit/mdc-tab/foundation.test.js
+++ b/test/unit/mdc-tab/foundation.test.js
@@ -38,7 +38,7 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'setAttr',
     'activateIndicator', 'deactivateIndicator', 'computeIndicatorClientRect',
     'getOffsetLeft', 'getOffsetWidth', 'getContentOffsetLeft', 'getContentOffsetWidth',
-    'notifySelected', 'notifyActivated',
+    'notifyInteracted', 'notifyActivated',
   ]);
 });
 
@@ -169,37 +169,36 @@ test('#handleTransitionEnd does nothing when triggered by a pseudo element', () 
   td.verify(mockAdapter.deregisterEventHandler('transitionend', td.matchers.isA(Function)), {times: 0});
 });
 
-test('on transitionend, do nothing when triggered by a pseudeo element', () => {
+test('on transitionend, call #handleTransitionEnd', () => {
   const {foundation, mockAdapter} = setupTest();
   const handlers = captureHandlers(mockAdapter, 'registerEventHandler');
+  foundation.handleTransitionEnd = td.function('handles transitionend');
   foundation.activate();
-  handlers.transitionend({pseudoElement: '::after'});
-  td.verify(mockAdapter.removeClass(MDCTabFoundation.cssClasses.ANIMATING_ACTIVATE), {times: 0});
-  td.verify(mockAdapter.removeClass(MDCTabFoundation.cssClasses.ANIMATING_DEACTIVATE), {times: 0});
-  td.verify(mockAdapter.deregisterEventHandler('transitionend', td.matchers.isA(Function)), {times: 0});
+  handlers.transitionend();
+  td.verify(foundation.handleTransitionEnd(td.matchers.anything()), {times: 1});
 });
 
 test('#handleClick does nothing if the tab is already active', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(MDCTabFoundation.cssClasses.ACTIVE)).thenReturn(true);
   foundation.handleClick();
-  td.verify(mockAdapter.notifySelected(td.matchers.anything()), {times: 0});
+  td.verify(mockAdapter.notifyInteracted(td.matchers.anything()), {times: 0});
 });
 
 test('#handleClick emits the selected event if it is not active', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(MDCTabFoundation.cssClasses.ACTIVE)).thenReturn(false);
   foundation.handleClick();
-  td.verify(mockAdapter.notifySelected(), {times: 1});
+  td.verify(mockAdapter.notifyInteracted(), {times: 1});
 });
 
-test('on click, do nothing if the Tab is already active', () => {
+test('on click, call #handleClick', () => {
   const {foundation, mockAdapter} = setupTest();
   const handlers = captureHandlers(mockAdapter, 'registerEventHandler');
+  foundation.handleClick = td.function('handles click');
   foundation.init();
-  td.when(mockAdapter.hasClass(MDCTabFoundation.cssClasses.ACTIVE)).thenReturn(true);
   handlers.click();
-  td.verify(mockAdapter.notifySelected(), {times: 0});
+  td.verify(foundation.handleClick(), {times: 1});
 });
 
 test('#computeDimensions() returns the dimensions of the tab', () => {

--- a/test/unit/mdc-tab/mdc-tab.test.js
+++ b/test/unit/mdc-tab/mdc-tab.test.js
@@ -142,12 +142,12 @@ test('#adapter.getContentOffsetLeft() returns the offsetLeft of the content elem
   assert.strictEqual(component.getDefaultFoundation().adapter_.getContentOffsetLeft(), content.offsetLeft);
 });
 
-test(`#adapter.notifySelected() emits the ${MDCTabFoundation.strings.SELECTED_EVENT} event`, () => {
+test(`#adapter.notifyInteracted() emits the ${MDCTabFoundation.strings.INTERACTED_EVENT} event`, () => {
   const {component} = setupTest();
   const handler = td.func('interaction handler');
 
-  component.listen(MDCTabFoundation.strings.SELECTED_EVENT, handler);
-  component.getDefaultFoundation().adapter_.notifySelected();
+  component.listen(MDCTabFoundation.strings.INTERACTED_EVENT, handler);
+  component.getDefaultFoundation().adapter_.notifyInteracted();
   td.verify(handler(td.matchers.anything()));
 });
 


### PR DESCRIPTION
Add `notifySelected` and `notifyActivated` methods to adapter. Add `handleClick` to the foundation. Update tests and demo. Update readme. Closes #3123 