### PR TITLE
chore(infrastructure): Add "enable animation" checkbox

### DIFF
--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -201,7 +201,7 @@
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/21_05_09_679/spec/mdc-drawer/classes/permanent.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/classes/permanent.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/classes/permanent.html.windows_edge_17.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/18_30_40_648/spec/mdc-drawer/classes/permanent.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/classes/permanent.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/classes/permanent.html.windows_ie_11.png"
     }
@@ -228,7 +228,7 @@
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/21_05_09_679/spec/mdc-drawer/mixins/fill-color-accessible.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_edge_17.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/18_30_40_648/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_ie_11.png"
     }
@@ -237,7 +237,7 @@
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/21_05_09_679/spec/mdc-drawer/mixins/fill-color.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/18_30_40_648/spec/mdc-drawer/mixins/fill-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/fill-color.html.windows_ie_11.png"
     }
@@ -246,7 +246,7 @@
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/21_05_09_679/spec/mdc-drawer/mixins/ink-color.html",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/ink-color.html.windows_chrome_67.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/ink-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/14/18_30_40_648/spec/mdc-drawer/mixins/ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/ink-color.html.windows_firefox_61.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/19/21_11_42_130/spec/mdc-drawer/mixins/ink-color.html.windows_ie_11.png"
     }

--- a/test/screenshot/spec/fixture.scss
+++ b/test/screenshot/spec/fixture.scss
@@ -22,6 +22,7 @@ $test-layout-cell-grid-color: #dddddd;
 
 .test-container {
   display: flex;
+  flex-direction: column;
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -82,7 +83,12 @@ $test-layout-cell-grid-color: #dddddd;
   height: 20px;
 }
 
-.test-animation--paused {
+.test-animation--paused,
+.test-animation--paused::before,
+.test-animation--paused::after,
+.test-animation--paused *,
+.test-animation--paused *::before,
+.test-animation--paused *::after {
   animation-play-state: paused !important;
   transition: none !important;
 }

--- a/test/screenshot/spec/mdc-linear-progress/classes/baseline.html
+++ b/test/screenshot/spec/mdc-linear-progress/classes/baseline.html
@@ -25,108 +25,112 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-linear-progress/fixture.css">
   </head>
 
-  <body class="test-container mdc-typography">
+  <body class="test-container mdc-typography test-animation--paused">
     <main class="test-viewport test-viewport--mobile">
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Determinate</div>
-        <div class="mdc-linear-progress test-animation--paused"
+        <div class="mdc-linear-progress"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Indeterminate</div>
-        <div class="mdc-linear-progress mdc-linear-progress--indeterminate test-animation--paused"
+        <div class="mdc-linear-progress mdc-linear-progress--indeterminate"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Buffer</div>
-        <div class="mdc-linear-progress test-animation--paused"
+        <div class="mdc-linear-progress"
              data-test-linear-progress-value="0.5"
              data-test-linear-progress-buffer="0.75"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Determinate (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Indeterminate (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate test-animation--paused"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Buffer (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed"
              data-test-linear-progress-value="0.5"
              data-test-linear-progress-buffer="0.75"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
     </main>
+
+    <footer class="test-footer">
+      <label><input type="checkbox" id="test-linear-progress-enable-animation"> Enable animation</label>
+    </footer>
 
     <!-- Automatically provides/replaces `Promise` if missing or broken. -->
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>

--- a/test/screenshot/spec/mdc-linear-progress/fixture.js
+++ b/test/screenshot/spec/mdc-linear-progress/fixture.js
@@ -14,20 +14,51 @@
  * limitations under the License.
  */
 
-mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-linear-progress'), (progressEl) => {
-    const linearProgress = mdc.linearProgress.MDCLinearProgress.attachTo(progressEl);
+import 'url-search-params-polyfill';
 
-    // TODO(acdvorak): Implement this in MDCLinearProgress initialSyncWithDOM()
-    const progressValue = parseFloat(progressEl.getAttribute('data-test-linear-progress-value'));
-    const bufferValue = parseFloat(progressEl.getAttribute('data-test-linear-progress-buffer'));
+[].forEach.call(document.querySelectorAll('.mdc-linear-progress'), (progressEl) => {
+  const linearProgress = mdc.linearProgress.MDCLinearProgress.attachTo(progressEl);
 
-    if (progressValue > 0) {
-      linearProgress.progress = progressValue;
-    }
+  // TODO(acdvorak): Implement this in MDCLinearProgress initialSyncWithDOM()
+  const progressValue = parseFloat(progressEl.getAttribute('data-test-linear-progress-value'));
+  const bufferValue = parseFloat(progressEl.getAttribute('data-test-linear-progress-buffer'));
 
-    if (bufferValue > 0) {
-      linearProgress.buffer = bufferValue;
-    }
-  });
+  if (progressValue > 0) {
+    linearProgress.progress = progressValue;
+  }
+
+  if (bufferValue > 0) {
+    linearProgress.buffer = bufferValue;
+  }
 });
+
+const enableAnimationCheckboxEl = document.querySelector('#test-linear-progress-enable-animation');
+
+function checkUrlParams() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('enable_animation') && params.get('enable_animation') !== 'false') {
+    document.body.classList.remove('test-animation--paused');
+    enableAnimationCheckboxEl.checked = true;
+  } else {
+    document.body.classList.add('test-animation--paused');
+    enableAnimationCheckboxEl.checked = false;
+  }
+}
+
+enableAnimationCheckboxEl.addEventListener('change', (evt) => {
+  const params = new URLSearchParams(window.location.search);
+  if (evt.target.checked) {
+    params.set('enable_animation', 'true');
+  } else {
+    params.delete('enable_animation');
+  }
+  const path = window.location.pathname;
+  const qs = String(params) ? '?' + String(params) : '';
+  const hash = window.location.hash;
+  window.history.replaceState({}, 'title', `${path}${qs}${hash}`);
+  setTimeout(checkUrlParams, 100);
+});
+
+window.addEventListener('popstate', checkUrlParams);
+
+checkUrlParams();

--- a/test/screenshot/spec/mdc-linear-progress/mixins/bar-color.html
+++ b/test/screenshot/spec/mdc-linear-progress/mixins/bar-color.html
@@ -25,108 +25,112 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-linear-progress/fixture.css">
   </head>
 
-  <body class="test-container mdc-typography">
+  <body class="test-container mdc-typography test-animation--paused">
     <main class="test-viewport test-viewport--mobile">
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Determinate</div>
-        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--bar-color"
+        <div class="mdc-linear-progress custom-linear-progress--bar-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Indeterminate</div>
-        <div class="mdc-linear-progress mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--bar-color"
+        <div class="mdc-linear-progress mdc-linear-progress--indeterminate custom-linear-progress--bar-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Buffer</div>
-        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--bar-color"
+        <div class="mdc-linear-progress custom-linear-progress--bar-color"
              data-test-linear-progress-value="0.5"
              data-test-linear-progress-buffer="0.75"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Determinate (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--bar-color"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed custom-linear-progress--bar-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Indeterminate (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--bar-color"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate custom-linear-progress--bar-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Buffer (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--bar-color"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed custom-linear-progress--bar-color"
              data-test-linear-progress-value="0.5"
              data-test-linear-progress-buffer="0.75"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
     </main>
+
+    <footer class="test-footer test-footer--linear-progress">
+      <label><input type="checkbox" id="test-linear-progress-enable-animation"> Enable animation</label>
+    </footer>
 
     <!-- Automatically provides/replaces `Promise` if missing or broken. -->
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>

--- a/test/screenshot/spec/mdc-linear-progress/mixins/buffer-color.html
+++ b/test/screenshot/spec/mdc-linear-progress/mixins/buffer-color.html
@@ -25,108 +25,112 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-linear-progress/fixture.css">
   </head>
 
-  <body class="test-container mdc-typography">
+  <body class="test-container mdc-typography test-animation--paused">
     <main class="test-viewport test-viewport--mobile">
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Determinate</div>
-        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--buffer-color"
+        <div class="mdc-linear-progress custom-linear-progress--buffer-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Indeterminate</div>
-        <div class="mdc-linear-progress mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--buffer-color"
+        <div class="mdc-linear-progress mdc-linear-progress--indeterminate custom-linear-progress--buffer-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Buffer</div>
-        <div class="mdc-linear-progress test-animation--paused custom-linear-progress--buffer-color"
+        <div class="mdc-linear-progress custom-linear-progress--buffer-color"
              data-test-linear-progress-value="0.5"
              data-test-linear-progress-buffer="0.75"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Determinate (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--buffer-color"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed custom-linear-progress--buffer-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Indeterminate (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate test-animation--paused custom-linear-progress--buffer-color"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed mdc-linear-progress--indeterminate custom-linear-progress--buffer-color"
              data-test-linear-progress-value="0.5"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
       <div class="test-cell test-cell--linear-progress">
         <div class="test-cell__heading">Buffer (reversed)</div>
-        <div class="mdc-linear-progress mdc-linear-progress--reversed test-animation--paused custom-linear-progress--buffer-color"
+        <div class="mdc-linear-progress mdc-linear-progress--reversed custom-linear-progress--buffer-color"
              data-test-linear-progress-value="0.5"
              data-test-linear-progress-buffer="0.75"
              role="progressbar">
-          <div class="mdc-linear-progress__buffering-dots test-animation--paused"></div>
-          <div class="mdc-linear-progress__buffer test-animation--paused"></div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__buffering-dots"></div>
+          <div class="mdc-linear-progress__buffer"></div>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
-          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar test-animation--paused">
-            <span class="mdc-linear-progress__bar-inner test-animation--paused"></span>
+          <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
+            <span class="mdc-linear-progress__bar-inner"></span>
           </div>
         </div>
       </div>
 
     </main>
+
+    <footer class="test-footer test-footer--linear-progress">
+      <label><input type="checkbox" id="test-linear-progress-enable-animation"> Enable animation</label>
+    </footer>
 
     <!-- Automatically provides/replaces `Promise` if missing or broken. -->
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>


### PR DESCRIPTION
### What it does

- Adds an "Enable animation" checkbox to `linear-progress` pages:
    - For screenshot test pages to replace demo pages, we need to be able to manually verify animations. However, we also need to ensure consistent rendering for screenshot tests.
    - The checkbox is positioned _outside_ the green cropping border, so it does not appear in screenshot images.
    - Checkbox state is synchronized with a URL param to enable persistence between reloads and linking to a specific state (e.g., [animation enabled](https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/14/18_05_33_820/spec/mdc-linear-progress/classes/baseline.html?enable_animation=true) vs. [animation disabled](https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/14/18_05_33_820/spec/mdc-linear-progress/classes/baseline.html?enable_animation=false))
    - This is a proof-of-concept for adding a "show redlines" checkbox to `mdc-textfield` pages.
- Adds `flex-direction: column` to `.test-container`
    - Causes subpixel rendering to change slightly for Drawer screenshots in Edge.
- Simplifies `test-animation--paused`:
    - Moves `test-animation--paused` from multiple subelements to `<body>`
    - Adds `::before`/`::after` and descendant `*` selectors to `.test-animation--paused` rule
    - One top-level CSS class now disables all animations on the page, and can be toggled on/off

### Example output

![image](https://user-images.githubusercontent.com/409245/44109382-bdb70928-9fb1-11e8-913a-15a04a3c9b48.png)
