### PR TITLE
fix(switch): Fix showing switch ripple focus state in Edge

### DIFF
--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -65,9 +65,7 @@
   @include mdc-rtl-reflexive-position(left, -14px);
   @include mdc-ripple-surface();
   @include mdc-ripple-radius-unbounded;
-  @include mdc-states(
-    $mdc-switch-baseline-theme-color,
-    $has-nested-focusable-element: true);
+  @include mdc-states(mdc-switch-baseline-theme-color);
 
   display: flex;
   position: absolute;

--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -65,7 +65,7 @@
   @include mdc-rtl-reflexive-position(left, -14px);
   @include mdc-ripple-surface();
   @include mdc-ripple-radius-unbounded;
-  @include mdc-states(mdc-switch-baseline-theme-color);
+  @include mdc-states($mdc-switch-baseline-theme-color);
 
   display: flex;
   position: absolute;


### PR DESCRIPTION
Realized that having '$has-nested-focusable-element' in mdc-states for switch was causing the focus state to not show up properly in Edge. 

In addition, since we're no longer supporting CSS only switch with the new version that requires JS for styling, it's not necessary to have the focus-within selector for ripple anyway and should be safe to remove.

Tested on Edge, Chrome, and Firefox.