### PR TITLE
chore(list): Remove dead code

### DIFF
--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -292,7 +292,6 @@ Method Signature | Description
 `addClassForElementIndex(index: Number, className: String) => void` | Adds the `className` class to the list item at `index`.
 `removeClassForElementIndex(index: Number, className: String) => void` | Removes the `className` class to the list item at `index`.
 `focusItemAtIndex(index: Number) => void` | Focuses the list item at the `index` value specified.
-`isElementFocusable(ele: Element) => boolean` | Returns true if `ele` contains a focusable child element.
 `setTabIndexForListItemChildren(index: Number, value: Number) => void` | Sets the `tabindex` attribute to `value` for each child `button` and `a` element in the list item at the `index` specified.
 
 ### `MDCListFoundation`

--- a/packages/mdc-list/adapter.js
+++ b/packages/mdc-list/adapter.js
@@ -79,12 +79,6 @@ class MDCListAdapter {
   focusItemAtIndex(index) {}
 
   /**
-   * Checks if the provided element is a focusable sub-element.
-   * @param {Element} ele
-   */
-  isElementFocusable(ele) {}
-
-  /**
    * Checks if the provided element is contains the mdc-list-item class.
    * @param {Element} ele
    */

--- a/packages/mdc-list/foundation.js
+++ b/packages/mdc-list/foundation.js
@@ -53,7 +53,6 @@ class MDCListFoundation extends MDCFoundation {
       addClassForElementIndex: () => {},
       removeClassForElementIndex: () => {},
       focusItemAtIndex: () => {},
-      isElementFocusable: () => {},
       isListItem: () => {},
       setTabIndexForListItemChildren: () => {},
     });

--- a/packages/mdc-list/index.js
+++ b/packages/mdc-list/index.js
@@ -168,14 +168,6 @@ class MDCList extends MDCComponent {
           element.focus();
         }
       },
-      isElementFocusable: (ele) => {
-        if (!ele) return false;
-        let matches = Element.prototype.matches;
-        if (!matches) { // IE uses a different name for the same functionality
-          matches = Element.prototype.msMatchesSelector;
-        }
-        return matches.call(ele, strings.FOCUSABLE_CHILD_ELEMENTS);
-      },
       setTabIndexForListItemChildren: (listItemIndex, tabIndexValue) => {
         const element = this.listElements_[listItemIndex];
         const listItemChildren = [].slice.call(element.querySelectorAll(strings.FOCUSABLE_CHILD_ELEMENTS));

--- a/test/unit/mdc-list/foundation.test.js
+++ b/test/unit/mdc-list/foundation.test.js
@@ -44,7 +44,7 @@ test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCListFoundation, [
     'getListItemCount', 'getFocusedElementIndex', 'getListItemIndex', 'setAttributeForElementIndex',
     'removeAttributeForElementIndex', 'addClassForElementIndex', 'removeClassForElementIndex',
-    'focusItemAtIndex', 'isElementFocusable', 'isListItem', 'setTabIndexForListItemChildren',
+    'focusItemAtIndex', 'isListItem', 'setTabIndexForListItemChildren',
   ]);
 });
 
@@ -597,7 +597,6 @@ test('#handleClick when singleSelection=true on a button subelement should not c
     const event = {target, preventDefault};
 
     td.when(mockAdapter.getFocusedElementIndex()).thenReturn(-1);
-    td.when(mockAdapter.isElementFocusable(td.matchers.anything())).thenReturn(true);
     td.when(mockAdapter.getListItemIndex(td.matchers.anything())).thenReturn(1);
     td.when(mockAdapter.isListItem(td.matchers.anything())).thenReturn(false);
     foundation.setSingleSelection(true);
@@ -614,7 +613,6 @@ test('#handleClick when singleSelection=true on an element not in a list item sh
     const event = {target, preventDefault};
 
     td.when(mockAdapter.getFocusedElementIndex()).thenReturn(-1);
-    td.when(mockAdapter.isElementFocusable(td.matchers.anything())).thenReturn(true);
     td.when(mockAdapter.getListItemIndex(td.matchers.anything())).thenReturn(-1);
     foundation.setSingleSelection(true);
     foundation.handleClick(event);
@@ -630,7 +628,6 @@ test('#handleClick when singleSelection=true on the first element when already s
     const event = {target, preventDefault};
 
     td.when(mockAdapter.getFocusedElementIndex()).thenReturn(0);
-    td.when(mockAdapter.isElementFocusable(td.matchers.anything())).thenReturn(true);
     td.when(mockAdapter.getListItemIndex(td.matchers.anything())).thenReturn(0);
     foundation.setSingleSelection(true);
     foundation.handleClick(event);

--- a/test/unit/mdc-list/mdc-list.test.js
+++ b/test/unit/mdc-list/mdc-list.test.js
@@ -236,25 +236,6 @@ test('adapter#isListItem returns false if the element is a not a list item', () 
   assert.isFalse(component.getDefaultFoundation().adapter_.isListItem(item1));
 });
 
-test('adapter#isElementFocusable returns true if the element is a focusable list item sub-element', () => {
-  const {root, component} = setupTest();
-  const item1 = root.querySelectorAll('.mdc-list-item button')[0];
-  assert.isTrue(component.getDefaultFoundation().adapter_.isElementFocusable(item1));
-});
-
-test('adapter#isElementFocusable returns false if the element is not a focusable list item sub-element',
-  () => {
-    const {root, component} = setupTest();
-    const item1 = root.querySelectorAll('.mdc-list-item')[2];
-    assert.isFalse(component.getDefaultFoundation().adapter_.isElementFocusable(item1));
-  });
-
-test('adapter#isElementFocusable returns false if the element is null/undefined',
-  () => {
-    const {component} = setupTest();
-    assert.isFalse(component.getDefaultFoundation().adapter_.isElementFocusable());
-  });
-
 test('#adapter.setTabIndexForListItemChildren sets the child button/a elements of index', () => {
   const {root, component} = setupTest();
   document.body.appendChild(root);


### PR DESCRIPTION
`MDCListAdapter.isElementFocusable` was never actually called from `MDCListFoundation`