### PR TITLE
feat(tab): Remove activation event emitting

### DIFF
--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -130,7 +130,6 @@ Method Signature | Description
 Event Name | Event Data Structure | Description
 --- | --- | ---
 `MDCTab:interacted` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is interacted with, regardless of its active state. Used by parent components to know which Tab to activate.
-`MDCTab:activated` | `{"detail": {"tab": MDCTab}}` | Emitted when the Tab is activated. Listen for this to update content when a Tab becomes active.
 
 ## Usage within Web Frameworks
 
@@ -154,7 +153,6 @@ Method Signature | Description
 `getContentOffsetLeft() => number` | Returns the `offsetLeft` value of the content element.
 `getContentOffsetWidth() => number` | Returns the `offsetWidth` value of the content element.
 `notifyInteracted() => void` | Emits the `MDCTab:interacted` event.
-`notifyActivated() => void` | Emits the `MDCTab:activated` event.
 `focus() => void` | Applies focus to the root element.
 
 ### `MDCTabFoundation`

--- a/packages/mdc-tab/adapter.js
+++ b/packages/mdc-tab/adapter.js
@@ -97,11 +97,6 @@ class MDCTabAdapter {
   notifyInteracted() {}
 
   /**
-   * Emits the MDCTab:activated event for use by parent components
-   */
-  notifyActivated() {}
-
-  /**
    * Returns the offsetLeft value of the root element.
    * @return {number}
    */

--- a/packages/mdc-tab/constants.js
+++ b/packages/mdc-tab/constants.js
@@ -30,7 +30,6 @@ const strings = {
   TAB_INDICATOR_SELECTOR: '.mdc-tab-indicator',
   TABINDEX: 'tabIndex',
   INTERACTED_EVENT: 'MDCTab:interacted',
-  ACTIVATED_EVENT: 'MDCTab:activated',
 };
 
 export {

--- a/packages/mdc-tab/foundation.js
+++ b/packages/mdc-tab/foundation.js
@@ -57,7 +57,6 @@ class MDCTabFoundation extends MDCFoundation {
       deactivateIndicator: () => {},
       computeIndicatorClientRect: () => {},
       notifyInteracted: () => {},
-      notifyActivated: () => {},
       getOffsetLeft: () => {},
       getOffsetWidth: () => {},
       getContentOffsetLeft: () => {},
@@ -129,7 +128,6 @@ class MDCTabFoundation extends MDCFoundation {
     this.adapter_.setAttr(strings.TABINDEX, '0');
     this.adapter_.activateIndicator(previousIndicatorClientRect);
     this.adapter_.focus();
-    this.adapter_.notifyActivated();
   }
 
   /**

--- a/packages/mdc-tab/index.js
+++ b/packages/mdc-tab/index.js
@@ -90,7 +90,6 @@ class MDCTab extends MDCComponent {
         deactivateIndicator: () => this.tabIndicator_.deactivate(),
         computeIndicatorClientRect: () => this.tabIndicator_.computeContentClientRect(),
         notifyInteracted: () => this.emit(MDCTabFoundation.strings.INTERACTED_EVENT, {tab: this}, true /* bubble */),
-        notifyActivated: () => this.emit(MDCTabFoundation.strings.ACTIVATED_EVENT, {tab: this}, true /* bubble */),
         getOffsetLeft: () => this.root_.offsetLeft,
         getOffsetWidth: () => this.root_.offsetWidth,
         getContentOffsetLeft: () => this.content_.offsetLeft,

--- a/test/unit/mdc-tab/foundation.test.js
+++ b/test/unit/mdc-tab/foundation.test.js
@@ -38,7 +38,7 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'setAttr',
     'activateIndicator', 'deactivateIndicator', 'computeIndicatorClientRect',
     'getOffsetLeft', 'getOffsetWidth', 'getContentOffsetLeft', 'getContentOffsetWidth',
-    'notifyInteracted', 'notifyActivated',
+    'notifyInteracted',
     'focus',
   ]);
 });
@@ -93,12 +93,6 @@ test('#activate focuses the root node', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.activate({width: 100, left: 200});
   td.verify(mockAdapter.focus());
-});
-
-test(`#activate emits the ${MDCTabFoundation.strings.ACTIVATED_EVENT} event`, () => {
-  const {foundation, mockAdapter} = setupTest();
-  foundation.activate();
-  td.verify(mockAdapter.notifyActivated());
 });
 
 test('#computeIndicatorClientRect calls computeIndicatorClientRect on the adapter', () => {

--- a/test/unit/mdc-tab/mdc-tab.test.js
+++ b/test/unit/mdc-tab/mdc-tab.test.js
@@ -159,15 +159,6 @@ test(`#adapter.notifyInteracted() emits the ${MDCTabFoundation.strings.INTERACTE
   td.verify(handler(td.matchers.anything()));
 });
 
-test(`#adapter.notifyActivated() emits the ${MDCTabFoundation.strings.ACTIVATED_EVENT} event`, () => {
-  const {component} = setupTest();
-  const handler = td.func('interaction handler');
-
-  component.listen(MDCTabFoundation.strings.ACTIVATED_EVENT, handler);
-  component.getDefaultFoundation().adapter_.notifyActivated();
-  td.verify(handler(td.matchers.anything()));
-});
-
 function setupMockFoundationTest(root = getFixture()) {
   const MockFoundationConstructor = td.constructor(MDCTabFoundation);
   const mockFoundation = new MockFoundationConstructor();


### PR DESCRIPTION
Remove the MDCTab:activated event emitting from the adapter, foundation, and component. Update the readme and tests to reflect the change.