### PR TITLE
docs(text-field): Remove outdated image

### DIFF
--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -6,13 +6,6 @@ iconId: text_field
 path: /catalog/input-controls/text-field/
 -->
 
-## Important - Default Style Deprecation Notice
-
-The existing default text field style will be changed in an upcoming release. The Material spec indicates that
-the default style will be the filled variant (currently referred to as the box variant). This will become the
-default style. Continuing to add the `mdc-text-field--box` class to the text field will
-result in no change.
-
 # Text Field
 
 Text fields allow users to input, edit, and select text.

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -15,13 +15,6 @@ result in no change.
 
 # Text Field
 
-<!--<div class="article__asset">
-  <a class="article__asset-link"
-     href="https://material-components.github.io/material-components-web-catalog/#/component/text-field">
-    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/textfields.png" width="240" alt="Text fields screenshot">
-  </a>
-</div>-->
-
 Text fields allow users to input, edit, and select text.
 
 ## Design & API Documentation


### PR DESCRIPTION
Currently the Web Text Field page on material.io has this image:

![Text Field](https://material.io/develop/images/mdc_web_screenshots/textfields.png)

(Note: the background of the image blends in with the background of the area it occupies in the page; this is showing the old default variant, not filled.)

We've removed that variant as it's no longer in spec, and currently don't have infrastructure to quickly update this image, so I'm removing it to avoid confusion.