### PR TITLE
feat(tabs): Add missing docs and create helper util API

### DIFF
--- a/packages/mdc-tab-scroller/README.md
+++ b/packages/mdc-tab-scroller/README.md
@@ -82,6 +82,7 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 
 Method Signature | Description
 --- | ---
+`eventTargetMatchesSelector(eventTarget: EventTarget, selector: string) => boolean` | Returns `true` if the given event target satisfies the given CSS selector.
 `addClass(className: string) => void` | Adds a class to the root element.
 `addScrollAreaClass(className: string) => void` | Adds a class to the scroll area element.
 `removeClass(className: string) => void` | Removes a class from the root element.
@@ -94,8 +95,14 @@ Method Signature | Description
 `getScrollAreaOffsetWidth() => number` | Returns the scroll area element's `offsetWidth`.
 `computeHorizontalScrollbarHeight() => number` | Returns the height of the browser's horizontal scrollbars (in px).
 
-> *NOTE*: MDC Tab Scroller provides an implementation for `computeHorizontalScrollbarHeight` in its `util` module;
-> simply pass it the `document` object.
+#### `util` Functions
+
+MDC Tab Scroller provides a `util` module with functions to help implement adapter methods.
+
+Function Signature | Description
+--- | ---
+`computeHorizontalScrollbarHeight(document: Document) => number` | Returns the height of the browser's horizontal scrollbars (in px).
+`getMatchesProperty(HTMLElementPrototype: Object) => string` | Returns the appropriate property name for the `matches` API in the current browser environment.
 
 ### `MDCTabScrollerFoundation`
 

--- a/packages/mdc-tab-scroller/index.js
+++ b/packages/mdc-tab-scroller/index.js
@@ -83,12 +83,9 @@ class MDCTabScroller extends MDCComponent {
    */
   getDefaultFoundation() {
     const adapter = /** @type {!MDCTabScrollerAdapter} */ ({
-      eventTargetMatchesSelector: (evtTarget, className) => {
-        let matches = Element.prototype.matches;
-        if (matches === undefined) {
-          matches = Element.prototype.msMatchesSelector;
-        }
-        return matches.call(evtTarget, className);
+      eventTargetMatchesSelector: (evtTarget, selector) => {
+        const MATCHES = util.getMatchesProperty(HTMLElement.prototype);
+        return evtTarget[MATCHES](selector);
       },
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-tab-scroller/util.js
+++ b/packages/mdc-tab-scroller/util.js
@@ -48,4 +48,14 @@ function computeHorizontalScrollbarHeight(documentObj, shouldCacheResult = true)
   return horizontalScrollbarHeight;
 }
 
-export {computeHorizontalScrollbarHeight};
+/**
+ * @param {!Object} HTMLElementPrototype
+ * @return {!Array<string>}
+ */
+function getMatchesProperty(HTMLElementPrototype) {
+  return [
+    'msMatchesSelector', 'matches',
+  ].filter((p) => p in HTMLElementPrototype).pop();
+}
+
+export {computeHorizontalScrollbarHeight, getMatchesProperty};

--- a/test/unit/mdc-tab-scroller/util.test.js
+++ b/test/unit/mdc-tab-scroller/util.test.js
@@ -51,3 +51,12 @@ test('#computeHorizontalScrollbarHeight returns value based on difference betwee
     expectedHeight);
   td.verify(classListAddFunc(cssClasses.SCROLL_TEST));
 });
+
+test('#getMatchesProperty returns the correct property for selector matching', () => {
+  assert.strictEqual(util.getMatchesProperty({matches: () => {}}), 'matches');
+  assert.strictEqual(util.getMatchesProperty({msMatchesSelector: () => {}}), 'msMatchesSelector');
+});
+
+test('#getMatchesProperty returns the standard function if more than one method is present', () => {
+  assert.strictEqual(util.getMatchesProperty({matches: () => {}, msMatchesSelector: () => {}}), 'matches');
+});


### PR DESCRIPTION
This PR:

* Documents `eventTargetMatchesSelector` in the tab-scroller readme
* Adds a util API akin to one in mdc-ripple to help implement this adapter API
* Documents the util APIs in their own subsection