### PR TITLE
fix(drawer): list-item activation demo

### DIFF
--- a/demos/drawer/temporary-drawer.html
+++ b/demos/drawer/temporary-drawer.html
@@ -165,7 +165,7 @@
             if (activatedItem) {
               activatedItem.classList.remove(activatedClass);
             }
-            event.target.classList.add(activatedClass);
+            el.classList.add(activatedClass);
           }
         });
 


### PR DESCRIPTION
Fix the drawer list item selection/activation demo which causes strange behaviour in certain cases, like when `mdc-list-item` inside drawer has multiple children like below:

        <a class="mdc-list-item" href="#">
            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">add_box</i>
            <span class='global-lang'>Hello</span>
            <span class='local-lang'>שלום</span>
        </a>