### PR TITLE
feat(icon-button): Add SVG support

### DIFF
--- a/demos/card.html
+++ b/demos/card.html
@@ -62,7 +62,7 @@
                  aria-pressed="false"
                  aria-label="Add to favorites"
                  title="Add to favorites" data-demo-toggle>
-                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
                 <i class="material-icons mdc-icon-button__icon">favorite_border</i>
               </button>
               <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
@@ -149,14 +149,14 @@
                aria-pressed="false"
                aria-label="Add to favorites"
                title="Add to favorites" data-demo-toggle>
-              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
               <i class="material-icons mdc-icon-button__icon">favorite_border</i>
             </button>
             <button class="mdc-icon-button mdc-card__action mdc-card__action--icon"
                aria-pressed="false"
                aria-label="Add bookmark"
                title="Add bookmark" data-demo-toggle>
-              <i class="material-icons mdc-icon-button__icon" data-toggle-on>bookmark</i>
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">bookmark</i>
               <i class="material-icons mdc-icon-button__icon">bookmark_border</i>
             </button>
             <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"

--- a/demos/card.html
+++ b/demos/card.html
@@ -58,14 +58,13 @@
               <button class="mdc-button mdc-card__action mdc-card__action--button">Bookmark</button>
             </div>
             <div class="mdc-card__action-icons">
-              <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
+              <button class="mdc-icon-button mdc-card__action mdc-card__action--icon"
                  aria-pressed="false"
                  aria-label="Add to favorites"
-                 title="Add to favorites"
-                 data-toggle-on-content="favorite"
-                 data-toggle-on-label="Remove from favorites"
-                 data-toggle-off-content="favorite_border"
-                 data-toggle-off-label="Add to favorites">favorite_border</button>
+                 title="Add to favorites" data-demo-toggle>
+                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+              </button>
               <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
                  data-mdc-ripple-is-unbounded
                  title="Share">share</button>
@@ -146,22 +145,20 @@
             </div>
           </a>
           <div class="mdc-card__actions mdc-card__action-icons">
-            <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
+            <button class="mdc-icon-button mdc-card__action mdc-card__action--icon"
                aria-pressed="false"
                aria-label="Add to favorites"
-               title="Add to favorites"
-               data-toggle-on-content="favorite"
-               data-toggle-on-label="Remove from favorites"
-               data-toggle-off-content="favorite_border"
-               data-toggle-off-label="Add to favorites">favorite_border</button>
-            <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
+               title="Add to favorites" data-demo-toggle>
+              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+            </button>
+            <button class="mdc-icon-button mdc-card__action mdc-card__action--icon"
                aria-pressed="false"
                aria-label="Add bookmark"
-               title="Add bookmark"
-               data-toggle-on-content="bookmark"
-               data-toggle-on-label="Remove bookmark"
-               data-toggle-off-content="bookmark_border"
-               data-toggle-off-label="Add bookmark">bookmark_border</button>
+               title="Add bookmark" data-demo-toggle>
+              <i class="material-icons mdc-icon-button__icon" data-toggle-on>bookmark</i>
+              <i class="material-icons mdc-icon-button__icon">bookmark_border</i>
+            </button>
             <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
                data-mdc-ripple-is-unbounded
                title="Share">share</button>
@@ -233,7 +230,7 @@
           mdc.ripple.MDCRipple.attachTo(surface);
         });
 
-        [].forEach.call(document.querySelectorAll('.mdc-icon-button[data-toggle-on-content]'), function(iconButtonToggle) {
+        [].forEach.call(document.querySelectorAll('.mdc-icon-button[data-demo-toggle]'), function(iconButtonToggle) {
           mdc.iconButton.MDCIconButtonToggle.attachTo(iconButtonToggle);
         });
 

--- a/demos/icon-button.html
+++ b/demos/icon-button.html
@@ -40,14 +40,13 @@
       <div class="mdc-toolbar-fixed-adjust"></div>
       <section class="hero">
         <div class="demo-wrapper">
-          <button class="mdc-icon-button material-icons"
+          <button class="mdc-icon-button"
              aria-label="Add to favorites"
              aria-pressed="false"
-             data-demo-toggle
-             data-toggle-on-content="favorite"
-             data-toggle-on-label="Remove From Favorites"
-             data-toggle-off-content="favorite_border"
-             data-toggle-off-label="Add to Favorites">favorite_border</button>
+             data-demo-toggle>
+            <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+            <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+          </button>
         </div>
       </section>
 
@@ -138,14 +137,13 @@
               <div class="demo-wrapper">
                 <button
                    id="add-to-favorites"
-                   class="mdc-icon-button material-icons"
+                   class="mdc-icon-button"
                    aria-label="Add to favorites"
                    aria-pressed="false"
-                   data-demo-toggle
-                   data-toggle-on-content="favorite"
-                   data-toggle-on-label="Remove From Favorites"
-                   data-toggle-off-content="favorite_border"
-                   data-toggle-off-label="Add to Favorites">favorite_border</button>
+                   data-demo-toggle>
+                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+                </button>
               </div>
               <p>Favorited? <span id="favorited-status">no</span></p>
             </div>
@@ -153,16 +151,32 @@
             <div class="toggle-example">
               <h2 class="mdc-typography--headline6">Using Font Awesome</h2>
               <div class="demo-wrapper">
-            <button class="mdc-icon-button mdc-icon-button--on"
-                  aria-label="Unstar this item"
-                  aria-pressed="true" data-demo-toggle
-                  data-icon-inner-selector=".fa"
-                  data-toggle-on-class="fa-star"
-                  data-toggle-on-label="Unstar this item"
-                  data-toggle-off-class="fa-star-o"
-                  data-toggle-off-label="Star this item">
-              <i class="fa fa-star" aria-hidden="true"></i>
-            </button>
+                <button class="mdc-icon-button mdc-icon-button--on"
+                        aria-label="Unstar this item"
+                        aria-pressed="true"
+                        data-demo-toggle>
+                  <i class="fa fa-star mdc-icon-button__icon" data-toggle-on></i>
+                  <i class="fa fa-star-o mdc-icon-button__icon"></i>
+                </button>
+              </div>
+            </div>
+
+            <div class="toggle-example">
+              <h2 class="mdc-typography--headline6">Using SVG Icons</h2>
+              <div class="demo-wrapper">
+                <button class="mdc-icon-button mdc-icon-button--on"
+                        aria-label="Unstar this item"
+                        aria-pressed="true"
+                        data-demo-toggle>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon" data-toggle-on>
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
+                    </svg>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
+                    </svg>
+                </button>
               </div>
             </div>
 
@@ -173,11 +187,10 @@
                    aria-label="Add to favorites"
                    aria-pressed="false"
                    data-demo-toggle
-                   disabled
-                   data-toggle-on-content="favorite"
-                   data-toggle-on-label="Remove From Favorites"
-                   data-toggle-off-content="favorite_border"
-                   data-toggle-off-label="Add to Favorites">favorite_border</button>
+                   disabled>
+                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+                </button>
               </div>
             </div>
           </div>
@@ -187,40 +200,37 @@
           <div id="demo-color-combos">
             <div id="light-on-bg" class="demo-color-combo">
               <div>
-                <button class="mdc-icon-button material-icons mdc-theme--on-primary"
+                <button class="mdc-icon-button mdc-theme--on-primary"
                    aria-label="Add to favorites"
                    aria-pressed="false"
-                   data-demo-toggle
-                   data-toggle-on-content="favorite"
-                   data-toggle-on-label="Remove From Favorites"
-                   data-toggle-off-content="favorite_border"
-                   data-toggle-off-label="Add to Favorites">favorite_border</button>
+                   data-demo-toggle>
+                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+                </button>
               </div>
               <div class="mdc-theme--on-primary">Light icon on background</div>
             </div>
             <div id="dark-on-bg" class="demo-color-combo">
               <div class="mdc-theme--primary">
-                <button class="mdc-icon-button material-icons"
+                <button class="mdc-icon-button mdc-icon-button--on"
                    aria-label="Add to favorites"
-                   aria-pressed="false"
-                   data-demo-toggle
-                   data-toggle-on-content="favorite"
-                   data-toggle-on-label="Remove From Favorites"
-                   data-toggle-off-content="favorite_border"
-                   data-toggle-off-label="Add to Favorites">favorite_border</button>
+                   aria-pressed="true"
+                   data-demo-toggle>
+                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+                </button>
               </div>
               <div>Dark icon on background</div>
             </div>
             <div id="custom-color-combo" class="demo-color-combo">
               <div>
-                <button class="mdc-icon-button material-icons"
+                <button class="mdc-icon-button"
                    aria-label="Add to favorites"
                    aria-pressed="false"
-                   data-demo-toggle
-                   data-toggle-on-content="favorite"
-                   data-toggle-on-label="Remove From Favorites"
-                   data-toggle-off-content="favorite_border"
-                   data-toggle-off-label="Add to Favorites">favorite_border</button>
+                   data-demo-toggle>
+                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+                </button>
               </div>
               <div>Custom color</div>
             </div>

--- a/demos/icon-button.html
+++ b/demos/icon-button.html
@@ -44,7 +44,7 @@
               aria-label="Add to favorites"
               aria-pressed="false"
               data-demo-toggle>
-        <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+        <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
         <i class="material-icons mdc-icon-button__icon">favorite_border</i>
       </button>
     </div>
@@ -141,7 +141,7 @@
                     aria-label="Add to favorites"
                     aria-pressed="false"
                     data-demo-toggle>
-              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
               <i class="material-icons mdc-icon-button__icon">favorite_border</i>
             </button>
           </div>
@@ -155,7 +155,7 @@
                     aria-label="Unstar this item"
                     aria-pressed="true"
                     data-demo-toggle>
-              <i class="fa fa-star mdc-icon-button__icon" data-toggle-on></i>
+              <i class="fa fa-star mdc-icon-button__icon mdc-icon-button__icon--on"></i>
               <i class="fa fa-star-o mdc-icon-button__icon"></i>
             </button>
           </div>
@@ -168,7 +168,7 @@
                     aria-label="Unstar this item"
                     aria-pressed="true"
                     data-demo-toggle>
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon" data-toggle-on>
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon mdc-icon-button__icon--on">
                 <path d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
               </svg>
@@ -187,7 +187,7 @@
                     aria-label="Unstar this item"
                     aria-pressed="true"
                     data-demo-toggle>
-              <img src="images/ic_button_24px.svg" class="mdc-icon-button__icon" data-toggle-on/>
+              <img src="images/ic_button_24px.svg" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
               <img src="images/ic_card_24px.svg" class="mdc-icon-button__icon"/>
             </button>
           </div>
@@ -196,12 +196,12 @@
         <div class="toggle-example">
           <h2 class="mdc-typography--headline6">Disabled Icons</h2>
           <div class="demo-wrapper">
-            <button class="mdc-icon-button material-icons"
+            <button class="mdc-icon-button"
                     aria-label="Add to favorites"
                     aria-pressed="false"
                     data-demo-toggle
                     disabled>
-              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
               <i class="material-icons mdc-icon-button__icon">favorite_border</i>
             </button>
           </div>
@@ -217,7 +217,7 @@
                       aria-label="Add to favorites"
                       aria-pressed="false"
                       data-demo-toggle>
-                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
                 <i class="material-icons mdc-icon-button__icon">favorite_border</i>
               </button>
             </div>
@@ -229,7 +229,7 @@
                       aria-label="Add to favorites"
                       aria-pressed="true"
                       data-demo-toggle>
-                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
                 <i class="material-icons mdc-icon-button__icon">favorite_border</i>
               </button>
             </div>
@@ -241,7 +241,7 @@
                       aria-label="Add to favorites"
                       aria-pressed="false"
                       data-demo-toggle>
-                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
                 <i class="material-icons mdc-icon-button__icon">favorite_border</i>
               </button>
             </div>

--- a/demos/icon-button.html
+++ b/demos/icon-button.html
@@ -15,252 +15,265 @@
   limitations under the License
 -->
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Icon Button - Material Components Demo</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css">
-    <link rel="stylesheet" href="/assets/icon-button.css">
-    <script src="/ready.js"></script>
-  </head>
-  <body class="mdc-typography">
-    <header class="mdc-toolbar mdc-toolbar--fixed">
-      <div class="mdc-toolbar__row">
-        <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
-          <a href="/" class="catalog-back mdc-toolbar__menu-icon"><i class="material-icons">&#xE5C4;</i></a>
-          <span class="mdc-toolbar__title catalog-title">Icon Buttons</span>
-        </section>
+<head>
+  <meta charset="utf-8">
+  <title>Icon Button - Material Components Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/png" href="/images/logo_components_color_2x_web_48dp.png">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css">
+  <link rel="stylesheet" href="/assets/icon-button.css">
+  <script src="/ready.js"></script>
+</head>
+<body class="mdc-typography">
+<header class="mdc-toolbar mdc-toolbar--fixed">
+  <div class="mdc-toolbar__row">
+    <section class="mdc-toolbar__section mdc-toolbar__section--align-start">
+      <a href="/" class="catalog-back mdc-toolbar__menu-icon"><i class="material-icons">&#xE5C4;</i></a>
+      <span class="mdc-toolbar__title catalog-title">Icon Buttons</span>
+    </section>
+  </div>
+</header>
+<main>
+  <div class="mdc-toolbar-fixed-adjust"></div>
+  <section class="hero">
+    <div class="demo-wrapper">
+      <button class="mdc-icon-button"
+              aria-label="Add to favorites"
+              aria-pressed="false"
+              data-demo-toggle>
+        <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+        <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+      </button>
+    </div>
+  </section>
+
+  <section class="example">
+    <div>
+      <div>
+        <h1 class="mdc-typography--headline5">Buttons</h1>
       </div>
-    </header>
-    <main>
-      <div class="mdc-toolbar-fixed-adjust"></div>
-      <section class="hero">
-        <div class="demo-wrapper">
-          <button class="mdc-icon-button"
-             aria-label="Add to favorites"
-             aria-pressed="false"
-             data-demo-toggle>
-            <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
-            <i class="material-icons mdc-icon-button__icon">favorite_border</i>
-          </button>
-        </div>
-      </section>
-
-      <section class="example">
-        <div>
-          <div>
-            <h1 class="mdc-typography--headline5">Buttons</h1>
-          </div>
-          <div class="toggle-examples-container">
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">Material Icons</h2>
-              <div class="demo-wrapper">
-                <button class="mdc-icon-button material-icons"
-                   role="button"
-                   aria-label="Add to favorites"
-                   aria-pressed="false">favorite</button>
-                <button class="mdc-icon-button material-icons"
-                   aria-label="Airplane Mode active"
-                   aria-pressed="false">airplanemode_active</button>
-                <a href="#"
-                   class="mdc-icon-button material-icons"
-                   aria-label="Transit directions"
-                   aria-pressed="false">directions_transit</a>
-              </div>
-            </div>
-
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">SVG Icon</h2>
-              <div class="demo-wrapper">
-                <button class="mdc-icon-button"
-                   aria-label="Add to favorites"
-                   aria-pressed="false">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path fill="none" d="M0 0h24v24H0z"/>
-                    <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
-                  </svg>
-                </button>
-              </div>
-            </div>
-
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">Disabled Buttons</h2>
-              <div class="demo-wrapper">
-                <button class="mdc-icon-button material-icons"
-                        aria-label="Airplane Mode active"
-                        aria-pressed="false"
-                        disabled>airplanemode_active</button>
-                <button class="mdc-icon-button"
-                        aria-label="Add to favorites"
-                        aria-pressed="false"
-                        disabled>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path fill="none" d="M0 0h24v24H0z"/>
-                    <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
-                  </svg>
-                </button>
-              </div>
-            </div>
-
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">Larger Buttons</h2>
-              <div class="demo-wrapper">
-                <button class="mdc-icon-button material-icons demo-icon-button-large"
-                        aria-label="Airplane Mode active"
-                        aria-pressed="false">airplanemode_active</button>
-                <button class="mdc-icon-button demo-icon-button-large"
-                        aria-label="Add to favorites"
-                        aria-pressed="false">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path fill="none" d="M0 0h24v24H0z"/>
-                    <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
-                  </svg>
-                </button>
-              </div>
-            </div>
+      <div class="toggle-examples-container">
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Material Icons</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button material-icons"
+                    role="button"
+                    aria-label="Add to favorites"
+                    aria-pressed="false">favorite</button>
+            <button class="mdc-icon-button material-icons"
+                    aria-label="Airplane Mode active"
+                    aria-pressed="false">airplanemode_active</button>
+            <a href="#"
+               class="mdc-icon-button material-icons"
+               aria-label="Transit directions"
+               aria-pressed="false">directions_transit</a>
           </div>
         </div>
-      </section>
-
-      <section class="example">
-        <div>
-          <div>
-            <h1 class="mdc-typography--headline5">Button Toggles</h1>
-          </div>
-          <div class="toggle-examples-container">
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">Using Material Icons</h2>
-              <div class="demo-wrapper">
-                <button
-                   id="add-to-favorites"
-                   class="mdc-icon-button"
-                   aria-label="Add to favorites"
-                   aria-pressed="false"
-                   data-demo-toggle>
-                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
-                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
-                </button>
-              </div>
-              <p>Favorited? <span id="favorited-status">no</span></p>
-            </div>
-
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">Using Font Awesome</h2>
-              <div class="demo-wrapper">
-                <button class="mdc-icon-button mdc-icon-button--on"
-                        aria-label="Unstar this item"
-                        aria-pressed="true"
-                        data-demo-toggle>
-                  <i class="fa fa-star mdc-icon-button__icon" data-toggle-on></i>
-                  <i class="fa fa-star-o mdc-icon-button__icon"></i>
-                </button>
-              </div>
-            </div>
-
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">Using SVG Icons</h2>
-              <div class="demo-wrapper">
-                <button class="mdc-icon-button mdc-icon-button--on"
-                        aria-label="Unstar this item"
-                        aria-pressed="true"
-                        data-demo-toggle>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon" data-toggle-on>
-                      <path d="M0 0h24v24H0z" fill="none"></path>
-                      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
-                    </svg>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon">
-                      <path d="M0 0h24v24H0z" fill="none"></path>
-                      <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
-                    </svg>
-                </button>
-              </div>
-            </div>
-
-            <div class="toggle-example">
-              <h2 class="mdc-typography--headline6">Disabled Icons</h2>
-              <div class="demo-wrapper">
-                <button class="mdc-icon-button material-icons"
-                   aria-label="Add to favorites"
-                   aria-pressed="false"
-                   data-demo-toggle
-                   disabled>
-                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
-                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
-                </button>
-              </div>
-            </div>
-          </div>
 
         <div class="toggle-example">
-          <h2 class="mdc-typography--headline6">Additional Color Combinations</h2>
-          <div id="demo-color-combos">
-            <div id="light-on-bg" class="demo-color-combo">
-              <div>
-                <button class="mdc-icon-button mdc-theme--on-primary"
-                   aria-label="Add to favorites"
-                   aria-pressed="false"
-                   data-demo-toggle>
-                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
-                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
-                </button>
-              </div>
-              <div class="mdc-theme--on-primary">Light icon on background</div>
-            </div>
-            <div id="dark-on-bg" class="demo-color-combo">
-              <div class="mdc-theme--primary">
-                <button class="mdc-icon-button mdc-icon-button--on"
-                   aria-label="Add to favorites"
-                   aria-pressed="true"
-                   data-demo-toggle>
-                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
-                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
-                </button>
-              </div>
-              <div>Dark icon on background</div>
-            </div>
-            <div id="custom-color-combo" class="demo-color-combo">
-              <div>
-                <button class="mdc-icon-button"
-                   aria-label="Add to favorites"
-                   aria-pressed="false"
-                   data-demo-toggle>
-                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
-                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
-                </button>
-              </div>
-              <div>Custom color</div>
-            </div>
+          <h2 class="mdc-typography--headline6">SVG Icon</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button"
+                    aria-label="Add to favorites"
+                    aria-pressed="false">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path fill="none" d="M0 0h24v24H0z"/>
+                <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+              </svg>
+            </button>
           </div>
         </div>
+
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Disabled Buttons</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button material-icons"
+                    aria-label="Airplane Mode active"
+                    aria-pressed="false"
+                    disabled>airplanemode_active</button>
+            <button class="mdc-icon-button"
+                    aria-label="Add to favorites"
+                    aria-pressed="false"
+                    disabled>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path fill="none" d="M0 0h24v24H0z"/>
+                <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+              </svg>
+            </button>
+          </div>
         </div>
-      </section>
-    </main>
 
-    <script src="/assets/material-components-web.js" async></script>
-    <script src="/assets/common.js" async></script>
-    <script>
-      demoReady(function() {
-        var nodes = document.querySelectorAll('[data-demo-toggle]');
-        for (var i = 0, node; node = nodes[i]; i++) {
-          mdc.iconButton.MDCIconButtonToggle.attachTo(node);
-        }
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Larger Buttons</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button material-icons demo-icon-button-large"
+                    aria-label="Airplane Mode active"
+                    aria-pressed="false">airplanemode_active</button>
+            <button class="mdc-icon-button demo-icon-button-large"
+                    aria-label="Add to favorites"
+                    aria-pressed="false">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path fill="none" d="M0 0h24v24H0z"/>
+                <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
-        var buttons = document.querySelectorAll('.mdc-icon-button:not([data-demo-toggle])');
-        for (var x = 0, button; button = buttons[x]; x++) {
-          mdc.ripple.MDCRipple.attachTo(button, {isUnbounded: true});
-        }
+  <section class="example">
+    <div>
+      <div>
+        <h1 class="mdc-typography--headline5">Button Toggles</h1>
+      </div>
+      <div class="toggle-examples-container">
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Using Material Icons</h2>
+          <div class="demo-wrapper">
+            <button
+                    id="add-to-favorites"
+                    class="mdc-icon-button"
+                    aria-label="Add to favorites"
+                    aria-pressed="false"
+                    data-demo-toggle>
+              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+            </button>
+          </div>
+          <p>Favorited? <span id="favorited-status">no</span></p>
+        </div>
 
-        var addToFavorites = document.getElementById('add-to-favorites');
-        var favoritedStatus = document.getElementById('favorited-status');
-        addToFavorites.addEventListener('MDCIconButtonToggle:change', function(evt) {
-          var newStatus = evt.detail.isOn ? 'yes' : 'no';
-          favoritedStatus.textContent = newStatus;
-        });
-      });
-    </script>
-  </body>
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Using Font Awesome</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button mdc-icon-button--on"
+                    aria-label="Unstar this item"
+                    aria-pressed="true"
+                    data-demo-toggle>
+              <i class="fa fa-star mdc-icon-button__icon" data-toggle-on></i>
+              <i class="fa fa-star-o mdc-icon-button__icon"></i>
+            </button>
+          </div>
+        </div>
+
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Using SVG Icons</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button mdc-icon-button--on"
+                    aria-label="Unstar this item"
+                    aria-pressed="true"
+                    data-demo-toggle>
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon" data-toggle-on>
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
+              </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Using Image Icons</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button mdc-icon-button--on"
+                    aria-label="Unstar this item"
+                    aria-pressed="true"
+                    data-demo-toggle>
+              <img src="images/ic_button_24px.svg" class="mdc-icon-button__icon" data-toggle-on/>
+              <img src="images/ic_card_24px.svg" class="mdc-icon-button__icon"/>
+            </button>
+          </div>
+        </div>
+
+        <div class="toggle-example">
+          <h2 class="mdc-typography--headline6">Disabled Icons</h2>
+          <div class="demo-wrapper">
+            <button class="mdc-icon-button material-icons"
+                    aria-label="Add to favorites"
+                    aria-pressed="false"
+                    data-demo-toggle
+                    disabled>
+              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="toggle-example">
+        <h2 class="mdc-typography--headline6">Additional Color Combinations</h2>
+        <div id="demo-color-combos">
+          <div id="light-on-bg" class="demo-color-combo">
+            <div>
+              <button class="mdc-icon-button mdc-theme--on-primary"
+                      aria-label="Add to favorites"
+                      aria-pressed="false"
+                      data-demo-toggle>
+                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+              </button>
+            </div>
+            <div class="mdc-theme--on-primary">Light icon on background</div>
+          </div>
+          <div id="dark-on-bg" class="demo-color-combo">
+            <div class="mdc-theme--primary">
+              <button class="mdc-icon-button mdc-icon-button--on"
+                      aria-label="Add to favorites"
+                      aria-pressed="true"
+                      data-demo-toggle>
+                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+              </button>
+            </div>
+            <div>Dark icon on background</div>
+          </div>
+          <div id="custom-color-combo" class="demo-color-combo">
+            <div>
+              <button class="mdc-icon-button"
+                      aria-label="Add to favorites"
+                      aria-pressed="false"
+                      data-demo-toggle>
+                <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+              </button>
+            </div>
+            <div>Custom color</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script src="/assets/material-components-web.js" async></script>
+<script src="/assets/common.js" async></script>
+<script>
+  demoReady(function() {
+    var nodes = document.querySelectorAll('[data-demo-toggle]');
+    for (var i = 0, node; node = nodes[i]; i++) {
+      mdc.iconButton.MDCIconButtonToggle.attachTo(node);
+    }
+
+    var buttons = document.querySelectorAll('.mdc-icon-button:not([data-demo-toggle])');
+    for (var x = 0, button; button = buttons[x]; x++) {
+      mdc.ripple.MDCRipple.attachTo(button, {isUnbounded: true});
+    }
+
+    var addToFavorites = document.getElementById('add-to-favorites');
+    var favoritedStatus = document.getElementById('favorited-status');
+    addToFavorites.addEventListener('MDCIconButtonToggle:change', function(evt) {
+      var newStatus = evt.detail.isOn ? 'yes' : 'no';
+      favoritedStatus.textContent = newStatus;
+    });
+  });
+</script>
+</body>
 </html>

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -327,14 +327,13 @@
                 <button class="mdc-button mdc-card__action mdc-card__action--button">Bookmark</button>
               </div>
               <div class="mdc-card__action-icons">
-                <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
+                <button class="mdc-icon-button mdc-card__action mdc-card__action--icon"
                    aria-pressed="false"
                    aria-label="Add to favorites"
-                   title="Add to favorites"
-                   data-toggle-on-content="favorite"
-                   data-toggle-on-label="Remove from favorites"
-                   data-toggle-off-content="favorite_border"
-                   data-toggle-off-label="Add to favorites">favorite_border</button>
+                   title="Add to favorites" data-demo-toggle>
+                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+                </button>
                 <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
                    data-mdc-ripple-is-unbounded
                    title="Share">share</button>
@@ -496,26 +495,23 @@
           <div class="mdc-elevation--z2 demo-icon-toggle-tile">
             <h4 class="mdc-typography--subtitle1">Enabled</h4>
 
-            <button class="mdc-icon-button material-icons"
+            <button class="mdc-icon-button"
                aria-label="Add to favorites"
-               aria-pressed="false"
-               data-toggle-on-content="favorite"
-               data-toggle-on-label="Remove from favorites"
-               data-toggle-off-content="favorite_border"
-               data-toggle-off-label="Add to favorites">favorite_border</button>
+               aria-pressed="false" data-demo-toggle>
+              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon">favorite_border</i></button>
           </div>
 
           <div class="mdc-elevation--z2 demo-icon-toggle-tile">
             <h4 class="mdc-typography--subtitle1">Disabled</h4>
 
-            <button class="mdc-icon-button  material-icons"
+            <button class="mdc-icon-button"
                aria-label="Add to favorites"
                aria-pressed="false"
-               disabled
-               data-toggle-on-content="favorite"
-               data-toggle-on-label="Remove from favorites"
-               data-toggle-off-content="favorite_border"
-               data-toggle-off-label="Add to favorites">favorite_border</button>
+               disabled data-demo-toggle>
+              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+            </button>
           </div>
         </div>
       </section>
@@ -893,7 +889,7 @@
          * Icon Toggle
          */
 
-        [].forEach.call(document.querySelectorAll('.mdc-icon-button[data-toggle-on-content]'), function(iconButtonToggleEl) {
+        [].forEach.call(document.querySelectorAll('.mdc-icon-button[data-demo-toggle]'), function(iconButtonToggleEl) {
           mdc.iconButton.MDCIconButtonToggle.attachTo(iconButtonToggleEl);
         });
 

--- a/demos/theme/index.html
+++ b/demos/theme/index.html
@@ -331,7 +331,7 @@
                    aria-pressed="false"
                    aria-label="Add to favorites"
                    title="Add to favorites" data-demo-toggle>
-                  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+                  <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
                   <i class="material-icons mdc-icon-button__icon">favorite_border</i>
                 </button>
                 <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
@@ -498,7 +498,7 @@
             <button class="mdc-icon-button"
                aria-label="Add to favorites"
                aria-pressed="false" data-demo-toggle>
-              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
               <i class="material-icons mdc-icon-button__icon">favorite_border</i></button>
           </div>
 
@@ -509,7 +509,7 @@
                aria-label="Add to favorites"
                aria-pressed="false"
                disabled data-demo-toggle>
-              <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
               <i class="material-icons mdc-icon-button__icon">favorite_border</i>
             </button>
           </div>

--- a/packages/material-components-web/README.md
+++ b/packages/material-components-web/README.md
@@ -46,7 +46,7 @@ DOM, and attach the `data-mdc-auto-init="MDCIconButtonToggle"` attribute.
    aria-label="Add to favorites"
    aria-pressed="false"
    data-mdc-auto-init="MDCIconButtonToggle">
-  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+  <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
   <i class="material-icons mdc-icon-button__icon">favorite_border</i>
 </button>
 ```

--- a/packages/material-components-web/README.md
+++ b/packages/material-components-web/README.md
@@ -42,13 +42,13 @@ For example, say you want to use an [icon button toogle](../mdc-icon-button). Si
 DOM, and attach the `data-mdc-auto-init="MDCIconButtonToggle"` attribute.
 
 ```html
-<button class="mdc-icon-button material-icons" 
+<button class="mdc-icon-button" 
    aria-label="Add to favorites"
-   data-toggle-on-content="favorite"
-   data-toggle-on-label="Remove from favorites"
-   data-toggle-off-content="favorite_border"
-   data-toggle-off-label="Add to favorites"
-   data-mdc-auto-init="MDCIconButtonToggle">favorite_border</i>
+   aria-pressed="false"
+   data-mdc-auto-init="MDCIconButtonToggle">
+  <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+  <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+</button>
 ```
 
 Then at the bottom of your html, insert this one-line script tag:

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -125,7 +125,7 @@ above, or with icon buttons, as below:
      aria-pressed="false"
      aria-label="Add to favorites"
      title="Add to favorites">
-   <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+   <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
    <i class="material-icons mdc-icon-button__icon">favorite_border</i>
   </button>
   <button class="material-icons mdc-icon-button mdc-card__action mdc-card__action--icon" title="Share">share</button>

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -121,14 +121,13 @@ above, or with icon buttons, as below:
 
 ```html
 <div class="mdc-card__actions">
-  <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon"
+  <button class="mdc-icon-button mdc-card__action mdc-card__action--icon"
      aria-pressed="false"
      aria-label="Add to favorites"
-     title="Add to favorites"
-     data-toggle-on-content="favorite"
-     data-toggle-on-label="Remove from favorites"
-     data-toggle-off-content="favorite_border"
-     data-toggle-off-label="Add to favorites">favorite_border</button>
+     title="Add to favorites">
+   <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i>
+   <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+  </button>
   <button class="material-icons mdc-icon-button mdc-card__action mdc-card__action--icon" title="Share">share</button>
   <button class="material-icons mdc-icon-button mdc-card__action mdc-card__action--icon" title="More options">more_vert</button>
 </div>

--- a/packages/mdc-icon-button/README.md
+++ b/packages/mdc-icon-button/README.md
@@ -70,19 +70,20 @@ iconButtonRipple.unbounded = true;
 
 ### Icon Button Toggle
 
-The icon button can be used to toggle between an on and off icon. To style an icon button as an icon button toggle, add the
-`data-toggle-on` and `data-toggle-off` attributes to the `mdc-icon-button` element. Then instantiate an `MDCIconButtonToggle` on the root element.
+The icon button can be used to toggle between an on and off icon. To style an icon button as an icon button toggle, add
+both icons as child elements and place the `data-toggle-on` attribute on the icon that should be on. If the button
+should be initialized in the "on" state, then add the `mdc-icon-button--on` class to the parent `button`. Then
+instantiate an `MDCIconButtonToggle` on the root element.
 
 ```html
 <button id="add-to-favorites"
-   class="mdc-icon-button material-icons"
+   class="mdc-icon-button"
    aria-label="Add to favorites"
    aria-hidden="true"
-   aria-pressed="false"
-   data-toggle-on-content="favorite"
-   data-toggle-on-label="Remove from favorites"
-   data-toggle-off-content="favorite_border"
-   data-toggle-off-label="Add to favorites">favorite_border</button>
+   aria-pressed="false">
+   <i class="material-icons mdc-icon-button__icon">favorite</i>
+   <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite_border</i>
+</button>
 ```
 
 ```js
@@ -91,38 +92,38 @@ var toggleButton = new mdc.iconButton.MDCIconButtonToggle(document.getElementByI
 
 #### Icon Button Toggle States
 
-Note the use of `data-toggle-*` properties in the above examples. When an MDCIconButtonToggle
-instance is toggled, it looks at these data attributes to determine how to update the element. This is what
-allows MDCIconButtonToggle to be so flexible. The `data-toggle-on-*` properties will be used when the is
-MDCIconButtonToggle is toggled on, and vice versa for `data-toggle-off-*`.
+Note the use of `data-toggle-on` attribute in the above examples. When an MDCIconButtonToggle
+instance is toggled, it looks at this data attribute to determine which element is the on element. This is what
+allows MDCIconButtonToggle to be so flexible. The `data-toggle-on` properties will be as the `on` value, and the
+`mdc-icon-button--on` class will be used to indicate the `on` state.
 
 Attribute | Description
 --- | ---
-`data-toggle-<TOGGLE STATE>-label` | The value to apply to the element's "aria-label" attribute.
-`data-toggle-<TOGGLE STATE>-content` | The text content to set on the element. Note that if an inner icon is used, the text content will be set on that element instead.
-`data-toggle-<TOGGLE STATE>-class` | A CSS class to apply to the icon element. The same rules regarding inner icon elements described for `content` apply here as well.
+`data-toggle-on` | Used to indicate which element in an icon button toggle is the `on` value.
 
-#### Icon Button Toggle with Font Awesome
+#### Icon Button Toggle with SVG
 
-The icon button toggle can be used with other font libraries such as Font Awesome that use an inner icon element.
+The icon button toggle can be used with SVGs.
 
 ```html
 <button id="star-this-item"
-   class="mdc-icon-button"
+   class="mdc-icon-button mdc-icon-button--on"
    aria-label="Unstar this item"
    aria-hidden="true"
-   aria-pressed="true"
-   data-toggle-on-class="fa-star"
-   data-toggle-on-label="Unstar this item"
-   data-toggle-off-class="fa-star-o"
-   data-toggle-off-label="Star this item"><i class="fa fa-2x fa-star"></i></button>
+   aria-pressed="true">
+   <svg class="mdc-icon-button__icon">
+     ...
+   </svg>
+   <svg class="mdc-icon-button__icon" data-toggle-on>
+     ...
+  </svg>
+</button>
 ```
 
 ### Icons
 
-The icon button can be used with a standard icon library such as Material Icons or Font Awesome, or with an `svg`.
-The icon button toggle should only be used with an standard icon library. We recommend you use 
-[Material Icons](https://material.io/tools/icons) from Google Fonts.
+The icon button can be used with a standard icon library such as Material Icons, or with an `svg`.
+We recommend you use [Material Icons](https://material.io/tools/icons) from Google Fonts.
 
 ### Disabled
 
@@ -140,6 +141,7 @@ cannot be disabled. Disabled icon buttons cannot be interacted with and have no 
 CSS Class | Description
 --- | ---
 `mdc-icon-button` | Mandatory.
+`mdc-icon-button--on` | Used to indicate the toggle button icon that is the not-selected option.
 
 ### Sass Mixins
 
@@ -171,9 +173,8 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 
 Method Signature | Description
 --- | ---
-`addClass(className: string) => void` | Adds a class to the root element, or the inner icon element.
-`removeClass(className: string) => void` | Removes a class from the root element, or the inner icon element.
-`setText(text: string) => void` | Sets the text content of the root element, or the inner icon element.
+`addClass(className: string) => void` | Adds a class to a icon element.
+`removeClass(className: string) => void` | Removes a class from a icon element.
 `getAttr(name: string) => string` | Returns the value of the attribute `name` on the root element. Can also return `null`, similar to `getAttribute()`.
 `setAttr(name: string, value: string) => void` | Sets the attribute `name` to `value` on the root element.
 `notifyChange(evtData: {isOn: boolean}) => void` | Broadcasts a change notification, passing along the `evtData` to the environment's event handling system. In our vanilla implementation, Custom Events are used for this.

--- a/packages/mdc-icon-button/README.md
+++ b/packages/mdc-icon-button/README.md
@@ -71,9 +71,9 @@ iconButtonRipple.unbounded = true;
 ### Icon Button Toggle
 
 The icon button can be used to toggle between an on and off icon. To style an icon button as an icon button toggle, add
-both icons as child elements and place the `data-toggle-on` attribute on the icon that should be on. If the button
-should be initialized in the "on" state, then add the `mdc-icon-button--on` class to the parent `button`. Then
-instantiate an `MDCIconButtonToggle` on the root element.
+both icons as child elements and place the `mdc-icon-button__icon--on` class on the icon that represents the on element.
+If the button should be initialized in the "on" state, then add the `mdc-icon-button--on` class to the parent `button`. 
+Then instantiate an `MDCIconButtonToggle` on the root element.
 
 ```html
 <button id="add-to-favorites"
@@ -82,25 +82,13 @@ instantiate an `MDCIconButtonToggle` on the root element.
    aria-hidden="true"
    aria-pressed="false">
    <i class="material-icons mdc-icon-button__icon">favorite</i>
-   <i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite_border</i>
+   <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite_border</i>
 </button>
 ```
 
 ```js
 var toggleButton = new mdc.iconButton.MDCIconButtonToggle(document.getElementById('add-to-favorites'));
 ```
-
-#### Icon Button Toggle States
-
-Note the use of `data-toggle-on` attribute in the above examples. This attribute indicates which element is the
-on element. When the `mdc-icon-button--on` class is present, the element with the `data-toggle-on` attribute
-will be shown and the other element will be hidden. When the `mdc-icon-button--on` class is not present, the element
-with the `data-toggle-on` attribute will be hidden and the other element will beshown. This is what allows
-MDCIconButtonToggle to be so flexible. 
-
-Attribute | Description
---- | ---
-`data-toggle-on` | Used to indicate which element in an icon button toggle is the `on` value.
 
 #### Icon Button Toggle with SVG
 
@@ -115,7 +103,7 @@ The icon button toggle can be used with SVGs.
    <svg class="mdc-icon-button__icon">
      ...
    </svg>
-   <svg class="mdc-icon-button__icon" data-toggle-on>
+   <svg class="mdc-icon-button__icon mdc-icon-button__icon--on">
      ...
   </svg>
 </button>
@@ -132,7 +120,7 @@ The icon button toggle can be used with `img` tags.
    aria-hidden="true"
    aria-pressed="true">
    <img src="" class="mdc-icon-button__icon"/>
-   <img src="" class="mdc-icon-button__icon" data-toggle-on/>
+   <img src="" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
 </button>
 ```
 
@@ -157,7 +145,9 @@ cannot be disabled. Disabled icon buttons cannot be interacted with and have no 
 CSS Class | Description
 --- | ---
 `mdc-icon-button` | Mandatory.
-`mdc-icon-button--on` | Used to indicate the toggle button icon that is the not-selected option.
+`mdc-icon-button--on` | This class is applied to the root element and is used to indicate if the icon button toggle is in the "on" state.
+`mdc-icon-button__icon` | This class is applied to each icon element for the icon button toggle.
+`mdc-icon-button__icon--on` | This class is applied to a icon element and is used to indicate the toggle button icon that is represents the "on" icon.
 
 ### Sass Mixins
 
@@ -167,7 +157,6 @@ Mixin | Description
 --- | ---
 `mdc-icon-button-size($width, $height, $padding)` | Sets the width, height, font-size and padding for the icon and ripple. `$height` is optional and defaults to `$width`. `$padding` is optional and defaults to `max($width, $height)/2`. `font-size` is set to `max($width, $height)`.
 `mdc-icon-button-ink-color($color)` | Sets the font color and the ripple color to the provided color value.
-
 
 ## `MDCIconButtonToggle` Properties and Methods
 
@@ -189,9 +178,8 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 
 Method Signature | Description
 --- | ---
-`addClass(className: string) => void` | Adds a class to a icon element.
-`removeClass(className: string) => void` | Removes a class from a icon element.
-`getAttr(name: string) => string` | Returns the value of the attribute `name` on the root element. Can also return `null`, similar to `getAttribute()`.
+`addClass(className: string) => void` | Adds a class to the root element.
+`removeClass(className: string) => void` | Removes a class from the root element.
 `setAttr(name: string, value: string) => void` | Sets the attribute `name` to `value` on the root element.
 `notifyChange(evtData: {isOn: boolean}) => void` | Broadcasts a change notification, passing along the `evtData` to the environment's event handling system. In our vanilla implementation, Custom Events are used for this.
 

--- a/packages/mdc-icon-button/README.md
+++ b/packages/mdc-icon-button/README.md
@@ -92,10 +92,11 @@ var toggleButton = new mdc.iconButton.MDCIconButtonToggle(document.getElementByI
 
 #### Icon Button Toggle States
 
-Note the use of `data-toggle-on` attribute in the above examples. When an MDCIconButtonToggle
-instance is toggled, it looks at this data attribute to determine which element is the on element. This is what
-allows MDCIconButtonToggle to be so flexible. The `data-toggle-on` properties will be as the `on` value, and the
-`mdc-icon-button--on` class will be used to indicate the `on` state.
+Note the use of `data-toggle-on` attribute in the above examples. This attribute indicates which element is the
+on element. When the `mdc-icon-button--on` class is present, the element with the `data-toggle-on` attribute
+will be shown and the other element will be hidden. When the `mdc-icon-button--on` class is not present, the element
+with the `data-toggle-on` attribute will be hidden and the other element will beshown. This is what allows
+MDCIconButtonToggle to be so flexible. 
 
 Attribute | Description
 --- | ---
@@ -117,6 +118,21 @@ The icon button toggle can be used with SVGs.
    <svg class="mdc-icon-button__icon" data-toggle-on>
      ...
   </svg>
+</button>
+```
+
+#### Icon Button Toggle with an Image
+
+The icon button toggle can be used with `img` tags.
+
+```html
+<button id="star-this-item"
+   class="mdc-icon-button mdc-icon-button--on"
+   aria-label="Unstar this item"
+   aria-hidden="true"
+   aria-pressed="true">
+   <img src="" class="mdc-icon-button__icon"/>
+   <img src="" class="mdc-icon-button__icon" data-toggle-on/>
 </button>
 ```
 

--- a/packages/mdc-icon-button/adapter.js
+++ b/packages/mdc-icon-button/adapter.js
@@ -44,31 +44,16 @@ class MDCIconButtonToggleAdapter {
   removeClass(className) {}
 
   /**
-   * @param {string} type
-   * @param {!EventListener} handler
-   */
-  registerInteractionHandler(type, handler) {}
+   * @param {string} className
+   * @return {boolean}
+   * */
+  hasClass(className) {}
 
   /**
-   * @param {string} type
-   * @param {!EventListener} handler
+   * @param {string} attrName
+   * @param {string} attrValue
    */
-  deregisterInteractionHandler(type, handler) {}
-
-  /** @param {string} text */
-  setText(text) {}
-
-  /**
-   * @param {string} name
-   * @return {string}
-   */
-  getAttr(name) {}
-
-  /**
-   * @param {string} name
-   * @param {string} value
-   */
-  setAttr(name, value) {}
+  setAttr(attrName, attrValue) {}
 
   /** @param {!IconButtonToggleEvent} evtData */
   notifyChange(evtData) {}

--- a/packages/mdc-icon-button/constants.js
+++ b/packages/mdc-icon-button/constants.js
@@ -18,16 +18,12 @@
 /** @enum {string} */
 const cssClasses = {
   ROOT: 'mdc-icon-button',
+  ICON_BUTTON_ON_CLASS: 'mdc-icon-button--on',
 };
 
 /** @enum {string} */
 const strings = {
-  DATA_TOGGLE_ON_LABEL: 'data-toggle-on-label',
-  DATA_TOGGLE_ON_CONTENT: 'data-toggle-on-content',
-  DATA_TOGGLE_ON_CLASS: 'data-toggle-on-class',
-  DATA_TOGGLE_OFF_LABEL: 'data-toggle-off-label',
-  DATA_TOGGLE_OFF_CONTENT: 'data-toggle-off-content',
-  DATA_TOGGLE_OFF_CLASS: 'data-toggle-off-class',
+  DATA_TOGGLE_ON_ATTR: 'data-toggle-on',
   ARIA_PRESSED: 'aria-pressed',
   ARIA_LABEL: 'aria-label',
   CHANGE_EVENT: 'MDCIconButtonToggle:change',

--- a/packages/mdc-icon-button/constants.js
+++ b/packages/mdc-icon-button/constants.js
@@ -18,12 +18,11 @@
 /** @enum {string} */
 const cssClasses = {
   ROOT: 'mdc-icon-button',
-  ICON_BUTTON_ON_CLASS: 'mdc-icon-button--on',
+  ICON_BUTTON_ON: 'mdc-icon-button--on',
 };
 
 /** @enum {string} */
 const strings = {
-  DATA_TOGGLE_ON_ATTR: 'data-toggle-on',
   ARIA_PRESSED: 'aria-pressed',
   ARIA_LABEL: 'aria-label',
   CHANGE_EVENT: 'MDCIconButtonToggle:change',

--- a/packages/mdc-icon-button/foundation.js
+++ b/packages/mdc-icon-button/foundation.js
@@ -60,15 +60,15 @@ class MDCIconButtonToggleFoundation extends MDCFoundation {
 
   /** @return {boolean} */
   isOn() {
-    return this.adapter_.hasClass(cssClasses.ICON_BUTTON_ON_CLASS);
+    return this.adapter_.hasClass(cssClasses.ICON_BUTTON_ON);
   }
 
   /** @param {boolean=} isOn */
   toggle(isOn = !this.isOn()) {
     if (isOn) {
-      this.adapter_.addClass(cssClasses.ICON_BUTTON_ON_CLASS);
+      this.adapter_.addClass(cssClasses.ICON_BUTTON_ON);
     } else {
-      this.adapter_.removeClass(cssClasses.ICON_BUTTON_ON_CLASS);
+      this.adapter_.removeClass(cssClasses.ICON_BUTTON_ON);
     }
 
     this.adapter_.setAttr(strings.ARIA_PRESSED, `${isOn}`);

--- a/packages/mdc-icon-button/foundation.js
+++ b/packages/mdc-icon-button/foundation.js
@@ -34,48 +34,27 @@ class MDCIconButtonToggleFoundation extends MDCFoundation {
 
   static get defaultAdapter() {
     return {
-      addClass: (/* className: string */) => {},
-      removeClass: (/* className: string */) => {},
-      setText: (/* text: string */) => {},
-      getAttr: (/* name: string */) => /* string */ '',
-      setAttr: (/* name: string, value: string */) => {},
-      notifyChange: (/* evtData: IconButtonToggleEvent */) => {},
+      addClass: () => {},
+      removeClass: () => {},
+      hasClass: () => {},
+      setAttr: () => {},
+      notifyChange: () => {},
     };
   }
 
   constructor(adapter) {
     super(Object.assign(MDCIconButtonToggleFoundation.defaultAdapter, adapter));
 
-    const {ARIA_PRESSED} = MDCIconButtonToggleFoundation.strings;
+    const {ICON_BUTTON_ON_CLASS} = MDCIconButtonToggleFoundation.cssClasses;
 
     /** @private {boolean} */
-    this.on_ = this.adapter_.getAttr(ARIA_PRESSED) === 'true';
-
+    this.on_ = this.adapter_.hasClass(ICON_BUTTON_ON_CLASS) || false;
     /** @private {boolean} */
     this.disabled_ = false;
-
-    /** @private {?IconButtonToggleState} */
-    this.toggleOnData_ = null;
-
-    /** @private {?IconButtonToggleState} */
-    this.toggleOffData_ = null;
   }
 
   init() {
-    this.refreshToggleData();
-  }
-
-  refreshToggleData() {
-    this.toggleOnData_ = {
-      label: this.adapter_.getAttr(strings.DATA_TOGGLE_ON_LABEL),
-      content: this.adapter_.getAttr(strings.DATA_TOGGLE_ON_CONTENT),
-      cssClass: this.adapter_.getAttr(strings.DATA_TOGGLE_ON_CLASS),
-    };
-    this.toggleOffData_ = {
-      label: this.adapter_.getAttr(strings.DATA_TOGGLE_OFF_LABEL),
-      content: this.adapter_.getAttr(strings.DATA_TOGGLE_OFF_CONTENT),
-      cssClass: this.adapter_.getAttr(strings.DATA_TOGGLE_OFF_CLASS),
-    };
+    this.adapter_.setAttr(strings.ARIA_PRESSED, `${this.isOn()}`);
   }
 
   handleClick() {
@@ -91,52 +70,20 @@ class MDCIconButtonToggleFoundation extends MDCFoundation {
 
   /** @param {boolean=} isOn */
   toggle(isOn = !this.on_) {
+    const {ICON_BUTTON_ON_CLASS} = MDCIconButtonToggleFoundation.cssClasses;
+
     this.on_ = isOn;
-
-    const {ARIA_LABEL, ARIA_PRESSED} = MDCIconButtonToggleFoundation.strings;
-
-    this.adapter_.setAttr(ARIA_PRESSED, this.on_.toString());
-
-    const {cssClass: classToRemove} =
-        this.on_ ? this.toggleOffData_ : this.toggleOnData_;
-
-    if (classToRemove) {
-      this.adapter_.removeClass(classToRemove);
+    if (this.isOn()) {
+      this.adapter_.addClass(ICON_BUTTON_ON_CLASS);
+    } else {
+      this.adapter_.removeClass(ICON_BUTTON_ON_CLASS);
     }
 
-    const {content, label, cssClass} = this.on_ ? this.toggleOnData_ : this.toggleOffData_;
-
-    if (cssClass) {
-      this.adapter_.addClass(cssClass);
-    }
-    if (content) {
-      this.adapter_.setText(content);
-    }
-    if (label) {
-      this.adapter_.setAttr(ARIA_LABEL, label);
-    }
+    this.adapter_.setAttr(strings.ARIA_PRESSED, `${this.isOn()}`);
   }
 }
 
 /** @record */
 class IconButtonToggleState {}
-
-/**
- * The aria-label value of the icon toggle, or undefined if there is no aria-label.
- * @export {string|undefined}
- */
-IconButtonToggleState.prototype.label;
-
-/**
- * The text for the icon toggle, or undefined if there is no text.
- * @export {string|undefined}
- */
-IconButtonToggleState.prototype.content;
-
-/**
- * The CSS class to add to the icon toggle, or undefined if there is no CSS class.
- * @export {string|undefined}
- */
-IconButtonToggleState.prototype.cssClass;
 
 export default MDCIconButtonToggleFoundation;

--- a/packages/mdc-icon-button/foundation.js
+++ b/packages/mdc-icon-button/foundation.js
@@ -45,10 +45,6 @@ class MDCIconButtonToggleFoundation extends MDCFoundation {
   constructor(adapter) {
     super(Object.assign(MDCIconButtonToggleFoundation.defaultAdapter, adapter));
 
-    const {ICON_BUTTON_ON_CLASS} = MDCIconButtonToggleFoundation.cssClasses;
-
-    /** @private {boolean} */
-    this.on_ = this.adapter_.hasClass(ICON_BUTTON_ON_CLASS) || false;
     /** @private {boolean} */
     this.disabled_ = false;
   }
@@ -59,27 +55,23 @@ class MDCIconButtonToggleFoundation extends MDCFoundation {
 
   handleClick() {
     this.toggle();
-    const {on_: isOn} = this;
-    this.adapter_.notifyChange(/** @type {!IconButtonToggleEvent} */ ({isOn}));
+    this.adapter_.notifyChange(/** @type {!IconButtonToggleEvent} */ ({isOn: this.isOn()}));
   }
 
   /** @return {boolean} */
   isOn() {
-    return this.on_;
+    return this.adapter_.hasClass(cssClasses.ICON_BUTTON_ON_CLASS);
   }
 
   /** @param {boolean=} isOn */
-  toggle(isOn = !this.on_) {
-    const {ICON_BUTTON_ON_CLASS} = MDCIconButtonToggleFoundation.cssClasses;
-
-    this.on_ = isOn;
-    if (this.isOn()) {
-      this.adapter_.addClass(ICON_BUTTON_ON_CLASS);
+  toggle(isOn = !this.isOn()) {
+    if (isOn) {
+      this.adapter_.addClass(cssClasses.ICON_BUTTON_ON_CLASS);
     } else {
-      this.adapter_.removeClass(ICON_BUTTON_ON_CLASS);
+      this.adapter_.removeClass(cssClasses.ICON_BUTTON_ON_CLASS);
     }
 
-    this.adapter_.setAttr(strings.ARIA_PRESSED, `${this.isOn()}`);
+    this.adapter_.setAttr(strings.ARIA_PRESSED, `${isOn}`);
   }
 }
 

--- a/packages/mdc-icon-button/index.js
+++ b/packages/mdc-icon-button/index.js
@@ -36,13 +36,6 @@ class MDCIconButtonToggle extends MDCComponent {
     this.handleClick_;
   }
 
-  /** @return {!Element} */
-  get iconEl_() {
-    const {'iconInnerSelector': sel} = this.root_.dataset;
-    return sel ?
-      /** @type {!Element} */ (this.root_.querySelector(sel)) : this.root_;
-  }
-
   /**
    * @return {!MDCRipple}
    * @private
@@ -62,18 +55,16 @@ class MDCIconButtonToggle extends MDCComponent {
   /** @return {!MDCIconButtonToggleFoundation} */
   getDefaultFoundation() {
     return new MDCIconButtonToggleFoundation({
-      addClass: (className) => this.iconEl_.classList.add(className),
-      removeClass: (className) => this.iconEl_.classList.remove(className),
-      setText: (text) => this.iconEl_.textContent = text,
-      getAttr: (name) => this.root_.getAttribute(name),
-      setAttr: (name, value) => this.root_.setAttribute(name, value),
+      addClass: (className) => this.root_.classList.add(className),
+      removeClass: (className) => this.root_.classList.remove(className),
+      hasClass: (className) => this.root_.classList.contains(className),
+      setAttr: (attrName, attrValue) => this.root_.setAttribute(attrName, attrValue),
       notifyChange: (evtData) => this.emit(MDCIconButtonToggleFoundation.strings.CHANGE_EVENT, evtData),
     });
   }
 
   initialSyncWithDOM() {
     this.handleClick_ = this.foundation_.handleClick.bind(this.foundation_);
-    this.on = this.root_.getAttribute(MDCIconButtonToggleFoundation.strings.ARIA_PRESSED) === 'true';
     this.root_.addEventListener('click', this.handleClick_);
   }
 
@@ -90,10 +81,6 @@ class MDCIconButtonToggle extends MDCComponent {
   /** @param {boolean} isOn */
   set on(isOn) {
     this.foundation_.toggle(isOn);
-  }
-
-  refreshToggleData() {
-    this.foundation_.refreshToggleData();
   }
 }
 

--- a/packages/mdc-icon-button/mdc-icon-button.scss
+++ b/packages/mdc-icon-button/mdc-icon-button.scss
@@ -23,4 +23,22 @@
   @include mdc-states;
 }
 
+.mdc-icon-button__icon {
+  display: inline-block;
+
+  &[data-toggle-on] {
+    display: none;
+  }
+}
+
+.mdc-icon-button--on {
+  .mdc-icon-button__icon {
+    display: none;
+
+    &[data-toggle-on] {
+      display: inline-block;
+    }
+  }
+}
+
 // postcss-bem-linter: end

--- a/packages/mdc-icon-button/mdc-icon-button.scss
+++ b/packages/mdc-icon-button/mdc-icon-button.scss
@@ -26,7 +26,8 @@
 .mdc-icon-button__icon {
   display: inline-block;
 
-  &[data-toggle-on] {
+  // stylelint-disable-next-line plugin/selector-bem-pattern
+  &.mdc-icon-button__icon--on {
     display: none;
   }
 }
@@ -35,7 +36,8 @@
   .mdc-icon-button__icon {
     display: none;
 
-    &[data-toggle-on] {
+    // stylelint-disable-next-line plugin/selector-bem-pattern
+    &.mdc-icon-button__icon--on {
       display: inline-block;
     }
   }

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -157,7 +157,7 @@
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_chrome_67.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/07/21_44_56_840/spec/mdc-card/classes/baseline.html.windows_firefox_61.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/07/22_34_23_854/spec/mdc-card/classes/baseline.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_ie_11.png"
     }
   },

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -157,7 +157,7 @@
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_chrome_67.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/07/22_34_23_854/spec/mdc-card/classes/baseline.html.windows_firefox_61.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/07/22_51_57_136/spec/mdc-card/classes/baseline.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_ie_11.png"
     }
   },

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -157,7 +157,7 @@
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_chrome_67.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_firefox_61.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/07/21_44_56_840/spec/mdc-card/classes/baseline.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/04_55_54_478/spec/mdc-card/classes/baseline.html.windows_ie_11.png"
     }
   },

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -314,6 +314,15 @@
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html.windows_ie_11.png"
     }
   },
+  "spec/mdc-icon-button/classes/baseline-icon-button-toggle.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/08/21_42_24_233/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/08/21_42_24_233/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_chrome_68.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/08/21_42_24_233/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/08/21_42_24_233/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/08/21_42_24_233/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_ie_11.png"
+    }
+  },
   "spec/mdc-icon-button/classes/baseline.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/07_29_10_421/spec/mdc-icon-button/classes/baseline.html",
     "screenshots": {

--- a/test/screenshot/spec/mdc-card/classes/baseline.html
+++ b/test/screenshot/spec/mdc-card/classes/baseline.html
@@ -57,7 +57,7 @@
             <button class="mdc-button mdc-card__action mdc-card__action--button">No</button>
           </div>
           <div class="mdc-card__action-icons">
-            <button class="mdc-icon-button mdc-card__action mdc-card__action--icon" aria-pressed="false" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;"><i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i><i class="material-icons mdc-icon-button__icon">favorite_border</i></button>
+            <button class="mdc-icon-button mdc-card__action mdc-card__action--icon" aria-pressed="false" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;"><i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i><i class="material-icons mdc-icon-button__icon">favorite_border</i></button>
             <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon" data-mdc-ripple-is-unbounded title="Share" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;">share</button>
             <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon" data-mdc-ripple-is-unbounded title="More options" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;">more_vert</button>
           </div>

--- a/test/screenshot/spec/mdc-card/classes/baseline.html
+++ b/test/screenshot/spec/mdc-card/classes/baseline.html
@@ -57,7 +57,7 @@
             <button class="mdc-button mdc-card__action mdc-card__action--button">No</button>
           </div>
           <div class="mdc-card__action-icons">
-            <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon" aria-pressed="false" aria-label="Add to favorites" title="Add to favorites" data-toggle-on-content="favorite" data-toggle-on-label="Remove from favorites" data-toggle-off-content="favorite_border" data-toggle-off-label="Add to favorites" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;">favorite_border</button>
+            <button class="mdc-icon-button mdc-card__action mdc-card__action--icon" aria-pressed="false" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;"><i class="material-icons mdc-icon-button__icon" data-toggle-on>favorite</i><i class="material-icons mdc-icon-button__icon">favorite_border</i></button>
             <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon" data-mdc-ripple-is-unbounded title="Share" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;">share</button>
             <button class="mdc-icon-button material-icons mdc-card__action mdc-card__action--icon" data-mdc-ripple-is-unbounded title="More options" style="--mdc-ripple-fg-size:28.8px; --mdc-ripple-fg-scale:1.66667; --mdc-ripple-left:10px; --mdc-ripple-top:10px;">more_vert</button>
           </div>

--- a/test/screenshot/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html
+++ b/test/screenshot/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html
@@ -17,7 +17,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Baseline Icon Button - MDC Web Screenshot Test</title>
+    <title>Baseline Icon Button Toggle - MDC Web Screenshot Test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css">
     <link rel="stylesheet" href="../../../out/mdc.icon-button.css">

--- a/test/screenshot/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html
+++ b/test/screenshot/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Baseline Icon Button - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css">
+    <link rel="stylesheet" href="../../../out/mdc.icon-button.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-icon-button/fixture.css">
+  </head>
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--icon-button">
+          <button class="mdc-icon-button mdc-icon-button--on"
+                  aria-label="Add to favorites"
+                  aria-pressed="true">
+            <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
+            <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+          </button>
+        </div>
+        <div class="test-cell test-cell--icon-button">
+            <button class="mdc-icon-button"
+                    aria-label="Add to favorites"
+                    aria-pressed="false">
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
+              <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+          </button>
+        </div>
+        <div class="test-cell test-cell--icon-button">
+          <button class="mdc-icon-button mdc-icon-button--on"
+                  aria-label="Unstar this item"
+                  aria-pressed="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon mdc-icon-button__icon--on">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
+            </svg>
+          </button>
+        </div>
+        <div class="test-cell test-cell--icon-button">
+          <button class="mdc-icon-button"
+                  aria-label="Unstar this item"
+                  aria-pressed="false">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon mdc-icon-button__icon--on">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="mdc-icon-button__icon">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
+            </svg>
+          </button>
+        </div>
+        <div class="test-cell test-cell--icon-button">
+          <button class="mdc-icon-button mdc-icon-button--on mdc-theme--primary"
+                  aria-label="Add to favorites"
+                  aria-pressed="true">
+            <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
+            <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+          </button>
+        </div>
+        <div class="test-cell test-cell--icon-button mdc-theme--primary">
+            <button class="mdc-icon-button material-icons"
+                    aria-label="Add to favorites"
+                    aria-pressed="false">
+              <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
+              <i class="material-icons mdc-icon-button__icon">favorite_border</i>
+            </button>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-icon-button/fixture.scss
+++ b/test/screenshot/spec/mdc-icon-button/fixture.scss
@@ -16,6 +16,7 @@
 
 @import "../../../../packages/mdc-icon-button/mixins";
 @import "../../../../packages/mdc-theme/color-palette";
+@import "../../../../packages/mdc-theme/mdc-theme";
 
 $custom-icon-button-icon-ink-color: $material-color-red-500;
 $custom-icon-button-size: 36px;

--- a/test/unit/mdc-icon-button/foundation.test.js
+++ b/test/unit/mdc-icon-button/foundation.test.js
@@ -43,14 +43,14 @@ const setupTest = () => setupFoundationTest(MDCIconButtonToggleFoundation);
 
 test('#constructor sets on to false', () => {
   const {mockAdapter} = setupTest();
-  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(false);
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON)).thenReturn(false);
   const foundation = new MDCIconButtonToggleFoundation(mockAdapter);
   assert.isFalse(foundation.isOn());
 });
 
-test(`#constructor sets on to true if the ${cssClasses.ICON_BUTTON_ON_CLASS} is present`, () => {
+test(`#constructor sets on to true if the ${cssClasses.ICON_BUTTON_ON} is present`, () => {
   const {mockAdapter} = setupTest();
-  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(true);
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON)).thenReturn(true);
   const foundation = new MDCIconButtonToggleFoundation(mockAdapter);
   assert.isTrue(foundation.isOn());
 });
@@ -65,7 +65,7 @@ test('#handleClick calls #toggle', () => {
 
 test('#handleClick calls notifyChange', () => {
   const {foundation, mockAdapter} = setupTest();
-  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(true);
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON)).thenReturn(true);
   foundation.init();
   foundation.handleClick();
   td.verify(mockAdapter.notifyChange({isOn: true}), {times: 1});
@@ -74,12 +74,12 @@ test('#handleClick calls notifyChange', () => {
 test('#toggle flips on', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.init();
-  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(true, false);
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON)).thenReturn(true, false);
 
   foundation.toggle();
-  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
+  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON), {times: 1});
   foundation.toggle();
-  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
+  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON), {times: 1});
 });
 
 test('#toggle accepts boolean argument denoting toggle state', () => {
@@ -87,9 +87,9 @@ test('#toggle accepts boolean argument denoting toggle state', () => {
   foundation.init();
 
   foundation.toggle(false);
-  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
+  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON), {times: 1});
   foundation.toggle(true);
-  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
+  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON), {times: 1});
 });
 
 test('#toggle sets "aria-pressed" to true when toggled on', () => {

--- a/test/unit/mdc-icon-button/foundation.test.js
+++ b/test/unit/mdc-icon-button/foundation.test.js
@@ -22,6 +22,7 @@ import {verifyDefaultAdapter} from '../helpers/foundation';
 import MDCIconButtonToggleFoundation from '../../../packages/mdc-icon-button/foundation';
 
 const {strings} = MDCIconButtonToggleFoundation;
+const {cssClasses} = MDCIconButtonToggleFoundation;
 
 suite('MDCIconButtonToggleFoundation');
 
@@ -35,8 +36,7 @@ test('exports cssClasses', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCIconButtonToggleFoundation, [
-    'addClass', 'removeClass',
-    'setText', 'getAttr', 'setAttr', 'notifyChange',
+    'addClass', 'removeClass', 'hasClass', 'setAttr', 'notifyChange',
   ]);
 });
 
@@ -44,14 +44,14 @@ const setupTest = () => setupFoundationTest(MDCIconButtonToggleFoundation);
 
 test('#constructor sets on to false', () => {
   const {mockAdapter} = setupTest();
-  td.when(mockAdapter.getAttr(strings.ARIA_PRESSED)).thenReturn('false');
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(false);
   const foundation = new MDCIconButtonToggleFoundation(mockAdapter);
   assert.isFalse(foundation.isOn());
 });
 
-test('#constructor sets on to true if the toggle is pressed', () => {
+test(`#constructor sets on to true if the ${cssClasses.ICON_BUTTON_ON_CLASS} is present`, () => {
   const {mockAdapter} = setupTest();
-  td.when(mockAdapter.getAttr(strings.ARIA_PRESSED)).thenReturn('true');
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(true);
   const foundation = new MDCIconButtonToggleFoundation(mockAdapter);
   assert.isTrue(foundation.isOn());
 });
@@ -93,115 +93,28 @@ test('#toggle accepts boolean argument denoting toggle state', () => {
 
 test('#toggle sets "aria-pressed" to true when toggled on', () => {
   const {foundation, mockAdapter} = setupTest();
-  foundation.init();
 
   foundation.toggle(true);
   td.verify(mockAdapter.setAttr(strings.ARIA_PRESSED, 'true'));
 });
 
-test('#toggle removes cssClass in "data-toggle-off-class" if specified when toggled on', () => {
+test(`#toggle sets the ${cssClasses.ICON_BUTTON_ON_CLASS} class on the button when toggled on`, () => {
   const {foundation, mockAdapter} = setupTest();
-  const cssClass = 'toggle-off-css-class';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_OFF_CLASS)).thenReturn(cssClass);
-  foundation.init();
 
   foundation.toggle(true);
-  td.verify(mockAdapter.removeClass(cssClass));
-});
-
-test('#toggle adds cssClass in "data-toggle-on-class" if specified when toggled on', () => {
-  const {foundation, mockAdapter} = setupTest();
-  const cssClass = 'toggle-on-css-class';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_ON_CLASS)).thenReturn(cssClass);
-  foundation.init();
-
-  foundation.toggle(true);
-  td.verify(mockAdapter.addClass(cssClass));
-});
-
-test('#toggle sets text to content in "data-toggle-on-content" if specified when toggled on', () => {
-  const {foundation, mockAdapter} = setupTest();
-  const content = 'toggle on content';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_ON_CONTENT)).thenReturn(content);
-  foundation.init();
-
-  foundation.toggle(true);
-  td.verify(mockAdapter.setText(content));
-});
-
-test('#toggle sets aria-label to label in "data-toggle-on" if specified when toggled on', () => {
-  const {foundation, mockAdapter} = setupTest();
-  const label = 'toggle on label';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_ON_LABEL)).thenReturn(label);
-  foundation.init();
-
-  foundation.toggle(true);
-  td.verify(mockAdapter.setAttr(strings.ARIA_LABEL, label));
+  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
 });
 
 test('#toggle sets "aria-pressed" to false when toggled off', () => {
   const {foundation, mockAdapter} = setupTest();
-  foundation.init();
 
   foundation.toggle(false);
-  td.verify(mockAdapter.setAttr(strings.ARIA_PRESSED, 'false'));
+  td.verify(mockAdapter.setAttr(strings.ARIA_PRESSED, 'false'), {times: 1});
 });
 
-test('#toggle removes cssClass in "data-toggle-on-class" if specified when toggled off', () => {
+test(`#toggle removes the ${cssClasses.ICON_BUTTON_ON_CLASS} css class on the button when toggled off`, () => {
   const {foundation, mockAdapter} = setupTest();
-  const cssClass = 'toggle-on-css-class';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_ON_CLASS)).thenReturn(cssClass);
-  foundation.init();
 
   foundation.toggle(false);
-  td.verify(mockAdapter.removeClass(cssClass));
-});
-
-test('#toggle adds cssClass in "data-toggle-off-class" if specified when toggled off', () => {
-  const {foundation, mockAdapter} = setupTest();
-  const cssClass = 'toggle-off-css-class';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_OFF_CLASS)).thenReturn(cssClass);
-  foundation.init();
-
-  foundation.toggle(false);
-  td.verify(mockAdapter.addClass(cssClass));
-});
-
-test('#toggle sets text to content in "data-toggle-off-content" if specified when toggled off', () => {
-  const {foundation, mockAdapter} = setupTest();
-  const content = 'toggle off content';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_OFF_CONTENT)).thenReturn(content);
-  foundation.init();
-
-  foundation.toggle(false);
-  td.verify(mockAdapter.setText(content));
-});
-
-test('#toggle sets aria-label to label in "data-toggle-off-label" if specified when toggled off', () => {
-  const {foundation, mockAdapter} = setupTest();
-  const label = 'toggle off label';
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_OFF_LABEL)).thenReturn(label);
-  foundation.init();
-
-  foundation.toggle(false);
-  td.verify(mockAdapter.setAttr(strings.ARIA_LABEL, label));
-});
-
-test('#refreshToggleData syncs the foundation state with data-toggle-on, data-toggle-off', () => {
-  const {foundation, mockAdapter} = setupTest();
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_ON_CLASS)).thenReturn('first-class-on');
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_OFF_CLASS)).thenReturn('first-class-off');
-  foundation.init();
-
-  foundation.toggle(true);
-  td.verify(mockAdapter.addClass('first-class-on'));
-  td.verify(mockAdapter.removeClass('first-class-off'));
-
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_ON_CLASS)).thenReturn('second-class-on');
-  td.when(mockAdapter.getAttr(strings.DATA_TOGGLE_OFF_CLASS)).thenReturn('second-class-off');
-  foundation.refreshToggleData();
-
-  foundation.toggle(true);
-  td.verify(mockAdapter.addClass('second-class-on'));
-  td.verify(mockAdapter.removeClass('second-class-off'));
+  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
 });

--- a/test/unit/mdc-icon-button/foundation.test.js
+++ b/test/unit/mdc-icon-button/foundation.test.js
@@ -41,17 +41,15 @@ test('defaultAdapter returns a complete adapter implementation', () => {
 
 const setupTest = () => setupFoundationTest(MDCIconButtonToggleFoundation);
 
-test('#constructor sets on to false', () => {
-  const {mockAdapter} = setupTest();
+test(`isOn is false if hasClass{${cssClasses.ICON_BUTTON_ON}) returns false`, () => {
+  const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON)).thenReturn(false);
-  const foundation = new MDCIconButtonToggleFoundation(mockAdapter);
   assert.isFalse(foundation.isOn());
 });
 
-test(`#constructor sets on to true if the ${cssClasses.ICON_BUTTON_ON} is present`, () => {
-  const {mockAdapter} = setupTest();
+test(`isOn is true if hasClass{${cssClasses.ICON_BUTTON_ON}) returns true`, () => {
+  const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON)).thenReturn(true);
-  const foundation = new MDCIconButtonToggleFoundation(mockAdapter);
   assert.isTrue(foundation.isOn());
 });
 

--- a/test/unit/mdc-icon-button/foundation.test.js
+++ b/test/unit/mdc-icon-button/foundation.test.js
@@ -21,17 +21,16 @@ import {setupFoundationTest} from '../helpers/setup';
 import {verifyDefaultAdapter} from '../helpers/foundation';
 import MDCIconButtonToggleFoundation from '../../../packages/mdc-icon-button/foundation';
 
-const {strings} = MDCIconButtonToggleFoundation;
-const {cssClasses} = MDCIconButtonToggleFoundation;
+const {strings, cssClasses} = MDCIconButtonToggleFoundation;
 
 suite('MDCIconButtonToggleFoundation');
 
 test('exports strings', () => {
-  assert.isOk('strings' in MDCIconButtonToggleFoundation);
+  assert.isTrue('strings' in MDCIconButtonToggleFoundation);
 });
 
 test('exports cssClasses', () => {
-  assert.isOk('cssClasses' in MDCIconButtonToggleFoundation);
+  assert.isTrue('cssClasses' in MDCIconButtonToggleFoundation);
 });
 
 test('defaultAdapter returns a complete adapter implementation', () => {
@@ -66,29 +65,31 @@ test('#handleClick calls #toggle', () => {
 
 test('#handleClick calls notifyChange', () => {
   const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(true);
   foundation.init();
   foundation.handleClick();
   td.verify(mockAdapter.notifyChange({isOn: true}), {times: 1});
 });
 
 test('#toggle flips on', () => {
-  const {foundation} = setupTest();
+  const {foundation, mockAdapter} = setupTest();
   foundation.init();
+  td.when(mockAdapter.hasClass(cssClasses.ICON_BUTTON_ON_CLASS)).thenReturn(true, false);
 
   foundation.toggle();
-  assert.isOk(foundation.isOn());
+  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
   foundation.toggle();
-  assert.isNotOk(foundation.isOn());
+  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
 });
 
 test('#toggle accepts boolean argument denoting toggle state', () => {
-  const {foundation} = setupTest();
+  const {foundation, mockAdapter} = setupTest();
   foundation.init();
 
   foundation.toggle(false);
-  assert.isNotOk(foundation.isOn());
+  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
   foundation.toggle(true);
-  assert.isOk(foundation.isOn());
+  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
 });
 
 test('#toggle sets "aria-pressed" to true when toggled on', () => {
@@ -98,23 +99,9 @@ test('#toggle sets "aria-pressed" to true when toggled on', () => {
   td.verify(mockAdapter.setAttr(strings.ARIA_PRESSED, 'true'));
 });
 
-test(`#toggle sets the ${cssClasses.ICON_BUTTON_ON_CLASS} class on the button when toggled on`, () => {
-  const {foundation, mockAdapter} = setupTest();
-
-  foundation.toggle(true);
-  td.verify(mockAdapter.addClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
-});
-
 test('#toggle sets "aria-pressed" to false when toggled off', () => {
   const {foundation, mockAdapter} = setupTest();
 
   foundation.toggle(false);
   td.verify(mockAdapter.setAttr(strings.ARIA_PRESSED, 'false'), {times: 1});
-});
-
-test(`#toggle removes the ${cssClasses.ICON_BUTTON_ON_CLASS} css class on the button when toggled off`, () => {
-  const {foundation, mockAdapter} = setupTest();
-
-  foundation.toggle(false);
-  td.verify(mockAdapter.removeClass(cssClasses.ICON_BUTTON_ON_CLASS), {times: 1});
 });

--- a/test/unit/mdc-icon-button/mdc-icon-button-toggle.test.js
+++ b/test/unit/mdc-icon-button/mdc-icon-button-toggle.test.js
@@ -59,7 +59,7 @@ function setupTest({tabIndex = undefined, useInnerIconElement = false, createMoc
 suite('MDCIconButtonToggle');
 
 test('attachTo initializes and returns a MDCIconButtonToggle instance', () => {
-  assert.isOk(MDCIconButtonToggle.attachTo(document.createElement('i')) instanceof MDCIconButtonToggle);
+  assert.isTrue(MDCIconButtonToggle.attachTo(document.createElement('i')) instanceof MDCIconButtonToggle);
 });
 
 if (supportsCssVariables(window)) {
@@ -67,7 +67,7 @@ if (supportsCssVariables(window)) {
     const raf = createMockRaf();
     const {root} = setupTest();
     raf.flush();
-    assert.isOk(root.classList.contains('mdc-ripple-upgraded'));
+    assert.isTrue(root.classList.contains('mdc-ripple-upgraded'));
     raf.restore();
   });
 
@@ -77,7 +77,7 @@ if (supportsCssVariables(window)) {
     raf.flush();
     component.destroy();
     raf.flush();
-    assert.isNotOk(root.classList.contains('mdc-ripple-upgraded'));
+    assert.isFalse(root.classList.contains('mdc-ripple-upgraded'));
     raf.restore();
   });
 }
@@ -85,77 +85,30 @@ if (supportsCssVariables(window)) {
 test('set/get on', () => {
   const {root, component} = setupTest();
   component.on = true;
-  assert.isOk(component.on);
+  assert.isTrue(component.on);
   assert.equal(root.getAttribute('aria-pressed'), 'true');
 
   component.on = false;
-  assert.isNotOk(component.on);
+  assert.isFalse(component.on);
   assert.equal(root.getAttribute('aria-pressed'), 'false');
-});
-
-
-test('#refreshToggleData proxies to foundation.refreshToggleData()', () => {
-  const MockIconToggleFoundation = td.constructor(MDCIconButtonToggleFoundation);
-  const root = document.createElement('i');
-  const foundation = new MockIconToggleFoundation();
-  const component = new MDCIconButtonToggle(root, foundation);
-  component.refreshToggleData();
-  td.verify(foundation.refreshToggleData());
-});
-
-test('intially set to on if root has aria-pressed=true', () => {
-  const root = bel`<button class="mdc-icon-button" aria-pressed="true"></button>`;
-  const component = new MDCIconButtonToggle(root);
-  assert.isOk(component.on);
 });
 
 test('get ripple returns a MDCRipple instance', () => {
   const {component} = setupTest();
-  assert.isOk(component.ripple instanceof MDCRipple);
+  assert.isTrue(component.ripple instanceof MDCRipple);
 });
 
 test('#adapter.addClass adds a class to the root element', () => {
   const {root, component} = setupTest();
   component.getDefaultFoundation().adapter_.addClass('foo');
-  assert.isOk(root.classList.contains('foo'));
-});
-
-test('#adapter.addClass adds a class to the inner icon element when used', () => {
-  const {root, component} = setupTest({useInnerIconElement: true});
-  component.getDefaultFoundation().adapter_.addClass('foo');
-  assert.isOk(root.querySelector('#icon').classList.contains('foo'));
+  assert.isTrue(root.classList.contains('foo'));
 });
 
 test('#adapter.removeClass removes a class from the root element', () => {
   const {root, component} = setupTest();
   root.classList.add('foo');
   component.getDefaultFoundation().adapter_.removeClass('foo');
-  assert.isNotOk(root.classList.contains('foo'));
-});
-
-test('#adapter.removeClass adds a class to the inner icon element when used', () => {
-  const {root, component} = setupTest({useInnerIconElement: true});
-  root.querySelector('#icon').classList.add('foo');
-  component.getDefaultFoundation().adapter_.removeClass('foo');
-  assert.isNotOk(root.querySelector('#icon').classList.contains('foo'));
-});
-
-test('#adapter.setText sets the text content of the root element', () => {
-  const {root, component} = setupTest();
-  component.getDefaultFoundation().adapter_.setText('foo');
-  assert.equal(root.textContent, 'foo');
-});
-
-test('#adapter.setText sets the text content of the inner icon element when used', () => {
-  const {root, component} = setupTest({useInnerIconElement: true});
-  component.getDefaultFoundation().adapter_.setText('foo');
-  assert.equal(root.querySelector('#icon').textContent, 'foo');
-});
-
-test('#adapter.getAttr retrieves an attribute from the root element', () => {
-  const {root, component} = setupTest();
-  root.setAttribute('aria-label', 'hello');
-  assert.equal(component.getDefaultFoundation().adapter_.getAttr('aria-label'), 'hello');
+  assert.isFalse(root.classList.contains('foo'));
 });
 
 test('#adapter.setAttr sets an attribute on the root element', () => {
@@ -175,13 +128,13 @@ test(`#adapter.notifyChange broadcasts a ${MDCIconButtonToggleFoundation.strings
 test('assert keydown does not trigger ripple', () => {
   const {root} = setupTest();
   domEvents.emit(root, 'keydown');
-  assert.isNotOk(root.classList.contains(cssClasses.FG_ACTIVATION));
+  assert.isFalse(root.classList.contains(cssClasses.FG_ACTIVATION));
 });
 
 test('assert keyup does not trigger ripple', () => {
   const {root} = setupTest();
   domEvents.emit(root, 'keyup');
-  assert.isNotOk(root.classList.contains(cssClasses.FG_ACTIVATION));
+  assert.isFalse(root.classList.contains(cssClasses.FG_ACTIVATION));
 });
 
 test('click handler is added to root element', () => {

--- a/test/unit/mdc-icon-button/mdc-icon-button-toggle.test.js
+++ b/test/unit/mdc-icon-button/mdc-icon-button-toggle.test.js
@@ -31,22 +31,9 @@ function getFixture() {
   `;
 }
 
-function getIconFixture() {
-  return bel`
-    <i id="icon"></i>
-  `;
-}
-
-function setupTest({tabIndex = undefined, useInnerIconElement = false, createMockFoundation = false} = {}) {
+function setupTest({createMockFoundation = false} = {}) {
   const root = getFixture();
-  if (useInnerIconElement) {
-    const icon = getIconFixture();
-    root.dataset.iconInnerSelector = `#${icon.id}`;
-    root.appendChild(icon);
-  }
-  if (tabIndex !== undefined) {
-    root.tabIndex = tabIndex;
-  }
+
   let mockFoundation;
   if (createMockFoundation) {
     const MockFoundationCtor = td.constructor(MDCIconButtonToggleFoundation);


### PR DESCRIPTION
fixes: #3277 , resolves #3154, resolves #3107
BREAKING CHANGE: Removes the previous `data` attributes and no longer dynamically changes the label. Allows developers to add both elements to the button, with one indicated as the `on` state by using a `data-toggle-on` attribute. State is now changed by adding/removing the `mdc-icon-button--on` class to the `mdc-icon-button` element. All icon elements should have the `mdc-icon-button__icon` class. 