### PR TITLE
chore(infrastructure): Fail Travis if PR has diffs #KenWasRight

### DIFF
--- a/test/screenshot/infra/lib/controller.js
+++ b/test/screenshot/infra/lib/controller.js
@@ -215,12 +215,6 @@ class Controller {
    * @return {!Promise<number>}
    */
   async getTestExitCode(reportData) {
-    // Pull requests display screenshot diffs as a separate "status check" in the GitHub UI, so we don't want to mark
-    // the Travis run as "failed".
-    if (Number(process.env.TRAVIS_PULL_REQUEST)) {
-      return ExitCode.OK;
-    }
-
     // TODO(acdvorak): Store this directly in the proto so we don't have to recalculate it all over the place
     const numChanges =
       reportData.screenshots.changed_screenshot_list.length +

--- a/test/screenshot/spec/mdc-button/fixture.scss
+++ b/test/screenshot/spec/mdc-button/fixture.scss
@@ -17,7 +17,7 @@
 @import "../../../../packages/mdc-button/mixins";
 @import "../../../../packages/mdc-theme/color-palette";
 
-$custom-button-color: $material-color-red-900;
+$custom-button-color: $material-color-red-300;
 $custom-button-custom-corner-radius: 8px;
 $custom-button-custom-outline-width: 4px;
 $custom-button-custom-horizontal-padding: 24px;

--- a/test/screenshot/spec/mdc-button/fixture.scss
+++ b/test/screenshot/spec/mdc-button/fixture.scss
@@ -17,7 +17,7 @@
 @import "../../../../packages/mdc-button/mixins";
 @import "../../../../packages/mdc-theme/color-palette";
 
-$custom-button-color: $material-color-red-300;
+$custom-button-color: $material-color-red-900;
 $custom-button-custom-corner-radius: 8px;
 $custom-button-custom-outline-width: 4px;
 $custom-button-custom-horizontal-padding: 24px;


### PR DESCRIPTION
Ken Was Right.

If there are screenshot diffs, we _should_ fail Travis PR builds by returning a non-zero exit code.

Otherwise, when you look at the build history in Travis, commits that have screenshot diffs are misleadingly displayed with a happy green "passed" badge.