### PR TITLE
feat(menu-surface): Emit an event after the menu is opened

### DIFF
--- a/packages/mdc-menu-surface/README.md
+++ b/packages/mdc-menu-surface/README.md
@@ -119,6 +119,7 @@ Method Signature | Description
 `registerBodyClickHandler(handler: EventListener) => void` | Adds an event listener `handler` for event type `click` on the body.
 `deregisterBodyClickHandler(handler: EventListener) => void` | Removes an event listener `handler` for event type `click` on the body.
 `notifyClose() => void` | Dispatches an event notifying listeners that the menu surface has been closed.
+`notifyOpen() => void` | Dispatches an event notifying listeners that the menu surface has been opened.
 `isElementInContainer(el: Element) => Boolean` | Returns true if the `el` Element is inside the `mdc-menu-surface` container.
 `isRtl() => boolean` | Returns boolean indicating whether the current environment is RTL.
 `setTransformOrigin(value: string) => void` | Sets the transform origin for the menu surface element.
@@ -157,4 +158,5 @@ Method Signature | Description
 
 Event Name | Data | Description
 --- | --- | ---
-`MDCMenuSurface:close` | none | Event emitted after the menu surface is closed.
+`MDCMenuSurface:closed` | none | Event emitted after the menu surface is closed.
+`MDCMenuSurface:opened` | none | Event emitted after the menu surface is opened.

--- a/packages/mdc-menu-surface/adapter.js
+++ b/packages/mdc-menu-surface/adapter.js
@@ -73,6 +73,9 @@ class MDCMenuSurfaceAdapter {
   /** Emits an event when the menu surface is closed. */
   notifyClose() {}
 
+  /** Emits an event when the menu surface is opened. */
+  notifyOpen() {}
+
   /**
    * @return {boolean}
    * @param {EventTarget} el

--- a/packages/mdc-menu-surface/constants.js
+++ b/packages/mdc-menu-surface/constants.js
@@ -28,7 +28,8 @@ const cssClasses = {
 /** @enum {string} */
 const strings = {
   ARIA_DISABLED_ATTR: 'aria-disabled',
-  CLOSE_EVENT: 'MDCMenuSurface:close',
+  CLOSED_EVENT: 'MDCMenuSurface:closed',
+  OPENED_EVENT: 'MDCMenuSurface:opened',
   FOCUSABLE_ELEMENTS: 'button:not(:disabled), [href]:not([aria-disabled="true"]), input:not(:disabled), ' +
   'select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"]):not([aria-disabled="true"])',
 };

--- a/packages/mdc-menu-surface/foundation.js
+++ b/packages/mdc-menu-surface/foundation.js
@@ -85,6 +85,7 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
       registerBodyClickHandler: () => {},
       deregisterBodyClickHandler: () => {},
       notifyClose: () => {},
+      notifyOpen: () => {},
       isElementInContainer: () => false,
       isRtl: () => false,
       setTransformOrigin: () => {},
@@ -473,10 +474,13 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
       this.dimensions_ = this.adapter_.getInnerDimensions();
       this.autoPosition_();
       this.adapter_.registerBodyClickHandler(this.documentClickHandler_);
-      if (!this.quickOpen_) {
+      if (this.quickOpen_) {
+        this.adapter_.notifyOpen();
+      } else {
         this.openAnimationEndTimerId_ = setTimeout(() => {
           this.openAnimationEndTimerId_ = 0;
           this.adapter_.removeClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_OPEN);
+          this.adapter_.notifyOpen();
         }, numbers.TRANSITION_OPEN_DURATION);
       }
     });
@@ -495,7 +499,9 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
 
     requestAnimationFrame(() => {
       this.adapter_.removeClass(MDCMenuSurfaceFoundation.cssClasses.OPEN);
-      if (!this.quickOpen_) {
+      if (this.quickOpen_) {
+        this.adapter_.notifyClose();
+      } else {
         this.closeAnimationEndTimerId_ = setTimeout(() => {
           this.closeAnimationEndTimerId_ = 0;
           this.adapter_.removeClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_CLOSED);

--- a/packages/mdc-menu-surface/index.js
+++ b/packages/mdc-menu-surface/index.js
@@ -150,7 +150,8 @@ class MDCMenuSurface extends MDCComponent {
         deregisterInteractionHandler: (type, handler) => this.root_.removeEventListener(type, handler),
         registerBodyClickHandler: (handler) => document.body.addEventListener('click', handler),
         deregisterBodyClickHandler: (handler) => document.body.removeEventListener('click', handler),
-        notifyClose: () => this.emit(MDCMenuSurfaceFoundation.strings.CLOSE_EVENT, {}),
+        notifyClose: () => this.emit(MDCMenuSurfaceFoundation.strings.CLOSED_EVENT, {}),
+        notifyOpen: () => this.emit(MDCMenuSurfaceFoundation.strings.OPENED_EVENT, {}),
         isElementInContainer: (el) => this.root_ === el || this.root_.contains(el),
         isRtl: () => getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
         setTransformOrigin: (origin) => {

--- a/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
+++ b/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
@@ -200,11 +200,19 @@ test('adapter#deregisterBodyClickHandler proxies to removeEventListener', () => 
   td.verify(handler(td.matchers.anything()), {times: 0});
 });
 
-test(`adapter#notifyClose fires an ${strings.CLOSE_EVENT} custom event`, () => {
+test(`adapter#notifyClose fires an ${strings.CLOSED_EVENT} custom event`, () => {
   const {root, component} = setupTest();
   const handler = td.func('notifyClose handler');
-  root.addEventListener(strings.CLOSE_EVENT, handler);
+  root.addEventListener(strings.CLOSED_EVENT, handler);
   component.getDefaultFoundation().adapter_.notifyClose();
+  td.verify(handler(td.matchers.anything()));
+});
+
+test(`adapter#notifyOpen fires an ${strings.OPENED_EVENT} custom event`, () => {
+  const {root, component} = setupTest();
+  const handler = td.func('notifyOpen handler');
+  root.addEventListener(strings.OPENED_EVENT, handler);
+  component.getDefaultFoundation().adapter_.notifyOpen();
   td.verify(handler(td.matchers.anything()));
 });
 

--- a/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
+++ b/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
@@ -98,7 +98,7 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'registerBodyClickHandler', 'deregisterBodyClickHandler', 'notifyClose', 'isElementInContainer', 'isRtl',
     'setTransformOrigin', 'isFocused', 'saveFocus', 'restoreFocus', 'isFirstElementFocused', 'isLastElementFocused',
     'focusFirstElement', 'focusLastElement', 'getInnerDimensions', 'getAnchorDimensions', 'getWindowDimensions',
-    'getBodyDimensions', 'getWindowScroll', 'setPosition', 'setMaxHeight',
+    'getBodyDimensions', 'getWindowScroll', 'setPosition', 'setMaxHeight', 'notifyOpen',
   ]);
 });
 
@@ -141,6 +141,17 @@ testFoundation('#open removes the animation class at the end of the animation',
     clock.tick(numbers.TRANSITION_OPEN_DURATION);
     mockRaf.flush();
     td.verify(mockAdapter.removeClass(cssClasses.ANIMATING_OPEN));
+  });
+
+testFoundation('#open emits the close event at the end of the animation',
+  ({foundation, mockAdapter, mockRaf}) => {
+    const clock = lolex.install();
+    foundation.open();
+    mockRaf.flush();
+    mockRaf.flush();
+    clock.tick(numbers.TRANSITION_OPEN_DURATION);
+    mockRaf.flush();
+    td.verify(mockAdapter.notifyOpen());
   });
 
 /** Testing various layout cases for autopositioning */

--- a/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
+++ b/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
@@ -95,10 +95,10 @@ test('exports MenuSurfaceCorner', () => {
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCMenuSurfaceFoundation, [
     'addClass', 'removeClass', 'hasClass', 'hasAnchor', 'registerInteractionHandler', 'deregisterInteractionHandler',
-    'registerBodyClickHandler', 'deregisterBodyClickHandler', 'notifyClose', 'isElementInContainer', 'isRtl',
-    'setTransformOrigin', 'isFocused', 'saveFocus', 'restoreFocus', 'isFirstElementFocused', 'isLastElementFocused',
-    'focusFirstElement', 'focusLastElement', 'getInnerDimensions', 'getAnchorDimensions', 'getWindowDimensions',
-    'getBodyDimensions', 'getWindowScroll', 'setPosition', 'setMaxHeight', 'notifyOpen',
+    'registerBodyClickHandler', 'deregisterBodyClickHandler', 'notifyClose', 'notifyOpen', 'isElementInContainer',
+    'isRtl', 'setTransformOrigin', 'isFocused', 'saveFocus', 'restoreFocus', 'isFirstElementFocused',
+    'isLastElementFocused', 'focusFirstElement', 'focusLastElement', 'getInnerDimensions', 'getAnchorDimensions',
+    'getWindowDimensions', 'getBodyDimensions', 'getWindowScroll', 'setPosition', 'setMaxHeight',
   ]);
 });
 
@@ -143,7 +143,7 @@ testFoundation('#open removes the animation class at the end of the animation',
     td.verify(mockAdapter.removeClass(cssClasses.ANIMATING_OPEN));
   });
 
-testFoundation('#open emits the close event at the end of the animation',
+testFoundation('#open emits the open event at the end of the animation',
   ({foundation, mockAdapter, mockRaf}) => {
     const clock = lolex.install();
     foundation.open();


### PR DESCRIPTION
Adds a custom event for when the menu is opened to match the event when the menu is closed. 

Focusing a menu item before the menu is opened causes the window to scroll to the initial position of the menu. If the menu is hoisted to the body, it will be initially positioned at the bottom of the page. This PR will cause the menu-surface to emit an event after the menu is opened, so the menu can listen to that event prior to the list item being focused. 