### PR TITLE
chore(infrastructure): Don't throw error if Selenium test can't be killed

### DIFF
--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -399,9 +399,14 @@ https://crossbrowsertesting.com/account
   async killSeleniumTests(seleniumTestIds, silent = false) {
     await Promise.all(seleniumTestIds.map((seleniumTestId) => {
       if (!silent) {
-        console.log(`${CliColor.red('Killing')} zombie Selenium test ${CliColor.bold(seleniumTestId)}`);
+        console.log(`${CliColor.magenta('Killing')} stalled Selenium test ${CliColor.bold(seleniumTestId)}`);
       }
-      return this.sendRequest_('DELETE', `/selenium/${seleniumTestId}`);
+      return this.sendRequest_('DELETE', `/selenium/${seleniumTestId}`).catch((err) => {
+        if (!silent) {
+          console.warn(`${CliColor.red('Failed')} to kill stalled Selenium test ${CliColor.bold(seleniumTestId)}:`);
+          console.warn(err);
+        }
+      });
     }));
   }
 


### PR DESCRIPTION
Throwing an error can mask the true root cause, particularly when a test is being killed _in response to_ another error.

For example: Chrome threw an error, so we tried to kill the Chrome VM, but CBT already killed it, so we get a spurious error instead of the real one:

```
FINISHED: Firefox 61 on Windows 10!
QUITTING: Firefox 61 on Windows 10!
  FAILED: Chrome 67.0.3396 on Windows 10!

Killing zombie Selenium test b112ac67-f0cc-40b0-b74d-81f95adaf30e

Waiting for CBT cancellation requests to complete...

ERROR: { VError: Failed to run screenshot tests: Session no longer available: b112ac67-f0cc-40b0-b74d-81f95adaf30e
    at Object.diffEmAll_ (/Users/advorak/dev/mdc-web/test/screenshot/infra/commands/test.js:151:13)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7)
  jse_shortmsg: 'Failed to run screenshot tests',
  jse_cause: { WebDriverError: Session no longer available: b112ac67-f0cc-40b0-b74d-81f95adaf30e
    at parseHttpResponse (/Users/advorak/dev/mdc-web/node_modules/selenium-webdriver/lib/http.js:559:11)
    at Executor.execute (/Users/advorak/dev/mdc-web/node_modules/selenium-webdriver/lib/http.js:468:26)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7) name: 'WebDriverError', remoteStacktrace: '' },
  jse_info: {},
  message: 'Failed to run screenshot tests: Session no longer available: b112ac67-f0cc-40b0-b74d-81f95adaf30e' }
```

CBT run: https://app.crossbrowsertesting.com/selenium/13126056?view=commands