### PR TITLE
fix(theme): Example of runtime TextField theming fix

### DIFF
--- a/packages/mdc-floating-label/_mixins.scss
+++ b/packages/mdc-floating-label/_mixins.scss
@@ -17,8 +17,9 @@
 @import "@material/rtl/mixins";
 @import "./variables";
 
-@mixin mdc-floating-label-ink-color($color) {
+@mixin mdc-floating-label-ink-color($color, $opacity: 1) {
   @include mdc-theme-prop(color, $color);
+  opacity: $opacity;
 }
 
 // Used for textarea in case of scrolling

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -564,7 +564,7 @@
 
 @mixin mdc-text-field-label-ink-color_($color) {
   .mdc-floating-label {
-    @include mdc-floating-label-ink-color($color);
+    @include mdc-floating-label-ink-color($color, 0.87);
   }
 
   // CSS-only version

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -25,7 +25,7 @@ $mdc-text-field-placeholder: rgba(mdc-theme-prop-value(on-surface), .6);
 $mdc-text-field-ink-color: rgba(mdc-theme-prop-value(on-surface), .87);
 $mdc-text-field-helper-text-color: rgba(mdc-theme-prop-value(on-surface), .6);
 $mdc-text-field-icon-color: rgba(mdc-theme-prop-value(on-surface), .54);
-$mdc-text-field-focused-label-color: rgba(mdc-theme-prop-value(primary), .87);
+$mdc-text-field-focused-label-color: var(--mdc-theme-primary, mdc-theme-prop-value(primary));
 
 $mdc-text-field-disabled-label-color: rgba(mdc-theme-prop-value(on-surface), .37);
 $mdc-text-field-disabled-ink-color: rgba(mdc-theme-prop-value(on-surface), .37);


### PR DESCRIPTION
This PR is intended to be more of an example than anything, but if the contributors are ok with this approach, I'd be happy to go ahead and apply this to the whole codebase.

## The issue
![image](https://user-images.githubusercontent.com/975256/42947805-1e9d8486-8b3c-11e8-9efb-debd09f997ed.png)

This is an example of setting red as the `mdc-theme-primary` color at runtime, and the resulting `mdc-floating-label` still using the default purple theme color.

## The short version
Anytime the `mdc-theme-prop-value` function is used in SASS, the value is being hardcoded into the CSS which means you can never override it with the runtime css variables. The issue is compounded by using the `rgba` function to add opacity to the color.

## Proposed fixes / Ideas
- Don't use that function
- Handle dynamic opacity using standard opacity OR define the different percent color stops as runtime CSS Vars. Both have their trade offs.
- A slightly crazier idea would be to just define R, G, and B as numeric variables. This would allow you to do something like this during runtime. This still results in a simple mdc-theme-primary variable consumers can use, and allow for dynamic opacity.
![image](https://user-images.githubusercontent.com/975256/42948648-f35901cc-8b3d-11e8-9b6f-957631fc313e.png)


## Why don't you just recompile the SASS?
I have apps that use themes in a variety of ways
- One app has a light and a dark mode in the UI. Using RMWC ThemeProvider I just set the new variables and everything works like magic
- I have another app where the theme is applied dynamically based on their brand colors.
- The runtime theming stuff is too magical to pass up. I'd love to just get it working across the board as expected.