### PR TITLE
test(checkbox): Add screenshot tests for Sass mixins

### DIFF
--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -161,6 +161,24 @@
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/mattgoo/2018/07/18/19_29_49_289/spec/mdc-checkbox/classes/baseline.html.windows_ie_11.png"
     }
   },
+  "spec/mdc-checkbox/mixins/container-colors.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-checkbox/mixins/ink-color.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_chrome_67.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_ie_11.png"
+    }
+  },
   "spec/mdc-drawer/classes/permanent.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/21_05_09_679/spec/mdc-drawer/classes/permanent.html",
     "screenshots": {

--- a/test/screenshot/spec/mdc-checkbox/fixture.scss
+++ b/test/screenshot/spec/mdc-checkbox/fixture.scss
@@ -14,7 +14,23 @@
 // limitations under the License.
 //
 
+@import "../../../../packages/mdc-checkbox/mixins";
+@import "../../../../packages/mdc-theme/color-palette";
+
+$custom-checkbox-color: $material-color-red-300;
+
 .test-cell--checkbox {
   width: 91px;
   height: 91px;
+}
+
+.custom-checkbox--container-colors {
+  @include mdc-checkbox-container-colors(
+    $unmarked-stroke-color: $custom-checkbox-color,
+    $marked-fill-color: $custom-checkbox-color
+  );
+}
+
+.custom-checkbox--ink-color {
+  @include mdc-checkbox-ink-color($custom-checkbox-color);
 }

--- a/test/screenshot/spec/mdc-checkbox/mixins/container-colors.html
+++ b/test/screenshot/spec/mdc-checkbox/mixins/container-colors.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>container-colors Checkbox Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.checkbox.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-checkbox/fixture.css">
+  </head>
+
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox custom-checkbox--container-colors">
+            <input type="checkbox"
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-unchecked"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox custom-checkbox--container-colors">
+            <input type="checkbox"
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-checked"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox custom-checkbox--container-colors">
+            <input type="checkbox"
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-indeterminate"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--disabled custom-checkbox--container-colors">
+            <input type="checkbox"
+                   disabled
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-unchecked-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--disabled custom-checkbox--container-colors">
+            <input type="checkbox"
+                   disabled
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-checked-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--disabled custom-checkbox--container-colors">
+            <input type="checkbox"
+                   disabled
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-indeterminate-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-checkbox/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-checkbox/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-checkbox/mixins/ink-color.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>ink-color Checkbox Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.checkbox.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-checkbox/fixture.css">
+  </head>
+
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox custom-checkbox--ink-color">
+            <input type="checkbox"
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-unchecked"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox custom-checkbox--ink-color">
+            <input type="checkbox"
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-checked"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox custom-checkbox--ink-color">
+            <input type="checkbox"
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-indeterminate"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--disabled custom-checkbox--ink-color">
+            <input type="checkbox"
+                   disabled
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-unchecked-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--disabled custom-checkbox--ink-color">
+            <input type="checkbox"
+                   disabled
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-checked-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--disabled custom-checkbox--ink-color">
+            <input type="checkbox"
+                   disabled
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-indeterminate-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-checkbox/fixture.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds screenshot test pages for checkbox mixins:

- `mdc-checkbox-container-colors()`
- `mdc-checkbox-ink-color()`