### PR TITLE
docs(tab-bar): Update Tabs redirect to point to Tab Bar

### DIFF
--- a/docs/docsite-tabs.md
+++ b/docs/docsite-tabs.md
@@ -7,7 +7,7 @@ section: components
 excerpt: "Components for tabbed navigation."
 iconId: tabs
 path: /catalog/tabs/
-redirect_path: /catalog/tabs/tab/
+redirect_path: /catalog/tabs/tab-bar/
 ---
 
 {% include redirect-page.html %}


### PR DESCRIPTION
It probably makes more sense to redirect straight to tab bar, since that's what most people should be interested in.