### PR TITLE
chore(infrastructure): Ensure text files end with a newline

### DIFF
--- a/test/screenshot/infra/commands/index.js
+++ b/test/screenshot/infra/commands/index.js
@@ -125,7 +125,7 @@ class IndexCommand {
     </main>
   </body>
 </html>
-      `;
+      `.trim();
 
       await localStorage.writeTextFile(path.join(parentDirPath, 'index.html'), html);
     }

--- a/test/screenshot/infra/lib/golden-io.js
+++ b/test/screenshot/infra/lib/golden-io.js
@@ -131,10 +131,10 @@ ${serialized}
 
   /**
    * @param {!Object|!Array} object
-   * @return {!Promise<string>}
+   * @return {string}
    */
   async stringify_(object) {
-    return stringify(object, {space: '  '}) + '\n';
+    return stringify(object, {space: '  '});
   }
 }
 

--- a/test/screenshot/infra/lib/local-storage.js
+++ b/test/screenshot/infra/lib/local-storage.js
@@ -84,10 +84,13 @@ class LocalStorage {
 
   /**
    * @param {string} filePath
-   * @param {string|!Buffer} fileContent
+   * @param {string} fileContent
    * @return {!Promise<void>}
    */
   async writeTextFile(filePath, fileContent) {
+    if (!fileContent.endsWith('\n')) {
+      fileContent += '\n';
+    }
     try {
       mkdirp.sync(path.dirname(filePath));
       await fs.writeFile(filePath, fileContent, {encoding: 'utf8'});
@@ -152,10 +155,12 @@ class LocalStorage {
    * @return {!Array<string>}
    */
   globFiles(pattern, cwd = process.cwd()) {
-    if (pattern.endsWith('/')) {
-      pattern = pattern.replace(new RegExp('/+$'), '');
-    }
-    return glob.sync(pattern, {cwd, nodir: true});
+    return glob.sync(pattern, {
+      cwd,
+      nodir: true,
+      dot: true,
+      ignore: ['**/node_modules/**'],
+    });
   }
 
   /**
@@ -167,7 +172,12 @@ class LocalStorage {
     if (!pattern.endsWith('/')) {
       pattern += '/';
     }
-    return glob.sync(pattern, {cwd, nodir: false});
+    return glob.sync(pattern, {
+      cwd,
+      nodir: false,
+      dot: false,
+      ignore: ['**/node_modules/**'],
+    });
   }
 
   /**


### PR DESCRIPTION
Also:

- Ignores `node_modules` in `LocalStorage` `globFiles()` and `globDirs()` methods
- Includes dotfiles in `globFiles()`
- Removes unused `!Buffer` type annotation from `writeTextFile()` JSDoc