### PR TITLE
docs: Update pre-release docs RE lerna option to pick

### DIFF
--- a/docs/open_source/release-process.md
+++ b/docs/open_source/release-process.md
@@ -81,7 +81,9 @@ pass prior to releasing (lerna will update versions for us in the next step).
 $(npm bin)/lerna publish --skip-git --npm-tag=next --since=<previous-patch-tag>
 ```
 
-When lerna prompts for version, choose Pre-minor.
+When lerna prompts for version, choose **Pre-minor** for the first pre-release in a cycle, or **Prerelease** for
+subsequent pre-releases.
+(The resulting version number should always have the same minor version as the next planned release.)
 
 Be sure to include the command-line flags:
 


### PR DESCRIPTION
Hopefully fixing these docs once and for all.

A couple of months back, I got confused when I noticed that selecting Pre-Minor for a second pre-release would actually rev the minor version number, which we don't want. In that particular case we should select Prerelease which revs the existing pre-release version number.