### PR TITLE
chore(infrastructure): Disable `git fetch` by default

### DIFF
--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -51,7 +51,7 @@ module.exports = {
       await gitHubApi.setPullRequestStatusAuto(reportData);
     } catch (err) {
       await gitHubApi.setPullRequestError();
-      throw new VError(err, 'Failed running screenshot tests');
+      throw new VError(err, 'Failed to run screenshot tests');
     }
 
     return await controller.getTestExitCode(reportData);

--- a/test/screenshot/infra/lib/cli.js
+++ b/test/screenshot/infra/lib/cli.js
@@ -355,8 +355,8 @@ E.g.: '--browser=chrome,-mobile' is the same as '--browser=chrome --browser=-mob
   }
 
   /** @return {boolean} */
-  get shouldFetch() {
-    return !this.args_['--no-fetch'];
+  get skipFetch() {
+    return this.args_['--no-fetch'];
   }
 
   /** @return {?string} */

--- a/test/screenshot/infra/lib/controller.js
+++ b/test/screenshot/infra/lib/controller.js
@@ -101,10 +101,6 @@ class Controller {
    */
   async initForCapture() {
     const isOnline = this.cli_.isOnline();
-    const shouldFetch = this.cli_.shouldFetch;
-    if (isOnline && shouldFetch) {
-      await this.gitRepo_.fetch();
-    }
     if (isOnline) {
       await this.cbtApi_.killStalledSeleniumTests();
     }
@@ -115,11 +111,6 @@ class Controller {
    * @return {!Promise<!mdc.proto.ReportData>}
    */
   async initForDemo() {
-    const isOnline = this.cli_.isOnline();
-    const shouldFetch = this.cli_.shouldFetch;
-    if (isOnline && shouldFetch) {
-      await this.gitRepo_.fetch();
-    }
     return this.reportBuilder_.initForDemo();
   }
 

--- a/test/screenshot/infra/lib/diff-base-parser.js
+++ b/test/screenshot/infra/lib/diff-base-parser.js
@@ -65,7 +65,6 @@ class DiffBaseParser {
   }
 
   /**
-   * TODO(acdvorak): Move this method out of DiffBaseParser class - it doesn't belong here.
    * @param {string} rawDiffBase
    * @return {!Promise<!mdc.proto.DiffBase>}
    */
@@ -88,7 +87,6 @@ class DiffBaseParser {
   }
 
   /**
-   * TODO(acdvorak): Move this method out of DiffBaseParser class - it doesn't belong here.
    * @param {string} rawDiffBase
    * @return {!Promise<!mdc.proto.DiffBase>}
    * @private
@@ -110,6 +108,16 @@ class DiffBaseParser {
 
     const [inputGoldenRef, inputGoldenPath] = rawDiffBase.split(':');
     const goldenFilePath = inputGoldenPath || GOLDEN_JSON_RELATIVE_PATH;
+
+    const isRemoteBranch = inputGoldenRef.startsWith('origin/');
+    const isVersionTag = /^v[0-9.]+$/.test(inputGoldenRef);
+    const isFetchable = isRemoteBranch || isVersionTag;
+    const skipFetch = this.cli_.skipFetch;
+    const isOnline = this.cli_.isOnline();
+    if (isFetchable && !skipFetch && isOnline) {
+      await this.gitRepo_.fetch();
+    }
+
     const fullGoldenRef = await this.gitRepo_.getFullSymbolicName(inputGoldenRef);
 
     // Diff against a specific git commit.

--- a/test/screenshot/infra/lib/git-repo.js
+++ b/test/screenshot/infra/lib/git-repo.js
@@ -21,6 +21,8 @@ const simpleGit = require('simple-git/promise');
 const mdcProto = require('../proto/mdc.pb').mdc.proto;
 const {User} = mdcProto;
 
+let hasFetched = false;
+
 class GitRepo {
   constructor(workingDirPath = undefined) {
     /**
@@ -49,6 +51,11 @@ class GitRepo {
    * @return {!Promise<void>}
    */
   async fetch(args = []) {
+    if (hasFetched) {
+      return;
+    }
+    hasFetched = true;
+
     console.log('Fetching remote git commits...');
 
     const prFetchRef = '+refs/pull/*/head:refs/remotes/origin/pr/*';

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -305,7 +305,7 @@ class ReportBuilder {
    */
   async prefetchGoldenImages_(reportData) {
     // TODO(acdvorak): Figure out how to handle offline mode for prefetching and diffing
-    console.log('Prefetching golden images...');
+    console.log('Fetching golden images...');
     await Promise.all(
       reportData.screenshots.expected_screenshot_list.map((expectedScreenshot) => {
         return this.prefetchScreenshotImages_(expectedScreenshot);

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -219,7 +219,7 @@ class SeleniumApi {
     } catch (err) {
       logResult(CliStatuses.FAILED);
       await this.killBrowsers_();
-      throw new VError(err, 'Failed driving web browser');
+      throw new VError(err, 'Failed to drive web browser');
     } finally {
       logResult(CliStatuses.QUITTING);
       await driver.quit();

--- a/test/screenshot/report/_footer.hbs
+++ b/test/screenshot/report/_footer.hbs
@@ -46,10 +46,10 @@
     <span class="report-toolbar__column-label">Collapse:</span>
     <div class="report-toolbar__column-content">
       <button class="report-toolbar__button" onclick="mdc.reportUi.collapseAll()">
-        ▼ All
+        ▶ All
       </button>
       <button class="report-toolbar__button" onclick="mdc.reportUi.collapseNone()">
-        ▶ None
+        ▼ None
       </button>
       <button class="report-toolbar__button" onclick="mdc.reportUi.collapseImages()">
         🌅 Images

--- a/test/screenshot/report/report.scss
+++ b/test/screenshot/report/report.scss
@@ -316,7 +316,7 @@ th {
 }
 
 .report-review-status--hidden {
-  visibility: hidden;
+  display: none;
 }
 
 .report-review-status[data-review-status="approve"] {


### PR DESCRIPTION
### What it does

- Disables `git fetch` by default, but enables it IFF:
    1. `--diff-base` looks like a remote branch or version tag (e.g., `origin/master` or `v0.37.1`); and
    2. the user has not explicitly disabled fetching with the `--no-fetch` CLI flag
- Swaps the icons for "Collapse All" and "Collapse None" buttons
- Removes the blank space between the browser name and `#` deep link on the report page
- Tweaks the wording of a few log messages

### Example output

<img src="https://user-images.githubusercontent.com/409245/43032416-1a3b7a30-8c6b-11e8-88ec-c369e5a12594.png" height="40" alt="screenshot">
