### PR TITLE
docs: Update release-process docs to include fetching tags

### DIFF
--- a/docs/open_source/release-process.md
+++ b/docs/open_source/release-process.md
@@ -29,7 +29,7 @@ team know NOT to merge PRs during this release process.
 Check out the master branch and update:
 
 ```
-git checkout master && git pull
+git checkout master && git pull && git fetch --all --tags
 ```
 
 This will pull the latest tags and `master` commits into your local repository.

--- a/docs/open_source/release-process.md
+++ b/docs/open_source/release-process.md
@@ -29,7 +29,7 @@ team know NOT to merge PRs during this release process.
 Check out the master branch and update:
 
 ```
-git checkout master && git pull && git fetch --all --tags
+git checkout master && git pull && git fetch --tags
 ```
 
 This will pull the latest tags and `master` commits into your local repository.


### PR DESCRIPTION
I didn't have the latest tags and lerna failed as a result since I was using the `--since` option. 