### PR TITLE
fix(switch): Update switch checked styling on foundation init

### DIFF
--- a/packages/mdc-switch/foundation.js
+++ b/packages/mdc-switch/foundation.js
@@ -48,6 +48,9 @@ class MDCSwitchFoundation extends MDCFoundation {
 
   constructor(adapter) {
     super(Object.assign(MDCSwitchFoundation.defaultAdapter, adapter));
+
+    // Do an initial update based on the state of the native control.
+    this.handleChange();
   }
 
   /** @return {boolean} */

--- a/packages/mdc-switch/foundation.js
+++ b/packages/mdc-switch/foundation.js
@@ -48,8 +48,11 @@ class MDCSwitchFoundation extends MDCFoundation {
 
   constructor(adapter) {
     super(Object.assign(MDCSwitchFoundation.defaultAdapter, adapter));
+  }
 
-    // Do an initial update based on the state of the native control.
+  /** @override */
+  init() {
+    // Do an initial state update based on the state of the native control.
     this.handleChange();
   }
 

--- a/test/unit/mdc-switch/foundation.test.js
+++ b/test/unit/mdc-switch/foundation.test.js
@@ -45,6 +45,22 @@ function setupTest() {
   return {foundation, mockAdapter};
 }
 
+test('#init adds mdc-switch--checked to the switch element if the switch is initially checked', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.isNativeControlChecked()).thenReturn(true);
+
+  foundation.init();
+  td.verify(mockAdapter.addClass(MDCSwitchFoundation.cssClasses.CHECKED));
+});
+
+test('#init removes mdc-switch--checked from the switch element if the switch is initially unchecked', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.isNativeControlChecked()).thenReturn(false);
+
+  foundation.init();
+  td.verify(mockAdapter.removeClass(MDCSwitchFoundation.cssClasses.CHECKED));
+});
+
 test('#isChecked returns true when the value of adapter.isChecked() is true', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.isNativeControlChecked()).thenReturn(true);


### PR DESCRIPTION
This fixes an issue where Firefox would remember the state of the hidden input element on refresh which could result in a mismatch between switch styling and actual checked state.