### PR TITLE
chore(infrastructure): Log Selenium session ID and public CBT URL

### DIFF
--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -147,6 +147,16 @@ https://crossbrowsertesting.com/account
   }
 
   /**
+   * @param {string} sessionId
+   * @return {!Promise<string>}
+   */
+  async getPublicTestResultUrl(sessionId) {
+    const stackTrace = getStackTrace('getPublicTestResultUrl');
+    const responseBody = await this.sendRequest_(stackTrace, 'GET', `/selenium/${sessionId}`);
+    return responseBody['show_result_public_url'];
+  }
+
+  /**
    * @param {string} seleniumSessionId
    * @param {!Array<!mdc.proto.Screenshot>} changedScreenshots
    * @return {!Promise<void>}

--- a/test/screenshot/infra/lib/report-writer.js
+++ b/test/screenshot/infra/lib/report-writer.js
@@ -400,9 +400,13 @@ class ReportWriter {
      */
     function getIconHtml(userAgent) {
       const title = userAgent.navigator ? userAgent.navigator.full_name : userAgent.alias;
-      return `
+      const img = `
 <img src="${userAgent.browser_icon_url}" width="16" height="16" class="report-user-agent__icon" title="${title}">
 `.trim();
+      if (userAgent.selenium_result_url) {
+        return `<a href="${userAgent.selenium_result_url}">${img}</a>`;
+      }
+      return img;
     }
 
     const runnableHtml = runnableUserAgents.map(getIconHtml).join(' ');

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -279,30 +279,23 @@ class SeleniumApi {
 
     /** @type {!Session} */
     const session = await driver.getSession();
-    const seleniumSessionId = session.getId();
+    const sessionId = session.getId();
 
     /** @type {?Array<!mdc.proto.Screenshot>} */
     let changedScreenshots;
 
-    this.seleniumSessionIds_.add(seleniumSessionId);
-
-    const logResult = (status, ...args) => {
-      /* eslint-disable camelcase */
-      const {os_name, os_version, browser_name, browser_version} = userAgent.navigator;
-      this.logStatus_(status, `${browser_name} ${browser_version} on ${os_name} ${os_version}!`, ...args);
-      /* eslint-enable camelcase */
-    };
+    this.seleniumSessionIds_.add(sessionId);
 
     try {
       stackTrace = getStackTrace('captureAllPagesInOneBrowser_');
       changedScreenshots = await this.driveBrowser_({reportData, userAgent, driver});
-      logResult(CliStatuses.FINISHED);
+      this.logSession_(CliStatuses.FINISHED, userAgent);
     } catch (err) {
       runtimeError = new VError(err, stackTrace);
-      logResult(CliStatuses.FAILED);
+      this.logSession_(CliStatuses.FAILED, userAgent);
     } finally {
       this.numSessionsEnded_++;
-      logResult(CliStatuses.QUITTING);
+      this.logSession_(CliStatuses.QUITTING, userAgent);
       await driver.quit().catch(() => 0);
     }
 
@@ -314,13 +307,13 @@ class SeleniumApi {
       return;
     }
 
-    this.seleniumSessionIds_.delete(seleniumSessionId);
+    this.seleniumSessionIds_.delete(sessionId);
 
     await this.printBrowserConsoleLogs_(driver);
 
     if (this.cli_.isOnline()) {
       await this.cbtApi_.setTestScore({
-        seleniumSessionId,
+        seleniumSessionId: sessionId,
         changedScreenshots,
       });
     }
@@ -427,16 +420,18 @@ class SeleniumApi {
     /** @type {!mdc.proto.UserAgent.Navigator} */
     const navigator = await this.getUserAgentNavigator_(driver);
 
-    /* eslint-disable camelcase */
-    const {os_name, os_version, browser_name, browser_version} = navigator;
+    /** @type {!Session} */
+    const session = await driver.getSession();
+    const sessionId = session.getId();
 
     userAgent.navigator = navigator;
+    userAgent.browser_version_value = navigator.browser_version;
+    userAgent.selenium_session_id = sessionId;
+    userAgent.selenium_result_url = await this.cbtApi_.getPublicTestResultUrl(sessionId);
     userAgent.actual_capabilities = actualCapabilities;
-    userAgent.browser_version_value = browser_version;
     userAgent.image_filename_suffix = this.getImageFileNameSuffix_(userAgent);
 
-    this.logStatus_(CliStatuses.STARTED, `${browser_name} ${browser_version} on ${os_name} ${os_version}!`);
-    /* eslint-enable camelcase */
+    this.logSession_(CliStatuses.STARTED, userAgent);
 
     return driver;
   }
@@ -712,6 +707,7 @@ class SeleniumApi {
       }
 
       if (screenshot.retry_count > 0) {
+        // TODO(acdvorak): Print this info when a test fails.
         const {width, height} = diffImageResult.diff_image_dimensions;
         const whichMsg = `${screenshot.actual_html_file.public_url} > ${userAgent.alias}`;
         const countMsg = `attempt ${screenshot.retry_count} of ${maxRetries}`;
@@ -799,7 +795,8 @@ class SeleniumApi {
     const {width: uncroppedWidth, height: uncroppedHeight} = uncroppedJimpImage.bitmap;
     const {width: croppedWidth, height: croppedHeight} = croppedJimpImage.bitmap;
 
-    const message = `${urlWithQsParams} > ${userAgent.alias} screenshot from ` +
+    const message =
+      `${urlWithQsParams} > ${userAgent.alias} screenshot from ` +
       `${uncroppedWidth}x${uncroppedHeight} to ${croppedWidth}x${croppedHeight}`;
     this.logStatus_(CliStatuses.CROP, message);
 
@@ -922,6 +919,21 @@ class SeleniumApi {
    */
   async sleep_(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * @param {!CliStatus} status
+   * @param {!mdc.proto.UserAgent} userAgent
+   * @private
+   */
+  logSession_(status, userAgent) {
+    const navigator = userAgent.navigator;
+    const browser = CliColor.bold(`${navigator.browser_name} ${navigator.browser_version}`);
+    const os = `${navigator.os_name} ${navigator.os_version}`;
+    const sessionId = userAgent.selenium_session_id;
+    const publicCbtUrl = CliColor.underline(userAgent.selenium_result_url);
+
+    this.logStatus_(status, `${browser} on ${os}! - video: ${publicCbtUrl} (Selenium session ID: ${sessionId})`);
   }
 
   /**

--- a/test/screenshot/infra/proto/mdc.pb.js
+++ b/test/screenshot/infra/proto/mdc.pb.js
@@ -2575,6 +2575,8 @@ $root.mdc = (function() {
              * @property {selenium.proto.IRawCapabilities|null} [desired_capabilities] UserAgent desired_capabilities
              * @property {selenium.proto.IRawCapabilities|null} [actual_capabilities] UserAgent actual_capabilities
              * @property {mdc.proto.UserAgent.INavigator|null} [navigator] UserAgent navigator
+             * @property {string|null} [selenium_session_id] UserAgent selenium_session_id
+             * @property {string|null} [selenium_result_url] UserAgent selenium_result_url
              * @property {boolean|null} [is_enabled_by_cli] UserAgent is_enabled_by_cli
              * @property {boolean|null} [is_available_locally] UserAgent is_available_locally
              * @property {boolean|null} [is_runnable] UserAgent is_runnable
@@ -2703,6 +2705,22 @@ $root.mdc = (function() {
             UserAgent.prototype.navigator = null;
 
             /**
+             * UserAgent selenium_session_id.
+             * @member {string} selenium_session_id
+             * @memberof mdc.proto.UserAgent
+             * @instance
+             */
+            UserAgent.prototype.selenium_session_id = "";
+
+            /**
+             * UserAgent selenium_result_url.
+             * @member {string} selenium_result_url
+             * @memberof mdc.proto.UserAgent
+             * @instance
+             */
+            UserAgent.prototype.selenium_result_url = "";
+
+            /**
              * UserAgent is_enabled_by_cli.
              * @member {boolean} is_enabled_by_cli
              * @memberof mdc.proto.UserAgent
@@ -2812,6 +2830,10 @@ $root.mdc = (function() {
                     writer.uint32(/* id 18, wireType 2 =*/146).string(message.browser_icon_url);
                 if (message.os_icon_url != null && message.hasOwnProperty("os_icon_url"))
                     writer.uint32(/* id 19, wireType 2 =*/154).string(message.os_icon_url);
+                if (message.selenium_session_id != null && message.hasOwnProperty("selenium_session_id"))
+                    writer.uint32(/* id 20, wireType 2 =*/162).string(message.selenium_session_id);
+                if (message.selenium_result_url != null && message.hasOwnProperty("selenium_result_url"))
+                    writer.uint32(/* id 21, wireType 2 =*/170).string(message.selenium_result_url);
                 return writer;
             };
 
@@ -2884,6 +2906,12 @@ $root.mdc = (function() {
                         break;
                     case 13:
                         message.navigator = $root.mdc.proto.UserAgent.Navigator.decode(reader, reader.uint32());
+                        break;
+                    case 20:
+                        message.selenium_session_id = reader.string();
+                        break;
+                    case 21:
+                        message.selenium_result_url = reader.string();
                         break;
                     case 14:
                         message.is_enabled_by_cli = reader.bool();
@@ -3013,6 +3041,12 @@ $root.mdc = (function() {
                     if (error)
                         return "navigator." + error;
                 }
+                if (message.selenium_session_id != null && message.hasOwnProperty("selenium_session_id"))
+                    if (!$util.isString(message.selenium_session_id))
+                        return "selenium_session_id: string expected";
+                if (message.selenium_result_url != null && message.hasOwnProperty("selenium_result_url"))
+                    if (!$util.isString(message.selenium_result_url))
+                        return "selenium_result_url: string expected";
                 if (message.is_enabled_by_cli != null && message.hasOwnProperty("is_enabled_by_cli"))
                     if (typeof message.is_enabled_by_cli !== "boolean")
                         return "is_enabled_by_cli: boolean expected";
@@ -3153,6 +3187,10 @@ $root.mdc = (function() {
                         throw TypeError(".mdc.proto.UserAgent.navigator: object expected");
                     message.navigator = $root.mdc.proto.UserAgent.Navigator.fromObject(object.navigator);
                 }
+                if (object.selenium_session_id != null)
+                    message.selenium_session_id = String(object.selenium_session_id);
+                if (object.selenium_result_url != null)
+                    message.selenium_result_url = String(object.selenium_result_url);
                 if (object.is_enabled_by_cli != null)
                     message.is_enabled_by_cli = Boolean(object.is_enabled_by_cli);
                 if (object.is_available_locally != null)
@@ -3201,6 +3239,8 @@ $root.mdc = (function() {
                     object.image_filename_suffix = "";
                     object.browser_icon_url = "";
                     object.os_icon_url = "";
+                    object.selenium_session_id = "";
+                    object.selenium_result_url = "";
                 }
                 if (message.alias != null && message.hasOwnProperty("alias"))
                     object.alias = message.alias;
@@ -3240,6 +3280,10 @@ $root.mdc = (function() {
                     object.browser_icon_url = message.browser_icon_url;
                 if (message.os_icon_url != null && message.hasOwnProperty("os_icon_url"))
                     object.os_icon_url = message.os_icon_url;
+                if (message.selenium_session_id != null && message.hasOwnProperty("selenium_session_id"))
+                    object.selenium_session_id = message.selenium_session_id;
+                if (message.selenium_result_url != null && message.hasOwnProperty("selenium_result_url"))
+                    object.selenium_result_url = message.selenium_result_url;
                 return object;
             };
 

--- a/test/screenshot/infra/proto/mdc.proto
+++ b/test/screenshot/infra/proto/mdc.proto
@@ -173,6 +173,8 @@ message UserAgent {
   RawCapabilities desired_capabilities = 11;
   RawCapabilities actual_capabilities = 12;
   Navigator navigator = 13;
+  string selenium_session_id = 20;
+  string selenium_result_url = 21;
 
   bool is_enabled_by_cli = 14;
   bool is_available_locally = 15;


### PR DESCRIPTION
### What it does

When a CBT browser VM starts or terminates, we now print the browser's:
- Selenium session ID (e.g., `a149dd53-b1c6-4ea8-9fc5-9b68c1eefc89`)
- Public CBT result page URL (e.g., [Chrome 68 on Windows 10](https://app.crossbrowsertesting.com/public/ib956cb930a76197/selenium/13590389/))

In addition, the browser icons in the "Metadata" section of the [report page](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/15/21_24_46_592/report/report.html) now link to their corresponding CBT test result pages. The pages are public and contain a video capture of each test.

This makes it much easier to debug flaky tests and report errors to CBT.

### Example output

#### Test killed with <kbd>Ctrl</kbd>+<kbd>C</kbd>:

![image](https://user-images.githubusercontent.com/409245/44174597-71d41e00-a098-11e8-8895-fa18a0a3d288.png)
