### PR TITLE
chore(infrastructure): Try to fix Travis for merges into master

### DIFF
--- a/test/screenshot/infra/lib/git-repo.js
+++ b/test/screenshot/infra/lib/git-repo.js
@@ -196,6 +196,10 @@ class GitRepo {
     }
 
     const logEntry = logEntries[0];
+    if (!logEntry) {
+      throw new VError(err, `Unable to get author for commit "${commit}":\n${stackTrace}`);
+    }
+
     return User.create({
       name: logEntry.author_name,
       email: logEntry.author_email,

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -18,6 +18,9 @@ const VError = require('verror');
 const debounce = require('debounce');
 const octokit = require('@octokit/rest');
 
+/** @type {!CliColor} */
+const colors = require('colors');
+
 const GitRepo = require('./git-repo');
 const getStackTrace = require('./stacktrace')('GitHubApi');
 
@@ -25,12 +28,13 @@ class GitHubApi {
   constructor() {
     this.gitRepo_ = new GitRepo();
     this.octokit_ = octokit();
+    this.isAuthenticated_ = false;
+    this.hasWarnedNoAuth_ = false;
     this.authenticate_();
+    this.initStatusThrottle_();
   }
 
-  /**
-   * @private
-   */
+  /** @private */
   authenticate_() {
     let token;
 
@@ -46,6 +50,11 @@ class GitHubApi {
       token: token,
     });
 
+    this.isAuthenticated_ = true;
+  }
+
+  /** @private */
+  initStatusThrottle_() {
     const throttle = (fn, delay) => {
       let lastCall = 0;
       return (...args) => {
@@ -163,6 +172,15 @@ class GitHubApi {
    * @private
    */
   async createStatusUnthrottled_({state, targetUrl, description = undefined}) {
+    if (!this.isAuthenticated_) {
+      if (!this.hasWarnedNoAuth_) {
+        const warning = colors.magenta('WARNING');
+        console.warn(`${warning}: Cannot set GitHub commit status because no API credentials were found.`);
+        this.hasWarnedNoAuth_ = true;
+      }
+      return null;
+    }
+
     const sha = process.env.TRAVIS_PULL_REQUEST_SHA || await this.gitRepo_.getFullCommitHash();
     let stackTrace;
 

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -181,7 +181,10 @@ class GitHubApi {
       return null;
     }
 
-    const sha = process.env.TRAVIS_PULL_REQUEST_SHA || await this.gitRepo_.getFullCommitHash();
+    const travisPrSha = process.env.TRAVIS_PULL_REQUEST_SHA;
+    const travisCommit = process.env.TRAVIS_COMMIT;
+    const sha = travisPrSha || travisCommit || await this.gitRepo_.getFullCommitHash();
+
     let stackTrace;
 
     try {


### PR DESCRIPTION
### What it does

- (Hopefully) Fixes failing screenshot tests on Travis for merges into `master`
- Uses the `TRAVIS_COMMIT` env var instead of querying `git`
    - Looking up the commit with `git rev-parse master` seems to fail on Travis for some reason
- Stops trying to set GitHub commit status if API credentials are not found
    - Previously, this would throw an error and kill the whole test
- Adds a bit of logging