### PR TITLE
fix(tab-scroller): Fix incorrect animation stopping scroll value in RTL

### DIFF
--- a/packages/mdc-tab-scroller/foundation.js
+++ b/packages/mdc-tab-scroller/foundation.js
@@ -305,10 +305,25 @@ class MDCTabScrollerFoundation extends MDCFoundation {
    */
   stopScrollAnimation_() {
     this.isAnimating_ = false;
-    const currentScrollPosition = this.getScrollPosition();
+    const currentScrollPosition = this.getAnimatingScrollPosition_();
     this.adapter_.removeClass(MDCTabScrollerFoundation.cssClasses.ANIMATING);
     this.adapter_.setScrollContentStyleProperty('transform', 'translateX(0px)');
     this.adapter_.setScrollAreaScrollLeft(currentScrollPosition);
+  }
+
+  /**
+   * Gets the current scroll position during animation
+   * @return {number}
+   * @private
+   */
+  getAnimatingScrollPosition_() {
+    const currentTranslateX = this.calculateCurrentTranslateX_();
+    const scrollLeft = this.adapter_.getScrollAreaScrollLeft();
+    if (this.isRTL_()) {
+      return this.getRTLScroller().getAnimatingScrollPosition(scrollLeft, currentTranslateX);
+    }
+
+    return scrollLeft - currentTranslateX;
   }
 
   /**

--- a/packages/mdc-tab-scroller/rtl-default-scroller.js
+++ b/packages/mdc-tab-scroller/rtl-default-scroller.js
@@ -64,6 +64,14 @@ class MDCTabScrollerRTLDefault extends MDCTabScrollerRTL {
   }
 
   /**
+   * @param {number} scrollX
+   * @return {number}
+   */
+  getAnimatingScrollPosition(scrollX) {
+    return scrollX;
+  }
+
+  /**
    * @return {!MDCTabScrollerHorizontalEdges}
    * @private
    */

--- a/packages/mdc-tab-scroller/rtl-negative-scroller.js
+++ b/packages/mdc-tab-scroller/rtl-negative-scroller.js
@@ -62,6 +62,15 @@ class MDCTabScrollerRTLNegative extends MDCTabScrollerRTL {
   }
 
   /**
+   * @param {number} scrollX
+   * @param {number} translateX
+   * @return {number}
+   */
+  getAnimatingScrollPosition(scrollX, translateX) {
+    return scrollX - translateX;
+  }
+
+  /**
    * @return {!MDCTabScrollerHorizontalEdges}
    * @private
    */

--- a/packages/mdc-tab-scroller/rtl-reverse-scroller.js
+++ b/packages/mdc-tab-scroller/rtl-reverse-scroller.js
@@ -63,6 +63,14 @@ class MDCTabScrollerRTLReverse extends MDCTabScrollerRTL {
   }
 
   /**
+   * @param {number} scrollX
+   * @return {number}
+   */
+  getAnimatingScrollPosition(scrollX, translateX) {
+    return scrollX + translateX;
+  }
+
+  /**
    * @return {!MDCTabScrollerHorizontalEdges}
    * @private
    */

--- a/packages/mdc-tab-scroller/rtl-scroller.js
+++ b/packages/mdc-tab-scroller/rtl-scroller.js
@@ -51,6 +51,14 @@ class MDCTabScrollerRTL {
    * @abstract
    */
   incrementScrollRTL(scrollX) {}
+
+  /**
+   * @param {number} scrollX The current scrollX position
+   * @param {number} translateX The current translateX position
+   * @return {number}
+   * @abstract
+   */
+  getAnimatingScrollPosition(scrollX, translateX) {}
 }
 
 export default MDCTabScrollerRTL;

--- a/test/unit/mdc-tab-scroller/rtl-default-scroller.test.js
+++ b/test/unit/mdc-tab-scroller/rtl-default-scroller.test.js
@@ -89,3 +89,8 @@ test('#incrementScrollRTL() returns max scroll value for scrollX property when s
     assert.strictEqual(scroller.incrementScrollRTL(-124).finalScrollPosition, 800);
   }
 );
+
+test('#getAnimatingScrollPosition() returns just the scrollX value', () => {
+  const {scroller} = setupTest({rootWidth: 200, contentWidth: 1000, scrollLeft: 677});
+  assert.strictEqual(scroller.getAnimatingScrollPosition(123, 11), 123);
+});

--- a/test/unit/mdc-tab-scroller/rtl-negative-scroller.test.js
+++ b/test/unit/mdc-tab-scroller/rtl-negative-scroller.test.js
@@ -94,3 +94,8 @@ test('#incrementScrollRTL() returns min scroll value for scrollX property when s
     assert.strictEqual(scroller.incrementScrollRTL(124).finalScrollPosition, -800);
   }
 );
+
+test('#getAnimatingScrollPosition() returns the difference between the scrollX value and the translateX value', () => {
+  const {scroller} = setupTest({rootWidth: 200, contentWidth: 1000, scrollLeft: 677});
+  assert.strictEqual(scroller.getAnimatingScrollPosition(123, 11), 112);
+});

--- a/test/unit/mdc-tab-scroller/rtl-reverse-scroller.test.js
+++ b/test/unit/mdc-tab-scroller/rtl-reverse-scroller.test.js
@@ -94,3 +94,8 @@ test('#incrementScrollRTL() returns max scroll value for scrollX property when s
     assert.strictEqual(scroller.incrementScrollRTL(124).finalScrollPosition, 800);
   }
 );
+
+test('#getAnimatingScrollPosition() returns the sum of the scrollX value and the translateX value', () => {
+  const {scroller} = setupTest({rootWidth: 200, contentWidth: 1000, scrollLeft: 677});
+  assert.strictEqual(scroller.getAnimatingScrollPosition(123, 11), 134);
+});

--- a/test/unit/mdc-tab-scroller/rtl-scroller.test.js
+++ b/test/unit/mdc-tab-scroller/rtl-scroller.test.js
@@ -43,3 +43,8 @@ test('#incrementScrollRTL() is abstract and does nothing', () => {
   const {scroller} = setup();
   assert.isUndefined(scroller.incrementScrollRTL());
 });
+
+test('#getAnimatingScrollPosition() is abstract and does nothing', () => {
+  const {scroller} = setup();
+  assert.isUndefined(scroller.getAnimatingScrollPosition());
+});


### PR DESCRIPTION
Fixes a bug where the scroll position updates during animation were being incorrectly applied in RTL. Adds a new `getAnimatingScrollPosition` method to the `MDCTabScrollerRTL` abstract class that takes the current scroll position and the current translateX value. Appropriately implements the `getAnimatingScrollPosition` method in the default, reverse, and negative `MDCTabScrollerRTL` concrete classes. Add tests for each implementation and for the abstract method. Add a new private `getAnimatingScrollPosition_` method to the `MDCTabScroller` foundation that uses the RTL tab scroller's new `getAnimatingScrollPosition` method when the text direction is RTL. Update the scroll position calculation method use in `stopScrollAnimation_` to use the new private `getAnimatingScrollPosition_` method. Have a party. Closes #3109.