### PR TITLE
chore(infrastructure): Add chrome to tests for local debugging

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -140,7 +140,8 @@ const getLaunchers = () => {
   } else {
     return ['Chrome'];
   }
-}
+};
+
 const getBrowsers = () => Object.keys(getLaunchers());
 
 module.exports = function(config) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -134,7 +134,13 @@ const SAUCE_LAUNCHERS = {
   // },
 };
 
-const getLaunchers = () => USING_SL ? SAUCE_LAUNCHERS : LOCAL_LAUNCHERS;
+const getLaunchers = () => {
+  if (USING_TRAVISCI) {
+    return USING_SL ? SAUCE_LAUNCHERS : LOCAL_LAUNCHERS;
+  } else {
+    return ['Chrome'];
+  }
+}
 const getBrowsers = () => Object.keys(getLaunchers());
 
 module.exports = function(config) {


### PR DESCRIPTION
Headless chrome should only be used for TravisCI, since locally we need to be able to debug unit tests in a normal chrome browser. 

Fixes: #3217 