### PR TITLE
docs: add a Need Help section to main Readme to add discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This will produce a Material Design ripple on the button!
 
 ## Need help?
 
-We're constantly trying to improve our components. If Github Issues doesn't fit your needs then please visit us on our [Discord Channel](https://discord.gg/material-components).
+We're constantly trying to improve our components. If Github Issues don't fit your needs, then please visit us on our [Discord Channel](https://discord.gg/material-components).
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This will produce a Material Design ripple on the button!
 - [Material.io](https://www.material.io) (external site)
 - [Material Design Guidelines](https://material.io/guidelines) (external site)
 
-## Need help
+## Need help?
 
 We're constantly trying to improve our components. If Github Issues doesn't fit your needs then please visit us on our [Discord Channel](https://discordapp.com/invite/material-components).
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This will produce a Material Design ripple on the button!
 
 ## Need help?
 
-We're constantly trying to improve our components. If Github Issues doesn't fit your needs then please visit us on our [Discord Channel](https://discordapp.com/invite/material-components).
+We're constantly trying to improve our components. If Github Issues doesn't fit your needs then please visit us on our [Discord Channel](https://discord.gg/material-components).
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ This will produce a Material Design ripple on the button!
 - [Material.io](https://www.material.io) (external site)
 - [Material Design Guidelines](https://material.io/guidelines) (external site)
 
+## Need help
+
+We're constantly trying to improve our components. If Github Issues doesn't fit your needs then please visit us on our [Discord Channel](https://discordapp.com/invite/material-components).
+
 ## Browser support
 
 We officially support the last two versions of every major browser. Specifically, we test on the following browsers:


### PR DESCRIPTION
We only have a `chat` badge to link to our discord channel. Just adding this section to increase visibility.