### PR TITLE
refactor(chips): Pass chip ids instead of foundations in events 

### DIFF
--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -248,22 +248,21 @@ Method Signature | Description
 `addClassToLeadingIcon(className: string) => void` | Adds a class to the leading icon element
 `removeClassFromLeadingIcon(className: string) => void` | Removes a class from the leading icon element
 `eventTargetHasClass(target: EventTarget, className: string) => boolean` | Returns true if target has className, false otherwise
-`notifyInteraction() => void` | Emits a custom event `MDCChip:interaction` denoting the chip has been interacted with
-`notifyTrailingIconInteraction() => void` | Emits a custom event `MDCChip:trailingIconInteraction` denoting the chip's trailing icon has been interacted with
-`notifyRemoval() => void` | Emits a custom event `MDCChip:removal` denoting the chip will be removed
+`notifyInteraction() => void` | Emits a custom event `MDCChip:interaction` denoting the chip has been interacted with*
+`notifyTrailingIconInteraction() => void` | Emits a custom event `MDCChip:trailingIconInteraction` denoting the chip's trailing icon has been interacted with*
+`notifyRemoval() => void` | Emits a custom event `MDCChip:removal` denoting the chip will be removed*
 `getComputedStyleValue(propertyName: string) => string` | Returns the computed property value of the given style property on the root element
 `setStyleProperty(propertyName: string, value: string) => void` | Sets the property value of the given style property on the root element
 
-> _NOTE_: The custom events emitted by `notifyInteraction` and `notifyTrailingIconInteraction` must pass along the target chip in its event `detail`, as well as bubble to the parent `mdc-chip-set` element.
-
-> _NOTE_: The custom event emitted by `notifyRemoval` must pass along the target chip and its root element in the event `detail`, as well as bubble to the parent `mdc-chip-set` element.
+> *_NOTE_: The custom events emitted by `notifyInteraction`, `notifyTrailingIconInteraction` and `notifyRemoval` must pass along the target chip's ID in its event `detail`, as well as bubble to the parent `mdc-chip-set` element.
 
 #### `MDCChipSetAdapter`
 
 Method Signature | Description
 --- | ---
 `hasClass(className: string) => boolean` | Returns whether the chip set element has the given class
-`removeChip(chip: MDCChip) => void` | Removes the chip object from the chip set
+`removeChip(chipId: string) => void` | Removes the chip with the given id from the chip set
+`setSelected(chipId: string, selected: boolean) => void` | Sets the selected state of the chip with the given id
 
 ### Foundations: `MDCChipFoundation` and `MDCChipSetFoundation`
 
@@ -284,7 +283,8 @@ Method Signature | Description
 
 Method Signature | Description
 --- | ---
-`select(chipFoundation: MDCChipFoundation) => void` | Selects the given chip
-`deselect(chipFoundation: MDCChipFoundation) => void` | Deselects the given chip
+`select(chipId: string) => void` | Selects the chip with the given id
+`deselect(chipId: string) => void` | Deselects the chip with the given id
+`toggleSelect(chipId: string) => void` | Toggles selection of the chip with the given id
 `handleChipInteraction(evt: Event) => void` | Handles a custom `MDCChip:interaction` event on the root element
 `handleChipRemoval(evt: Event) => void` | Handles a custom `MDCChip:removal` event on the root element

--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -209,24 +209,27 @@ To use the `MDCChip` and `MDCChipSet` classes, [import](../../docs/importing-js.
 
 #### `MDCChip`
 
-Method Signature | Description
---- | ---
-`isSelected() => boolean` | Proxies to the foundation's `isSelected` method
-`beginExit() => void` | Proxies to the foundation's `beginExit` method
-
 Property | Value Type | Description
 --- | --- | ---
-`foundation` | MDCChipFoundation | The foundation
-`shouldRemoveOnTrailingIconClick` | Boolean | Proxies to the foundation's `getShouldRemoveOnTrailingIconClick`/`setShouldRemoveOnTrailingIconClick` methods
+`id` | string | Unique identifier on the chip*
+`selected` | Boolean | Proxies to the foundation's `isSelected`/`setSelected` methods
+`shouldRemoveOnTrailingIconClick` | Boolean | Proxies to the foundation's `getShouldRemoveOnTrailingIconClick`/`setShouldRemoveOnTrailingIconClick` methods**
 `ripple` | `MDCRipple` | The `MDCRipple` instance for the root element that `MDCChip` initializes
 
->_NOTE_: If `shouldRemoveOnTrailingIconClick` is set to false, you must manually call `beginExit()` on the chip to remove it.
+> *_NOTE_: By default, this will be the same as the `id` attribute on the root element. If an `id` is not provided, a random one will be generated.
+
+> **_NOTE_: If `shouldRemoveOnTrailingIconClick` is set to false, you must manually call `beginExit()` on the chip to remove it.
+
+Method Signature | Description
+--- | ---
+`beginExit() => void` | Proxies to the foundation's `beginExit` method
 
 #### `MDCChipSet`
 
 Method Signature | Description
 --- | ---
 `addChip(chipEl: Element) => void` | Adds a new `MDCChip` instance to the chip set based on the given `mdc-chip` element
+`getSelectedChipIds() => boolean` | Returns an array of the IDs of all selected chips
 
 Property | Value Type | Description
 --- | --- | ---
@@ -286,5 +289,6 @@ Method Signature | Description
 `select(chipId: string) => void` | Selects the chip with the given id
 `deselect(chipId: string) => void` | Deselects the chip with the given id
 `toggleSelect(chipId: string) => void` | Toggles selection of the chip with the given id
+`getSelectedChipIds() => boolean` | Returns an array of the IDs of all selected chips
 `handleChipInteraction(evt: Event) => void` | Handles a custom `MDCChip:interaction` event on the root element
 `handleChipRemoval(evt: Event) => void` | Handles a custom `MDCChip:removal` event on the root element

--- a/packages/mdc-chips/chip-set/adapter.js
+++ b/packages/mdc-chips/chip-set/adapter.js
@@ -39,10 +39,17 @@ class MDCChipSetAdapter {
   hasClass(className) {}
 
   /**
-   * Removes the chip object from the chip set.
-   * @param {!Object} chip
+   * Removes the chip with the given id from the chip set.
+   * @param {string} chipId
    */
-  removeChip(chip) {}
+  removeChip(chipId) {}
+
+  /**
+   * Sets the selected state of the chip with the given id.
+   * @param {string} chipId
+   * @param {boolean} selected
+   */
+  setSelected(chipId, selected) {}
 }
 
 export default MDCChipSetAdapter;

--- a/packages/mdc-chips/chip-set/foundation.js
+++ b/packages/mdc-chips/chip-set/foundation.js
@@ -18,7 +18,7 @@
 import MDCFoundation from '@material/base/foundation';
 import MDCChipSetAdapter from './adapter';
 // eslint-disable-next-line no-unused-vars
-import {MDCChipFoundation, MDCChipInteractionEventType} from '../chip/foundation';
+import {MDCChipInteractionEventType} from '../chip/foundation';
 import {strings, cssClasses} from './constants';
 
 /**
@@ -60,6 +60,14 @@ class MDCChipSetFoundation extends MDCFoundation {
      * @private {!Array<string>}
      */
     this.selectedChipIds_ = [];
+  }
+
+  /**
+   * Returns an array of the IDs of all selected chips.
+   * @return {!Array<string>}
+   */
+  getSelectedChipIds() {
+    return this.selectedChipIds_;
   }
 
   /**
@@ -111,7 +119,7 @@ class MDCChipSetFoundation extends MDCFoundation {
    */
   handleChipInteraction(evt) {
     const {chipId} = evt.detail;
-    this.handleSelect(chipId);
+    this.toggleSelect(chipId);
   }
 
   /**

--- a/packages/mdc-chips/chip-set/foundation.js
+++ b/packages/mdc-chips/chip-set/foundation.js
@@ -90,11 +90,11 @@ class MDCChipSetFoundation extends MDCFoundation {
    */
   select(chipId) {
     if (this.adapter_.hasClass(cssClasses.CHOICE)) {
-      // Deselect all selected chips.
-      this.selectedChipIds_.forEach((chipId) => {
-        this.adapter_.setSelected(chipId, false);
-      });
-      this.selectedChipIds_.length = 0;
+      const selectedChipId = this.selectedChipIds_.length > 0 && this.selectedChipIds_[0];
+      if (selectedChipId && selectedChipId != chipId) {
+        this.adapter_.setSelected(selectedChipId, false);
+        this.selectedChipIds_.length = 0;
+      }
     }
     this.adapter_.setSelected(chipId, true);
     this.selectedChipIds_.push(chipId);

--- a/packages/mdc-chips/chip-set/foundation.js
+++ b/packages/mdc-chips/chip-set/foundation.js
@@ -45,6 +45,7 @@ class MDCChipSetFoundation extends MDCFoundation {
     return /** @type {!MDCChipSetAdapter} */ ({
       hasClass: () => {},
       removeChip: () => {},
+      setSelected: () => {},
     });
   }
 
@@ -55,27 +56,45 @@ class MDCChipSetFoundation extends MDCFoundation {
     super(Object.assign(MDCChipSetFoundation.defaultAdapter, adapter));
 
     /**
-     * The selected chips in the set. Only used for choice chip set or filter chip set.
-     * @private {!Array<number>}
+     * The ids of the selected chips in the set. Only used for choice chip set or filter chip set.
+     * @private {!Array<string>}
      */
     this.selectedChipIds_ = [];
   }
 
   /**
-   * Selects the given chip. Deselects all other chips if the chip set is of the choice variant.
-   * @param {!MDCChipFoundation} chipFoundation
+   * Toggles selection of the chip with the given id.
+   * @param {string} chipId
+   */
+  toggleSelect(chipId) {
+    if (this.adapter_.hasClass(cssClasses.CHOICE) || this.adapter_.hasClass(cssClasses.FILTER)) {
+      if (this.selectedChipIds_.indexOf(chipId) >= 0) {
+        this.deselect(chipId);
+      } else {
+        this.select(chipId);
+      }
+    }
+  }
+
+  /**
+   * Selects the chip with the given id. Deselects all other chips if the chip set is of the choice variant.
+   * @param {string} chipId
    */
   select(chipId) {
     if (this.adapter_.hasClass(cssClasses.CHOICE)) {
-      this.deselectAll_();
+      // Deselect all selected chips.
+      this.selectedChipIds_.forEach((chipId) => {
+        this.adapter_.setSelected(chipId, false);
+      });
+      this.selectedChipIds_.length = 0;
     }
     this.adapter_.setSelected(chipId, true);
     this.selectedChipIds_.push(chipId);
   }
 
   /**
-   * Deselects the given chip.
-   * @param {!MDCChipFoundation} chipFoundation
+   * Deselects the chip with the given id.
+   * @param {string} chipId
    */
   deselect(chipId) {
     const index = this.selectedChipIds_.indexOf(chipId);
@@ -85,14 +104,6 @@ class MDCChipSetFoundation extends MDCFoundation {
     this.adapter_.setSelected(chipId, false);
   }
 
-  /** Deselects all selected chips. */
-  deselectAll_() {
-    this.selectedChipIds_.forEach((chipId) => {
-      this.adapter_.setSelected(chipId, false);
-    });
-    this.selectedChipIds_.length = 0;
-  }
-
   /**
    * Handles a chip interaction event
    * @param {!MDCChipInteractionEventType} evt
@@ -100,13 +111,7 @@ class MDCChipSetFoundation extends MDCFoundation {
    */
   handleChipInteraction(evt) {
     const {chipId} = evt.detail;
-    if (this.adapter_.hasClass(cssClasses.CHOICE) || this.adapter_.hasClass(cssClasses.FILTER)) {
-      if (this.selectedChipIds_.includes(chipId)) {
-        this.deselect(chipId);
-      } else {
-        this.select(chipId);
-      }
-    }
+    this.handleSelect(chipId);
   }
 
   /**
@@ -115,9 +120,9 @@ class MDCChipSetFoundation extends MDCFoundation {
    * @private
    */
   handleChipRemoval(evt) {
-    const {chip} = evt.detail;
-    this.deselect(chip.foundation);
-    this.adapter_.removeChip(chip);
+    const {chipId} = evt.detail;
+    this.deselect(chipId);
+    this.adapter_.removeChip(chipId);
   }
 }
 

--- a/packages/mdc-chips/chip-set/foundation.js
+++ b/packages/mdc-chips/chip-set/foundation.js
@@ -69,7 +69,7 @@ class MDCChipSetFoundation extends MDCFoundation {
     if (this.adapter_.hasClass(cssClasses.CHOICE)) {
       this.deselectAll_();
     }
-    this.adapter_setSelected(chipId, true);
+    this.adapter_.setSelected(chipId, true);
     this.selectedChipIds_.push(chipId);
   }
 
@@ -82,13 +82,13 @@ class MDCChipSetFoundation extends MDCFoundation {
     if (index >= 0) {
       this.selectedChipIds_.splice(index, 1);
     }
-    this.adapter_setSelected(chipId, false);
+    this.adapter_.setSelected(chipId, false);
   }
 
   /** Deselects all selected chips. */
   deselectAll_() {
     this.selectedChipIds_.forEach((chipId) => {
-      this.adapter_setSelected(chipId, false);
+      this.adapter_.setSelected(chipId, false);
     });
     this.selectedChipIds_.length = 0;
   }

--- a/packages/mdc-chips/chip-set/foundation.js
+++ b/packages/mdc-chips/chip-set/foundation.js
@@ -56,41 +56,41 @@ class MDCChipSetFoundation extends MDCFoundation {
 
     /**
      * The selected chips in the set. Only used for choice chip set or filter chip set.
-     * @private {!Array<!MDCChipFoundation>}
+     * @private {!Array<number>}
      */
-    this.selectedChips_ = [];
+    this.selectedChipIds_ = [];
   }
 
   /**
    * Selects the given chip. Deselects all other chips if the chip set is of the choice variant.
    * @param {!MDCChipFoundation} chipFoundation
    */
-  select(chipFoundation) {
+  select(chipId) {
     if (this.adapter_.hasClass(cssClasses.CHOICE)) {
       this.deselectAll_();
     }
-    chipFoundation.setSelected(true);
-    this.selectedChips_.push(chipFoundation);
+    this.adapter_setSelected(chipId, true);
+    this.selectedChipIds_.push(chipId);
   }
 
   /**
    * Deselects the given chip.
    * @param {!MDCChipFoundation} chipFoundation
    */
-  deselect(chipFoundation) {
-    const index = this.selectedChips_.indexOf(chipFoundation);
+  deselect(chipId) {
+    const index = this.selectedChipIds_.indexOf(chipId);
     if (index >= 0) {
-      this.selectedChips_.splice(index, 1);
+      this.selectedChipIds_.splice(index, 1);
     }
-    chipFoundation.setSelected(false);
+    this.adapter_setSelected(chipId, false);
   }
 
   /** Deselects all selected chips. */
   deselectAll_() {
-    this.selectedChips_.forEach((chipFoundation) => {
-      chipFoundation.setSelected(false);
+    this.selectedChipIds_.forEach((chipId) => {
+      this.adapter_setSelected(chipId, false);
     });
-    this.selectedChips_.length = 0;
+    this.selectedChipIds_.length = 0;
   }
 
   /**
@@ -99,12 +99,12 @@ class MDCChipSetFoundation extends MDCFoundation {
    * @private
    */
   handleChipInteraction(evt) {
-    const chipFoundation = evt.detail.chip.foundation;
+    const {chipId} = evt.detail;
     if (this.adapter_.hasClass(cssClasses.CHOICE) || this.adapter_.hasClass(cssClasses.FILTER)) {
-      if (chipFoundation.isSelected()) {
-        this.deselect(chipFoundation);
+      if (this.selectedChipIds_.includes(chipId)) {
+        this.deselect(chipId);
       } else {
-        this.select(chipFoundation);
+        this.select(chipId);
       }
     }
   }

--- a/packages/mdc-chips/chip-set/index.js
+++ b/packages/mdc-chips/chip-set/index.js
@@ -63,7 +63,7 @@ class MDCChipSet extends MDCComponent {
   initialSyncWithDOM() {
     this.chips.forEach((chip) => {
       if (chip.isSelected()) {
-        this.foundation_.select(chip.foundation);
+        this.foundation_.select(chip.id);
       }
     });
 
@@ -108,8 +108,11 @@ class MDCChipSet extends MDCComponent {
         chip.destroy();
       },
       setSelected: (chipId, selected) => {
+        console.log(this.chips);
         const chip = this.chips.find((chip) => chip.id === chipId);
-        chip.setSelected(selected);
+        if (chip) {
+          chip.setSelected(selected);
+        }
       },
     })));
   }

--- a/packages/mdc-chips/chip-set/index.js
+++ b/packages/mdc-chips/chip-set/index.js
@@ -102,16 +102,17 @@ class MDCChipSet extends MDCComponent {
   getDefaultFoundation() {
     return new MDCChipSetFoundation(/** @type {!MDCChipSetAdapter} */ (Object.assign({
       hasClass: (className) => this.root_.classList.contains(className),
-      removeChip: (chip) => {
-        const index = this.chips.indexOf(chip);
-        this.chips.splice(index, 1);
-        chip.destroy();
+      removeChip: (chipId) => {
+        const index = this.findChipIndex_(chipId);
+        if (index >= 0) {
+          this.chips[index].destroy();
+          this.chips.splice(index, 1);
+        }
       },
       setSelected: (chipId, selected) => {
-        console.log(this.chips);
-        const chip = this.chips.find((chip) => chip.id === chipId);
-        if (chip) {
-          chip.setSelected(selected);
+        const index = this.findChipIndex_(chipId);
+        if (index >= 0) {
+          this.chips[index].setSelected(selected);
         }
       },
     })));
@@ -125,6 +126,20 @@ class MDCChipSet extends MDCComponent {
   instantiateChips_(chipFactory) {
     const chipElements = [].slice.call(this.root_.querySelectorAll(MDCChipSetFoundation.strings.CHIP_SELECTOR));
     return chipElements.map((el) => chipFactory(el));
+  }
+
+  /**
+   * Returns the index of the chip with the given id, or -1 if the chip does not exist.
+   * @param {string} chipId
+   * @return {number}
+   */
+  findChipIndex_(chipId){
+    for (i = 0; i < this.chips.length; i++) {
+      if (this.chips[i].id === chipId) {
+        return i;
+      }
+    }
+    return -1;
   }
 }
 

--- a/packages/mdc-chips/chip-set/index.js
+++ b/packages/mdc-chips/chip-set/index.js
@@ -107,6 +107,10 @@ class MDCChipSet extends MDCComponent {
         this.chips.splice(index, 1);
         chip.destroy();
       },
+      setSelected: (chipId, selected) => {
+        const chip = this.chips.find((chip) => chip.id === chipId);
+        chip.setSelected(selected);
+      },
     })));
   }
 

--- a/packages/mdc-chips/chip-set/index.js
+++ b/packages/mdc-chips/chip-set/index.js
@@ -62,7 +62,7 @@ class MDCChipSet extends MDCComponent {
 
   initialSyncWithDOM() {
     this.chips.forEach((chip) => {
-      if (chip.isSelected()) {
+      if (chip.selected) {
         this.foundation_.select(chip.id);
       }
     });
@@ -97,6 +97,14 @@ class MDCChipSet extends MDCComponent {
   }
 
   /**
+   * Returns an array of the IDs of all selected chips.
+   * @return {!Array<string>}
+   */
+  getSelectedChipIds() {
+    return this.foundation_.getSelectedChipIds();
+  }
+
+  /**
    * @return {!MDCChipSetFoundation}
    */
   getDefaultFoundation() {
@@ -112,7 +120,7 @@ class MDCChipSet extends MDCComponent {
       setSelected: (chipId, selected) => {
         const index = this.findChipIndex_(chipId);
         if (index >= 0) {
-          this.chips[index].setSelected(selected);
+          this.chips[index].selected = selected;
         }
       },
     })));
@@ -134,7 +142,7 @@ class MDCChipSet extends MDCComponent {
    * @return {number}
    */
   findChipIndex_(chipId){
-    for (i = 0; i < this.chips.length; i++) {
+    for (let i = 0; i < this.chips.length; i++) {
       if (this.chips[i].id === chipId) {
         return i;
       }

--- a/packages/mdc-chips/chip-set/index.js
+++ b/packages/mdc-chips/chip-set/index.js
@@ -141,7 +141,7 @@ class MDCChipSet extends MDCComponent {
    * @param {string} chipId
    * @return {number}
    */
-  findChipIndex_(chipId){
+  findChipIndex_(chipId) {
     for (let i = 0; i < this.chips.length; i++) {
       if (this.chips[i].id === chipId) {
         return i;

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -36,7 +36,7 @@ class MDCChip extends MDCComponent {
     super(...args);
 
     /** @type {number} */
-    this.id_ = Math.random();
+    this.id = Math.random();
     /** @private {?Element} */
     this.leadingIcon_;
     /** @private {?Element} */
@@ -178,9 +178,9 @@ class MDCChip extends MDCComponent {
         }
       },
       eventTargetHasClass: (target, className) => target.classList.contains(className),
-      notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chipId: this.id_}, true /* shouldBubble */),
+      notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
       notifyTrailingIconInteraction: () => this.emit(
-        strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id_}, true /* shouldBubble */),
+        strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
       notifyRemoval: () => this.emit(strings.REMOVAL_EVENT, {chip: this, root: this.root_}, true /* shouldBubble */),
       getComputedStyleValue: (propertyName) => window.getComputedStyle(this.root_).getPropertyValue(propertyName),
       setStyleProperty: (propertyName, value) => this.root_.style.setProperty(propertyName, value),

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -179,7 +179,8 @@ class MDCChip extends MDCComponent {
       notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
       notifyTrailingIconInteraction: () => this.emit(
         strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
-      notifyRemoval: () => this.emit(strings.REMOVAL_EVENT, {chipId: this.id, root: this.root_}, true /* shouldBubble */),
+      notifyRemoval: () =>
+        this.emit(strings.REMOVAL_EVENT, {chipId: this.id, root: this.root_}, true /* shouldBubble */),
       getComputedStyleValue: (propertyName) => window.getComputedStyle(this.root_).getPropertyValue(propertyName),
       setStyleProperty: (propertyName, value) => this.root_.style.setProperty(propertyName, value),
     })));

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -36,7 +36,7 @@ class MDCChip extends MDCComponent {
     super(...args);
 
     /** @type {number} */
-    this.id = Math.random();
+    this.id_ = Math.random();
     /** @private {?Element} */
     this.leadingIcon_;
     /** @private {?Element} */
@@ -178,9 +178,9 @@ class MDCChip extends MDCComponent {
         }
       },
       eventTargetHasClass: (target, className) => target.classList.contains(className),
-      notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
+      notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chipId: this.id_}, true /* shouldBubble */),
       notifyTrailingIconInteraction: () => this.emit(
-        strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
+        strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id_}, true /* shouldBubble */),
       notifyRemoval: () => this.emit(strings.REMOVAL_EVENT, {chip: this, root: this.root_}, true /* shouldBubble */),
       getComputedStyleValue: (propertyName) => window.getComputedStyle(this.root_).getPropertyValue(propertyName),
       setStyleProperty: (propertyName, value) => this.root_.style.setProperty(propertyName, value),

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -178,9 +178,9 @@ class MDCChip extends MDCComponent {
         }
       },
       eventTargetHasClass: (target, className) => target.classList.contains(className),
-      notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chip: this}, true /* shouldBubble */),
+      notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
       notifyTrailingIconInteraction: () => this.emit(
-        strings.TRAILING_ICON_INTERACTION_EVENT, {chip: this}, true /* shouldBubble */),
+        strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
       notifyRemoval: () => this.emit(strings.REMOVAL_EVENT, {chip: this, root: this.root_}, true /* shouldBubble */),
       getComputedStyleValue: (propertyName) => window.getComputedStyle(this.root_).getPropertyValue(propertyName),
       setStyleProperty: (propertyName, value) => this.root_.style.setProperty(propertyName, value),

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -35,8 +35,8 @@ class MDCChip extends MDCComponent {
   constructor(...args) {
     super(...args);
 
-    /** @type {number} */
-    this.id = Math.random();
+    /** @type {string} */
+    this.id;
     /** @private {?Element} */
     this.leadingIcon_;
     /** @private {?Element} */
@@ -61,6 +61,7 @@ class MDCChip extends MDCComponent {
   }
 
   initialize() {
+    this.id = this.root_.id || this.root_.innerText.slice(0, -1) + Math.random();
     this.leadingIcon_ = this.root_.querySelector(strings.LEADING_ICON_SELECTOR);
     this.trailingIcon_ = this.root_.querySelector(strings.TRAILING_ICON_SELECTOR);
 
@@ -118,29 +119,19 @@ class MDCChip extends MDCComponent {
   }
 
   /**
-   * Returns true if the chip is selected.
+   * Returns whether the chip is selected.
    * @return {boolean}
    */
-  isSelected() {
+  get selected() {
     return this.foundation_.isSelected();
   }
 
-  setSelected(selected) {
+  /**
+   * Sets selected state on the chip.
+   * @param {boolean}
+   */
+  set selected(selected) {
     return this.foundation_.setSelected(selected);
-  }
-
-  /**
-   * Begins the exit animation which leads to removal of the chip.
-   */
-  beginExit() {
-    this.foundation_.beginExit();
-  }
-
-  /**
-   * @return {!MDCChipFoundation}
-   */
-  get foundation() {
-    return this.foundation_;
   }
 
   /**
@@ -157,6 +148,13 @@ class MDCChip extends MDCComponent {
    */
   set shouldRemoveOnTrailingIconClick(shouldRemove) {
     return this.foundation_.setShouldRemoveOnTrailingIconClick(shouldRemove);
+  }
+
+  /**
+   * Begins the exit animation which leads to removal of the chip.
+   */
+  beginExit() {
+    this.foundation_.beginExit();
   }
 
   /**
@@ -181,7 +179,7 @@ class MDCChip extends MDCComponent {
       notifyInteraction: () => this.emit(strings.INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
       notifyTrailingIconInteraction: () => this.emit(
         strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
-      notifyRemoval: () => this.emit(strings.REMOVAL_EVENT, {chip: this, root: this.root_}, true /* shouldBubble */),
+      notifyRemoval: () => this.emit(strings.REMOVAL_EVENT, {chipId: this.id, root: this.root_}, true /* shouldBubble */),
       getComputedStyleValue: (propertyName) => window.getComputedStyle(this.root_).getPropertyValue(propertyName),
       setStyleProperty: (propertyName, value) => this.root_.style.setProperty(propertyName, value),
     })));

--- a/packages/mdc-chips/chip/index.js
+++ b/packages/mdc-chips/chip/index.js
@@ -35,6 +35,8 @@ class MDCChip extends MDCComponent {
   constructor(...args) {
     super(...args);
 
+    /** @type {number} */
+    this.id = Math.random();
     /** @private {?Element} */
     this.leadingIcon_;
     /** @private {?Element} */
@@ -121,6 +123,10 @@ class MDCChip extends MDCComponent {
    */
   isSelected() {
     return this.foundation_.isSelected();
+  }
+
+  setSelected(selected) {
+    return this.foundation_.setSelected(selected);
   }
 
   /**

--- a/test/unit/mdc-chips/mdc-chip-set.foundation.test.js
+++ b/test/unit/mdc-chips/mdc-chip-set.foundation.test.js
@@ -34,118 +34,75 @@ test('exports cssClasses', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCChipSetFoundation, [
-    'hasClass', 'removeChip',
+    'hasClass', 'removeChip', 'setSelected',
   ]);
 });
 
 const setupTest = () => {
   const mockAdapter = td.object(MDCChipSetFoundation.defaultAdapter);
   const foundation = new MDCChipSetFoundation(mockAdapter);
-  const chipA = td.object({
-    foundation: {
-      isSelected: () => {},
-      setSelected: () => {},
-    },
-  });
-  const chipB = td.object({
-    foundation: {
-      isSelected: () => {},
-      setSelected: () => {},
-    },
-  });
-  return {foundation, mockAdapter, chipA, chipB};
+  return {foundation, mockAdapter};
 };
 
-test('in choice chips, #handleChipInteraction selects chip if no chips are selected', () => {
-  const {foundation, mockAdapter, chipA} = setupTest();
+test('in choice chips, #select selects chip if no chips are selected', () => {
+  const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.CHOICE)).thenReturn(true);
-  td.when(chipA.foundation.isSelected()).thenReturn(false);
-  assert.equal(foundation.selectedChips_.length, 0);
+  assert.equal(foundation.getSelectedChipIds().length, 0);
 
-  foundation.handleChipInteraction({
-    detail: {
-      chip: chipA,
-    },
-  });
-  td.verify(chipA.foundation.setSelected(true));
-  assert.equal(foundation.selectedChips_.length, 1);
+  foundation.select('chipA');
+  td.verify(mockAdapter.setSelected('chipA', true));
+  assert.equal(foundation.getSelectedChipIds().length, 1);
 });
 
-test('in choice chips, #handleChipInteraction deselects chip if another chip is selected', () => {
-  const {foundation, mockAdapter, chipA, chipB} = setupTest();
+test('in choice chips, #select deselects chip if another chip is selected', () => {
+  const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.CHOICE)).thenReturn(true);
-  foundation.select(chipB.foundation);
-  td.when(chipA.foundation.isSelected()).thenReturn(false);
-  td.when(chipB.foundation.isSelected()).thenReturn(true);
-  assert.equal(foundation.selectedChips_.length, 1);
+  foundation.select('chipB');
+  assert.equal(foundation.getSelectedChipIds().length, 1);
 
-  foundation.handleChipInteraction({
-    detail: {
-      chip: chipA,
-    },
-  });
-  td.verify(chipA.foundation.setSelected(true));
-  td.verify(chipB.foundation.setSelected(false));
-  assert.equal(foundation.selectedChips_.length, 1);
+  foundation.select('chipA');
+  td.verify(mockAdapter.setSelected('chipB', false));
+  td.verify(mockAdapter.setSelected('chipA', true));
+  assert.equal(foundation.getSelectedChipIds().length, 1);
 });
 
-test('in filter chips, #handleChipInteraction selects multiple chips', () => {
-  const {foundation, mockAdapter, chipA, chipB} = setupTest();
+test('in filter chips, #select selects multiple chips', () => {
+  const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.FILTER)).thenReturn(true);
-  td.when(chipA.foundation.isSelected()).thenReturn(false);
-  td.when(chipB.foundation.isSelected()).thenReturn(false);
-  assert.equal(foundation.selectedChips_.length, 0);
+  assert.equal(foundation.getSelectedChipIds().length, 0);
 
-  foundation.handleChipInteraction({
-    detail: {
-      chip: chipA,
-    },
-  });
-  td.verify(chipA.foundation.setSelected(true));
-  assert.equal(foundation.selectedChips_.length, 1);
+  foundation.select('chipA');
+  td.verify(mockAdapter.setSelected('chipA', true));
+  assert.equal(foundation.getSelectedChipIds().length, 1);
 
-  foundation.handleChipInteraction({
-    detail: {
-      chip: chipB,
-    },
-  });
-  td.verify(chipB.foundation.setSelected(true));
-  assert.equal(foundation.selectedChips_.length, 2);
+  foundation.select('chipB');
+  td.verify(mockAdapter.setSelected('chipB', true));
+  assert.equal(foundation.getSelectedChipIds().length, 2);
 });
 
-test('in filter chips, #handleChipInteraction event deselects selected chips', () => {
-  const {foundation, mockAdapter, chipA, chipB} = setupTest();
+test('in filter chips, #deselect deselects selected chips', () => {
+  const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.FILTER)).thenReturn(true);
-  foundation.select(chipA.foundation);
-  foundation.select(chipB.foundation);
-  td.when(chipA.foundation.isSelected()).thenReturn(true);
-  td.when(chipB.foundation.isSelected()).thenReturn(true);
-  assert.equal(foundation.selectedChips_.length, 2);
+  foundation.select('chipA');
+  foundation.select('chipB');
+  assert.equal(foundation.getSelectedChipIds().length, 2);
 
-  foundation.handleChipInteraction({
-    detail: {
-      chip: chipB,
-    },
-  });
-  td.verify(chipB.foundation.setSelected(false));
-  assert.equal(foundation.selectedChips_.length, 1);
+  foundation.deselect('chipB');
+  td.verify(mockAdapter.setSelected('chipB', false));
+  assert.equal(foundation.getSelectedChipIds().length, 1);
 
-  foundation.handleChipInteraction({
-    detail: {
-      chip: chipA,
-    },
-  });
-  td.verify(chipA.foundation.setSelected(false));
-  assert.equal(foundation.selectedChips_.length, 0);
+  foundation.deselect('chipA');
+  td.verify(mockAdapter.setSelected('chipA', false));
+  assert.equal(foundation.getSelectedChipIds().length, 0);
 });
 
 test('#handleChipRemoval removes chip', () => {
-  const {foundation, mockAdapter, chipA} = setupTest();
+  const {foundation, mockAdapter} = setupTest();
 
   foundation.handleChipRemoval({
     detail: {
-      chip: chipA,
+      chipId: 'chipA',
     },
   });
-  td.verify(mockAdapter.removeChip(chipA));
+  td.verify(mockAdapter.removeChip('chipA'));
 });

--- a/test/unit/mdc-chips/mdc-chip-set.test.js
+++ b/test/unit/mdc-chips/mdc-chip-set.test.js
@@ -22,13 +22,13 @@ import {MDCChipSet} from '../../../packages/mdc-chips/chip-set';
 
 const getFixture = () => bel`
   <div class="mdc-chip-set">
-    <div class="mdc-chip">
+    <div class="mdc-chip" id="chip1">
       <div class="mdc-chip__text">Chip content</div>
     </div>
-    <div class="mdc-chip">
+    <div class="mdc-chip" id="chip2">
       <div class="mdc-chip__text">Chip content</div>
     </div>
-    <div class="mdc-chip">
+    <div class="mdc-chip" id="chip3">
       <div class="mdc-chip__text">Chip content</div>
     </div>
   </div>
@@ -43,7 +43,7 @@ test('attachTo returns an MDCChipSet instance', () => {
 class FakeChip {
   constructor() {
     this.destroy = td.func('.destroy');
-    this.isSelected = td.func('.isSelected');
+    this.selected = td.func('.selected');
   }
 }
 
@@ -81,24 +81,6 @@ test('#addChip adds a new chip to the chip set', () => {
   assert.instanceOf(component.chips[3], FakeChip);
 });
 
-class FakeSelectedChip {
-  constructor() {
-    this.foundation = td.object({
-      setSelected: () => {},
-    });
-    this.destroy = td.func('.destroy');
-    this.isSelected = () => true;
-  }
-}
-
-test('#initialSyncWithDOM sets selects chips with mdc-chip--selected class', () => {
-  const root = getFixture();
-  const component = new MDCChipSet(root, undefined, (el) => new FakeSelectedChip(el));
-  td.verify(component.foundation_.select(component.chips[0].foundation));
-  td.verify(component.foundation_.select(component.chips[1].foundation));
-  td.verify(component.foundation_.select(component.chips[2].foundation));
-});
-
 function setupTest() {
   const root = getFixture();
   const component = new MDCChipSet(root);
@@ -115,7 +97,15 @@ test('#adapter.removeChip removes the chip object from the chip set', () => {
   const root = getFixture();
   const component = new MDCChipSet(root, undefined, (el) => new FakeChip(el));
   const chip = component.chips[0];
-  component.getDefaultFoundation().adapter_.removeChip(chip);
+  component.getDefaultFoundation().adapter_.removeChip(chip.id);
   assert.equal(component.chips.length, 2);
   td.verify(chip.destroy());
+});
+
+test('#adapter.setSelected sets select on chip object', () => {
+  const root = getFixture();
+  const component = new MDCChipSet(root, undefined, (el) => new FakeChip(el));
+  const chip = component.chips[0];
+  component.getDefaultFoundation().adapter_.setSelected(chip, true);
+  assert.equal(chip.selected, true);
 });

--- a/test/unit/mdc-chips/mdc-chip.test.js
+++ b/test/unit/mdc-chips/mdc-chip.test.js
@@ -48,6 +48,16 @@ test('get ripple returns MDCRipple instance', () => {
   assert.isTrue(component.ripple instanceof MDCRipple);
 });
 
+test('sets id on chip if attribute exists', () => {
+  const root = bel`
+    <div class="mdc-chip" id="hello-chip">
+      <div class="mdc-chip__text">Hello</div>
+    </div>
+  `;
+  const component = new MDCChip(root);
+  assert.equal(component.id, 'hello-chip');
+});
+
 test('#adapter.hasClass returns true if class is set on chip set element', () => {
   const {root, component} = setupTest();
   root.classList.add('foo');
@@ -146,10 +156,15 @@ function setupMockFoundationTest(root = getFixture()) {
   return {root, component, mockFoundation};
 }
 
-test('#isSelected proxies to foundation', () => {
+test('#get selected proxies to foundation', () => {
   const {component, mockFoundation} = setupMockFoundationTest();
-  component.isSelected();
-  td.verify(mockFoundation.isSelected());
+  assert.equal(component.selected, mockFoundation.isSelected());
+});
+
+test('#set selected proxies to foundation', () => {
+  const {component, mockFoundation} = setupMockFoundationTest();
+  component.selected = true;
+  td.verify(mockFoundation.setSelected(true));
 });
 
 test('#get shouldRemoveOnTrailingIconClick proxies to foundation', () => {


### PR DESCRIPTION
Passing an id rather than an `MDCChipFoundation` for Chip-to-ChipSet events allows users to do more with the component without needing to access foundations. For example, users can tell the `MDCChipSet` to select a chip by passing in the chip's ID. Previously, this would only be possible if users passed in an `MDCChipFoundation` or added a class to the DOM element.

This is necessary in MDC React, where the `ChipSet` wrapper needs to be able to set selection state without a DOM. 