### PR TITLE
feat(menu-surface): Add ability to position a menu-surface by x/y

### DIFF
--- a/demos/menu-surface.html
+++ b/demos/menu-surface.html
@@ -166,9 +166,50 @@
             <div>
               <label><input type="checkbox" name="fixed-position"> Fixed Position Menu Surface</label>
             </div>
+            <div>
+              <label><input type="checkbox" name="right-click"> Enable Right-Click Menu Surface</label>
+            </div>
             <hr>
           </div>
         </div>
+      </div>
+
+
+      <div class="mdc-menu-surface" tabindex="-1" id="demo-context-menu">
+        <ul class="mdc-image-list standard-image-list demo-menu-surface" role="menu">
+          <li role="menuitem" class="mdc-image-list__item" tabindex="0">
+            <div class="mdc-image-list__image-aspect-container">
+              <img class="mdc-image-list__image" src="images/photos/3x2/1.jpg">
+            </div>
+            <div class="mdc-image-list__supporting">
+              <span class="mdc-image-list__label">Text label</span>
+            </div>
+          </li>
+          <li role="menuitem" class="mdc-image-list__item" tabindex="0">
+            <div class="mdc-image-list__image-aspect-container">
+              <img class="mdc-image-list__image" src="images/photos/3x2/2.jpg">
+            </div>
+            <div class="mdc-image-list__supporting">
+              <span class="mdc-image-list__label">Text label</span>
+            </div>
+          </li>
+          <li role="menuitem" class="mdc-image-list__item" tabindex="0">
+            <div class="mdc-image-list__image-aspect-container">
+              <img class="mdc-image-list__image" src="images/photos/3x2/3.jpg">
+            </div>
+            <div class="mdc-image-list__supporting">
+              <span class="mdc-image-list__label">Text label</span>
+            </div>
+          </li>
+          <li role="menuitem" class="mdc-image-list__item" tabindex="0">
+            <div class="mdc-image-list__image-aspect-container">
+              <img class="mdc-image-list__image" src="images/photos/3x2/4.jpg">
+            </div>
+            <div class="mdc-image-list__supporting">
+              <span class="mdc-image-list__label">Text label</span>
+            </div>
+          </li>
+        </ul>
       </div>
     </main>
 
@@ -178,6 +219,10 @@
         var menuEl = document.querySelector('#demo-menu');
         var menu = mdc.menuSurface.MDCMenuSurface.attachTo(menuEl);
         var menuButtonEl = document.querySelector('#menu-button');
+
+        var contextMenuEl = document.querySelector('#demo-context-menu');
+        var contextMenu = mdc.menuSurface.MDCMenuSurface.attachTo(contextMenuEl);
+        contextMenu.hoistMenuToBody();
 
         menuButtonEl.addEventListener('click', function() {
           menu.open = !menu.open;
@@ -304,7 +349,25 @@
 
         fixedPosition.addEventListener('change', function() {
           menu.setFixedPosition(fixedPosition.checked);
+          contextMenu.setFixedPosition(fixedPosition.checked);
         });
+
+        var contextMenuFunc = function(clickEvent) {
+          contextMenu.setAbsolutePosition(clickEvent.clientX, clickEvent.clientY);
+          contextMenu.show();
+          clickEvent.preventDefault();
+          return false;
+        };
+
+        var rightClickCheckbox = document.querySelector('input[name="right-click"]');
+        rightClickCheckbox.addEventListener('change', function() {
+          if (rightClickCheckbox.checked) {
+            document.body.addEventListener('contextmenu', contextMenuFunc);
+          } else {
+            document.body.removeEventListener('contextmenu', contextMenuFunc);
+          }
+        });
+
       });
     </script>
   </body>

--- a/packages/mdc-menu-surface/README.md
+++ b/packages/mdc-menu-surface/README.md
@@ -97,6 +97,7 @@ Method Signature | Description
 `setAnchorCorner(Corner) => void` | Proxies to the foundation's `setAnchorCorner(Corner)` method.
 `setAnchorMargin(AnchorMargin) => void` | Proxies to the foundation's `setAnchorMargin(AnchorMargin)` method.
 `setFixedPosition(isFixed: boolean) => void` | Adds the `mdc-menu-surface--fixed` class to the `mdc-menu-surface` element. Proxies to the foundation's `setIsHoisted()` and `setFixedPosition()` methods.
+`setAbsolutePosition(x: number, y: number) => void` | Proxies to the foundation's `setAbsolutePosition(x, y)` method. Used to set the absolute x/y position of the menu on the page. Should only be used when the menu is hoisted to the body.
 `setMenuSurfaceAnchorElement(element: Element) => void` | Changes the element used as an anchor for `menu-surface` positioning logic. Should be used with conjunction with `hoistMenuToBody()`.
 `hoistMenuToBody() => void` | Removes the `menu-surface` element from the DOM and appends it to the `body` element. Should be used to overcome `overflow: hidden` issues.
 `setIsHoisted() => void` | Proxies tot he foundation's `setIsHoisted` method.
@@ -147,6 +148,7 @@ Method Signature | Description
 `setAnchorMargin(margin: AnchorMargin) => void` | Sets the distance from the anchor point that the menu surface should be shown.
 `setIsHoisted(isHoisted: boolean) => void` | Sets whether the menu surface has been hoisted to the body so that the offsets are calculated relative to the page and not the anchor.
 `setFixedPosition(isFixed: boolean) => void` | Sets whether the menu surface is using fixed positioning.
+`setAbsolutePosition(x: number, y: numnber) => void` | Sets the absolute x/y position of the menu. Should only be used when the menu is hoisted or using fixed positioning.
 `handleDocumentClick(event: Event) => void` | Method used as the callback function for the `click` event.
 `handleKeyboardDown(event: Event) => void` | Method used as the callback function for the `keydown` events.
 `open() => void` | Opens the menu surface. Optionally accepts an object with a `focusIndex` parameter to indicate which element should receive focus when the menu surface is opened.

--- a/packages/mdc-menu-surface/foundation.js
+++ b/packages/mdc-menu-surface/foundation.js
@@ -136,6 +136,8 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
     this.hoistedElement_ = false;
     /** @private {boolean} */
     this.isFixedPosition_ = false;
+    /** @private {{x: {number}, y: {number}}} */
+    this.position_ = {x: 0, y: 0};
   }
 
   init() {
@@ -178,14 +180,30 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
     this.anchorMargin_.left = typeof margin.left === 'number' ? margin.left : 0;
   }
 
+  /**
+   * Used to indicate if the menu-surface is hoisted to the body.
+   * @param {boolean} isHoisted
+   */
   setIsHoisted(isHoisted) {
-    this.close();
     this.hoistedElement_ = isHoisted;
   }
 
+  /**
+   * Used to set the menu-surface calculations based on a fixed position menu.
+   * @param {boolean} isFixedPosition
+   */
   setFixedPosition(isFixedPosition) {
-    this.close();
     this.isFixedPosition_ = isFixedPosition;
+  }
+
+  /**
+   * Sets the menu-surface position on the page.
+   * @param x
+   * @param y
+   */
+  setAbsolutePosition(x, y) {
+    this.position_.x = x;
+    this.position_.y = y;
   }
 
   /** @param {boolean} quickOpen */
@@ -236,10 +254,23 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
    * @return {AutoLayoutMeasurements} Measurements used to position menu surface popup.
    */
   getAutoLayoutMeasurements_() {
-    const anchorRect = this.adapter_.getAnchorDimensions();
+    let anchorRect = this.adapter_.getAnchorDimensions();
     const viewport = this.adapter_.getWindowDimensions();
     const bodyDimensions = this.adapter_.getBodyDimensions();
     const windowScroll = this.adapter_.getWindowScroll();
+
+    if (!anchorRect) {
+      anchorRect = /** @type {ClientRect} */ ({
+        x: this.position_.x,
+        y: this.position_.y,
+        top: this.position_.y,
+        bottom: this.position_.y,
+        left: this.position_.x,
+        right: this.position_.x,
+        height: 0,
+        width: 0,
+      });
+    }
 
     return {
       viewport,
@@ -376,10 +407,6 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
 
   /** @private */
   autoPosition_() {
-    if (!this.adapter_.hasAnchor()) {
-      return;
-    }
-
     // Compute measurements for autoposition methods reuse.
     this.measures_ = this.getAutoLayoutMeasurements_();
 

--- a/packages/mdc-menu-surface/foundation.js
+++ b/packages/mdc-menu-surface/foundation.js
@@ -202,8 +202,8 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
    * @param {number} y
    */
   setAbsolutePosition(x, y) {
-    this.position_.x = Number.isFinite(x) ? x : 0;
-    this.position_.y = Number.isFinite(y) ? y : 0;
+    this.position_.x = this.typeCheckisFinite_(x) ? x : 0;
+    this.position_.y = this.typeCheckisFinite_(y) ? y : 0;
   }
 
   /** @param {boolean} quickOpen */
@@ -555,6 +555,17 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
   /** @return {boolean} */
   isOpen() {
     return this.isOpen_;
+  }
+
+  /**
+   * Number.isNaN that doesn't force conversion to number type.
+   * Equivalent to Number.isNaN in ES2015, but is not included in IE11.
+   * @param {number} num
+   * @return {boolean}
+   * @private
+   */
+  typeCheckisFinite_(num) {
+    return typeof num === 'number' && isFinite(num);
   }
 }
 

--- a/packages/mdc-menu-surface/foundation.js
+++ b/packages/mdc-menu-surface/foundation.js
@@ -558,8 +558,8 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
   }
 
   /**
-   * Number.isNaN that doesn't force conversion to number type.
-   * Equivalent to Number.isNaN in ES2015, but is not included in IE11.
+   * isFinite that doesn't force conversion to number type.
+   * Equivalent to Number.isFinite in ES2015, but is not included in IE11.
    * @param {number} num
    * @return {boolean}
    * @private

--- a/packages/mdc-menu-surface/foundation.js
+++ b/packages/mdc-menu-surface/foundation.js
@@ -202,8 +202,8 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
    * @param {number} y
    */
   setAbsolutePosition(x, y) {
-    this.position_.x = isNaN(x) ? 0 : x;
-    this.position_.y = isNaN(y) ? 0 : y;
+    this.position_.x = Number.isFinite(x) ? x : 0;
+    this.position_.y = Number.isFinite(y) ? y : 0;
   }
 
   /** @param {boolean} quickOpen */

--- a/packages/mdc-menu-surface/foundation.js
+++ b/packages/mdc-menu-surface/foundation.js
@@ -136,7 +136,7 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
     this.hoistedElement_ = false;
     /** @private {boolean} */
     this.isFixedPosition_ = false;
-    /** @private {{x: {number}, y: {number}}} */
+    /** @private {{x: number, y: number}} */
     this.position_ = {x: 0, y: 0};
   }
 
@@ -198,12 +198,12 @@ class MDCMenuSurfaceFoundation extends MDCFoundation {
 
   /**
    * Sets the menu-surface position on the page.
-   * @param x
-   * @param y
+   * @param {number} x
+   * @param {number} y
    */
   setAbsolutePosition(x, y) {
-    this.position_.x = x;
-    this.position_.y = y;
+    this.position_.x = isNaN(x) ? 0 : x;
+    this.position_.y = isNaN(y) ? 0 : y;
   }
 
   /** @param {boolean} quickOpen */

--- a/packages/mdc-menu-surface/index.js
+++ b/packages/mdc-menu-surface/index.js
@@ -120,8 +120,8 @@ class MDCMenuSurface extends MDCComponent {
 
   /**
    * Sets the absolute x/y position to position based on. Requires the menu to be hoisted.
-   * @param {number] x
-   * @param {number] y
+   * @param {number} x
+   * @param {number} y
    */
   setAbsolutePosition(x, y) {
     this.foundation_.setAbsolutePosition(x, y);

--- a/packages/mdc-menu-surface/index.js
+++ b/packages/mdc-menu-surface/index.js
@@ -119,6 +119,16 @@ class MDCMenuSurface extends MDCComponent {
   }
 
   /**
+   * Sets the absolute x/y position to position based on. Requires the menu to be hoisted.
+   * @param {number] x
+   * @param {number] y
+   */
+  setAbsolutePosition(x, y) {
+    this.foundation_.setAbsolutePosition(x, y);
+    this.setIsHoisted(true);
+  }
+
+  /**
    * @param {MenuSurfaceCorner} corner Default anchor corner alignment of top-left
    *     surface corner.
    */

--- a/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
+++ b/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
@@ -123,7 +123,7 @@ test('setFixedPosition is true', () => {
 test('setAbsolutePosition calls the foundation setAbsolutePosition function', () => {
   const {component, mockFoundation} = setupTest();
   component.setAbsolutePosition(10, 10);
-  td.verify(mockFoundation.setAbsolutePosition(10,10));
+  td.verify(mockFoundation.setAbsolutePosition(10, 10));
   td.verify(mockFoundation.setIsHoisted(true));
 });
 

--- a/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
+++ b/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
@@ -68,6 +68,17 @@ test('show opens the menu surface', () => {
   td.verify(mockFoundation.open());
 });
 
+test('show opens the menu surface does not throw error if no focusable elements', () => {
+  const {root, component, mockFoundation} = setupTest();
+
+  while (root.firstChild) {
+    root.removeChild(root.firstChild);
+  }
+
+  assert.doesNotThrow(() => component.show());
+  td.verify(mockFoundation.open());
+});
+
 test('hide closes the menu surface', () => {
   const {component, mockFoundation} = setupTest();
   component.open = true;
@@ -107,6 +118,13 @@ test('setFixedPosition is true', () => {
   component.setFixedPosition(true);
   assert.isTrue(root.classList.contains(cssClasses.FIXED));
   td.verify(mockFoundation.setFixedPosition(true));
+});
+
+test('setAbsolutePosition calls the foundation setAbsolutePosition function', () => {
+  const {component, mockFoundation} = setupTest();
+  component.setAbsolutePosition(10, 10);
+  td.verify(mockFoundation.setAbsolutePosition(10,10));
+  td.verify(mockFoundation.setIsHoisted(true));
 });
 
 test('setFixedPosition is false', () => {
@@ -243,6 +261,18 @@ test('adapter#restoreFocus does not restores the focus if never called adapter#s
   document.body.removeChild(root);
 });
 
+test('adapter#restoreFocus does nothing if the active focused element is not in the menu-surface', () => {
+  const {root, component} = setupTest(true);
+  const button = bel`<button>Foo</button>`;
+  document.body.appendChild(button);
+  document.body.appendChild(root);
+  button.focus();
+  component.getDefaultFoundation().adapter_.restoreFocus();
+  assert.equal(document.activeElement, button);
+  document.body.removeChild(button);
+  document.body.removeChild(root);
+});
+
 test('adapter#isFocused returns whether the menu surface is focused', () => {
   const {root, component} = setupTest(true);
   document.body.appendChild(root);
@@ -330,6 +360,14 @@ test('adapter#getAnchorDimensions returns the dimensions of the anchor element',
   document.body.removeChild(anchor);
 });
 
+test('adapter#getAnchorDimensions returns undefined if there is no anchor element', () => {
+  const {root, component} = setupTest(true);
+  document.body.appendChild(root);
+  component.initialSyncWithDOM();
+  assert.equal(component.getDefaultFoundation().adapter_.getAnchorDimensions(), undefined);
+  document.body.removeChild(root);
+});
+
 test('adapter#getWindowDimensions returns the dimensions of the window', () => {
   const {root, component} = setupTest(true);
   document.body.appendChild(root);
@@ -338,7 +376,7 @@ test('adapter#getWindowDimensions returns the dimensions of the window', () => {
   document.body.removeChild(root);
 });
 
-test('adapter#getBodyDimensions returns the scroll position of the window when not scrolled', () => {
+test('adapter#getBodyDimensions returns the body dimensions', () => {
   const {root, component} = setupTest(true);
   document.body.appendChild(root);
   assert.equal(component.getDefaultFoundation().adapter_.getBodyDimensions().height, document.body.clientHeight);
@@ -349,8 +387,8 @@ test('adapter#getBodyDimensions returns the scroll position of the window when n
 test('adapter#getWindowScroll returns the scroll position of the window when not scrolled', () => {
   const {root, component} = setupTest(true);
   document.body.appendChild(root);
-  assert.equal(component.getDefaultFoundation().adapter_.getWindowDimensions().height, window.innerHeight);
-  assert.equal(component.getDefaultFoundation().adapter_.getWindowDimensions().width, window.innerWidth);
+  assert.equal(component.getDefaultFoundation().adapter_.getWindowScroll().x, window.pageXOffset);
+  assert.equal(component.getDefaultFoundation().adapter_.getWindowScroll().y, window.pageYOffset);
   document.body.removeChild(root);
 });
 

--- a/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
+++ b/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
@@ -29,6 +29,7 @@ function setupTest() {
   const size = {width: 500, height: 200};
   td.when(mockAdapter.hasClass(cssClasses.ROOT)).thenReturn(true);
   td.when(mockAdapter.hasClass(cssClasses.OPEN)).thenReturn(false);
+  td.when(mockAdapter.getWindowDimensions()).thenReturn({width: window.innerWidth, height: window.innerHeight});
 
   td.when(mockAdapter.getInnerDimensions()).thenReturn(size);
 
@@ -330,6 +331,34 @@ testFoundation('#open from anchor in top right of viewport, absolute position, h
     td.verify(mockAdapter.setTransformOrigin('left top'));
     td.verify(mockAdapter.setPosition({left: '20px', top: '30px'}));
   });
+
+testFoundation('#open in absolute position at x/y=100, absolute position, hoisted menu surface, scrollY 10 px',
+  ({foundation, mockAdapter, mockRaf}) => {
+    initAnchorLayout(mockAdapter, smallTopLeft, true, 200, {x: 0, y: 10});
+    td.when(mockAdapter.hasAnchor()).thenReturn(false);
+    td.when(mockAdapter.getAnchorDimensions()).thenReturn(undefined);
+    foundation.setIsHoisted(true);
+    foundation.setAbsolutePosition(100, 100);
+    foundation.open();
+    mockRaf.flush();
+    td.verify(mockAdapter.setTransformOrigin('left top'));
+    td.verify(mockAdapter.setPosition({left: '100px', top: '110px'}));
+  });
+
+testFoundation('#open in absolute position at x/y=100, fixed position, hoisted menu surface, scrollY 10 px',
+  ({foundation, mockAdapter, mockRaf}) => {
+    initAnchorLayout(mockAdapter, smallTopLeft, true, 200, {x: 0, y: 10});
+    td.when(mockAdapter.hasAnchor()).thenReturn(false);
+    td.when(mockAdapter.getAnchorDimensions()).thenReturn(undefined);
+    foundation.setIsHoisted(true);
+    foundation.setFixedPosition(true);
+    foundation.setAbsolutePosition(100, 100);
+    foundation.open();
+    mockRaf.flush();
+    td.verify(mockAdapter.setTransformOrigin('left top'));
+    td.verify(mockAdapter.setPosition({left: '100px', top: '100px'}));
+  });
+
 
 testFoundation('#open from small anchor in left bottom of viewport, default (TOP_START) anchor corner, RTL',
   ({foundation, mockAdapter, mockRaf}) => {


### PR DESCRIPTION
Completely fixes #2770. 
Adds the ability to specify an absolute x/y that the menu should open to instead of being based on an element's position in the DOM.

Updates/adds a couple unrelated tests for additional coverage. 