### PR TITLE
docs: Update Travis CI URLs from legacy .org to new .com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We strive to make developing Material Components Web as frictionless as possible
 
 ### Setting up your development environment
 
-You'll need a recent version of [nodejs](https://nodejs.org/en/) to work on MDC Web. We [test our builds](https://travis-ci.org/material-components/material-components-web) using both the latest and LTS node versions, so use of one of those is recommended. You can use [nvm](https://github.com/creationix/nvm) to easily install and manage different versions of node on your system.
+You'll need a recent version of [nodejs](https://nodejs.org/en/) to work on MDC Web. We [test our builds](https://travis-ci.com/material-components/material-components-web) using both the latest and LTS node versions, so use of one of those is recommended. You can use [nvm](https://github.com/creationix/nvm) to easily install and manage different versions of node on your system.
 
 > **NOTE**: If you expect to commit updated or new dependencies, please ensure you are using npm 5, which will
 > also update `package-lock.json` correctly when you install or upgrade packages.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/travis/material-components/material-components-web/master.svg)](https://travis-ci.org/material-components/material-components-web/)
+[![Build Status](https://travis-ci.com/material-components/material-components-web.svg?branch=master)](https://travis-ci.com/material-components/material-components-web/)
 [![codecov](https://codecov.io/gh/material-components/material-components-web/branch/master/graph/badge.svg)](https://codecov.io/gh/material-components/material-components-web)
 [![Chat](https://img.shields.io/discord/259087343246508035.svg)](https://discord.gg/material-components)
 

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -103,7 +103,7 @@ class GitHubApi {
 
     this.createStatusThrottled_({
       state,
-      targetUrl: `https://travis-ci.org/material-components/material-components-web/jobs/${process.env.TRAVIS_JOB_ID}`,
+      targetUrl: `https://travis-ci.com/material-components/material-components-web/jobs/${process.env.TRAVIS_JOB_ID}`,
       description,
     });
   }
@@ -145,7 +145,7 @@ class GitHubApi {
       const numTotal = runnableScreenshots.length;
 
       state = GitHubApi.PullRequestState.PENDING;
-      targetUrl = `https://travis-ci.org/material-components/material-components-web/jobs/${process.env.TRAVIS_JOB_ID}`;
+      targetUrl = `https://travis-ci.com/material-components/material-components-web/jobs/${process.env.TRAVIS_JOB_ID}`;
       description = `Running ${numTotal.toLocaleString()} screenshots...`;
     }
 
@@ -159,7 +159,7 @@ class GitHubApi {
 
     return await this.createStatusUnthrottled_({
       state: GitHubApi.PullRequestState.ERROR,
-      targetUrl: `https://travis-ci.org/material-components/material-components-web/jobs/${process.env.TRAVIS_JOB_ID}`,
+      targetUrl: `https://travis-ci.com/material-components/material-components-web/jobs/${process.env.TRAVIS_JOB_ID}`,
       description: 'Error running screenshot tests',
     });
   }


### PR DESCRIPTION
Travis CI is migrating all projects from `travis-ci.org` (aka "legacy") to `travis-ci.com`.

I spoke to support@travis-ci.com, and they told me that all open source projects would be automatically migrated to `.com` at EOY 2018, but we could also manually migrate right now.

Rather than waiting for an unexpected migration to break things, I decided to get a head start and do the migration sooner.

* https://docs.travis-ci.com/user/open-source-on-travis-ci-com/#existing-open-source-repositories-on-travis-ciorg