### PR TITLE
Add installation instructions to floating-label and line-ripple

### DIFF
--- a/packages/mdc-floating-label/README.md
+++ b/packages/mdc-floating-label/README.md
@@ -21,6 +21,12 @@ Floating labels display the type of input a field requires. Every Text Field and
   </li>
 </ul>
 
+## Installation
+
+```
+npm install @material/floating-label
+```
+
 ## Basic Usage
 
 ### HTML Structure

--- a/packages/mdc-line-ripple/README.md
+++ b/packages/mdc-line-ripple/README.md
@@ -21,6 +21,12 @@ The line ripple is used to highlight user-specified input above it. When a line 
   </li>
 </ul>
 
+## Installation
+
+```
+npm install @material/line-ripple
+```
+
 ## Basic Usage
 
 ### HTML Structure

--- a/packages/mdc-notched-outline/README.md
+++ b/packages/mdc-notched-outline/README.md
@@ -22,6 +22,12 @@ The notched outline is a border around all sides of either a Text Field or Selec
   </li>
 </ul>
 
+## Installation
+
+```
+npm install @material/notched-outline
+```
+
 ## Basic Usage
 
 ### HTML Structure


### PR DESCRIPTION
I added installation instructions to the other two places it was missing, floating-label and line-ripple.

For some reason the notched-outline commit is in here as well. Let me know if I need to change anything in regards to that.