### PR TITLE
chore(infrastructure): Add fs/network logging; fix bugs

### DIFF
--- a/scripts/travis-env-vars.sh
+++ b/scripts/travis-env-vars.sh
@@ -92,5 +92,5 @@ fi
 
 if [[ "$TEST_SUITE" == 'screenshot' ]]; then
   # Only run screenshot tests if package JS/Sass files, non-Markdown screenshot test files, or image files changed.
-  check_for_testable_files '^packages/.+\.(js|css|sass)$' '^test/screenshot/.+[^m][^d]$' '\.(png|jpg|jpeg|gif|svg)$'
+  check_for_testable_files '^packages/.+\.(js|css|scss)$' '^test/screenshot/.+[^m][^d]$' '\.(png|jpg|jpeg|gif|svg)$'
 fi

--- a/test/screenshot/infra/commands/build.js
+++ b/test/screenshot/infra/commands/build.js
@@ -127,13 +127,15 @@ class BuildCommand {
   async shouldBuild_() {
     const cli = new Cli();
     if (cli.skipBuild) {
-      console.error('Skipping build step');
+      console.error(CliColor.magenta('Skipping build step.'));
+      console.error('');
       return false;
     }
 
     const pid = await this.getExistingProcessId_();
     if (pid) {
-      console.log(`Build is already running (pid ${pid})`);
+      console.log(CliColor.bold(`Build is already running (pid ${pid}).`));
+      console.log('');
       return false;
     }
 

--- a/test/screenshot/infra/commands/build.js
+++ b/test/screenshot/infra/commands/build.js
@@ -19,11 +19,9 @@
 const chokidar = require('chokidar');
 const debounce = require('debounce');
 
-/** @type {!CliColor} */
-const colors = require('colors');
-
 const CleanCommand = require('./clean');
 const Cli = require('../lib/cli');
+const CliColor = require('../lib/logger').colors;
 const IndexCommand = require('./index');
 const Logger = require('../lib/logger');
 const ProcessManager = require('../lib/process-manager');
@@ -32,7 +30,7 @@ const {TEST_DIR_RELATIVE_PATH} = require('../lib/constants');
 
 class BuildCommand {
   constructor() {
-    this.logger_ = new Logger(__filename);
+    this.logger_ = new Logger();
     this.processManager_ = new ProcessManager();
 
     this.cleanCommand_ = new CleanCommand();
@@ -72,7 +70,7 @@ class BuildCommand {
     if (!shouldWatch) {
       this.logger_.log('');
       this.logger_.log('');
-      this.logger_.log(colors.bold.green('✨✨✨ Aww yiss - MDC Web build succeeded! ✨✨✨'));
+      this.logger_.log(CliColor.bold.green('✨✨✨ Aww yiss - MDC Web build succeeded! ✨✨✨'));
       this.logger_.log('');
     }
   }

--- a/test/screenshot/infra/commands/serve.js
+++ b/test/screenshot/infra/commands/serve.js
@@ -16,13 +16,12 @@
 
 'use strict';
 
-/** @type {!CliColor} */
-const colors = require('colors');
 const detectPort = require('detect-port');
 const express = require('express');
 const serveIndex = require('serve-index');
 
 const Cli = require('../lib/cli');
+const CliColor = require('../lib/logger').colors;
 const {ExitCode} = require('../lib/constants');
 const {TEST_DIR_RELATIVE_PATH} = require('../lib/constants');
 
@@ -45,10 +44,10 @@ class ServeCommand {
 
     app.listen(port, () => {
       const urlPlain = `http://localhost:${port}/`;
-      const urlColor = colors.bold.underline(urlPlain);
+      const urlColor = CliColor.bold.underline(urlPlain);
       const noticePlain = `Local development server running on ${urlPlain}`;
       const noticeColor = `Local development server running on ${urlColor}`;
-      const borderColor = colors.green(''.padStart(noticePlain.length, '='));
+      const borderColor = CliColor.green(''.padStart(noticePlain.length, '='));
       console.log((`
 ${borderColor}
 ${noticeColor}

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -41,7 +41,7 @@ class TestCommand {
     this.diffBaseParser_ = new DiffBaseParser();
     this.gitHubApi_ = new GitHubApi();
     this.imageDiffer_ = new ImageDiffer();
-    this.logger_ = new Logger(__filename);
+    this.logger_ = new Logger();
   }
 
   /**
@@ -102,8 +102,12 @@ class TestCommand {
   async diffAgainstLocal_(goldenDiffBase) {
     const controller = new Controller();
 
+    this.logger_.debug('Initializing for capture...');
+
     /** @type {!mdc.proto.ReportData} */
     const reportData = await controller.initForCapture(goldenDiffBase);
+
+    this.logger_.debug('Initialized for capture!');
 
     try {
       await this.gitHubApi_.setPullRequestStatusAuto(reportData);

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -102,12 +102,8 @@ class TestCommand {
   async diffAgainstLocal_(goldenDiffBase) {
     const controller = new Controller();
 
-    this.logger_.debug('Initializing for capture...');
-
     /** @type {!mdc.proto.ReportData} */
     const reportData = await controller.initForCapture(goldenDiffBase);
-
-    this.logger_.debug('Initialized for capture!');
 
     try {
       await this.gitHubApi_.setPullRequestStatusAuto(reportData);

--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -30,6 +30,7 @@ const Cli = require('./cli');
 const CliColor = require('./logger').colors;
 const DiffBaseParser = require('./diff-base-parser');
 const Duration = require('./duration');
+const Logger = require('./logger');
 const getStackTrace = require('./stacktrace')('CbtApi');
 
 const MDC_CBT_USERNAME = process.env.MDC_CBT_USERNAME;
@@ -54,6 +55,12 @@ class CbtApi {
      * @private
      */
     this.diffBaseParser_ = new DiffBaseParser();
+
+    /**
+     * @type {!Logger}
+     * @private
+     */
+    this.logger_ = new Logger();
 
     this.validateEnvVars_();
   }
@@ -126,12 +133,17 @@ https://crossbrowsertesting.com/account
       return allBrowsersPromise;
     }
 
-    console.log('Fetching browsers from CBT...');
+    this.logger_.debug('Fetching browsers from CBT...');
 
     const stackTrace = getStackTrace('fetchAvailableDevices');
     allBrowsersPromise = this.sendRequest_(stackTrace, 'GET', '/selenium/browsers');
 
-    return allBrowsersPromise;
+    /** @type {!Array<!cbt.proto.CbtDevice>} */
+    const allBrowsers = await allBrowsersPromise;
+
+    this.logger_.debug(`Fetched ${allBrowsers.length} browsers from CBT!`);
+
+    return allBrowsers;
   }
 
   /**

--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -445,7 +445,7 @@ https://crossbrowsertesting.com/account
     if (this.cli_.isOffline()) {
       console.warn(
         `${CliColor.magenta('WARNING')}:`,
-        new Error('CbtApi#sendRequest_() should not be called in --offline mode')
+        new Error('CbtApi.sendRequest_() should not be called in --offline mode')
       );
       return [];
     }

--- a/test/screenshot/infra/lib/controller.js
+++ b/test/screenshot/infra/lib/controller.js
@@ -111,7 +111,7 @@ class Controller {
    * @param {!mdc.proto.ReportData} reportData
    */
   async uploadAllAssets(reportData) {
-    this.logger_.foldStart('screenshot.upload_assets', 'Controller#uploadAllAssets()');
+    this.logger_.foldStart('screenshot.upload_assets', 'Controller.uploadAllAssets()');
     await this.cloudStorage_.uploadAllAssets(reportData);
     this.logger_.foldEnd('screenshot.upload_assets');
   }
@@ -120,7 +120,7 @@ class Controller {
    * @param {!mdc.proto.ReportData} reportData
    */
   async captureAllPages(reportData) {
-    this.logger_.foldStart('screenshot.capture_images', 'Controller#captureAllPages()');
+    this.logger_.foldStart('screenshot.capture_images', 'Controller.captureAllPages()');
 
     let stackTrace;
 
@@ -149,7 +149,7 @@ class Controller {
    * @param {!mdc.proto.ReportData} reportData
    */
   async uploadAllImages(reportData) {
-    this.logger_.foldStart('screenshot.upload_images', 'Controller#uploadAllImages()');
+    this.logger_.foldStart('screenshot.upload_images', 'Controller.uploadAllImages()');
     await this.cloudStorage_.uploadAllScreenshots(reportData);
     await this.cloudStorage_.uploadAllDiffs(reportData);
     this.logger_.foldEnd('screenshot.upload_images');
@@ -159,7 +159,7 @@ class Controller {
    * @param {!mdc.proto.ReportData} reportData
    */
   async generateReportPage(reportData) {
-    this.logger_.foldStart('screenshot.generate_report', 'Controller#generateReportPage()');
+    this.logger_.foldStart('screenshot.generate_report', 'Controller.generateReportPage()');
     await this.reportWriter_.generateReportPage(reportData);
     await this.cloudStorage_.uploadDiffReport(reportData);
     this.logger_.foldEnd('screenshot.generate_report');

--- a/test/screenshot/infra/lib/controller.js
+++ b/test/screenshot/infra/lib/controller.js
@@ -59,7 +59,7 @@ class Controller {
      * @type {!Logger}
      * @private
      */
-    this.logger_ = new Logger(__filename);
+    this.logger_ = new Logger();
 
     /**
      * @type {!ReportBuilder}

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -18,9 +18,6 @@ const VError = require('verror');
 const debounce = require('debounce');
 const octokit = require('@octokit/rest');
 
-/** @type {!CliColor} */
-const colors = require('colors');
-
 const GitRepo = require('./git-repo');
 const getStackTrace = require('./stacktrace')('GitHubApi');
 
@@ -28,8 +25,8 @@ class GitHubApi {
   constructor() {
     this.gitRepo_ = new GitRepo();
     this.octokit_ = octokit();
+    this.isTravis_ = process.env.TRAVIS !== 'true';
     this.isAuthenticated_ = false;
-    this.hasWarnedNoAuth_ = false;
     this.authenticate_();
     this.initStatusThrottle_();
   }
@@ -97,7 +94,7 @@ class GitHubApi {
    * @param {string} description
    */
   setPullRequestStatusManual({state, description}) {
-    if (process.env.TRAVIS !== 'true') {
+    if (!this.isTravis_ || !this.isAuthenticated_) {
       return;
     }
 
@@ -113,7 +110,7 @@ class GitHubApi {
    * @return {!Promise<*>}
    */
   async setPullRequestStatusAuto(reportData) {
-    if (process.env.TRAVIS !== 'true') {
+    if (!this.isTravis_ || !this.isAuthenticated_) {
       return;
     }
 
@@ -153,7 +150,7 @@ class GitHubApi {
   }
 
   async setPullRequestError() {
-    if (process.env.TRAVIS !== 'true') {
+    if (!this.isTravis_ || !this.isAuthenticated_) {
       return;
     }
 
@@ -173,11 +170,6 @@ class GitHubApi {
    */
   async createStatusUnthrottled_({state, targetUrl, description = undefined}) {
     if (!this.isAuthenticated_) {
-      if (!this.hasWarnedNoAuth_) {
-        const warning = colors.magenta('WARNING');
-        console.warn(`${warning}: Cannot set GitHub commit status because no API credentials were found.`);
-        this.hasWarnedNoAuth_ = true;
-      }
       return null;
     }
 
@@ -287,6 +279,10 @@ class GitHubApi {
    * @return {!Promise<*>}
    */
   async createPullRequestComment({prNumber, comment}) {
+    if (!this.isTravis_ || !this.isAuthenticated_) {
+      return;
+    }
+
     let stackTrace;
 
     try {

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -25,7 +25,7 @@ class GitHubApi {
   constructor() {
     this.gitRepo_ = new GitRepo();
     this.octokit_ = octokit();
-    this.isTravis_ = process.env.TRAVIS !== 'true';
+    this.isTravis_ = process.env.TRAVIS === 'true';
     this.isAuthenticated_ = false;
     this.authenticate_();
     this.initStatusThrottle_();

--- a/test/screenshot/infra/lib/local-storage.js
+++ b/test/screenshot/infra/lib/local-storage.js
@@ -25,6 +25,7 @@ const mkdirp = require('mkdirp');
 const path = require('path');
 
 const GitRepo = require('./git-repo');
+const Logger = require('./logger');
 const {TEST_DIR_RELATIVE_PATH} = require('../lib/constants');
 
 class LocalStorage {
@@ -34,6 +35,12 @@ class LocalStorage {
      * @private
      */
     this.gitRepo_ = new GitRepo();
+
+    /**
+     * @type {!Logger}
+     * @private
+     */
+    this.logger_ = new Logger();
   }
 
   /**
@@ -46,6 +53,8 @@ class LocalStorage {
 
     const fileCopyPromises = [];
 
+    this.logger_.debug(`Copying ${allAssetFileRelativePaths.length} files to temp dir...`);
+
     for (const assetFileRelativePath of allAssetFileRelativePaths) {
       const assetFileshortPath = assetFileRelativePath.replace(TEST_DIR_RELATIVE_PATH, '');
       const sourceFilePathAbsolute = path.resolve(assetFileRelativePath);
@@ -56,6 +65,8 @@ class LocalStorage {
     }
 
     await Promise.all(fileCopyPromises);
+
+    this.logger_.debug(`Copied ${allAssetFileRelativePaths.length} files to temp dir!`);
   }
 
   /**
@@ -216,7 +227,15 @@ class LocalStorage {
    */
   async getAssetFileSourcePaths_() {
     const cwd = TEST_DIR_RELATIVE_PATH;
-    return (await this.filterIgnoredFiles_(glob.sync('**/*', {cwd, nodir: true}))).sort();
+
+    this.logger_.debug(`Finding all files in "${cwd}"...`);
+
+    /** @type {!Array<string>} */
+    const allFilePaths = glob.sync('**/*', {cwd, nodir: true});
+
+    this.logger_.debug(`Found ${allFilePaths.length.toLocaleString()} files in "${cwd}"!`);
+
+    return (await this.filterIgnoredFiles_(allFilePaths)).sort();
   }
 
   /**

--- a/test/screenshot/infra/lib/logger.js
+++ b/test/screenshot/infra/lib/logger.js
@@ -31,6 +31,12 @@ class Logger {
      * @private
      */
     this.foldStartTimeMap_ = new Map();
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.isTravis_ = process.env.TRAVIS === 'true';
   }
 
   /**
@@ -50,7 +56,7 @@ class Logger {
 
     this.foldStartTimeMap_.set(foldId, Date.now());
 
-    if (!this.isTravisJob_()) {
+    if (!this.isTravis_) {
       console.log('');
       console.log(colorMessage);
       console.log(colors.reset(''));
@@ -71,7 +77,7 @@ class Logger {
    * @param {string} foldId
    */
   foldEnd(foldId) {
-    if (!this.isTravisJob_()) {
+    if (!this.isTravis_) {
       return;
     }
 
@@ -137,14 +143,6 @@ class Logger {
    */
   error(...args) {
     console.error(...args);
-  }
-
-  /**
-   * @return {boolean}
-   * @private
-   */
-  isTravisJob_() {
-    return process.env.TRAVIS === 'true';
   }
 
   /**

--- a/test/screenshot/infra/lib/logger.js
+++ b/test/screenshot/infra/lib/logger.js
@@ -51,25 +51,20 @@ class Logger {
    * @param {string} shortMessage
    */
   foldStart(foldId, shortMessage) {
-    const timerId = this.getFoldTimerId_(foldId);
-    const colorMessage = colors.bold.yellow(shortMessage);
+    console.log('');
 
-    this.foldStartTimeMap_.set(foldId, Date.now());
+    if (this.isTravis_) {
+      const timerId = this.getFoldTimerId_(foldId);
+      this.foldStartTimeMap_.set(foldId, Date.now());
 
-    if (!this.isTravis_) {
-      console.log('');
-      console.log(colorMessage);
-      console.log(colors.reset(''));
-      return;
+      // Undocumented Travis CI job logging feature. See:
+      // https://github.com/travis-ci/docs-travis-ci-com/issues/949#issuecomment-276755003
+      // https://github.com/rspec/rspec-support/blob/5a1c6756a9d8322fc18639b982e00196f452974d/script/travis_functions.sh
+      console.log(`travis_fold:start:${foldId}`);
+      console.log(`travis_time:start:${timerId}`);
     }
 
-    // Undocumented Travis CI job logging features. See:
-    // https://github.com/travis-ci/docs-travis-ci-com/issues/949#issuecomment-276755003
-    // https://github.com/rspec/rspec-support/blob/5a1c6756a9d8322fc18639b982e00196f452974d/script/travis_functions.sh
-    console.log('');
-    console.log(`travis_fold:start:${foldId}`);
-    console.log(`travis_time:start:${timerId}`);
-    console.log(colorMessage);
+    console.log(colors.bold.yellow(shortMessage));
     console.log(colors.reset(''));
   }
 
@@ -86,16 +81,18 @@ class Logger {
     console.log(`travis_fold:end:${foldId}`);
 
     const startMs = this.foldStartTimeMap_.get(foldId);
-    if (startMs) {
-      const timerId = this.getFoldTimerId_(foldId);
-      const startNanos = Duration.millis(startMs).toNanos();
-      const finishNanos = Duration.millis(Date.now()).toNanos();
-      const durationNanos = finishNanos - startNanos;
-
-      // Undocumented Travis CI job logging feature. See:
-      // https://github.com/rspec/rspec-support/blob/5a1c6756a9d8322fc18639b982e00196f452974d/script/travis_functions.sh
-      console.log(`travis_time:end:${timerId}:start=${startNanos},finish=${finishNanos},duration=${durationNanos}`);
+    if (!startMs) {
+      return;
     }
+
+    const timerId = this.getFoldTimerId_(foldId);
+    const startNanos = Duration.millis(startMs).toNanos();
+    const finishNanos = Duration.millis(Date.now()).toNanos();
+    const durationNanos = finishNanos - startNanos;
+
+    // Undocumented Travis CI job logging feature. See:
+    // https://github.com/rspec/rspec-support/blob/5a1c6756a9d8322fc18639b982e00196f452974d/script/travis_functions.sh
+    console.log(`travis_time:end:${timerId}:start=${startNanos},finish=${finishNanos},duration=${durationNanos}`);
   }
 
   /**

--- a/test/screenshot/infra/lib/logger.js
+++ b/test/screenshot/infra/lib/logger.js
@@ -51,8 +51,6 @@ class Logger {
    * @param {string} shortMessage
    */
   foldStart(foldId, shortMessage) {
-    console.log('');
-
     if (this.isTravis_) {
       const timerId = this.getFoldTimerId_(foldId);
       this.foldStartTimeMap_.set(foldId, Date.now());

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -128,7 +128,7 @@ class ReportBuilder {
    * @return {!Promise<!mdc.proto.ReportData>}
    */
   async initForCapture(goldenDiffBase) {
-    this.logger_.foldStart('screenshot.init', 'ReportBuilder#initForCapture()');
+    this.logger_.foldStart('screenshot.init', 'ReportBuilder.initForCapture()');
 
     if (this.cli_.isOnline()) {
       await this.cbtApi_.fetchAvailableDevices();

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -309,12 +309,16 @@ class ReportBuilder {
     const expectedScreenshots = reportData.screenshots.expected_screenshot_list;
     // TODO(acdvorak): Figure out how to handle offline mode for prefetching and diffing
     this.logger_.debug(`Fetching ${expectedScreenshots.length.toLocaleString()} golden images...`);
-    await Promise.all(
-      expectedScreenshots.map((expectedScreenshot) => {
-        return this.prefetchScreenshotImages_(expectedScreenshot);
-      })
-    );
-    this.logger_.debug(`Fetched ${expectedScreenshots.length.toLocaleString()} golden images!`);
+
+    return new Promise(async (resolve) => {
+      await Promise.all(
+        expectedScreenshots.map((expectedScreenshot) => {
+          return this.prefetchScreenshotImages_(expectedScreenshot);
+        })
+      );
+      this.logger_.debug(`Fetched ${expectedScreenshots.length.toLocaleString()} golden images!`);
+      resolve();
+    });
   }
 
   /**

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -99,7 +99,7 @@ class ReportBuilder {
      * @type {!Logger}
      * @private
      */
-    this.logger_ = new Logger(__filename);
+    this.logger_ = new Logger();
 
     /**
      * @type {!UserAgentStore}
@@ -167,6 +167,7 @@ class ReportBuilder {
    * @return {!Promise<!mdc.proto.ReportData>}
    */
   async initForDemo() {
+    // TODO(acdvorak): Pass `goldenDiffBase` argument
     return ReportData.create({
       meta: await this.createReportMetaProto_(),
     });
@@ -305,13 +306,15 @@ class ReportBuilder {
    * @private
    */
   async prefetchGoldenImages_(reportData) {
+    const expectedScreenshots = reportData.screenshots.expected_screenshot_list;
     // TODO(acdvorak): Figure out how to handle offline mode for prefetching and diffing
-    console.log('Fetching golden images...');
+    this.logger_.debug(`Fetching ${expectedScreenshots.length.toLocaleString()} golden images...`);
     await Promise.all(
-      reportData.screenshots.expected_screenshot_list.map((expectedScreenshot) => {
+      expectedScreenshots.map((expectedScreenshot) => {
         return this.prefetchScreenshotImages_(expectedScreenshot);
       })
     );
+    this.logger_.debug(`Fetched ${expectedScreenshots.length.toLocaleString()} golden images!`);
   }
 
   /**

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -301,24 +301,24 @@ class ReportBuilder {
   }
 
   /**
+   * TODO(acdvorak): Figure out how to handle offline mode for prefetching and diffing
+   * TODO(acdvorak): Cache downloaded images on Travis
    * @param {!mdc.proto.ReportData} reportData
    * @return {!Promise<void>}
    * @private
    */
   async prefetchGoldenImages_(reportData) {
     const expectedScreenshots = reportData.screenshots.expected_screenshot_list;
-    // TODO(acdvorak): Figure out how to handle offline mode for prefetching and diffing
+
     this.logger_.debug(`Fetching ${expectedScreenshots.length.toLocaleString()} golden images...`);
 
-    return new Promise(async (resolve) => {
-      await Promise.all(
-        expectedScreenshots.map((expectedScreenshot) => {
-          return this.prefetchScreenshotImages_(expectedScreenshot);
-        })
-      );
-      this.logger_.debug(`Fetched ${expectedScreenshots.length.toLocaleString()} golden images!`);
-      resolve();
-    });
+    await Promise.all(
+      expectedScreenshots.map((expectedScreenshot) => {
+        return this.prefetchScreenshotImages_(expectedScreenshot);
+      })
+    );
+
+    this.logger_.debug(`Fetched ${expectedScreenshots.length.toLocaleString()} golden images!`);
   }
 
   /**

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -19,7 +19,6 @@
 const Jimp = require('jimp');
 const VError = require('verror');
 const UserAgentParser = require('useragent');
-const colors = require('colors/safe');
 const path = require('path');
 
 const mdcProto = require('../proto/mdc.pb').mdc.proto;
@@ -32,6 +31,7 @@ const {RawCapabilities} = seleniumProto;
 
 const CbtApi = require('./cbt-api');
 const Cli = require('./cli');
+const CliColor = require('./logger').colors;
 const Constants = require('./constants');
 const Duration = require('./duration');
 const GitHubApi = require('./github-api');
@@ -50,21 +50,21 @@ const {SELENIUM_FONT_LOAD_WAIT_MS} = Constants;
  */
 
 const CliStatuses = {
-  ACTIVE: {name: 'Active', color: colors.bold.cyan},
-  QUEUED: {name: 'Queued', color: colors.cyan},
-  WAITING: {name: 'Waiting', color: colors.magenta},
-  STARTING: {name: 'Starting', color: colors.green},
-  STARTED: {name: 'Started', color: colors.bold.green},
-  GET: {name: 'Get', color: colors.bold.white},
-  CROP: {name: 'Crop', color: colors.white},
-  PASS: {name: 'Pass', color: colors.green},
-  ADD: {name: 'Add', color: colors.bgGreen.black},
-  FAIL: {name: 'Fail', color: colors.red},
-  RETRY: {name: 'Retry', color: colors.magenta},
-  CAPTURED: {name: 'Captured', color: colors.bold.grey},
-  FINISHED: {name: 'Finished', color: colors.bold.green},
-  FAILED: {name: 'Failed', color: colors.bold.red},
-  QUITTING: {name: 'Quitting', color: colors.white},
+  ACTIVE: {name: 'Active', color: CliColor.bold.cyan},
+  QUEUED: {name: 'Queued', color: CliColor.cyan},
+  WAITING: {name: 'Waiting', color: CliColor.magenta},
+  STARTING: {name: 'Starting', color: CliColor.green},
+  STARTED: {name: 'Started', color: CliColor.bold.green},
+  GET: {name: 'Get', color: CliColor.bold.white},
+  CROP: {name: 'Crop', color: CliColor.white},
+  PASS: {name: 'Pass', color: CliColor.green},
+  ADD: {name: 'Add', color: CliColor.bgGreen.black},
+  FAIL: {name: 'Fail', color: CliColor.red},
+  RETRY: {name: 'Retry', color: CliColor.magenta},
+  CAPTURED: {name: 'Captured', color: CliColor.bold.grey},
+  FINISHED: {name: 'Finished', color: CliColor.bold.green},
+  FAILED: {name: 'Failed', color: CliColor.bold.red},
+  QUITTING: {name: 'Quitting', color: CliColor.white},
 };
 
 class SeleniumApi {
@@ -249,7 +249,7 @@ class SeleniumApi {
     });
 
     if (logEntries.length > 0) {
-      const messageColor = colors.bold.red('Browser console log:');
+      const messageColor = CliColor.bold.red('Browser console log:');
       console.log(`\n\n${messageColor}\n`, JSON.stringify(logEntries, null, 2), '\n');
     }
   }
@@ -523,14 +523,11 @@ class SeleniumApi {
           changedScreenshots.push(screenshot);
           this.numChanged_++;
           this.logStatus_(CliStatuses.FAIL, message);
+        } else if (screenshot.inclusion_type === InclusionType.ADD) {
+          this.logStatus_(CliStatuses.ADD, message);
         } else {
           unchangedScreenshots.push(screenshot);
-
-          if (screenshot.inclusion_type === InclusionType.ADD) {
-            this.logStatus_(CliStatuses.ADD, message);
-          } else {
-            this.logStatus_(CliStatuses.PASS, message);
-          }
+          this.logStatus_(CliStatuses.PASS, message);
         }
       }
     }
@@ -785,9 +782,9 @@ class SeleniumApi {
     const percent = (total === 0 ? 0 : (100 * completed / total).toFixed(1));
 
     const colorCaptured = CliStatuses.CAPTURED.color(CliStatuses.CAPTURED.name.toUpperCase());
-    const colorCompleted = colors.bold.white(completed.toLocaleString());
-    const colorTotal = colors.bold.white(total.toLocaleString());
-    const colorPercent = colors.bold.white(`${percent}%`);
+    const colorCompleted = CliColor.bold.white(completed.toLocaleString());
+    const colorTotal = CliColor.bold.white(total.toLocaleString());
+    const colorPercent = CliColor.bold.white(`${percent}%`);
 
     process.stdout.write(`${colorCaptured}: ${colorCompleted} of ${colorTotal} screenshots (${colorPercent} complete)`);
   }

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -170,6 +170,7 @@ class SeleniumApi {
     }
 
     console.log('');
+    console.log('');
 
     return reportData;
   }

--- a/test/screenshot/infra/lib/stacktrace.js
+++ b/test/screenshot/infra/lib/stacktrace.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-/** @type {!CliColor} */
-const colors = require('colors');
+const CliColor = require('./logger').colors;
 
 /**
  * @param {string} className
@@ -45,7 +44,7 @@ module.exports.formatError = formatError;
  */
 function formatError(err) {
   return formatErrorInternal(err)
-    .replace(/^([^\n]+)/, (fullMatch, line) => colors.bold.red(line))
+    .replace(/^([^\n]+)/, (fullMatch, line) => CliColor.bold.red(line))
   ;
 }
 
@@ -57,7 +56,7 @@ function formatErrorInternal(err) {
   const parentStr = stringifyError(err);
   if (err.jse_cause) {
     const childStr = formatError(err.jse_cause);
-    return `${childStr}\n\n${colors.italic('called from:')}\n\n${parentStr}`;
+    return `${childStr}\n\n${CliColor.italic('called from:')}\n\n${parentStr}`;
   }
   return parentStr;
 }
@@ -105,10 +104,10 @@ function formatClassMethod(errorLine) {
   return errorLine
     .replace(/^( +)(at) (\w+)\.(\w+)(.+)$/, (fullMatch, leadingSpaces, atPrefix, className, methodName, rest) => {
       if (className === 'process' && methodName === '_tickCallback') {
-        return colors.dim(fullMatch);
+        return CliColor.dim(fullMatch);
       }
       rest = formatFileNameAndLineNumber(rest);
-      return `${leadingSpaces}${atPrefix} ${colors.underline(className)}.${colors.bold(methodName)}${rest}`;
+      return `${leadingSpaces}${atPrefix} ${CliColor.underline(className)}.${CliColor.bold(methodName)}${rest}`;
     })
   ;
 }
@@ -121,7 +120,7 @@ function formatNamedFunction(errorLine) {
   return errorLine
     .replace(/^( +)(at) (\w+)([^.].+)$/, (fullMatch, leadingSpaces, atPrefix, functionName, rest) => {
       rest = formatFileNameAndLineNumber(rest);
-      return `${leadingSpaces}${atPrefix} ${colors.bold(functionName)}${rest}`;
+      return `${leadingSpaces}${atPrefix} ${CliColor.bold(functionName)}${rest}`;
     })
   ;
 }
@@ -132,7 +131,7 @@ function formatNamedFunction(errorLine) {
  */
 function formatAnonymousFunction(errorLine) {
   return errorLine.replace(/^ +at <anonymous>.*$/, (fullMatch) => {
-    return colors.dim(fullMatch);
+    return CliColor.dim(fullMatch);
   });
 }
 
@@ -142,6 +141,6 @@ function formatAnonymousFunction(errorLine) {
  */
 function formatFileNameAndLineNumber(errorLine) {
   return errorLine.replace(/\/([^/]+\.\w+):(\d+):(\d+)(\).*)$/, (fullMatch, fileName, lineNumber, colNumber, rest) => {
-    return `/${colors.underline(fileName)}:${colors.bold(lineNumber)}:${colNumber}${rest}`;
+    return `/${CliColor.underline(fileName)}:${CliColor.bold(lineNumber)}:${colNumber}${rest}`;
   });
 }

--- a/test/screenshot/infra/types/cbt-externs.js
+++ b/test/screenshot/infra/types/cbt-externs.js
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 
 /*
- * CBT (CrossBrowserTesting.com)
+ * CrossBrowserTesting.com
  */
 
 

--- a/test/screenshot/infra/types/node-externs.js
+++ b/test/screenshot/infra/types/node-externs.js
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -79,4 +79,53 @@
  *   command: string,
  *   arguments: !Array<string>,
  * }} PsNodeProcess
+ */
+
+
+/*
+ * colors API
+ */
+
+
+/**
+ * @typedef {(function(string):string|!AnsiColorProps)} AnsiColor
+ */
+
+/**
+ * @typedef {{
+ *   enable: !AnsiColor,
+ *   disable: !AnsiColor,
+ *   strip: !AnsiColor,
+ *   strip: !AnsiColor,
+ *   black: !AnsiColor,
+ *   red: !AnsiColor,
+ *   green: !AnsiColor,
+ *   yellow: !AnsiColor,
+ *   blue: !AnsiColor,
+ *   magenta: !AnsiColor,
+ *   cyan: !AnsiColor,
+ *   white: !AnsiColor,
+ *   gray: !AnsiColor,
+ *   grey: !AnsiColor,
+ *   bgBlack: !AnsiColor,
+ *   bgRed: !AnsiColor,
+ *   bgGreen: !AnsiColor,
+ *   bgYellow: !AnsiColor,
+ *   bgBlue: !AnsiColor,
+ *   bgMagenta: !AnsiColor,
+ *   bgCyan: !AnsiColor,
+ *   bgWhite: !AnsiColor,
+ *   reset: !AnsiColor,
+ *   bold: !AnsiColor,
+ *   dim: !AnsiColor,
+ *   italic: !AnsiColor,
+ *   underline: !AnsiColor,
+ *   inverse: !AnsiColor,
+ *   hidden: !AnsiColor,
+ *   strikethrough: !AnsiColor,
+ *   rainbow: !AnsiColor,
+ *   zebra: !AnsiColor,
+ *   america: !AnsiColor,
+ *   random: !AnsiColor,
+ * }} AnsiColorProps
  */


### PR DESCRIPTION
### What it does

- Adds logging for file copy operations and network fetches to help debug slow/flaky Travis builds
- Adds `Logger.debug()` method which prints the amount of time elapsed since the previous call
- Fixes typo that prevented PRs with only `.scss` files from being screenshot tested ([example](https://travis-ci.com/material-components/material-components-web/jobs/138129432))
- Fixes `master` diff report bug by only added _existing_ screenshots to the "unchanged" list. Previously, newly-added screenshots were listed under "unchanged" in addition to "added".
- Fixes missing `await` inside `try` statements that return a `Promise`
- Fixes `spawn E2BIG` error when the local repo has a lot of ignored files
- Fixes `GitHubApi.createPullRequestComment()` so that it exits early if it's not authenticated or it's not running on Travis
- Improves the consistency of spacing between fold sections in log output
- Refactors ANSI CLI color handling for consistency
- Removes unused methods and arguments from `Logger`

### Example output

![image](https://user-images.githubusercontent.com/409245/43661238-5dccdb30-9716-11e8-9d60-4900f6737907.png)
