### PR TITLE
fix(infrastructure): update saucelabs windows 8 to windows 10 IE11 browser

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -82,7 +82,7 @@ const SAUCE_LAUNCHERS = {
     base: 'SauceLabs',
     browserName: 'internet explorer',
     version: '11',
-    platform: 'Windows 8.1',
+    platform: 'Windows 10',
   },
 
   /*


### PR DESCRIPTION
Updating to windows 10 IE11 fixes 2 failing tests in #3165. Since Windows 10 is our main target, I'm switching SauceLabs to point to Windows 10 IE11.