### PR TITLE
chore(infrastructure): Rename test page CSS classes

### DIFF
--- a/test/screenshot/README.md
+++ b/test/screenshot/README.md
@@ -152,20 +152,20 @@ There are two types of components:
 1. **Large** fullpage components (dialog, drawer, top app bar, etc.)
 2. **Small** widget components (button, checkbox, linear progress, etc.)
 
-Test pages for **small** components must have a `test-main--mobile-viewport` class on the `<main>` element:
+Test pages for **small** components must have a `test-viewport--mobile` class on the `<main>` element:
 
 ```html
-<main class="test-main test-main--mobile-viewport">
+<main class="test-viewport test-viewport--mobile">
 ```
 
 This class ensures that all components on the page fit inside an "average" mobile viewport without scrolling.
 This is necessary because most browsers' WebDriver implementations do not support taking screenshots of the entire
 `document`.
 
-Test pages for **large** components, however, must _not_ use the `--mobile-viewport` class:
+Test pages for **large** components, however, must _not_ use the `test-viewport--mobile` class:
 
 ```html
-<main class="test-main">
+<main class="test-viewport">
 ```
 
 For **small** components, you also need to specify the dimensions of the `test-cell--FOO` class in your component's 
@@ -185,8 +185,8 @@ This prevents noisy diffs in the event that your component's `height` or `margin
 
 CSS Class | Description
 --- | ---
-`test-main` | Mandatory. Wraps all page content.
-`test-main--mobile-viewport` | Mandatory (**small** components only). Ensures that all page content fits in a mobile viewport.
+`test-viewport` | Mandatory. Wraps all page content.
+`test-viewport--mobile` | Mandatory (**small** components only). Ensures that all page content fits in a mobile viewport.
 `test-cell--<FOO>` | Mandatory (**small** components only). Sets the dimensions of cells in the grid.
 `custom-<FOO>--<MIXIN>` | Mandatory (mixin test pages only). Calls a single Sass theme mixin.
 

--- a/test/screenshot/infra/lib/image-cropper.js
+++ b/test/screenshot/infra/lib/image-cropper.js
@@ -16,7 +16,7 @@
 
 const Jimp = require('jimp');
 
-const TRIM_COLOR_CSS_VALUE = '#abc123'; // Value must match `$test-trim-color` in `fixture.scss`
+const TRIM_COLOR_CSS_VALUE = '#abc123'; // Value must match `$test-viewport-trim-color` in `fixture.scss`
 
 /**
  * Fractional value (0 to 1 inclusive) indicating the minimum percentage of pixels in a row or column that must

--- a/test/screenshot/spec/fixture.js
+++ b/test/screenshot/spec/fixture.js
@@ -45,8 +45,8 @@ window.mdc.testFixture = {
   },
 
   measureMobileViewport_() {
-    const mainEl = document.querySelector('.test-main');
-    if (!mainEl || !mainEl.classList.contains('test-main--mobile-viewport')) {
+    const mainEl = document.querySelector('.test-viewport');
+    if (!mainEl || !mainEl.classList.contains('test-viewport--mobile')) {
       return;
     }
 
@@ -57,12 +57,12 @@ window.mdc.testFixture = {
       mainEl.style.height = '';
 
       if (autoHeight > setHeight) {
-        mainEl.classList.add('test-main--overflowing');
+        mainEl.classList.add('test-viewport--overflowing');
         console.error(`
 Page content overflows a mobile viewport!
 Consider splitting this page into two separate pages.
 If you are trying to create a test page for a fullscreen component like drawer or top-app-bar,
-remove the 'test-main--mobile-viewport' class from the '<main class="test-main">' element.
+remove the 'test-viewport--mobile' class from the '<main class="test-viewport">' element.
           `.trim());
       }
     });

--- a/test/screenshot/spec/fixture.scss
+++ b/test/screenshot/spec/fixture.scss
@@ -17,30 +17,30 @@
 @import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700");
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
-$test-trim-color: #abc123; // Value must match `TRIM_COLOR_CSS_VALUE` in `image-cropper.js`
-$test-grid-color: #dddddd;
+$test-viewport-trim-color: #abc123; // Value must match `TRIM_COLOR_CSS_VALUE` in `image-cropper.js`
+$test-layout-cell-grid-color: #dddddd;
 
-.test-body {
+.test-container {
   display: flex;
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
-.test-main {
+.test-viewport {
   position: relative;
   box-sizing: border-box;
 }
 
-.test-main--mobile-viewport {
+.test-viewport--mobile {
   width: 350px; // fits 2 columns of buttons within a Galaxy S7 viewport
   height: 590px; // fits 8 rows of buttons within a Galaxy S7 viewport
   margin: 5px 0 5px 5px; // Extra padding ensures that CBT's "chromeless" screenshots don't get cut off
-  border: 1px solid $test-trim-color;
+  border: 1px solid $test-viewport-trim-color;
   overflow: hidden;
 }
 
-.test-main--overflowing::after {
+.test-viewport--overflowing::after {
   display: block;
   position: absolute;
   right: 0;
@@ -56,7 +56,7 @@ $test-grid-color: #dddddd;
   content: "ERROR: Content overflows mobile viewport!";
 }
 
-.test-grid {
+.test-layout {
   display: flex;
   flex-wrap: wrap;
   box-sizing: border-box;
@@ -72,8 +72,8 @@ $test-grid-color: #dddddd;
   // Ruler grid pattern
   // https://stackoverflow.com/a/32861765/467582
   background-image:
-    linear-gradient(to right, #{$test-grid-color} 1px, transparent 1.01px),  // fraction for IE 11
-    linear-gradient(to bottom, #{$test-grid-color} 1px, transparent 1.01px); // fraction for IE 11
+    linear-gradient(to right, #{$test-layout-cell-grid-color} 1px, transparent 1.01px),  // fraction for IE 11
+    linear-gradient(to bottom, #{$test-layout-cell-grid-color} 1px, transparent 1.01px); // fraction for IE 11
 
   background-size: 10px 10px;
 }

--- a/test/screenshot/spec/mdc-button/classes/baseline-button-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-button-with-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="mdc-button">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>

--- a/test/screenshot/spec/mdc-button/classes/baseline-button-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-button-without-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="mdc-button">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/classes/baseline-link-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-link-with-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <a href="#" class="mdc-button">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>

--- a/test/screenshot/spec/mdc-button/classes/baseline-link-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-link-without-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <a href="#" class="mdc-button">Link</a>
         </div>

--- a/test/screenshot/spec/mdc-button/classes/dense-button-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-button-with-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>

--- a/test/screenshot/spec/mdc-button/classes/dense-button-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-button-without-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--dense">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/classes/dense-link-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-link-with-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <a href="#" class="mdc-button mdc-button--dense">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>

--- a/test/screenshot/spec/mdc-button/classes/dense-link-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-link-without-icons.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <a href="#" class="mdc-button mdc-button--dense">Button</a>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/container-fill-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/container-fill-color.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--container-fill-color mdc-button mdc-button--raised">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/corner-radius.html
+++ b/test/screenshot/spec/mdc-button/mixins/corner-radius.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--corner-radius mdc-button">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/filled-accessible.html
+++ b/test/screenshot/spec/mdc-button/mixins/filled-accessible.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--filled-accessible mdc-button mdc-button--raised">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/horizontal-padding-baseline.html
+++ b/test/screenshot/spec/mdc-button/mixins/horizontal-padding-baseline.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/horizontal-padding-dense.html
+++ b/test/screenshot/spec/mdc-button/mixins/horizontal-padding-dense.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button--horizontal-padding mdc-button mdc-button--dense">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/icon-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/icon-color.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--icon-color mdc-button">
             <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>

--- a/test/screenshot/spec/mdc-button/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/ink-color.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--ink-color mdc-button">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/stroke-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/stroke-color.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-color mdc-button mdc-button--outlined">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-button/mixins/stroke-width.html
+++ b/test/screenshot/spec/mdc-button/mixins/stroke-width.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-button/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--button">
           <button class="custom-button custom-button--outline-width mdc-button mdc-button--outlined">Button</button>
         </div>

--- a/test/screenshot/spec/mdc-checkbox/classes/baseline.html
+++ b/test/screenshot/spec/mdc-checkbox/classes/baseline.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-checkbox/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--checkbox">
           <div class="mdc-checkbox">
             <input type="checkbox"

--- a/test/screenshot/spec/mdc-drawer/classes/permanent.html
+++ b/test/screenshot/spec/mdc-drawer/classes/permanent.html
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-drawer/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--drawer">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--drawer">
       <div class="test-drawer-column test-drawer-column--left">
         <aside class="mdc-drawer mdc-drawer--permanent">
           <nav class="mdc-drawer__drawer">

--- a/test/screenshot/spec/mdc-drawer/classes/persistent.html
+++ b/test/screenshot/spec/mdc-drawer/classes/persistent.html
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-drawer/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--drawer">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--drawer">
       <div class="test-drawer-column test-drawer-column--left">
         <aside class="mdc-drawer mdc-drawer--persistent">
           <nav class="mdc-drawer__drawer">

--- a/test/screenshot/spec/mdc-drawer/classes/temporary.html
+++ b/test/screenshot/spec/mdc-drawer/classes/temporary.html
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-drawer/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--drawer">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--drawer">
       <div class="test-drawer-column test-drawer-column--left">
         <aside class="mdc-drawer mdc-drawer--temporary">
           <nav class="mdc-drawer__drawer">

--- a/test/screenshot/spec/mdc-drawer/fixture.scss
+++ b/test/screenshot/spec/mdc-drawer/fixture.scss
@@ -20,7 +20,7 @@
 
 $custom-drawer-color: $material-color-orange-900;
 
-.test-main--drawer {
+.test-viewport--drawer {
   display: flex;
   flex-direction: row;
 }

--- a/test/screenshot/spec/mdc-drawer/mixins/fill-color-accessible.html
+++ b/test/screenshot/spec/mdc-drawer/mixins/fill-color-accessible.html
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-drawer/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--drawer">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--drawer">
       <div class="test-drawer-column test-drawer-column--left">
         <aside class="mdc-drawer mdc-drawer--permanent custom-drawer--fill-color-accessible">
           <nav class="mdc-drawer__drawer">

--- a/test/screenshot/spec/mdc-drawer/mixins/fill-color.html
+++ b/test/screenshot/spec/mdc-drawer/mixins/fill-color.html
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-drawer/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--drawer">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--drawer">
       <div class="test-drawer-column test-drawer-column--left">
         <aside class="mdc-drawer mdc-drawer--permanent custom-drawer--fill-color">
           <nav class="mdc-drawer__drawer">

--- a/test/screenshot/spec/mdc-drawer/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-drawer/mixins/ink-color.html
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-drawer/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--drawer">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--drawer">
       <div class="test-drawer-column test-drawer-column--left">
         <aside class="mdc-drawer mdc-drawer--permanent custom-drawer--ink-color">
           <nav class="mdc-drawer__drawer">

--- a/test/screenshot/spec/mdc-fab/classes/baseline.html
+++ b/test/screenshot/spec/mdc-fab/classes/baseline.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-fab/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--fab">
           <button class="mdc-fab" aria-label="Favorite">
             <span class="mdc-fab__icon material-icons">favorite_border</span>

--- a/test/screenshot/spec/mdc-fab/classes/extended.html
+++ b/test/screenshot/spec/mdc-fab/classes/extended.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-fab/fixture.css">
   </head>
 
-  <body class="test-body">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--fab-extended">
           <button class="mdc-fab mdc-fab--extended" aria-label="Create">
             <span class="material-icons mdc-fab__icon">add</span>

--- a/test/screenshot/spec/mdc-fab/classes/mini.html
+++ b/test/screenshot/spec/mdc-fab/classes/mini.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-fab/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--fab">
           <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
             <span class="mdc-fab__icon material-icons">favorite_border</span>

--- a/test/screenshot/spec/mdc-fab/mixins/extended-padding.html
+++ b/test/screenshot/spec/mdc-fab/mixins/extended-padding.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-fab/fixture.css">
   </head>
 
-  <body class="test-body">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--fab-extended">
           <button class="mdc-fab mdc-fab--extended custom-fab--extended-padding-and-icon-size" aria-label="Create">
             <span class="material-icons mdc-fab__icon">add</span>

--- a/test/screenshot/spec/mdc-icon-button/classes/baseline.html
+++ b/test/screenshot/spec/mdc-icon-button/classes/baseline.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/fixture.css">
     <link rel="stylesheet" href="../../../out/spec/mdc-icon-button/fixture.css">
   </head>
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--icon-button">
           <button class="mdc-icon-button material-icons">airplanemode_active</button>
         </div>

--- a/test/screenshot/spec/mdc-icon-button/mixins/icon-size.html
+++ b/test/screenshot/spec/mdc-icon-button/mixins/icon-size.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/fixture.css">
     <link rel="stylesheet" href="../../../out/spec/mdc-icon-button/fixture.css">
   </head>
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--icon-button">
           <button class="mdc-icon-button custom-icon-button--icon-size material-icons">airplanemode_active</button>
         </div>

--- a/test/screenshot/spec/mdc-icon-button/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-icon-button/mixins/ink-color.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/fixture.css">
     <link rel="stylesheet" href="../../../out/spec/mdc-icon-button/fixture.css">
   </head>
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--icon-button">
           <button class="mdc-icon-button custom-icon-button--ink-color material-icons">airplanemode_active</button>
         </div>

--- a/test/screenshot/spec/mdc-switch/classes/baseline.html
+++ b/test/screenshot/spec/mdc-switch/classes/baseline.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-switch/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--switch">
           <div class="mdc-switch">
             <div class="mdc-switch__track"></div>

--- a/test/screenshot/spec/mdc-switch/mixins/thumb-color.html
+++ b/test/screenshot/spec/mdc-switch/mixins/thumb-color.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-switch/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--switch">
           <div class="custom-switch custom-switch--thumb-color mdc-switch">
             <div class="mdc-switch__track"></div>

--- a/test/screenshot/spec/mdc-switch/mixins/track-color.html
+++ b/test/screenshot/spec/mdc-switch/mixins/track-color.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-switch/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--switch">
           <div class="custom-switch custom-switch--track-color mdc-switch">
             <div class="mdc-switch__track"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-textfield.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-textfield.html
@@ -24,9 +24,9 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-textfield/fixture.css">
   </head>
 
-  <body class="test-body mdc-typography">
-    <main class="test-main test-main--mobile-viewport">
-      <div class="test-grid">
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--box">
             <input type="text" id="filled-text-field" class="mdc-text-field__input">


### PR DESCRIPTION
Fixes #3183. Thanks for the great suggestions, @hastebrot! 🤜🤛

- Renames `test-body` to `test-container`
- Renames `test-main` to `test-viewport`
- Renames `test-main--mobile-viewport` to `test-viewport--mobile`
- Renames `test-grid` to `test-layout`
- Renames some Sass variables