### PR TITLE
Add missing material-icons class to tab example

### DIFF
--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -36,7 +36,7 @@ npm install @material/tab
 ```html
 <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
   <span class="mdc-tab__content">
-    <span class="mdc-tab__icon material-icons">heart</span>
+    <span class="mdc-tab__icon material-icons">favorite</span>
     <span class="mdc-tab__text-label">Favorites</span>
   </span>
   <span class="mdc-tab-indicator">
@@ -71,7 +71,7 @@ const tab = new MDCTab(document.querySelector('.mdc-tab'));
 ```html
 <button class="mdc-tab mdc-tab--active" role="tab" aria-selected="true">
   <span class="mdc-tab__content">
-    <span class="mdc-tab__icon material-icons">heart</span>
+    <span class="mdc-tab__icon material-icons">favorite</span>
     <span class="mdc-tab__text-label">Favorites</span>
   </span>
   <span class="mdc-tab-indicator mdc-tab-indicator--active">

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -36,7 +36,7 @@ npm install @material/tab
 ```html
 <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
   <span class="mdc-tab__content">
-    <span class="mdc-tab__icon">heart</span>
+    <span class="mdc-tab__icon material-icons">heart</span>
     <span class="mdc-tab__text-label">Favorites</span>
   </span>
   <span class="mdc-tab-indicator">
@@ -71,7 +71,7 @@ const tab = new MDCTab(document.querySelector('.mdc-tab'));
 ```html
 <button class="mdc-tab mdc-tab--active" role="tab" aria-selected="true">
   <span class="mdc-tab__content">
-    <span class="mdc-tab__icon">heart</span>
+    <span class="mdc-tab__icon material-icons">heart</span>
     <span class="mdc-tab__text-label">Favorites</span>
   </span>
   <span class="mdc-tab-indicator mdc-tab-indicator--active">


### PR DESCRIPTION
AFAICT the icon won't render w/o the `material-icons` class. /cc @filiph @Sfshaza