### PR TITLE
docs(tab): Fix tab markup to avoid div inside button

### DIFF
--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -39,14 +39,14 @@ npm install @material/tab-bar
     <div class="mdc-tab-scroller__scroll-area">
       <div class="mdc-tab-scroller__scroll-content">
         <button class="mdc-tab mdc-tab--active" role="tab" aria-selected="true" tabindex="0">
-          <div class="mdc-tab__content">
+          <span class="mdc-tab__content">
             <span class="mdc-tab__icon">heart</span>
             <span class="mdc-tab__text-label">Favorites</span>
-          </div>
+          </span>
           <span class="mdc-tab-indicator mdc-tab-indicator--active">
             <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
           </span>
-          <div class="mdc-tab__ripple"></div>
+          <span class="mdc-tab__ripple"></span>
         </button>
       </div>
     </div>

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -35,14 +35,14 @@ npm install @material/tab
 
 ```html
 <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
-  <div class="mdc-tab__content">
+  <span class="mdc-tab__content">
     <span class="mdc-tab__icon">heart</span>
     <span class="mdc-tab__text-label">Favorites</span>
-  </div>
+  </span>
   <span class="mdc-tab-indicator">
     <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
   </span>
-  <div class="mdc-tab__ripple"></div>
+  <span class="mdc-tab__ripple"></span>
 </button>
 ```
 
@@ -70,14 +70,14 @@ const tab = new MDCTab(document.querySelector('.mdc-tab'));
 
 ```html
 <button class="mdc-tab mdc-tab--active" role="tab" aria-selected="true">
-  <div class="mdc-tab__content">
-    <span class="mdc-tab__icon">heart</div>
-    <span class="mdc-tab__text-label">Favorites</div>
-  </div>
+  <span class="mdc-tab__content">
+    <span class="mdc-tab__icon">heart</span>
+    <span class="mdc-tab__text-label">Favorites</span>
+  </span>
   <span class="mdc-tab-indicator mdc-tab-indicator--active">
     <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
   </span>
-  <div class="mdc-tab__ripple"></div>
+  <span class="mdc-tab__ripple"></span>
 </button>
 ```
 

--- a/test/unit/mdc-tab/mdc-tab.test.js
+++ b/test/unit/mdc-tab/mdc-tab.test.js
@@ -24,10 +24,10 @@ import {MDCTab, MDCTabFoundation} from '../../../packages/mdc-tab';
 
 const getFixture = () => bel`
   <button class="mdc-tab" aria-selected="false" role="tab">
-    <div class="mdc-tab__content">
+    <span class="mdc-tab__content">
       <span class="mdc-tab__text-label">Foo</span>
       <span class="mdc-tab__icon"></span>
-    </div>
+    </span>
     <span class="mdc-tab__ripple"></span>
     <span class="mdc-tab-indicator">
       <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>


### PR DESCRIPTION
Demos already use spans in these instances, but the READMEs and test fixture documented div elements inside the button element, which is invalid.

Fixes #3301.