### PR TITLE
fix(ripple): Register focus/blur handlers in IE

### DIFF
--- a/packages/mdc-checkbox/_variables.scss
+++ b/packages/mdc-checkbox/_variables.scss
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+@import "@material/ripple/variables";
 @import "@material/theme/variables";
 
 $mdc-checkbox-mark-color: mdc-theme-prop-value(on-primary);
@@ -28,8 +29,7 @@ $mdc-checkbox-mark-stroke-size: 2/15 * $mdc-checkbox-size;
 $mdc-checkbox-border-width: 2px;
 $mdc-checkbox-transition-duration: 90ms;
 $mdc-checkbox-item-spacing: 4px;
-$mdc-checkbox-ripple-opacity: .14;
-$mdc-checkbox-focus-indicator-opacity: .26;
+$mdc-checkbox-focus-indicator-opacity: map-get($mdc-ripple-dark-ink-opacities, focus);
 
 // Manual calculation done on SVG
 $mdc-checkbox-mark-path-length_: 29.7833385;

--- a/packages/mdc-checkbox/mdc-checkbox.scss
+++ b/packages/mdc-checkbox/mdc-checkbox.scss
@@ -90,7 +90,7 @@
   @include mdc-checkbox__focus-indicator_;
 }
 
-.mdc-ripple-upgraded--unbounded .mdc-checkbox__background::before {
+.mdc-ripple-upgraded--background-focused .mdc-checkbox__background::before {
   @include mdc-checkbox__focus-indicator--ripple-upgraded-unbounded_;
 }
 

--- a/packages/mdc-radio/mdc-radio.scss
+++ b/packages/mdc-radio/mdc-radio.scss
@@ -17,6 +17,7 @@
 @import "@material/animation/functions";
 @import "@material/ripple/common";
 @import "@material/ripple/mixins";
+@import "@material/ripple/variables";
 @import "./functions";
 @import "./mixins";
 @import "./variables";
@@ -108,7 +109,7 @@
   }
 
   // stylelint-disable plugin/selector-bem-pattern
-  &.mdc-ripple-upgraded {
+  &.mdc-ripple-upgraded--background-focused {
     .mdc-radio__background::before {
       content: none;
     }
@@ -164,7 +165,7 @@
   + .mdc-radio__background::before {
     transform: scale(2, 2);
     transition: mdc-radio-enter(opacity), mdc-radio-enter(transform);
-    opacity: .26;
+    opacity: map-get($mdc-ripple-dark-ink-opacities, focus);
   }
 }
 


### PR DESCRIPTION
Ripple JS logic has historically always completely short-circuited browsers that don't support CSS variables. This changes it to still set up focus and blur handling, for the sake of components with complex DOM structure where a focusable element is not the root element of the ripple.

This also updates checkbox and radio styles to avoid applying their unique CSS-only focus styles to instances with JS ripples... and also fixes those CSS-only focus styles to use the same opacity as the JS ripples.

Fixes #3212.