### PR TITLE
fix(list): add list to webpack js bundler

### DIFF
--- a/scripts/webpack/js-bundle-factory.js
+++ b/scripts/webpack/js-bundle-factory.js
@@ -136,6 +136,7 @@ class JsBundleFactory {
         gridList: getAbsolutePath('/packages/mdc-grid-list/index.js'),
         iconButton: getAbsolutePath('/packages/mdc-icon-button/index.js'),
         iconToggle: getAbsolutePath('/packages/mdc-icon-toggle/index.js'),
+        list: getAbsolutePath('/packages/mdc-list/index.js'),
         lineRipple: getAbsolutePath('/packages/mdc-line-ripple/index.js'),
         linearProgress: getAbsolutePath('/packages/mdc-linear-progress/index.js'),
         menu: getAbsolutePath('/packages/mdc-menu/index.js'),


### PR DESCRIPTION
Webpack wasn't not creating a mdc.list.js file that was transpiled to ES5. 