### PR TITLE
chore(infrastructure): Build external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ matrix:
     git:
       depth: 200
     script: npm run screenshot:test -- --no-fetch
+    before_install:
+      # Source the script to run it in the same shell process. This ensures that any environment variables set by the
+      # script are visible to subsequent Travis CLI commands.
+      # https://superuser.com/a/176788/62792
+      - source test/screenshot/infra/commands/travis.sh
     install:
       - npm install
       #- npm ls # Noisy output, but useful for debugging npm package dependency version issues
-before_install:
-  # Source the script to run it in the same shell process. This ensures that any environment variables set by the
-  # script are visible to subsequent Travis CLI commands.
-  # https://superuser.com/a/176788/62792
-  - source test/screenshot/infra/commands/travis.sh

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -389,7 +389,7 @@ ${listItemMarkdown}
   isExternalPr_() {
     return Boolean(
       process.env.TRAVIS_PULL_REQUEST_SLUG &&
-      process.env.TRAVIS_PULL_REQUEST_SLUG.startsWith('material-components/')
+      !process.env.TRAVIS_PULL_REQUEST_SLUG.startsWith('material-components/')
     );
   }
 

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -49,6 +49,11 @@ class TestCommand {
   async runAsync() {
     await this.build_();
 
+    if (this.isExternalPr_()) {
+      this.logExternalPr_();
+      return ExitCode.OK;
+    }
+
     /** @type {!mdc.proto.DiffBase} */
     const snapshotDiffBase = await this.diffBaseParser_.parseGoldenDiffBase();
     const snapshotGitRev = snapshotDiffBase.git_revision;
@@ -360,16 +365,6 @@ ${listItemMarkdown}
   }
 
   /**
-   * @return {string}
-   * @private
-   */
-  getCongratulatoryMarkdown_() {
-    return `
-### No diffs! 💯🎉
-`;
-  }
-
-  /**
    * @param {!mdc.proto.ReportData} reportData
    * @return {!ExitCode|number}
    */
@@ -388,11 +383,38 @@ ${listItemMarkdown}
   }
 
   /**
+   * @return {boolean}
+   * @private
+   */
+  isExternalPr_() {
+    return Boolean(
+      process.env.TRAVIS_PULL_REQUEST_SLUG &&
+      process.env.TRAVIS_PULL_REQUEST_SLUG.startsWith('material-components/')
+    );
+  }
+
+  /**
+   * @private
+   */
+  logExternalPr_() {
+    this.logger_.warn(`
+
+${CliColor.bold.red('Screenshot tests are not supported on external PRs for security reasons.')}
+
+See ${CliColor.underline('https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions')}
+for more information.
+
+${CliColor.bold.red('Skipping screenshot tests.')}
+`);
+  }
+
+  /**
    * @param {number} prNumber
    * @private
    */
   logUntestablePr_(prNumber) {
     this.logger_.warn(`
+
 ${CliColor.underline(`PR #${prNumber}`)} does not contain any testable source file changes.
 
 ${CliColor.bold.green('Skipping screenshot tests.')}


### PR DESCRIPTION
### What it does

- Runs `npm run build` on external PRs
    - Screenshot tests no longer exit before building
- Only runs `test/screenshot/infra/commands/travis.sh` on `TEST_SUITE=screenshot` tests
    - Unit tests will no longer fail fast, and will no longer print a meaningful error message
- Skips extracting API credentials and installing/authorizing `gcloud` if required env vars are missing