### PR TITLE
chore(infrastructure): Always print report page URL

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -109,7 +109,6 @@ module.exports = function(config) {
     browsers: determineBrowsers(),
     browserDisconnectTimeout: 40000,
     browserNoActivityTimeout: 120000,
-    browserDisconnectTolerance: 1,
     captureTimeout: 240000,
     concurrency: USING_SL ? 4 : Infinity,
     customLaunchers: SL_LAUNCHERS,
@@ -127,7 +126,6 @@ module.exports = function(config) {
       mocha: {
         reporter: 'html',
         ui: 'qunit',
-        timeout: 10000, // Applies to each individual test case. Limits how long a test case can run in the browser.
       },
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -109,6 +109,7 @@ module.exports = function(config) {
     browsers: determineBrowsers(),
     browserDisconnectTimeout: 40000,
     browserNoActivityTimeout: 120000,
+    browserDisconnectTolerance: 1,
     captureTimeout: 240000,
     concurrency: USING_SL ? 4 : Infinity,
     customLaunchers: SL_LAUNCHERS,
@@ -126,6 +127,7 @@ module.exports = function(config) {
       mocha: {
         reporter: 'html',
         ui: 'qunit',
+        timeout: 10000, // Applies to each individual test case. Limits how long a test case can run in the browser.
       },
     },
 

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -236,12 +236,10 @@ class TestCommand {
 
     await Promise.all(promises);
 
+    const endTimeIsoUtc = new Date().toISOString();
     reportData.meta.start_time_iso_utc = startTimeIsoUtc;
-    reportData.meta.end_time_iso_utc = new Date().toISOString();
-    reportData.meta.duration_ms = Duration.elapsed(
-      reportData.meta.start_time_iso_utc,
-      reportData.meta.end_time_iso_utc
-    ).toMillis();
+    reportData.meta.end_time_iso_utc = endTimeIsoUtc;
+    reportData.meta.duration_ms = Duration.elapsed(startTimeIsoUtc, endTimeIsoUtc).toMillis();
 
     this.logger_.foldEnd('screenshot.compare_master');
   }

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -63,18 +63,19 @@ class TestCommand {
     // TODO(acdvorak): Find a better word than "local"
     /** @type {!mdc.proto.ReportData} */
     const localDiffReportData = await this.diffAgainstLocal_(snapshotDiffBase);
-
-    this.logTestResults_(localDiffReportData);
-
     const localDiffExitCode = this.getExitCode_(localDiffReportData);
     if (localDiffExitCode !== ExitCode.OK) {
+      this.logTestResults_(localDiffReportData);
       return localDiffExitCode;
     }
 
     if (isTravisPr) {
       /** @type {!mdc.proto.ReportData} */
       const masterDiffReportData = await this.diffAgainstMaster_({localDiffReportData, snapshotGitRev});
+      this.logTestResults_(localDiffReportData);
       this.logTestResults_(masterDiffReportData);
+    } else {
+      this.logTestResults_(localDiffReportData);
     }
 
     // Diffs against master shouldn't fail the Travis job.

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -63,16 +63,17 @@ class TestCommand {
     // TODO(acdvorak): Find a better word than "local"
     /** @type {!mdc.proto.ReportData} */
     const localDiffReportData = await this.diffAgainstLocal_(snapshotDiffBase);
+
+    this.logTestResults_(localDiffReportData);
+
     const localDiffExitCode = this.getExitCode_(localDiffReportData);
     if (localDiffExitCode !== ExitCode.OK) {
-      this.logTestResults_(localDiffReportData);
       return localDiffExitCode;
     }
 
     if (isTravisPr) {
       /** @type {!mdc.proto.ReportData} */
       const masterDiffReportData = await this.diffAgainstMaster_({localDiffReportData, snapshotGitRev});
-      this.logTestResults_(localDiffReportData);
       this.logTestResults_(masterDiffReportData);
     }
 

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -123,10 +123,11 @@ class TestCommand {
    * TODO(acdvorak): Rename this method
    * @param {!mdc.proto.DiffBase} goldenDiffBase
    * @param {!Array<!mdc.proto.Screenshot>} capturedScreenshots
+   * @param {string} startTimeIsoUtc
    * @return {!Promise<!mdc.proto.ReportData>}
    * @private
    */
-  async diffAgainstMasterImpl_(goldenDiffBase, capturedScreenshots) {
+  async diffAgainstMasterImpl_({goldenDiffBase, capturedScreenshots, startTimeIsoUtc}) {
     const controller = new Controller();
 
     /** @type {!mdc.proto.ReportData} */
@@ -134,7 +135,7 @@ class TestCommand {
 
     try {
       await controller.uploadAllAssets(reportData);
-      await this.copyAndCompareScreenshots_({reportData, capturedScreenshots});
+      await this.copyAndCompareScreenshots_({reportData, capturedScreenshots, startTimeIsoUtc});
 
       controller.populateMaps(reportData);
 
@@ -172,14 +173,11 @@ class TestCommand {
     const masterDiffBase = await this.diffBaseParser_.parseMasterDiffBase();
 
     /** @type {!mdc.proto.ReportData} */
-    const masterDiffReportData = await this.diffAgainstMasterImpl_(masterDiffBase, capturedScreenshots);
-
-    masterDiffReportData.meta.start_time_iso_utc = localDiffReportData.meta.start_time_iso_utc;
-    masterDiffReportData.meta.end_time_iso_utc = new Date().toISOString();
-    masterDiffReportData.meta.duration_ms = Duration.elapsed(
-      masterDiffReportData.meta.start_time_iso_utc,
-      masterDiffReportData.meta.end_time_iso_utc
-    ).toMillis();
+    const masterDiffReportData = await this.diffAgainstMasterImpl_({
+      goldenDiffBase: masterDiffBase,
+      capturedScreenshots,
+      startTimeIsoUtc: localDiffReportData.meta.start_time_iso_utc,
+    });
 
     const prNumber = snapshotGitRev.pr_number;
     const comment = this.getPrComment_({masterDiffReportData, snapshotGitRev});
@@ -191,10 +189,11 @@ class TestCommand {
   /**
    * @param {!mdc.proto.ReportData} reportData
    * @param {!Array<!mdc.proto.Screenshot>} capturedScreenshots
+   * @param {string} startTimeIsoUtc
    * @return {!Promise<void>}
    * @private
    */
-  async copyAndCompareScreenshots_({reportData, capturedScreenshots}) {
+  async copyAndCompareScreenshots_({reportData, capturedScreenshots, startTimeIsoUtc}) {
     const num = capturedScreenshots.length;
     const plural = num === 1 ? '' : 's';
     this.logger_.foldStart('screenshot.compare_master', `Comparing ${num} screenshot${plural} to master`);
@@ -236,6 +235,13 @@ class TestCommand {
     }
 
     await Promise.all(promises);
+
+    reportData.meta.start_time_iso_utc = startTimeIsoUtc;
+    reportData.meta.end_time_iso_utc = new Date().toISOString();
+    reportData.meta.duration_ms = Duration.elapsed(
+      reportData.meta.start_time_iso_utc,
+      reportData.meta.end_time_iso_utc
+    ).toMillis();
 
     this.logger_.foldEnd('screenshot.compare_master');
   }

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -454,7 +454,6 @@ class ReportBuilder {
       }),
       mdc_version: LibraryVersion.create({
         version_string: mdcVersionString,
-        commit_offset: await this.getCommitDistance_(mdcVersionString),
       }),
     });
   }
@@ -511,26 +510,6 @@ class ReportBuilder {
     const options = {cwd: process.env.PWD, env: process.env};
     const stdOut = await childProcess.exec(`${cmd} --version`, options);
     return stdOut[0].trim().replace(/^v/, ''); // `node --version` returns "v8.11.0", so we strip the leading 'v'
-  }
-
-  /**
-   * @param {string} mdcVersion
-   * @return {!Promise<number>}
-   */
-  async getCommitDistance_(mdcVersion) {
-    try {
-      return (await this.gitRepo_.getLog([`v${mdcVersion}..HEAD`])).length;
-    } catch (err) {
-      // To save time, Travis CI only clones a certain number of commits.
-      // Unfortunately, if the user's PR branch has a lot of commits, `git log` will fail with an error like this:
-      //
-      //   fatal: ambiguous argument 'v0.37.1..HEAD': unknown revision or path not in the working tree.
-      //   Use '--' to separate paths from revisions, like this:
-      //   'git <command> [<revision>...] -- [<file>...]'
-      //
-      // Commit distance isn't critical information, so just return 0.
-      return 0;
-    }
   }
 
   /**

--- a/test/screenshot/infra/proto/mdc.pb.js
+++ b/test/screenshot/infra/proto/mdc.pb.js
@@ -2120,7 +2120,6 @@ $root.mdc = (function() {
              * @memberof mdc.proto
              * @interface ILibraryVersion
              * @property {string|null} [version_string] LibraryVersion version_string
-             * @property {number|null} [commit_offset] LibraryVersion commit_offset
              */
 
             /**
@@ -2145,14 +2144,6 @@ $root.mdc = (function() {
              * @instance
              */
             LibraryVersion.prototype.version_string = "";
-
-            /**
-             * LibraryVersion commit_offset.
-             * @member {number} commit_offset
-             * @memberof mdc.proto.LibraryVersion
-             * @instance
-             */
-            LibraryVersion.prototype.commit_offset = 0;
 
             /**
              * Creates a new LibraryVersion instance using the specified properties.
@@ -2180,8 +2171,6 @@ $root.mdc = (function() {
                     writer = $Writer.create();
                 if (message.version_string != null && message.hasOwnProperty("version_string"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.version_string);
-                if (message.commit_offset != null && message.hasOwnProperty("commit_offset"))
-                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.commit_offset);
                 return writer;
             };
 
@@ -2218,9 +2207,6 @@ $root.mdc = (function() {
                     switch (tag >>> 3) {
                     case 1:
                         message.version_string = reader.string();
-                        break;
-                    case 2:
-                        message.commit_offset = reader.int32();
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -2260,9 +2246,6 @@ $root.mdc = (function() {
                 if (message.version_string != null && message.hasOwnProperty("version_string"))
                     if (!$util.isString(message.version_string))
                         return "version_string: string expected";
-                if (message.commit_offset != null && message.hasOwnProperty("commit_offset"))
-                    if (!$util.isInteger(message.commit_offset))
-                        return "commit_offset: integer expected";
                 return null;
             };
 
@@ -2280,8 +2263,6 @@ $root.mdc = (function() {
                 var message = new $root.mdc.proto.LibraryVersion();
                 if (object.version_string != null)
                     message.version_string = String(object.version_string);
-                if (object.commit_offset != null)
-                    message.commit_offset = object.commit_offset | 0;
                 return message;
             };
 
@@ -2298,14 +2279,10 @@ $root.mdc = (function() {
                 if (!options)
                     options = {};
                 var object = {};
-                if (options.defaults) {
+                if (options.defaults)
                     object.version_string = "";
-                    object.commit_offset = 0;
-                }
                 if (message.version_string != null && message.hasOwnProperty("version_string"))
                     object.version_string = message.version_string;
-                if (message.commit_offset != null && message.hasOwnProperty("commit_offset"))
-                    object.commit_offset = message.commit_offset;
                 return object;
             };
 

--- a/test/screenshot/infra/proto/mdc.proto
+++ b/test/screenshot/infra/proto/mdc.proto
@@ -109,7 +109,6 @@ message User {
 
 message LibraryVersion {
   string version_string = 1;
-  int32 commit_offset = 2;
 }
 
 message UserAgents {

--- a/test/screenshot/report/_metadata.hbs
+++ b/test/screenshot/report/_metadata.hbs
@@ -53,9 +53,6 @@
           <th class="report-metadata__cell report-metadata__cell--key">MDC Version:</th>
           <td class="report-metadata__cell report-metadata__cell--val">
             <a href="https://github.com/material-components/material-components-web/releases/tag/v{{meta.mdc_version.version_string}}">{{meta.mdc_version.version_string}}</a>
-            {{#if meta.mdc_version.commit_offset}}
-              <span class="report-metadata__commit-offset">+ {{meta.mdc_version.commit_offset}} commits</span>
-            {{/if}}
           </td>
         </tr>
         <tr class="report-metadata__row--top-divider">


### PR DESCRIPTION
- Fixes 2 bugs introduced in #3171:
    - Test runs with zero diffs would not print the report page URL to the console
    - Test duration calculation always returned `0 milliseconds` for diffs against `master`
- Also removes buggy `commit_offset` field:
    - It only works with non-bug-fix releases. It would fail on `v0.36.1`, for example.