### PR TITLE
Add missing material-icons class to tab-bar example

### DIFF
--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -40,7 +40,7 @@ npm install @material/tab-bar
       <div class="mdc-tab-scroller__scroll-content">
         <button class="mdc-tab mdc-tab--active" role="tab" aria-selected="true" tabindex="0">
           <span class="mdc-tab__content">
-            <span class="mdc-tab__icon">heart</span>
+            <span class="mdc-tab__icon material-icons">heart</span>
             <span class="mdc-tab__text-label">Favorites</span>
           </span>
           <span class="mdc-tab-indicator mdc-tab-indicator--active">

--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -40,7 +40,7 @@ npm install @material/tab-bar
       <div class="mdc-tab-scroller__scroll-content">
         <button class="mdc-tab mdc-tab--active" role="tab" aria-selected="true" tabindex="0">
           <span class="mdc-tab__content">
-            <span class="mdc-tab__icon material-icons">heart</span>
+            <span class="mdc-tab__icon material-icons">favorite</span>
             <span class="mdc-tab__text-label">Favorites</span>
           </span>
           <span class="mdc-tab-indicator mdc-tab-indicator--active">


### PR DESCRIPTION
AFAICT the icon won't render w/o the `material-icons` class. /cc @filiph @Sfshaza