### PR TITLE
test(linear-progress): Add screenshot tests

### DIFF
--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -354,7 +354,7 @@
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_chrome_68.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/14/07_44_08_226/spec/mdc-linear-progress/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_ie_11.png"
     }

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -350,6 +350,33 @@
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/ink-color.html.windows_ie_11.png"
     }
   },
+  "spec/mdc-linear-progress/classes/baseline.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_chrome_68.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/classes/baseline.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-linear-progress/mixins/bar-color.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/bar-color.html",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/bar-color.html.windows_chrome_68.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/bar-color.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/bar-color.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/bar-color.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-linear-progress/mixins/buffer-color.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/buffer-color.html",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/buffer-color.html.windows_chrome_68.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/buffer-color.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/buffer-color.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/07_30_19_707/spec/mdc-linear-progress/mixins/buffer-color.html.windows_ie_11.png"
+    }
+  },
   "spec/mdc-radio/classes/baseline.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/02/15_12_11_524/spec/mdc-radio/classes/baseline.html",
     "screenshots": {

--- a/test/screenshot/spec/fixture.scss
+++ b/test/screenshot/spec/fixture.scss
@@ -77,3 +77,12 @@ $test-layout-cell-grid-color: #dddddd;
 
   background-size: 10px 10px;
 }
+
+.test-cell__heading {
+  height: 20px;
+}
+
+.test-animation--paused {
+  animation-play-state: paused !important;
+  transition: none !important;
+}

--- a/test/screenshot/spec/mdc-linear-progress/classes/baseline.html
+++ b/test/screenshot/spec/mdc-linear-progress/classes/baseline.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Baseline Linear Progress - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.linear-progress.css">
+    <link rel="stylesheet" href="../../../out/mdc.typography.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-linear-progress/fixture.css">
+  </head>
+
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Determinate</div>
+        <div class="mdc-linear-progress test-animation--paused"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Indeterminate</div>
+        <div class="mdc-linear-progress mdc-linear-progress--indeterminate test-animation--paused"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Buffer</div>
+        <div class="mdc-linear-progress test-animation--paused"
+             data-test-linear-progress-value="0.5"
+             data-test-linear-progress-buffer="0.75"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Determinate (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Indeterminate (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate test-animation--paused"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Buffer (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused"
+             data-test-linear-progress-value="0.5"
+             data-test-linear-progress-buffer="0.75"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-linear-progress/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-linear-progress/fixture.js
+++ b/test/screenshot/spec/mdc-linear-progress/fixture.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mdc.testFixture.fontsLoaded.then(() => {
+  [].forEach.call(document.querySelectorAll('.mdc-linear-progress'), (progressEl) => {
+    const linearProgress = mdc.linearProgress.MDCLinearProgress.attachTo(progressEl);
+
+    // TODO(acdvorak): Implement this in MDCLinearProgress initialSyncWithDOM()
+    const progressValue = parseFloat(progressEl.getAttribute('data-test-linear-progress-value'));
+    const bufferValue = parseFloat(progressEl.getAttribute('data-test-linear-progress-buffer'));
+
+    if (progressValue > 0) {
+      linearProgress.progress = progressValue;
+    }
+
+    if (bufferValue > 0) {
+      linearProgress.buffer = bufferValue;
+    }
+  });
+});

--- a/test/screenshot/spec/mdc-linear-progress/fixture.scss
+++ b/test/screenshot/spec/mdc-linear-progress/fixture.scss
@@ -1,0 +1,33 @@
+//
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@import "../../../../packages/mdc-linear-progress/mixins";
+@import "../../../../packages/mdc-theme/color-palette";
+
+$custom-linear-progress-color: $material-color-red-300;
+
+.test-cell--linear-progress {
+  width: 341px;
+  height: 61px;
+}
+
+.custom-linear-progress--bar-color {
+  @include mdc-linear-progress-bar-color($custom-linear-progress-color);
+}
+
+.custom-linear-progress--buffer-color {
+  @include mdc-linear-progress-buffer-color($custom-linear-progress-color);
+}

--- a/test/screenshot/spec/mdc-linear-progress/mixins/bar-color.html
+++ b/test/screenshot/spec/mdc-linear-progress/mixins/bar-color.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>bar-color Linear Progress Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.linear-progress.css">
+    <link rel="stylesheet" href="../../../out/mdc.typography.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-linear-progress/fixture.css">
+  </head>
+
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Determinate</div>
+        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--bar-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Indeterminate</div>
+        <div class="mdc-linear-progress mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--bar-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Buffer</div>
+        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--bar-color"
+             data-test-linear-progress-value="0.5"
+             data-test-linear-progress-buffer="0.75"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Determinate (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--bar-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Indeterminate (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--bar-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Buffer (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--bar-color"
+             data-test-linear-progress-value="0.5"
+             data-test-linear-progress-buffer="0.75"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-linear-progress/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-linear-progress/mixins/buffer-color.html
+++ b/test/screenshot/spec/mdc-linear-progress/mixins/buffer-color.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>buffer-color Linear Progress Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.linear-progress.css">
+    <link rel="stylesheet" href="../../../out/mdc.typography.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-linear-progress/fixture.css">
+  </head>
+
+  <body class="test-container mdc-typography">
+    <main class="test-viewport test-viewport--mobile">
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Determinate</div>
+        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--buffer-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Indeterminate</div>
+        <div class="mdc-linear-progress mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--buffer-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Buffer</div>
+        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--buffer-color"
+             data-test-linear-progress-value="0.5"
+             data-test-linear-progress-buffer="0.75"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Determinate (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--buffer-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Indeterminate (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--buffer-color"
+             data-test-linear-progress-value="0.5"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="test-cell test-cell--linear-progress">
+        <div class="test-cell__heading">Buffer (reversed)</div>
+        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--buffer-color"
+             data-test-linear-progress-value="0.5"
+             data-test-linear-progress-buffer="0.75"
+             role="progressbar">
+          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
+          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
+            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          </div>
+        </div>
+      </div>
+
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-linear-progress/fixture.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
IE 11 💩  renders `mdc-linear-progress--reversed` incorrectly. This is being tracked in #3344.

#### IE:

![image](https://user-images.githubusercontent.com/409245/44078846-67ff8e24-9f5c-11e8-921d-d04b0a3a2ee0.png)

#### Edge:

![image](https://user-images.githubusercontent.com/409245/44078859-6eab481c-9f5c-11e8-8c4e-abe485a692e4.png)