### PR TITLE
fix(tab): Remove extraneous padding from the stacked text label in LTR

### DIFF
--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -128,11 +128,6 @@
   }
 }
 
-.mdc-tab .mdc-tab__icon + .mdc-tab__text-label {
+.mdc-tab:not(.mdc-tab--stacked) .mdc-tab__icon + .mdc-tab__text-label {
   @include mdc-rtl-reflexive-box(padding, left, 8px);
-}
-
-.mdc-tab--stacked .mdc-tab__icon + .mdc-tab__text-label {
-  padding-right: 0;
-  padding-left: 0;
 }


### PR DESCRIPTION
Closes #3192 