### PR TITLE
fix(switch): Update switch styling to match the design spec

### DIFF
--- a/packages/mdc-switch/_variables.scss
+++ b/packages/mdc-switch/_variables.scss
@@ -25,13 +25,15 @@ $mdc-switch-tap-target-size: 48px;
 $mdc-switch-thumb-offset: 4px;
 
 // Position for the tap target that contains the thumb to align the thumb correctly offset from the track.
-$mdc-switch-tap-target-initial-position: -$mdc-switch-tap-target-size / 2 + $mdc-switch-thumb-diameter / 2 - 
-                                          $mdc-switch-thumb-offset;
+$mdc-switch-tap-target-initial-position:
+  -$mdc-switch-tap-target-size / 2 + $mdc-switch-thumb-diameter / 2 -
+  $mdc-switch-thumb-offset;
 
 // Value to cover the whole switch area (including the ripple) with the native control.
-$mdc-switch-native-control-width: $mdc-switch-track-width + 
-                                  ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter) +
-                                  $mdc-switch-thumb-offset * 2;
+$mdc-switch-native-control-width:
+  $mdc-switch-track-width +
+  ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter) +
+  $mdc-switch-thumb-offset * 2;
 
 $mdc-switch-thumb-active-margin: $mdc-switch-track-width - $mdc-switch-thumb-diameter + $mdc-switch-thumb-offset * 2;
 

--- a/packages/mdc-switch/_variables.scss
+++ b/packages/mdc-switch/_variables.scss
@@ -20,7 +20,8 @@ $mdc-switch-track-width: 32px;
 $mdc-switch-track-height: 14px;
 $mdc-switch-thumb-diameter: 20px;
 $mdc-switch-tap-target-size: 48px;
-$mdc-switch-native-control-width: $mdc-switch-track-width + ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter);
+// Value to cover the whole switch area (including the ripple) with the native control.
+$mdc-switch-native-control-width: 68px;
 $mdc-switch-thumb-active-margin: 20px;
 
 $mdc-switch-toggled-off-thumb-color: mdc-theme-prop-value(surface);

--- a/packages/mdc-switch/_variables.scss
+++ b/packages/mdc-switch/_variables.scss
@@ -20,9 +20,20 @@ $mdc-switch-track-width: 32px;
 $mdc-switch-track-height: 14px;
 $mdc-switch-thumb-diameter: 20px;
 $mdc-switch-tap-target-size: 48px;
+
+// Amount the edge of the thumb should be offset from the edge of the track.
+$mdc-switch-thumb-offset: 4px;
+
+// Position for the tap target that contains the thumb to align the thumb correctly offset from the track.
+$mdc-switch-tap-target-initial-position: -$mdc-switch-tap-target-size / 2 + $mdc-switch-thumb-diameter / 2 - 
+                                          $mdc-switch-thumb-offset;
+
 // Value to cover the whole switch area (including the ripple) with the native control.
-$mdc-switch-native-control-width: 68px;
-$mdc-switch-thumb-active-margin: 20px;
+$mdc-switch-native-control-width: $mdc-switch-track-width + 
+                                  ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter) +
+                                  $mdc-switch-thumb-offset * 2;
+
+$mdc-switch-thumb-active-margin: $mdc-switch-track-width - $mdc-switch-thumb-diameter + $mdc-switch-thumb-offset * 2;
 
 $mdc-switch-toggled-off-thumb-color: mdc-theme-prop-value(surface);
 $mdc-switch-toggled-off-track-color: mdc-theme-prop-value(on-surface);

--- a/packages/mdc-switch/_variables.scss
+++ b/packages/mdc-switch/_variables.scss
@@ -21,7 +21,7 @@ $mdc-switch-track-height: 14px;
 $mdc-switch-thumb-diameter: 20px;
 $mdc-switch-tap-target-size: 48px;
 $mdc-switch-native-control-width: $mdc-switch-track-width + ($mdc-switch-tap-target-size - $mdc-switch-thumb-diameter);
-$mdc-switch-thumb-active-margin: $mdc-switch-track-width - $mdc-switch-thumb-diameter;
+$mdc-switch-thumb-active-margin: 20px;
 
 $mdc-switch-toggled-off-thumb-color: mdc-theme-prop-value(surface);
 $mdc-switch-toggled-off-track-color: mdc-theme-prop-value(on-surface);

--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -62,7 +62,7 @@
 }
 
 .mdc-switch__thumb-underlay {
-  @include mdc-rtl-reflexive-position(left, -18px);
+  @include mdc-rtl-reflexive-position(left, $mdc-switch-tap-target-initial-position);
   @include mdc-ripple-surface();
   @include mdc-ripple-radius-unbounded;
   @include mdc-states($mdc-switch-baseline-theme-color);

--- a/packages/mdc-switch/mdc-switch.scss
+++ b/packages/mdc-switch/mdc-switch.scss
@@ -62,7 +62,7 @@
 }
 
 .mdc-switch__thumb-underlay {
-  @include mdc-rtl-reflexive-position(left, -14px);
+  @include mdc-rtl-reflexive-position(left, -18px);
   @include mdc-ripple-surface();
   @include mdc-ripple-radius-unbounded;
   @include mdc-states($mdc-switch-baseline-theme-color);
@@ -70,7 +70,7 @@
   display: flex;
   position: absolute;
   // Ensures the knob is centered on the track.
-  top: -($mdc-switch-track-height / 2 + $mdc-switch-thumb-diameter / 2);
+  top: -(($mdc-switch-tap-target-size - $mdc-switch-track-height) / 2);
   align-items: center;
   justify-content: center;
   width: $mdc-switch-tap-target-size;


### PR DESCRIPTION
Checked with design and the knob should be further out than it was to make more of the track visible. This change results in 16px of the track being visible in both checked and unchecked positions (not covered by the knob). Before this change only 12px was visible.

Also added a no-op fix to correctly calculate underlay top.