### PR TITLE
fix(tab-bar): Move activateTab to adapter

### DIFF
--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -93,7 +93,7 @@ Mixin | Description
 
 Method Signature | Description
 --- | ---
-`setActiveTab(index: number) => void` | Sets the tab at the given index to be activated.
+`activateTab(index: number) => void` | Sets the tab at the given index to be activated.
 `scrollIntoView(index: number) => void` | Scrolls the tab at the given index into view.
 
 Event Name | Event Data Structure | Description
@@ -130,7 +130,7 @@ Method Signature | Description
 
 Method Signature | Description
 --- | ---
-`setActiveTab(index: number) => void` | Sets the tab at the given index to be activated.
+`activateTab(index: number) => void` | Sets the tab at the given index to be activated.
 `handleKeyDown(evt: Event) => void` | Handles the logic for the `"keydown"` event.
 `handleTabInteraction(evt: Event) => void` | Handles the logic for the `"MDCTab:interacted"` event.
 `scrollIntoView(index: number) => void` | Scrolls the Tab at the given index into view.

--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -114,7 +114,7 @@ Method Signature | Description
 `getScrollContentWidth() => number` | Returns the width of the Tab Scroller's scroll content element.
 `getOffsetWidth() => number` | Returns the offsetWidth of the root element.
 `isRTL() => boolean` | Returns if the text direction is RTL.
-`activateTabAtIndex(index: number) => void` | Activates the Tab at the given index.
+`activateTab(index: number) => void` | Activates the Tab at the given index.
 `activateTabAtIndex(index: number, clientRect: ClientRect) => void` | Activates the Tab at the given index with the given clientRect.
 `deactivateTabAtIndex(index) => void` | Deactivates the Tab at the given index.
 `focusTabAtIndex(index: number) => void` | Focuses the Tab at the given index.

--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -93,7 +93,7 @@ Mixin | Description
 
 Method Signature | Description
 --- | ---
-`activateTab(index: number) => void` | Sets the tab at the given index to be activated.
+`activateTab(index: number) => void` | Activates the tab at the given index.
 `scrollIntoView(index: number) => void` | Scrolls the tab at the given index into view.
 
 Event Name | Event Data Structure | Description
@@ -130,7 +130,7 @@ Method Signature | Description
 
 Method Signature | Description
 --- | ---
-`activateTab(index: number) => void` | Sets the tab at the given index to be activated.
+`activateTab(index: number) => void` | Activates the tab at the given index.
 `handleKeyDown(evt: Event) => void` | Handles the logic for the `"keydown"` event.
 `handleTabInteraction(evt: Event) => void` | Handles the logic for the `"MDCTab:interacted"` event.
 `scrollIntoView(index: number) => void` | Scrolls the Tab at the given index into view.

--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -93,7 +93,7 @@ Mixin | Description
 
 Method Signature | Description
 --- | ---
-`activateTab(index: number) => void` | Activates the tab at the given index.
+`setActiveTab(index: number) => void` | Sets the tab at the given index to be activated.
 `scrollIntoView(index: number) => void` | Scrolls the tab at the given index into view.
 
 Event Name | Event Data Structure | Description
@@ -114,7 +114,7 @@ Method Signature | Description
 `getScrollContentWidth() => number` | Returns the width of the Tab Scroller's scroll content element.
 `getOffsetWidth() => number` | Returns the offsetWidth of the root element.
 `isRTL() => boolean` | Returns if the text direction is RTL.
-`activateTab(index: number) => void` | Activates the Tab at the given index.
+`setActiveTab(index: number) => void` | Sets the tab at the given index to be activated.
 `activateTabAtIndex(index: number, clientRect: ClientRect) => void` | Activates the Tab at the given index with the given clientRect.
 `deactivateTabAtIndex(index) => void` | Deactivates the Tab at the given index.
 `focusTabAtIndex(index: number) => void` | Focuses the Tab at the given index.
@@ -130,7 +130,7 @@ Method Signature | Description
 
 Method Signature | Description
 --- | ---
-`activateTab(index: number) => void` | Activates the Tab at the given index.
+`setActiveTab(index: number) => void` | Sets the tab at the given index to be activated.
 `handleKeyDown(evt: Event) => void` | Handles the logic for the `"keydown"` event.
 `handleTabInteraction(evt: Event) => void` | Handles the logic for the `"MDCTab:interacted"` event.
 `scrollIntoView(index: number) => void` | Scrolls the Tab at the given index into view.

--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -114,6 +114,7 @@ Method Signature | Description
 `getScrollContentWidth() => number` | Returns the width of the Tab Scroller's scroll content element.
 `getOffsetWidth() => number` | Returns the offsetWidth of the root element.
 `isRTL() => boolean` | Returns if the text direction is RTL.
+`activateTabAtIndex(index: number) => void` | Activates the Tab at the given index.
 `activateTabAtIndex(index: number, clientRect: ClientRect) => void` | Activates the Tab at the given index with the given clientRect.
 `deactivateTabAtIndex(index) => void` | Deactivates the Tab at the given index.
 `focusTabAtIndex(index: number) => void` | Focuses the Tab at the given index.

--- a/packages/mdc-tab-bar/README.md
+++ b/packages/mdc-tab-bar/README.md
@@ -121,7 +121,7 @@ Method Signature | Description
 `getTabIndicatorClientRectAtIndex(index: number) => ClientRect` | Returns the client rect of the Tab at the given index.
 `getTabDimensionsAtIndex(index) => MDCTabDimensions` | Returns the dimensions of the Tab at the given index.
 `getTabListLength() => number` | Returns the number of child Tab components.
-`getActiveTabIndex() => number` | Returns the index of the active Tab.
+`getPreviousActiveTabIndex() => number` | Returns the index of the previously active Tab.
 `getFocusedTabIndex() => number` | Returns the index of the focused Tab.
 `getIndexOfTab(tab: MDCTab) => number` | Returns the index of the given Tab instance.
 `notifyTabActivated(index: number) => void` | Emits the `MDCTabBar:activated` event.

--- a/packages/mdc-tab-bar/adapter.js
+++ b/packages/mdc-tab-bar/adapter.js
@@ -121,10 +121,10 @@ class MDCTabBarAdapter {
   getTabListLength() {}
 
   /**
-   * Returns the index of the active tab
+   * Returns the index of the previously active tab
    * @return {number}
    */
-  getActiveTabIndex() {}
+  getPreviousActiveTabIndex() {}
 
   /**
    * Returns the index of the focused tab

--- a/packages/mdc-tab-bar/adapter.js
+++ b/packages/mdc-tab-bar/adapter.js
@@ -76,10 +76,10 @@ class MDCTabBarAdapter {
   isRTL() {}
 
   /**
-   * Activates the tab at the given index
+   * Sets the tab at the given index to be activated
    * @param {number} index The index of the tab to activate
    */
-  activateTab(index) {}
+  setActiveTab(index) {}
 
   /**
    * Activates the tab at the given index with the given client rect

--- a/packages/mdc-tab-bar/adapter.js
+++ b/packages/mdc-tab-bar/adapter.js
@@ -76,6 +76,12 @@ class MDCTabBarAdapter {
   isRTL() {}
 
   /**
+   * Activates the tab at the given index
+   * @param {number} index The index of the tab to activate
+   */
+  activateTab(index) {}
+
+  /**
    * Activates the tab at the given index with the given client rect
    * @param {number} index The index of the tab to activate
    * @param {!ClientRect} clientRect The client rect of the previously active Tab Indicator

--- a/packages/mdc-tab-bar/foundation.js
+++ b/packages/mdc-tab-bar/foundation.js
@@ -121,7 +121,7 @@ class MDCTabBarFoundation extends MDCFoundation {
   }
 
   /**
-   * Sets the tab at the given index to be activated
+   * Activates the tab at the given index
    * @param {number} index
    */
   activateTab(index) {

--- a/packages/mdc-tab-bar/foundation.js
+++ b/packages/mdc-tab-bar/foundation.js
@@ -81,13 +81,13 @@ class MDCTabBarFoundation extends MDCFoundation {
       getScrollContentWidth: () => {},
       getOffsetWidth: () => {},
       isRTL: () => {},
-      activateTab: () => {},
+      setActiveTab: () => {},
       activateTabAtIndex: () => {},
       deactivateTabAtIndex: () => {},
       focusTabAtIndex: () => {},
       getTabIndicatorClientRectAtIndex: () => {},
       getTabDimensionsAtIndex: () => {},
-      getActiveTabIndex: () => {},
+      getPreviousActiveTabIndex: () => {},
       getFocusedTabIndex: () => {},
       getIndexOfTab: () => {},
       getTabListLength: () => {},
@@ -106,7 +106,7 @@ class MDCTabBarFoundation extends MDCFoundation {
   }
 
   init() {
-    const activeIndex = this.adapter_.getActiveTabIndex();
+    const activeIndex = this.adapter_.getPreviousActiveTabIndex();
     this.scrollIntoView(activeIndex);
   }
 
@@ -123,8 +123,8 @@ class MDCTabBarFoundation extends MDCFoundation {
    * Activates the tab at the given index
    * @param {number} index
    */
-  activateTab(index) {
-    const previousActiveIndex = this.adapter_.getActiveTabIndex();
+  setActiveTab(index) {
+    const previousActiveIndex = this.adapter_.getPreviousActiveTabIndex();
     if (!this.indexIsInRange_(index)) {
       return;
     }
@@ -162,13 +162,13 @@ class MDCTabBarFoundation extends MDCFoundation {
         return;
       }
 
-      const index = this.determineTargetFromKey_(this.adapter_.getActiveTabIndex(), key);
-      this.adapter_.activateTab(index);
+      const index = this.determineTargetFromKey_(this.adapter_.getPreviousActiveTabIndex(), key);
+      this.adapter_.setActiveTab(index);
       this.scrollIntoView(index);
     } else {
       const focusedTabIndex = this.adapter_.getFocusedTabIndex();
       if (this.isActivationKey_(key)) {
-        this.adapter_.activateTab(focusedTabIndex);
+        this.adapter_.setActiveTab(focusedTabIndex);
       } else {
         const index = this.determineTargetFromKey_(focusedTabIndex, key);
         this.adapter_.focusTabAtIndex(index);
@@ -182,7 +182,7 @@ class MDCTabBarFoundation extends MDCFoundation {
    * @param {!Event} evt
    */
   handleTabInteraction(evt) {
-    this.adapter_.activateTab(this.adapter_.getIndexOfTab(evt.detail.tab));
+    this.adapter_.setActiveTab(this.adapter_.getIndexOfTab(evt.detail.tab));
   }
 
   /**

--- a/packages/mdc-tab-bar/foundation.js
+++ b/packages/mdc-tab-bar/foundation.js
@@ -106,6 +106,7 @@ class MDCTabBarFoundation extends MDCFoundation {
   }
 
   init() {
+    // Upon init, the active tab index is the same as the previous active tab index
     const activeIndex = this.adapter_.getPreviousActiveTabIndex();
     this.scrollIntoView(activeIndex);
   }
@@ -120,7 +121,7 @@ class MDCTabBarFoundation extends MDCFoundation {
   }
 
   /**
-   * Activates the tab at the given index
+   * Sets the tab at the given index to be activated
    * @param {number} index
    */
   setActiveTab(index) {

--- a/packages/mdc-tab-bar/foundation.js
+++ b/packages/mdc-tab-bar/foundation.js
@@ -27,7 +27,6 @@ import {strings, numbers} from './constants';
 import MDCTabBarAdapter from './adapter';
 
 /* eslint-disable no-unused-vars */
-import MDCTabFoundation from '@material/tab/foundation';
 import {MDCTabDimensions} from '@material/tab/adapter';
 /* eslint-enable no-unused-vars */
 
@@ -82,6 +81,7 @@ class MDCTabBarFoundation extends MDCFoundation {
       getScrollContentWidth: () => {},
       getOffsetWidth: () => {},
       isRTL: () => {},
+      activateTab: () => {},
       activateTabAtIndex: () => {},
       deactivateTabAtIndex: () => {},
       focusTabAtIndex: () => {},
@@ -163,12 +163,12 @@ class MDCTabBarFoundation extends MDCFoundation {
       }
 
       const index = this.determineTargetFromKey_(this.adapter_.getActiveTabIndex(), key);
-      this.activateTab(index);
+      this.adapter_.activateTab(index);
       this.scrollIntoView(index);
     } else {
       const focusedTabIndex = this.adapter_.getFocusedTabIndex();
       if (this.isActivationKey_(key)) {
-        this.activateTab(focusedTabIndex);
+        this.adapter_.activateTab(focusedTabIndex);
       } else {
         const index = this.determineTargetFromKey_(focusedTabIndex, key);
         this.adapter_.focusTabAtIndex(index);
@@ -182,7 +182,7 @@ class MDCTabBarFoundation extends MDCFoundation {
    * @param {!Event} evt
    */
   handleTabInteraction(evt) {
-    this.activateTab(this.adapter_.getIndexOfTab(evt.detail.tab));
+    this.adapter_.activateTab(this.adapter_.getIndexOfTab(evt.detail.tab));
   }
 
   /**

--- a/packages/mdc-tab-bar/foundation.js
+++ b/packages/mdc-tab-bar/foundation.js
@@ -124,7 +124,7 @@ class MDCTabBarFoundation extends MDCFoundation {
    * Sets the tab at the given index to be activated
    * @param {number} index
    */
-  setActiveTab(index) {
+  activateTab(index) {
     const previousActiveIndex = this.adapter_.getPreviousActiveTabIndex();
     if (!this.indexIsInRange_(index)) {
       return;

--- a/packages/mdc-tab-bar/foundation.js
+++ b/packages/mdc-tab-bar/foundation.js
@@ -105,12 +105,6 @@ class MDCTabBarFoundation extends MDCFoundation {
     this.useAutomaticActivation_ = false;
   }
 
-  init() {
-    // Upon init, the active tab index is the same as the previous active tab index
-    const activeIndex = this.adapter_.getPreviousActiveTabIndex();
-    this.scrollIntoView(activeIndex);
-  }
-
   /**
    * Switches between automatic and manual activation modes.
    * See https://www.w3.org/TR/wai-aria-practices/#tabpanel for examples.

--- a/packages/mdc-tab-bar/index.js
+++ b/packages/mdc-tab-bar/index.js
@@ -96,6 +96,13 @@ class MDCTabBar extends MDCComponent {
 
     this.root_.addEventListener(MDCTabFoundation.strings.INTERACTED_EVENT, this.handleTabInteraction_);
     this.root_.addEventListener('keydown', this.handleKeyDown_);
+
+    for (let i = 0; i < this.tabList_.length; i++) {
+      if (this.tabList_[i].active) {
+        this.scrollIntoView(i);
+        break;
+      }
+    }
   }
 
   destroy() {

--- a/packages/mdc-tab-bar/index.js
+++ b/packages/mdc-tab-bar/index.js
@@ -145,7 +145,7 @@ class MDCTabBar extends MDCComponent {
   }
 
   /**
-   * Sets the tab at the given index to be activated
+   * Activates the tab at the given index
    * @param {number} index The index of the tab
    */
   activateTab(index) {

--- a/packages/mdc-tab-bar/index.js
+++ b/packages/mdc-tab-bar/index.js
@@ -118,6 +118,7 @@ class MDCTabBar extends MDCComponent {
         getScrollContentWidth: () => this.tabScroller_.getScrollContentWidth(),
         getOffsetWidth: () => this.root_.offsetWidth,
         isRTL: () => window.getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
+        activateTab: (index) => this.foundation_.activateTab(index),
         activateTabAtIndex: (index, clientRect) => this.tabList_[index].activate(clientRect),
         deactivateTabAtIndex: (index) => this.tabList_[index].deactivate(),
         focusTabAtIndex: (index) => this.tabList_[index].focus(),

--- a/packages/mdc-tab-bar/index.js
+++ b/packages/mdc-tab-bar/index.js
@@ -118,7 +118,7 @@ class MDCTabBar extends MDCComponent {
         getScrollContentWidth: () => this.tabScroller_.getScrollContentWidth(),
         getOffsetWidth: () => this.root_.offsetWidth,
         isRTL: () => window.getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
-        setActiveTab: (index) => this.foundation_.setActiveTab(index),
+        setActiveTab: (index) => this.foundation_.activateTab(index),
         activateTabAtIndex: (index, clientRect) => this.tabList_[index].activate(clientRect),
         deactivateTabAtIndex: (index) => this.tabList_[index].deactivate(),
         focusTabAtIndex: (index) => this.tabList_[index].focus(),
@@ -148,8 +148,8 @@ class MDCTabBar extends MDCComponent {
    * Sets the tab at the given index to be activated
    * @param {number} index The index of the tab
    */
-  setActiveTab(index) {
-    this.foundation_.setActiveTab(index);
+  activateTab(index) {
+    this.foundation_.activateTab(index);
   }
 
   /**

--- a/packages/mdc-tab-bar/index.js
+++ b/packages/mdc-tab-bar/index.js
@@ -145,7 +145,7 @@ class MDCTabBar extends MDCComponent {
   }
 
   /**
-   * Activates the tab at the given index
+   * Sets the tab at the given index to be activated
    * @param {number} index The index of the tab
    */
   setActiveTab(index) {

--- a/packages/mdc-tab-bar/index.js
+++ b/packages/mdc-tab-bar/index.js
@@ -118,13 +118,13 @@ class MDCTabBar extends MDCComponent {
         getScrollContentWidth: () => this.tabScroller_.getScrollContentWidth(),
         getOffsetWidth: () => this.root_.offsetWidth,
         isRTL: () => window.getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
-        activateTab: (index) => this.foundation_.activateTab(index),
+        setActiveTab: (index) => this.foundation_.setActiveTab(index),
         activateTabAtIndex: (index, clientRect) => this.tabList_[index].activate(clientRect),
         deactivateTabAtIndex: (index) => this.tabList_[index].deactivate(),
         focusTabAtIndex: (index) => this.tabList_[index].focus(),
         getTabIndicatorClientRectAtIndex: (index) => this.tabList_[index].computeIndicatorClientRect(),
         getTabDimensionsAtIndex: (index) => this.tabList_[index].computeDimensions(),
-        getActiveTabIndex: () => {
+        getPreviousActiveTabIndex: () => {
           for (let i = 0; i < this.tabList_.length; i++) {
             if (this.tabList_[i].active) {
               return i;
@@ -148,8 +148,8 @@ class MDCTabBar extends MDCComponent {
    * Activates the tab at the given index
    * @param {number} index The index of the tab
    */
-  activateTab(index) {
-    this.foundation_.activateTab(index);
+  setActiveTab(index) {
+    this.foundation_.setActiveTab(index);
   }
 
   /**

--- a/packages/mdc-tab/README.md
+++ b/packages/mdc-tab/README.md
@@ -36,7 +36,7 @@ npm install @material/tab
 ```html
 <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
   <span class="mdc-tab__content">
-    <span class="mdc-tab__icon">heart</span>
+    <span class="mdc-tab__icon material-icons">favorite</span>
     <span class="mdc-tab__text-label">Favorites</span>
   </span>
   <span class="mdc-tab-indicator">
@@ -71,7 +71,7 @@ const tab = new MDCTab(document.querySelector('.mdc-tab'));
 ```html
 <button class="mdc-tab mdc-tab--active" role="tab" aria-selected="true">
   <span class="mdc-tab__content">
-    <span class="mdc-tab__icon">heart</span>
+    <span class="mdc-tab__icon material-icons">favorite</span>
     <span class="mdc-tab__text-label">Favorites</span>
   </span>
   <span class="mdc-tab-indicator mdc-tab-indicator--active">

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -360,7 +360,7 @@ test('#activateTab() does nothing if the index underflows the tab list', () => {
 
 test('#activateTab() does nothing if the index is the same as the previous active index', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(0);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(0);
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   foundation.activateTab(0);
   td.verify(mockAdapter.deactivateTabAtIndex(td.matchers.isA(Number)), {times: 0});

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -416,7 +416,7 @@ function setupScrollIntoViewTest({
   scrollPosition = 0,
   offsetWidth = 400,
   tabDimensionsMap = {}
-}) {
+} = {}) {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.getActiveTabIndex()).thenReturn(activeIndex);
   td.when(mockAdapter.getTabListLength()).thenReturn(tabListLength);

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -45,7 +45,7 @@ test('exports numbers', () => {
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTabBarFoundation, [
     'scrollTo', 'incrementScroll', 'getScrollPosition', 'getScrollContentWidth',
-    'getOffsetWidth', 'isRTL', 'activateTab',
+    'getOffsetWidth', 'isRTL', 'setActiveTab',
     'activateTabAtIndex', 'deactivateTabAtIndex', 'focusTabAtIndex',
     'getTabIndicatorClientRectAtIndex', 'getTabDimensionsAtIndex',
     'getPreviousActiveTabIndex', 'getFocusedTabIndex', 'getIndexOfTab', 'getTabListLength',

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -45,7 +45,7 @@ test('exports numbers', () => {
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCTabBarFoundation, [
     'scrollTo', 'incrementScroll', 'getScrollPosition', 'getScrollContentWidth',
-    'getOffsetWidth', 'isRTL',
+    'getOffsetWidth', 'isRTL', 'activateTab',
     'activateTabAtIndex', 'deactivateTabAtIndex', 'focusTabAtIndex',
     'getTabIndicatorClientRectAtIndex', 'getTabDimensionsAtIndex',
     'getActiveTabIndex', 'getFocusedTabIndex', 'getIndexOfTab', 'getTabListLength',
@@ -65,11 +65,10 @@ test('#init() scrolls the active tab into view', () => {
 
 const setupKeyDownTest = () => {
   const {foundation, mockAdapter} = setupTest();
-  const activateTab = td.function();
   foundation.setUseAutomaticActivation(false);
   foundation.scrollIntoView = td.function(); // Avoid errors due to adapters being stubs
-  foundation.activateTab = activateTab;
-  return {activateTab, foundation, mockAdapter};
+  foundation.activateTab = td.function();
+  return {foundation, mockAdapter};
 };
 
 const mockKeyDownEvent = ({key, keyCode}) => {
@@ -84,9 +83,9 @@ const mockKeyDownEvent = ({key, keyCode}) => {
 };
 
 test('#handleTabInteraction() activates the tab', () => {
-  const {foundation, activateTab} = setupKeyDownTest();
+  const {foundation, mockAdapter} = setupKeyDownTest();
   foundation.handleTabInteraction({detail: {}});
-  td.verify(activateTab(td.matchers.anything()), {times: 1});
+  td.verify(mockAdapter.activateTab(td.matchers.anything()), {times: 1});
 });
 
 test('#handleKeyDown() focuses the tab at the 0th index on home key press', () => {
@@ -209,7 +208,7 @@ test('#handleKeyDown() focuses the tab at the 0th index when the left arrow key 
 });
 
 test('#handleKeyDown() activates the current focused tab on space/enter press w/o useAutomaticActivation', () => {
-  const {foundation, mockAdapter, activateTab} = setupKeyDownTest();
+  const {foundation, mockAdapter} = setupKeyDownTest();
   const index = 2;
   td.when(mockAdapter.getFocusedTabIndex()).thenReturn(index);
   foundation.handleKeyDown(mockKeyDownEvent({key: MDCTabBarFoundation.strings.SPACE_KEY}).fakeEvent);
@@ -217,33 +216,33 @@ test('#handleKeyDown() activates the current focused tab on space/enter press w/
   foundation.handleKeyDown(mockKeyDownEvent({key: MDCTabBarFoundation.strings.ENTER_KEY}).fakeEvent);
   foundation.handleKeyDown(mockKeyDownEvent({keyCode: 13}).fakeEvent);
 
-  td.verify(activateTab(index), {times: 4});
+  td.verify(mockAdapter.activateTab(index), {times: 4});
 });
 
 test('#handleKeyDown() does nothing on space/enter press w/ useAutomaticActivation', () => {
-  const {foundation, activateTab} = setupKeyDownTest();
+  const {foundation, mockAdapter} = setupKeyDownTest();
   foundation.setUseAutomaticActivation(true);
   foundation.handleKeyDown(mockKeyDownEvent({key: MDCTabBarFoundation.strings.SPACE_KEY}).fakeEvent);
   foundation.handleKeyDown(mockKeyDownEvent({keyCode: 32}).fakeEvent);
   foundation.handleKeyDown(mockKeyDownEvent({key: MDCTabBarFoundation.strings.ENTER_KEY}).fakeEvent);
   foundation.handleKeyDown(mockKeyDownEvent({keyCode: 13}).fakeEvent);
 
-  td.verify(activateTab(td.matchers.anything()), {times: 0});
+  td.verify(mockAdapter.activateTab(td.matchers.anything()), {times: 0});
 });
 
 test('#handleKeyDown() activates the tab at the 0th index on home key press w/ useAutomaticActivation', () => {
-  const {foundation, activateTab} = setupKeyDownTest();
+  const {foundation, mockAdapter} = setupKeyDownTest();
   const {fakeEvent: fakeKeyEvent} = mockKeyDownEvent({key: MDCTabBarFoundation.strings.HOME_KEY});
   const {fakeEvent: fakeKeyCodeEvent} = mockKeyDownEvent({keyCode: 36});
   foundation.setUseAutomaticActivation(true);
 
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(activateTab(0), {times: 2});
+  td.verify(mockAdapter.activateTab(0), {times: 2});
 });
 
 test('#handleKeyDown() activates the tab at the N - 1 index on end key press w/ useAutomaticActivation', () => {
-  const {foundation, mockAdapter, activateTab} = setupKeyDownTest();
+  const {foundation, mockAdapter} = setupKeyDownTest();
   const {fakeEvent: fakeKeyEvent} = mockKeyDownEvent({key: MDCTabBarFoundation.strings.END_KEY});
   const {fakeEvent: fakeKeyCodeEvent} = mockKeyDownEvent({keyCode: 35});
   foundation.setUseAutomaticActivation(true);
@@ -251,11 +250,11 @@ test('#handleKeyDown() activates the tab at the N - 1 index on end key press w/ 
 
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(activateTab(12), {times: 2});
+  td.verify(mockAdapter.activateTab(12), {times: 2});
 });
 
 test('#handleKeyDown() activates the tab at the previous index on left arrow press w/ useAutomaticActivation', () => {
-  const {foundation, mockAdapter, activateTab} = setupKeyDownTest();
+  const {foundation, mockAdapter} = setupKeyDownTest();
   const {fakeEvent: fakeKeyEvent} = mockKeyDownEvent({key: MDCTabBarFoundation.strings.ARROW_LEFT_KEY});
   const {fakeEvent: fakeKeyCodeEvent} = mockKeyDownEvent({keyCode: 37});
   foundation.setUseAutomaticActivation(true);
@@ -264,7 +263,7 @@ test('#handleKeyDown() activates the tab at the previous index on left arrow pre
 
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(activateTab(1), {times: 2});
+  td.verify(mockAdapter.activateTab(1), {times: 2});
 });
 
 test('#handleKeyDown() prevents the default behavior for handled non-activation keys', () => {
@@ -328,12 +327,12 @@ test('#handleKeyDown() does not prevent the default behavior for unhandled keyCo
 });
 
 test('#handleKeyDown() does not activate a tab when an unhandled key is pressed', () => {
-  const {foundation, activateTab} = setupKeyDownTest();
+  const {foundation, mockAdapter} = setupKeyDownTest();
   const {fakeEvent: fakeKeyEvent} = mockKeyDownEvent({key: 'Shift'});
   const {fakeEvent: fakeKeyCodeEvent} = mockKeyDownEvent({keyCode: 16});
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(activateTab(), {times: 0});
+  td.verify(mockAdapter.activateTab(), {times: 0});
 });
 
 const setupActivateTabTest = () => {
@@ -416,7 +415,8 @@ function setupScrollIntoViewTest({
   scrollContentWidth = 1000,
   scrollPosition = 0,
   offsetWidth = 400,
-  tabDimensionsMap = {}} = {}) {
+  tabDimensionsMap = {}
+}) {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.getActiveTabIndex()).thenReturn(activeIndex);
   td.when(mockAdapter.getTabListLength()).thenReturn(tabListLength);

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -342,69 +342,69 @@ const setupActivateTabTest = () => {
   return {foundation, mockAdapter, scrollIntoView};
 };
 
-test('#setActiveTab() does nothing if the index overflows the tab list', () => {
+test('#activateTab() does nothing if the index overflows the tab list', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  foundation.setActiveTab(13);
+  foundation.activateTab(13);
   td.verify(mockAdapter.deactivateTabAtIndex(td.matchers.isA(Number)), {times: 0});
   td.verify(mockAdapter.activateTabAtIndex(td.matchers.isA(Number)), {times: 0});
 });
 
-test('#setActiveTab() does nothing if the index underflows the tab list', () => {
+test('#activateTab() does nothing if the index underflows the tab list', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  foundation.setActiveTab(-1);
+  foundation.activateTab(-1);
   td.verify(mockAdapter.deactivateTabAtIndex(td.matchers.isA(Number)), {times: 0});
   td.verify(mockAdapter.activateTabAtIndex(td.matchers.isA(Number)), {times: 0});
 });
 
-test(`#setActiveTab() does not emit the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} event if the index` +
+test(`#activateTab() does not emit the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} event if the index` +
   ' is the currently active index', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
-  foundation.setActiveTab(6);
+  foundation.activateTab(6);
   td.verify(mockAdapter.notifyTabActivated(td.matchers.anything()), {times: 0});
 });
 
-test('#setActiveTab() deactivates the previously active tab', () => {
+test('#activateTab() deactivates the previously active tab', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
-  foundation.setActiveTab(1);
+  foundation.activateTab(1);
   td.verify(mockAdapter.deactivateTabAtIndex(6), {times: 1});
 });
 
-test('#setActiveTab() activates the newly active tab with the previously active tab\'s indicatorClientRect', () => {
+test('#activateTab() activates the newly active tab with the previously active tab\'s indicatorClientRect', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
-  foundation.setActiveTab(1);
+  foundation.activateTab(1);
   td.verify(mockAdapter.activateTabAtIndex(1, {left: 22, right: 33}), {times: 1});
 });
 
-test('#setActiveTab() scrolls the new tab index into view', () => {
+test('#activateTab() scrolls the new tab index into view', () => {
   const {foundation, mockAdapter, scrollIntoView} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
-  foundation.setActiveTab(1);
+  foundation.activateTab(1);
   td.verify(scrollIntoView(1));
 });
 
-test(`#setActiveTab() emits the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} with the index of the tab`, () => {
+test(`#activateTab() emits the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} with the index of the tab`, () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
-  foundation.setActiveTab(1);
+  foundation.activateTab(1);
   td.verify(mockAdapter.notifyTabActivated(1));
 });
 

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -55,14 +55,6 @@ test('defaultAdapter returns a complete adapter implementation', () => {
 
 const setupTest = () => setupFoundationTest(MDCTabBarFoundation);
 
-test('#init() scrolls the active tab into view', () => {
-  const {foundation, mockAdapter} = setupTest();
-  foundation.scrollIntoView = td.function();
-  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(99);
-  foundation.init();
-  td.verify(foundation.scrollIntoView(99), {times: 1});
-});
-
 const setupKeyDownTest = () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.setUseAutomaticActivation(false);

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -85,7 +85,7 @@ const mockKeyDownEvent = ({key, keyCode}) => {
 test('#handleTabInteraction() activates the tab', () => {
   const {foundation, mockAdapter} = setupKeyDownTest();
   foundation.handleTabInteraction({detail: {}});
-  td.verify(mockAdapter.activateTab(td.matchers.anything()), {times: 1});
+  td.verify(mockAdapter.setActiveTab(td.matchers.anything()), {times: 1});
 });
 
 test('#handleKeyDown() focuses the tab at the 0th index on home key press', () => {
@@ -216,7 +216,7 @@ test('#handleKeyDown() activates the current focused tab on space/enter press w/
   foundation.handleKeyDown(mockKeyDownEvent({key: MDCTabBarFoundation.strings.ENTER_KEY}).fakeEvent);
   foundation.handleKeyDown(mockKeyDownEvent({keyCode: 13}).fakeEvent);
 
-  td.verify(mockAdapter.activateTab(index), {times: 4});
+  td.verify(mockAdapter.setActiveTab(index), {times: 4});
 });
 
 test('#handleKeyDown() does nothing on space/enter press w/ useAutomaticActivation', () => {
@@ -227,7 +227,7 @@ test('#handleKeyDown() does nothing on space/enter press w/ useAutomaticActivati
   foundation.handleKeyDown(mockKeyDownEvent({key: MDCTabBarFoundation.strings.ENTER_KEY}).fakeEvent);
   foundation.handleKeyDown(mockKeyDownEvent({keyCode: 13}).fakeEvent);
 
-  td.verify(mockAdapter.activateTab(td.matchers.anything()), {times: 0});
+  td.verify(mockAdapter.setActiveTab(td.matchers.anything()), {times: 0});
 });
 
 test('#handleKeyDown() activates the tab at the 0th index on home key press w/ useAutomaticActivation', () => {
@@ -238,7 +238,7 @@ test('#handleKeyDown() activates the tab at the 0th index on home key press w/ u
 
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(mockAdapter.activateTab(0), {times: 2});
+  td.verify(mockAdapter.setActiveTab(0), {times: 2});
 });
 
 test('#handleKeyDown() activates the tab at the N - 1 index on end key press w/ useAutomaticActivation', () => {
@@ -250,7 +250,7 @@ test('#handleKeyDown() activates the tab at the N - 1 index on end key press w/ 
 
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(mockAdapter.activateTab(12), {times: 2});
+  td.verify(mockAdapter.setActiveTab(12), {times: 2});
 });
 
 test('#handleKeyDown() activates the tab at the previous index on left arrow press w/ useAutomaticActivation', () => {
@@ -263,7 +263,7 @@ test('#handleKeyDown() activates the tab at the previous index on left arrow pre
 
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(mockAdapter.activateTab(1), {times: 2});
+  td.verify(mockAdapter.setActiveTab(1), {times: 2});
 });
 
 test('#handleKeyDown() prevents the default behavior for handled non-activation keys', () => {
@@ -332,7 +332,7 @@ test('#handleKeyDown() does not activate a tab when an unhandled key is pressed'
   const {fakeEvent: fakeKeyCodeEvent} = mockKeyDownEvent({keyCode: 16});
   foundation.handleKeyDown(fakeKeyEvent);
   foundation.handleKeyDown(fakeKeyCodeEvent);
-  td.verify(mockAdapter.activateTab(), {times: 0});
+  td.verify(mockAdapter.setActiveTab(), {times: 0});
 });
 
 const setupActivateTabTest = () => {
@@ -342,69 +342,69 @@ const setupActivateTabTest = () => {
   return {foundation, mockAdapter, scrollIntoView};
 };
 
-test('#activateTab() does nothing if the index overflows the tab list', () => {
+test('#setActiveTab() does nothing if the index overflows the tab list', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  foundation.activateTab(13);
+  foundation.setActiveTab(13);
   td.verify(mockAdapter.deactivateTabAtIndex(td.matchers.isA(Number)), {times: 0});
   td.verify(mockAdapter.activateTabAtIndex(td.matchers.isA(Number)), {times: 0});
 });
 
-test('#activateTab() does nothing if the index underflows the tab list', () => {
+test('#setActiveTab() does nothing if the index underflows the tab list', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  foundation.activateTab(-1);
+  foundation.setActiveTab(-1);
   td.verify(mockAdapter.deactivateTabAtIndex(td.matchers.isA(Number)), {times: 0});
   td.verify(mockAdapter.activateTabAtIndex(td.matchers.isA(Number)), {times: 0});
 });
 
-test(`#activateTab() does not emit the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} event if the index` +
+test(`#setActiveTab() does not emit the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} event if the index` +
   ' is the currently active index', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
-  foundation.activateTab(6);
+  foundation.setActiveTab(6);
   td.verify(mockAdapter.notifyTabActivated(td.matchers.anything()), {times: 0});
 });
 
-test('#activateTab() deactivates the previously active tab', () => {
+test('#setActiveTab() deactivates the previously active tab', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
-  foundation.activateTab(1);
+  foundation.setActiveTab(1);
   td.verify(mockAdapter.deactivateTabAtIndex(6), {times: 1});
 });
 
-test('#activateTab() activates the newly active tab with the previously active tab\'s indicatorClientRect', () => {
+test('#setActiveTab() activates the newly active tab with the previously active tab\'s indicatorClientRect', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
-  foundation.activateTab(1);
+  foundation.setActiveTab(1);
   td.verify(mockAdapter.activateTabAtIndex(1, {left: 22, right: 33}), {times: 1});
 });
 
-test('#activateTab() scrolls the new tab index into view', () => {
+test('#setActiveTab() scrolls the new tab index into view', () => {
   const {foundation, mockAdapter, scrollIntoView} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
-  foundation.activateTab(1);
+  foundation.setActiveTab(1);
   td.verify(scrollIntoView(1));
 });
 
-test(`#activateTab() emits the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} with the index of the tab`, () => {
+test(`#setActiveTab() emits the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} with the index of the tab`, () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
-  foundation.activateTab(1);
+  foundation.setActiveTab(1);
   td.verify(mockAdapter.notifyTabActivated(1));
 });
 

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -48,7 +48,7 @@ test('defaultAdapter returns a complete adapter implementation', () => {
     'getOffsetWidth', 'isRTL', 'activateTab',
     'activateTabAtIndex', 'deactivateTabAtIndex', 'focusTabAtIndex',
     'getTabIndicatorClientRectAtIndex', 'getTabDimensionsAtIndex',
-    'getActiveTabIndex', 'getFocusedTabIndex', 'getIndexOfTab', 'getTabListLength',
+    'getPreviousActiveTabIndex', 'getFocusedTabIndex', 'getIndexOfTab', 'getTabListLength',
     'notifyTabActivated',
   ]);
 });
@@ -58,7 +58,7 @@ const setupTest = () => setupFoundationTest(MDCTabBarFoundation);
 test('#init() scrolls the active tab into view', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.scrollIntoView = td.function();
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(99);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(99);
   foundation.init();
   td.verify(foundation.scrollIntoView(99), {times: 1});
 });
@@ -258,7 +258,7 @@ test('#handleKeyDown() activates the tab at the previous index on left arrow pre
   const {fakeEvent: fakeKeyEvent} = mockKeyDownEvent({key: MDCTabBarFoundation.strings.ARROW_LEFT_KEY});
   const {fakeEvent: fakeKeyCodeEvent} = mockKeyDownEvent({keyCode: 37});
   foundation.setUseAutomaticActivation(true);
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(2);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(2);
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
 
   foundation.handleKeyDown(fakeKeyEvent);
@@ -362,7 +362,7 @@ test(`#activateTab() does not emit the ${MDCTabBarFoundation.strings.TAB_ACTIVAT
   ' is the currently active index', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(6);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   foundation.activateTab(6);
   td.verify(mockAdapter.notifyTabActivated(td.matchers.anything()), {times: 0});
 });
@@ -370,7 +370,7 @@ test(`#activateTab() does not emit the ${MDCTabBarFoundation.strings.TAB_ACTIVAT
 test('#activateTab() deactivates the previously active tab', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(6);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   foundation.activateTab(1);
   td.verify(mockAdapter.deactivateTabAtIndex(6), {times: 1});
 });
@@ -378,7 +378,7 @@ test('#activateTab() deactivates the previously active tab', () => {
 test('#activateTab() activates the newly active tab with the previously active tab\'s indicatorClientRect', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(6);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
@@ -389,7 +389,7 @@ test('#activateTab() activates the newly active tab with the previously active t
 test('#activateTab() scrolls the new tab index into view', () => {
   const {foundation, mockAdapter, scrollIntoView} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(6);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
@@ -400,7 +400,7 @@ test('#activateTab() scrolls the new tab index into view', () => {
 test(`#activateTab() emits the ${MDCTabBarFoundation.strings.TAB_ACTIVATED_EVENT} with the index of the tab`, () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(6);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(6);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(6)).thenReturn({
     left: 22, right: 33,
   });
@@ -415,10 +415,10 @@ function setupScrollIntoViewTest({
   scrollContentWidth = 1000,
   scrollPosition = 0,
   offsetWidth = 400,
-  tabDimensionsMap = {}
+  tabDimensionsMap = {},
 } = {}) {
   const {foundation, mockAdapter} = setupTest();
-  td.when(mockAdapter.getActiveTabIndex()).thenReturn(activeIndex);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(activeIndex);
   td.when(mockAdapter.getTabListLength()).thenReturn(tabListLength);
   td.when(mockAdapter.getTabIndicatorClientRectAtIndex(td.matchers.isA(Number))).thenReturn(indicatorClientRect);
   td.when(mockAdapter.getScrollPosition()).thenReturn(scrollPosition);

--- a/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
+++ b/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
@@ -171,10 +171,10 @@ test('#adapter.getTabDimensionsAtIndex calls computeDimensions on the tab at the
   td.verify(component.tabList_[0].computeDimensions(), {times: 1});
 });
 
-test('#adapter.getActiveTabIndex returns the index of the active tab', () => {
+test('#adapter.getPreviousActiveTabIndex returns the index of the active tab', () => {
   const {component} = setupTest();
   component.tabList_[1].active = true;
-  assert.strictEqual(component.getDefaultFoundation().adapter_.getActiveTabIndex(), 1);
+  assert.strictEqual(component.getDefaultFoundation().adapter_.getPreviousActiveTabIndex(), 1);
 });
 
 test('#adapter.getIndexOfTab returns the index of the given tab', () => {

--- a/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
+++ b/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
@@ -205,7 +205,7 @@ function setupMockFoundationTest(root = getFixture()) {
 
 test('#activateTab calls activateTab', () => {
   const {component, mockFoundation} = setupMockFoundationTest();
-  component.setActiveTab(1);
+  component.activateTab(1);
   td.verify(mockFoundation.setActiveTab(1), {times: 1});
 });
 

--- a/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
+++ b/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
@@ -147,12 +147,6 @@ test('#adapter.isRTL returns the RTL state of the root element', () => {
   document.body.removeAttribute('dir');
 });
 
-test('#adapter.activateTab calls foundation.activateTab', () => {
-  const {component} = setupTest();
-  component.getDefaultFoundation().adapter_.activateTab(2);
-  td.verify(component.getDefaultFoundation().activateTab(2), {times: 1});
-});
-
 test('#adapter.activateTabAtIndex calls activate on the tab at the index', () => {
   const {component} = setupTest();
   component.getDefaultFoundation().adapter_.activateTabAtIndex(2, {});

--- a/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
+++ b/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
@@ -205,8 +205,8 @@ function setupMockFoundationTest(root = getFixture()) {
 
 test('#activateTab calls activateTab', () => {
   const {component, mockFoundation} = setupMockFoundationTest();
-  component.activateTab(1);
-  td.verify(mockFoundation.activateTab(1), {times: 1});
+  component.setActiveTab(1);
+  td.verify(mockFoundation.setActiveTab(1), {times: 1});
 });
 
 test('#scrollIntoView calls scrollIntoView', () => {

--- a/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
+++ b/test/unit/mdc-tab-bar/mdc-tab-bar.test.js
@@ -147,6 +147,12 @@ test('#adapter.isRTL returns the RTL state of the root element', () => {
   document.body.removeAttribute('dir');
 });
 
+test('#adapter.activateTab calls foundation.activateTab', () => {
+  const {component} = setupTest();
+  component.getDefaultFoundation().adapter_.activateTab(2);
+  td.verify(component.getDefaultFoundation().activateTab(2), {times: 1});
+});
+
 test('#adapter.activateTabAtIndex calls activate on the tab at the index', () => {
   const {component} = setupTest();
   component.getDefaultFoundation().adapter_.activateTabAtIndex(2, {});


### PR DESCRIPTION
Move the job of calling `activateTab` into an adapter method instead of directly in the foundation's handler methods. In the React wrapper, handler methods should only update props. `activateTab` will then be called in the `componentDidUpdate` lifecycle method. 

Also rename `getActiveTabIndex` to `getPreviousActiveTabIndex` to disambiguate. React wrapper stores the previous active index in state and returns it in this adapter method.