### PR TITLE
docs(icon-button): Update icon button variant example

### DIFF
--- a/packages/mdc-icon-button/README.md
+++ b/packages/mdc-icon-button/README.md
@@ -81,8 +81,8 @@ Then instantiate an `MDCIconButtonToggle` on the root element.
    aria-label="Add to favorites"
    aria-hidden="true"
    aria-pressed="false">
-   <i class="material-icons mdc-icon-button__icon">favorite</i>
-   <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite_border</i>
+   <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
+   <i class="material-icons mdc-icon-button__icon">favorite_border</i>
 </button>
 ```
 


### PR DESCRIPTION
Updating to match demo code.
- Use `mdc-icon-button__icon--on` for `favorite`, instead of `favorite_border`.