### PR TITLE
chore(infrastructure): Add image anchors and deep links to report page

### DIFF
--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -129,7 +129,9 @@ class ReportBuilder {
   async initForCapture() {
     this.logger_.foldStart('screenshot.init', 'ReportBuilder#initForCapture()');
 
-    await this.cbtApi_.fetchAvailableDevices();
+    if (this.cli_.isOnline()) {
+      await this.cbtApi_.fetchAvailableDevices();
+    }
 
     /** @type {!mdc.proto.ReportMeta} */
     const reportMeta = await this.createReportMetaProto_();

--- a/test/screenshot/report/_collection.hbs
+++ b/test/screenshot/report/_collection.hbs
@@ -103,6 +103,9 @@
                         ../html_file_path
                         user_agent.alias
                     }}{{/createApprovalStatusElement}}
+                    <a href="#{{../html_file_path}}:{{user_agent.alias}}"
+                       id="{{../html_file_path}}:{{user_agent.alias}}"
+                       class="report-user-agent__deeplink">#</a>
                   </span>
                 </summary>
                 <div class="report-user-agent__content">

--- a/test/screenshot/report/report.js
+++ b/test/screenshot/report/report.js
@@ -21,6 +21,7 @@ window.mdc.reportUi = (() => {
   class ReportUi {
     constructor() {
       this.bindEventListeners_();
+      this.collapseAllExceptDeepLink_();
 
       this.fetchReportData_().then((reportData) => {
         /**
@@ -116,6 +117,26 @@ window.mdc.reportUi = (() => {
       });
     }
 
+    collapseAllExceptDeepLink_() {
+      const [, id] = (/^#(.+)$/.exec(location.hash || '') || []);
+      if (!id) {
+        return;
+      }
+      const deepLinkElem = document.getElementById(id);
+      if (!deepLinkElem) {
+        return;
+      }
+      const htmlFileDetailsElems = Array.from(document.querySelectorAll('details.report-html-file'));
+      htmlFileDetailsElems.forEach((htmlFileDetailsElem) => {
+        htmlFileDetailsElem.open = htmlFileDetailsElem.contains(deepLinkElem);
+        if (htmlFileDetailsElem.open) {
+          htmlFileDetailsElem.querySelectorAll('details.report-user-agent').forEach((userAgentDetailsElem) => {
+            userAgentDetailsElem.open = userAgentDetailsElem.contains(deepLinkElem);
+          });
+        }
+      });
+    }
+
     collapseAll() {
       const allDetailsElems = Array.from(document.querySelectorAll('details'));
       allDetailsElems.forEach((detailsElem) => detailsElem.open = false);
@@ -127,15 +148,6 @@ window.mdc.reportUi = (() => {
     }
 
     collapseImages() {
-      this.collapseNone();
-
-      const collectionDetailsElems = Array.from(document.querySelectorAll('.report-collection'));
-      collectionDetailsElems.forEach((detailsElem) => {
-        const hasScreenshots = Number(detailsElem.getAttribute('data-num-screenshots')) > 0;
-        const isComparable = !['skipped', 'unchanged'].includes(detailsElem.getAttribute('data-collection-type'));
-        detailsElem.open = hasScreenshots && isComparable;
-      });
-
       const userAgentDetailsElems = Array.from(document.querySelectorAll('.report-user-agent'));
       userAgentDetailsElems.forEach((detailsElem) => detailsElem.open = false);
     }


### PR DESCRIPTION
### What it does

- Adds a `#` link on the right side of every screenshot:
    - Links to that exact screenshot on the report page
- Collapses all other screenshots if the hash link is present in the URL on page load
- Disables fetching CBT devices in `--offline` mode
- Changes the behavior of the "Collapse Images" button:
    - Only collapses images now
    - No longer expands/collapses other `<details>` elements

### Example output

![image](https://user-images.githubusercontent.com/409245/43018069-3d4c4cc4-8c0d-11e8-927b-4740581201cd.png)
