### PR TITLE
chore(infrastructure): Add URL params for Google Analytics

### DIFF
--- a/test/screenshot/infra/lib/analytics.js
+++ b/test/screenshot/infra/lib/analytics.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
+require('url-search-params-polyfill');
+
+class Analytics {
+  /**
+   * @param {string} url
+   * @param {string|undefined=} source
+   * @param {string|undefined=} type
+   * @param {string|undefined=} campaign
+   * @param {string|undefined=} medium
+   * @param {!Object<string, string>|undefined=} extraParams
+   * @return {string}
+   */
+  getUrl({
+    url,
+    source = undefined,
+    type = undefined,
+    campaign = undefined,
+    medium = undefined,
+    extraParams = undefined,
+  } = {}) {
+    const [resource, oldQuery] = url.split('?');
+    const params = new URLSearchParams(oldQuery);
+    if (source) {
+      params.set('utm_source', source);
+    }
+    if (type) {
+      params.set('utm_content', type);
+    }
+    if (campaign) {
+      params.set('utm_campaign', campaign);
+    }
+    if (medium) {
+      params.set('utm_medium', medium);
+    }
+    if (extraParams) {
+      for (const [key, value] of Object.entries(extraParams)) {
+        params.set(key, value);
+      }
+    }
+    const newQuery = params.toString();
+    if (!newQuery) {
+      return resource;
+    }
+    return `${resource}?${newQuery}`;
+  }
+}
+
+module.exports = Analytics;

--- a/test/screenshot/infra/lib/analytics.js
+++ b/test/screenshot/infra/lib/analytics.js
@@ -27,8 +27,11 @@ require('url-search-params-polyfill');
 
 class Analytics {
   /**
+   * See:
+   * - https://support.google.com/analytics/answer/1033863?hl=en
+   * - https://ga-dev-tools.appspot.com/campaign-url-builder/
    * @param {string} url
-   * @param {string|undefined=} source
+   * @param {string} source
    * @param {string|undefined=} type
    * @param {string|undefined=} campaign
    * @param {string|undefined=} medium
@@ -37,7 +40,7 @@ class Analytics {
    */
   getUrl({
     url,
-    source = undefined,
+    source,
     type = undefined,
     campaign = undefined,
     medium = undefined,
@@ -45,9 +48,7 @@ class Analytics {
   } = {}) {
     const [resource, oldQuery] = url.split('?');
     const params = new URLSearchParams(oldQuery);
-    if (source) {
-      params.set('utm_source', source);
-    }
+    params.set('utm_source', source);
     if (type) {
       params.set('utm_content', type);
     }

--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -47,7 +47,7 @@ const SELENIUM_SERVER_URL = `http://${MDC_CBT_USERNAME}:${MDC_CBT_AUTHKEY}@hub.c
 const {ExitCode, SELENIUM_ZOMBIE_SESSION_DURATION_MS} = require('./constants');
 
 /** @type {?Promise<!Array<!cbt.proto.CbtDevice>>} */
-let allBrowsersPromise;
+let allDevicesPromise;
 
 class CbtApi {
   constructor() {
@@ -136,21 +136,21 @@ https://crossbrowsertesting.com/account
    * @return {!Promise<!Array<!cbt.proto.CbtDevice>>}
    */
   async fetchAvailableDevices() {
-    if (allBrowsersPromise) {
-      return allBrowsersPromise;
+    if (allDevicesPromise) {
+      return allDevicesPromise;
     }
 
-    this.logger_.debug('Fetching browsers from CBT...');
+    this.logger_.debug('Fetching devices and browsers from CBT...');
 
     const stackTrace = getStackTrace('fetchAvailableDevices');
-    allBrowsersPromise = this.sendRequest_(stackTrace, 'GET', '/selenium/browsers');
+    allDevicesPromise = this.sendRequest_(stackTrace, 'GET', '/selenium/browsers');
 
     /** @type {!Array<!cbt.proto.CbtDevice>} */
-    const allBrowsers = await allBrowsersPromise;
+    const allDevices = await allDevicesPromise;
 
-    this.logger_.debug(`Fetched ${allBrowsers.length} browsers from CBT!`);
+    this.logger_.debug(`Fetched ${allDevices.length} devices from CBT!`);
 
-    return allBrowsers;
+    return allDevices;
   }
 
   /**

--- a/test/screenshot/infra/lib/cli.js
+++ b/test/screenshot/infra/lib/cli.js
@@ -29,6 +29,7 @@ const {ApprovalId} = mdcProto;
 const argparse = require('argparse');
 const checkIsOnline = require('is-online');
 
+const CliColor = require('./logger').colors;
 const Duration = require('./duration');
 const {GOLDEN_JSON_RELATIVE_PATH} = require('./constants');
 
@@ -64,6 +65,21 @@ class Cli {
     this.initTestCommand_();
 
     this.args_ = this.rootParser_.parseArgs();
+  }
+
+  /**
+   * @param {string} url
+   * @return {string}
+   */
+  colorizeUrl(url) {
+    return url.replace(/^([^?]+)(\?.*)?$/, (substring, resourcePlain, queryPlain) => {
+      const resourceColor = CliColor.reset(resourcePlain);
+      if (queryPlain) {
+        const queryColor = CliColor.dim(queryPlain);
+        return `${resourceColor}${queryColor}`;
+      }
+      return resourceColor;
+    });
   }
 
   /**

--- a/test/screenshot/infra/lib/cli.js
+++ b/test/screenshot/infra/lib/cli.js
@@ -75,7 +75,7 @@ class Cli {
     return url.replace(/^([^?]+)(\?.*)?$/, (substring, resourcePlain, queryPlain) => {
       const resourceColor = CliColor.reset(resourcePlain);
       if (queryPlain) {
-        const queryColor = CliColor.dim(queryPlain);
+        const queryColor = CliColor.gray(queryPlain);
         return `${resourceColor}${queryColor}`;
       }
       return resourceColor;

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -25,11 +25,13 @@ const VError = require('verror');
 const debounce = require('debounce');
 const octokit = require('@octokit/rest');
 
+const Analytics = require('./analytics');
 const GitRepo = require('./git-repo');
 const getStackTrace = require('./stacktrace')('GitHubApi');
 
 class GitHubApi {
   constructor() {
+    this.analytics_ = new Analytics();
     this.gitRepo_ = new GitRepo();
     this.octokit_ = octokit();
     this.isTravis_ = process.env.TRAVIS === 'true';
@@ -146,7 +148,7 @@ class GitHubApi {
         description = `${numChanged.toLocaleString()} screenshots differ from PR's golden.json`;
       }
 
-      targetUrl = meta.report_html_file.public_url;
+      targetUrl = reportFileUrl;
     } else {
       const runnableScreenshots = screenshots.runnable_screenshot_list;
       const numTotal = runnableScreenshots.length;
@@ -196,7 +198,7 @@ class GitHubApi {
         repo: 'material-components-web',
         sha,
         state,
-        target_url: targetUrl,
+        target_url: this.analytics_.getUrl({url: targetUrl, source: 'github', type: 'pr_commit_status'}),
         description,
         context: 'screenshot-test/butter-bot',
       });

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -148,7 +148,11 @@ class GitHubApi {
         description = `${numChanged.toLocaleString()} screenshots differ from PR's golden.json`;
       }
 
-      targetUrl = this.analytics_.getUrl({url: reportFileUrl, source: 'github', type: 'pr_commit_status'});
+      targetUrl = this.analytics_.getUrl({
+        url: reportFileUrl,
+        source: 'github',
+        type: 'status',
+      });
     } else {
       const runnableScreenshots = screenshots.runnable_screenshot_list;
       const numTotal = runnableScreenshots.length;

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -148,7 +148,7 @@ class GitHubApi {
         description = `${numChanged.toLocaleString()} screenshots differ from PR's golden.json`;
       }
 
-      targetUrl = reportFileUrl;
+      targetUrl = this.analytics_.getUrl({url: reportFileUrl, source: 'github', type: 'pr_commit_status'});
     } else {
       const runnableScreenshots = screenshots.runnable_screenshot_list;
       const numTotal = runnableScreenshots.length;
@@ -198,7 +198,7 @@ class GitHubApi {
         repo: 'material-components-web',
         sha,
         state,
-        target_url: this.analytics_.getUrl({url: targetUrl, source: 'github', type: 'pr_commit_status'}),
+        target_url: targetUrl,
         description,
         context: 'screenshot-test/butter-bot',
       });

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -151,7 +151,7 @@ class GitHubApi {
       targetUrl = this.analytics_.getUrl({
         url: reportFileUrl,
         source: 'github',
-        type: 'status',
+        type: 'pr_status',
       });
     } else {
       const runnableScreenshots = screenshots.runnable_screenshot_list;

--- a/test/screenshot/infra/lib/golden-file.js
+++ b/test/screenshot/infra/lib/golden-file.js
@@ -26,11 +26,19 @@
 const mdcProto = require('../proto/mdc.pb').mdc.proto;
 const {GoldenScreenshot, GoldenSuite, TestFile} = mdcProto;
 
+const Analytics = require('./analytics');
+
 class GoldenFile {
   /**
    * @param {!mdc.proto.GoldenSuite=} suiteJson
    */
   constructor(suiteJson = GoldenSuite.create()) {
+    /**
+     * @type {!Analytics}
+     * @private
+     */
+    this.analytics_ = new Analytics();
+
     /**
      * @type {!mdc.proto.GoldenSuite}
      * @private
@@ -94,7 +102,10 @@ class GoldenFile {
       };
     }
 
-    this.suiteJson_[htmlFilePath].public_url = htmlFileUrl;
+    this.suiteJson_[htmlFilePath].public_url = this.analytics_.getUrl({
+      url: htmlFileUrl,
+      source: 'golden_json',
+    });
     this.suiteJson_[htmlFilePath].screenshots[userAgentAlias] = screenshotImageUrl;
   }
 

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -989,7 +989,7 @@ class ReportBuilder {
         const publicUrl = this.analytics_.getUrl({
           url: htmlFile.public_url,
           source: 'cli',
-          type: 'run_params',
+          type: 'inventory',
         });
         console.log(`  - ${this.cli_.colorizeUrl(publicUrl)} > ${screenshot.user_agent.alias}`);
       }

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -37,6 +37,7 @@ const {Approvals, DiffImageResult, Dimensions, FlakeConfig, GitStatus, GoldenScr
 const {ReportData, ReportMeta, Screenshot, Screenshots, ScreenshotList, TestFile, User, UserAgents} = mdcProto;
 const {InclusionType, CaptureState} = Screenshot;
 
+const Analytics = require('./analytics');
 const CbtApi = require('./cbt-api');
 const Cli = require('./cli');
 const DiffBaseParser = require('./diff-base-parser');
@@ -54,6 +55,12 @@ const TEMP_DIR = os.tmpdir();
 
 class ReportBuilder {
   constructor() {
+    /**
+     * @type {!Analytics}
+     * @private
+     */
+    this.analytics_ = new Analytics();
+
     /**
      * @type {!CbtApi}
      * @private
@@ -979,8 +986,12 @@ class ReportBuilder {
     if (count > 0) {
       for (const screenshot of screenshots) {
         const htmlFile = screenshot.actual_html_file || screenshot.expected_html_file;
-        const publicUrl = htmlFile.public_url;
-        console.log(`  - ${publicUrl} > ${screenshot.user_agent.alias}`);
+        const publicUrl = this.analytics_.getUrl({
+          url: htmlFile.public_url,
+          source: 'cli',
+          type: 'run_params',
+        });
+        console.log(`  - ${this.cli_.colorizeUrl(publicUrl)} > ${screenshot.user_agent.alias}`);
       }
     }
     console.log();

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -33,11 +33,12 @@ const path = require('path');
 const mdcProto = require('../proto/mdc.pb').mdc.proto;
 const seleniumProto = require('../proto/selenium.pb').selenium.proto;
 
-const {Screenshot, TestFile, UserAgent} = mdcProto;
+const {CropResult, Screenshot, TestFile, UserAgent} = mdcProto;
 const {CaptureState, InclusionType} = Screenshot;
 const {BrowserVendorType, Navigator} = UserAgent;
 const {RawCapabilities} = seleniumProto;
 
+const Analytics = require('./analytics');
 const CbtApi = require('./cbt-api');
 const Cli = require('./cli');
 const CliColor = require('./logger').colors;
@@ -65,7 +66,6 @@ const CliStatuses = {
   STARTING: {name: 'Starting', color: CliColor.green},
   STARTED: {name: 'Started', color: CliColor.bold.green},
   GET: {name: 'Get', color: CliColor.bold.white},
-  CROP: {name: 'Crop', color: CliColor.white},
   PASS: {name: 'Pass', color: CliColor.green},
   ADD: {name: 'Add', color: CliColor.bgGreen.black},
   FAIL: {name: 'Fail', color: CliColor.red},
@@ -78,6 +78,12 @@ const CliStatuses = {
 
 class SeleniumApi {
   constructor() {
+    /**
+     * @type {!Analytics}
+     * @private
+     */
+    this.analytics_ = new Analytics();
+
     /**
      * @type {!CbtApi}
      * @private
@@ -630,7 +636,26 @@ class SeleniumApi {
         this.numPending_--;
         this.numCompleted_++;
 
-        const message = `${screenshot.actual_html_file.public_url} > ${screenshot.user_agent.alias}`;
+        const actualHtmlFileUrlPlain = this.analytics_.getUrl({
+          url: screenshot.actual_html_file.public_url,
+          source: 'cli',
+          type: 'test_progress',
+        });
+        const actualHtmlFileUrlColor = this.cli_.colorizeUrl(actualHtmlFileUrlPlain);
+        let cropColor = '';
+        if (screenshot.crop_result && screenshot.crop_result.uncropped_height > 0) {
+          const {
+            cropped_height: croppedHeight,
+            cropped_width: croppedWidth,
+            uncropped_height: uncroppedHeight,
+            uncropped_width: uncroppedWidth,
+          } = screenshot.crop_result;
+          cropColor = CliColor.dim(
+            ` (cropped from ${uncroppedWidth}x${uncroppedHeight} to ${croppedWidth}x${croppedHeight})`
+          );
+        }
+        const message = `${actualHtmlFileUrlColor} > ${screenshot.user_agent.alias}${cropColor}`;
+        // pixel cropping!
 
         if (diffImageResult.has_changed) {
           changedScreenshots.push(screenshot);
@@ -716,7 +741,12 @@ class SeleniumApi {
       if (screenshot.retry_count > 0) {
         // TODO(acdvorak): Print this info when a test fails.
         const {width, height} = diffImageResult.diff_image_dimensions;
-        const whichMsg = `${screenshot.actual_html_file.public_url} > ${userAgent.alias}`;
+        const actualHtmlFileUrl = this.analytics_.getUrl({
+          url: screenshot.actual_html_file.public_url,
+          source: 'cli',
+          type: 'test_progress',
+        });
+        const whichMsg = `${actualHtmlFileUrl} > ${userAgent.alias}`;
         const countMsg = `attempt ${screenshot.retry_count} of ${maxRetries}`;
         const pixelMsg = `${changedPixelCount.toLocaleString()} pixels differed`;
         const deltaMsg = `${diffImageResult.changed_pixel_percentage}% of ${width}x${height}`;
@@ -774,13 +804,17 @@ class SeleniumApi {
     const userAgent = screenshot.user_agent;
     const flakeConfig = screenshot.flake_config;
 
-    const qsParams = new URLSearchParams({
-      font_face_observer_timeout_ms: flakeConfig.font_face_observer_timeout_ms,
-      fonts_loaded_reflow_delay_ms: flakeConfig.fonts_loaded_reflow_delay_ms,
+    const urlWithQsParams = this.analytics_.getUrl({
+      url,
+      source: 'cbt',
+      type: 'screenshot_test',
+      extraParams: {
+        font_face_observer_timeout_ms: flakeConfig.font_face_observer_timeout_ms,
+        fonts_loaded_reflow_delay_ms: flakeConfig.fonts_loaded_reflow_delay_ms,
+      },
     });
-    const urlWithQsParams = `${url}?${qsParams}`;
 
-    this.logStatus_(CliStatuses.GET, `${urlWithQsParams} > ${userAgent.alias}...`);
+    this.logStatus_(CliStatuses.GET, `${this.cli_.colorizeUrl(urlWithQsParams)} > ${userAgent.alias}...`);
 
     const isOnline = this.cli_.isOnline();
     const fontLoadTimeoutMs = isOnline ? flakeConfig.font_face_observer_timeout_ms : 500;
@@ -802,10 +836,12 @@ class SeleniumApi {
     const {width: uncroppedWidth, height: uncroppedHeight} = uncroppedJimpImage.bitmap;
     const {width: croppedWidth, height: croppedHeight} = croppedJimpImage.bitmap;
 
-    const message =
-      `${urlWithQsParams} > ${userAgent.alias} screenshot from ` +
-      `${uncroppedWidth}x${uncroppedHeight} to ${croppedWidth}x${croppedHeight}`;
-    this.logStatus_(CliStatuses.CROP, message);
+    screenshot.crop_result = CropResult.create({
+      uncropped_width: uncroppedWidth,
+      uncropped_height: uncroppedHeight,
+      cropped_width: croppedWidth,
+      cropped_height: croppedHeight,
+    });
 
     return croppedImageBuffer;
   }
@@ -938,7 +974,7 @@ class SeleniumApi {
     const browser = CliColor.bold(`${navigator.browser_name} ${navigator.browser_version}`);
     const os = `${navigator.os_name} ${navigator.os_version}`;
     const sessionId = userAgent.selenium_session_id;
-    const publicCbtUrl = CliColor.underline(userAgent.selenium_result_url);
+    const publicCbtUrl = CliColor.yellow.underline(userAgent.selenium_result_url);
 
     this.logStatus_(status, `${browser} on ${os}! - video: ${publicCbtUrl} (Selenium session ID: ${sessionId})`);
   }

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -636,26 +636,7 @@ class SeleniumApi {
         this.numPending_--;
         this.numCompleted_++;
 
-        const actualHtmlFileUrlPlain = this.analytics_.getUrl({
-          url: screenshot.actual_html_file.public_url,
-          source: 'cli',
-          type: 'test_progress',
-        });
-        const actualHtmlFileUrlColor = this.cli_.colorizeUrl(actualHtmlFileUrlPlain);
-        let cropColor = '';
-        if (screenshot.crop_result && screenshot.crop_result.uncropped_height > 0) {
-          const {
-            cropped_height: croppedHeight,
-            cropped_width: croppedWidth,
-            uncropped_height: uncroppedHeight,
-            uncropped_width: uncroppedWidth,
-          } = screenshot.crop_result;
-          cropColor = CliColor.dim(
-            ` (cropped from ${uncroppedWidth}x${uncroppedHeight} to ${croppedWidth}x${croppedHeight})`
-          );
-        }
-        const message = `${actualHtmlFileUrlColor} > ${screenshot.user_agent.alias}${cropColor}`;
-        // pixel cropping!
+        const message = this.createStatusMessage_(screenshot);
 
         if (diffImageResult.has_changed) {
           changedScreenshots.push(screenshot);
@@ -962,6 +943,35 @@ class SeleniumApi {
    */
   async sleep_(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * @param {!mdc.proto.Screenshot} screenshot
+   * @return {string}
+   * @private
+   */
+  createStatusMessage_(screenshot) {
+    const actualHtmlFileUrlPlain = this.analytics_.getUrl({
+      url: screenshot.actual_html_file.public_url,
+      source: 'cli',
+      type: 'test_progress',
+    });
+    const actualHtmlFileUrlColor = this.cli_.colorizeUrl(actualHtmlFileUrlPlain);
+
+    let cropColor = '';
+    if (screenshot.crop_result && screenshot.crop_result.uncropped_height > 0) {
+      const {
+        cropped_height: croppedHeight,
+        cropped_width: croppedWidth,
+        uncropped_height: uncroppedHeight,
+        uncropped_width: uncroppedWidth,
+      } = screenshot.crop_result;
+      cropColor = CliColor.dim(
+        ` (cropped from ${uncroppedWidth}x${uncroppedHeight} to ${croppedWidth}x${croppedHeight})`
+      );
+    }
+
+    return `${actualHtmlFileUrlColor} > ${screenshot.user_agent.alias}${cropColor}`;
   }
 
   /**

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -725,7 +725,7 @@ class SeleniumApi {
         const actualHtmlFileUrl = this.analytics_.getUrl({
           url: screenshot.actual_html_file.public_url,
           source: 'cli',
-          type: 'test_progress',
+          type: 'progress',
         });
         const whichMsg = `${actualHtmlFileUrl} > ${userAgent.alias}`;
         const countMsg = `attempt ${screenshot.retry_count} of ${maxRetries}`;
@@ -788,7 +788,7 @@ class SeleniumApi {
     const urlWithQsParams = this.analytics_.getUrl({
       url,
       source: 'cbt',
-      type: 'screenshot_test',
+      type: 'selenium',
       extraParams: {
         font_face_observer_timeout_ms: flakeConfig.font_face_observer_timeout_ms,
         fonts_loaded_reflow_delay_ms: flakeConfig.fonts_loaded_reflow_delay_ms,
@@ -954,7 +954,7 @@ class SeleniumApi {
     const actualHtmlFileUrlPlain = this.analytics_.getUrl({
       url: screenshot.actual_html_file.public_url,
       source: 'cli',
-      type: 'test_progress',
+      type: 'progress',
     });
     const actualHtmlFileUrlColor = this.cli_.colorizeUrl(actualHtmlFileUrlPlain);
 

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -966,7 +966,7 @@ class SeleniumApi {
         uncropped_height: uncroppedHeight,
         uncropped_width: uncroppedWidth,
       } = screenshot.crop_result;
-      cropColor = CliColor.dim(
+      cropColor = CliColor.gray(
         ` (cropped from ${uncroppedWidth}x${uncroppedHeight} to ${croppedWidth}x${croppedHeight})`
       );
     }

--- a/test/screenshot/infra/proto/mdc.pb.js
+++ b/test/screenshot/infra/proto/mdc.pb.js
@@ -5545,6 +5545,7 @@ $root.mdc = (function() {
              * @property {mdc.proto.ITestFile|null} [actual_image_file] Screenshot actual_image_file
              * @property {mdc.proto.ITestFile|null} [diff_image_file] Screenshot diff_image_file
              * @property {mdc.proto.IDiffImageResult|null} [diff_image_result] Screenshot diff_image_result
+             * @property {mdc.proto.ICropResult|null} [crop_result] Screenshot crop_result
              * @property {number|null} [retry_count] Screenshot retry_count
              * @property {mdc.proto.IFlakeConfig|null} [flake_config] Screenshot flake_config
              */
@@ -5661,6 +5662,14 @@ $root.mdc = (function() {
             Screenshot.prototype.diff_image_result = null;
 
             /**
+             * Screenshot crop_result.
+             * @member {mdc.proto.ICropResult|null|undefined} crop_result
+             * @memberof mdc.proto.Screenshot
+             * @instance
+             */
+            Screenshot.prototype.crop_result = null;
+
+            /**
              * Screenshot retry_count.
              * @member {number} retry_count
              * @memberof mdc.proto.Screenshot
@@ -5728,6 +5737,8 @@ $root.mdc = (function() {
                     $root.mdc.proto.FlakeConfig.encode(message.flake_config, writer.uint32(/* id 13, wireType 2 =*/106).fork()).ldelim();
                 if (message.is_url_skipped_by_cli != null && message.hasOwnProperty("is_url_skipped_by_cli"))
                     writer.uint32(/* id 14, wireType 0 =*/112).bool(message.is_url_skipped_by_cli);
+                if (message.crop_result != null && message.hasOwnProperty("crop_result"))
+                    $root.mdc.proto.CropResult.encode(message.crop_result, writer.uint32(/* id 15, wireType 2 =*/122).fork()).ldelim();
                 return writer;
             };
 
@@ -5797,6 +5808,9 @@ $root.mdc = (function() {
                         break;
                     case 11:
                         message.diff_image_result = $root.mdc.proto.DiffImageResult.decode(reader, reader.uint32());
+                        break;
+                    case 15:
+                        message.crop_result = $root.mdc.proto.CropResult.decode(reader, reader.uint32());
                         break;
                     case 12:
                         message.retry_count = reader.uint32();
@@ -5904,6 +5918,11 @@ $root.mdc = (function() {
                     var error = $root.mdc.proto.DiffImageResult.verify(message.diff_image_result);
                     if (error)
                         return "diff_image_result." + error;
+                }
+                if (message.crop_result != null && message.hasOwnProperty("crop_result")) {
+                    var error = $root.mdc.proto.CropResult.verify(message.crop_result);
+                    if (error)
+                        return "crop_result." + error;
                 }
                 if (message.retry_count != null && message.hasOwnProperty("retry_count"))
                     if (!$util.isInteger(message.retry_count))
@@ -6013,6 +6032,11 @@ $root.mdc = (function() {
                         throw TypeError(".mdc.proto.Screenshot.diff_image_result: object expected");
                     message.diff_image_result = $root.mdc.proto.DiffImageResult.fromObject(object.diff_image_result);
                 }
+                if (object.crop_result != null) {
+                    if (typeof object.crop_result !== "object")
+                        throw TypeError(".mdc.proto.Screenshot.crop_result: object expected");
+                    message.crop_result = $root.mdc.proto.CropResult.fromObject(object.crop_result);
+                }
                 if (object.retry_count != null)
                     message.retry_count = object.retry_count >>> 0;
                 if (object.flake_config != null) {
@@ -6051,6 +6075,7 @@ $root.mdc = (function() {
                     object.retry_count = 0;
                     object.flake_config = null;
                     object.is_url_skipped_by_cli = false;
+                    object.crop_result = null;
                 }
                 if (message.is_runnable != null && message.hasOwnProperty("is_runnable"))
                     object.is_runnable = message.is_runnable;
@@ -6080,6 +6105,8 @@ $root.mdc = (function() {
                     object.flake_config = $root.mdc.proto.FlakeConfig.toObject(message.flake_config, options);
                 if (message.is_url_skipped_by_cli != null && message.hasOwnProperty("is_url_skipped_by_cli"))
                     object.is_url_skipped_by_cli = message.is_url_skipped_by_cli;
+                if (message.crop_result != null && message.hasOwnProperty("crop_result"))
+                    object.crop_result = $root.mdc.proto.CropResult.toObject(message.crop_result, options);
                 return object;
             };
 
@@ -6135,6 +6162,260 @@ $root.mdc = (function() {
             })();
 
             return Screenshot;
+        })();
+
+        proto.CropResult = (function() {
+
+            /**
+             * Properties of a CropResult.
+             * @memberof mdc.proto
+             * @interface ICropResult
+             * @property {number|null} [uncropped_width] CropResult uncropped_width
+             * @property {number|null} [uncropped_height] CropResult uncropped_height
+             * @property {number|null} [cropped_width] CropResult cropped_width
+             * @property {number|null} [cropped_height] CropResult cropped_height
+             */
+
+            /**
+             * Constructs a new CropResult.
+             * @memberof mdc.proto
+             * @classdesc Represents a CropResult.
+             * @implements ICropResult
+             * @constructor
+             * @param {mdc.proto.ICropResult=} [properties] Properties to set
+             */
+            function CropResult(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * CropResult uncropped_width.
+             * @member {number} uncropped_width
+             * @memberof mdc.proto.CropResult
+             * @instance
+             */
+            CropResult.prototype.uncropped_width = 0;
+
+            /**
+             * CropResult uncropped_height.
+             * @member {number} uncropped_height
+             * @memberof mdc.proto.CropResult
+             * @instance
+             */
+            CropResult.prototype.uncropped_height = 0;
+
+            /**
+             * CropResult cropped_width.
+             * @member {number} cropped_width
+             * @memberof mdc.proto.CropResult
+             * @instance
+             */
+            CropResult.prototype.cropped_width = 0;
+
+            /**
+             * CropResult cropped_height.
+             * @member {number} cropped_height
+             * @memberof mdc.proto.CropResult
+             * @instance
+             */
+            CropResult.prototype.cropped_height = 0;
+
+            /**
+             * Creates a new CropResult instance using the specified properties.
+             * @function create
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {mdc.proto.ICropResult=} [properties] Properties to set
+             * @returns {mdc.proto.CropResult} CropResult instance
+             */
+            CropResult.create = function create(properties) {
+                return new CropResult(properties);
+            };
+
+            /**
+             * Encodes the specified CropResult message. Does not implicitly {@link mdc.proto.CropResult.verify|verify} messages.
+             * @function encode
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {mdc.proto.ICropResult} message CropResult message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            CropResult.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.uncropped_width != null && message.hasOwnProperty("uncropped_width"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.uncropped_width);
+                if (message.uncropped_height != null && message.hasOwnProperty("uncropped_height"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.uncropped_height);
+                if (message.cropped_width != null && message.hasOwnProperty("cropped_width"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.cropped_width);
+                if (message.cropped_height != null && message.hasOwnProperty("cropped_height"))
+                    writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.cropped_height);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified CropResult message, length delimited. Does not implicitly {@link mdc.proto.CropResult.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {mdc.proto.ICropResult} message CropResult message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            CropResult.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a CropResult message from the specified reader or buffer.
+             * @function decode
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {mdc.proto.CropResult} CropResult
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            CropResult.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.mdc.proto.CropResult();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.uncropped_width = reader.uint32();
+                        break;
+                    case 2:
+                        message.uncropped_height = reader.uint32();
+                        break;
+                    case 3:
+                        message.cropped_width = reader.uint32();
+                        break;
+                    case 4:
+                        message.cropped_height = reader.uint32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a CropResult message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {mdc.proto.CropResult} CropResult
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            CropResult.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a CropResult message.
+             * @function verify
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            CropResult.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.uncropped_width != null && message.hasOwnProperty("uncropped_width"))
+                    if (!$util.isInteger(message.uncropped_width))
+                        return "uncropped_width: integer expected";
+                if (message.uncropped_height != null && message.hasOwnProperty("uncropped_height"))
+                    if (!$util.isInteger(message.uncropped_height))
+                        return "uncropped_height: integer expected";
+                if (message.cropped_width != null && message.hasOwnProperty("cropped_width"))
+                    if (!$util.isInteger(message.cropped_width))
+                        return "cropped_width: integer expected";
+                if (message.cropped_height != null && message.hasOwnProperty("cropped_height"))
+                    if (!$util.isInteger(message.cropped_height))
+                        return "cropped_height: integer expected";
+                return null;
+            };
+
+            /**
+             * Creates a CropResult message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {mdc.proto.CropResult} CropResult
+             */
+            CropResult.fromObject = function fromObject(object) {
+                if (object instanceof $root.mdc.proto.CropResult)
+                    return object;
+                var message = new $root.mdc.proto.CropResult();
+                if (object.uncropped_width != null)
+                    message.uncropped_width = object.uncropped_width >>> 0;
+                if (object.uncropped_height != null)
+                    message.uncropped_height = object.uncropped_height >>> 0;
+                if (object.cropped_width != null)
+                    message.cropped_width = object.cropped_width >>> 0;
+                if (object.cropped_height != null)
+                    message.cropped_height = object.cropped_height >>> 0;
+                return message;
+            };
+
+            /**
+             * Creates a plain object from a CropResult message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof mdc.proto.CropResult
+             * @static
+             * @param {mdc.proto.CropResult} message CropResult
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            CropResult.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.uncropped_width = 0;
+                    object.uncropped_height = 0;
+                    object.cropped_width = 0;
+                    object.cropped_height = 0;
+                }
+                if (message.uncropped_width != null && message.hasOwnProperty("uncropped_width"))
+                    object.uncropped_width = message.uncropped_width;
+                if (message.uncropped_height != null && message.hasOwnProperty("uncropped_height"))
+                    object.uncropped_height = message.uncropped_height;
+                if (message.cropped_width != null && message.hasOwnProperty("cropped_width"))
+                    object.cropped_width = message.cropped_width;
+                if (message.cropped_height != null && message.hasOwnProperty("cropped_height"))
+                    object.cropped_height = message.cropped_height;
+                return object;
+            };
+
+            /**
+             * Converts this CropResult to JSON.
+             * @function toJSON
+             * @memberof mdc.proto.CropResult
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            CropResult.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return CropResult;
         })();
 
         proto.FlakeConfig = (function() {

--- a/test/screenshot/infra/proto/mdc.proto
+++ b/test/screenshot/infra/proto/mdc.proto
@@ -260,9 +260,17 @@ message Screenshot {
   TestFile actual_image_file = 9;
   TestFile diff_image_file = 10;
   DiffImageResult diff_image_result = 11;
+  CropResult crop_result = 15;
 
   uint32 retry_count = 12;
   FlakeConfig flake_config = 13;
+}
+
+message CropResult {
+  uint32 uncropped_width = 1;
+  uint32 uncropped_height = 2;
+  uint32 cropped_width = 3;
+  uint32 cropped_height = 4;
 }
 
 message FlakeConfig {


### PR DESCRIPTION
### What it does

* Adds [custom GA params](https://support.google.com/analytics/answer/1033863?hl=en) to user-facing URLs:
    - HTML files displayed in:
        - Console output
        - GitHub PR status checks
        - GitHub PR report comments
        - `golden.json`'s `public_url` field
        - CBT Selenium tests
    - Params:
        - `utm_source=cbt&utm_content=selenium`
        - `utm_source=cli&utm_content=inventory`
        - `utm_source=cli&utm_content=progress`
        - `utm_source=github&utm_content=pr_status`
        - `utm_source=github&utm_content=pr_comment`
        - `utm_source=golden_json`

* Colorizes the output so that the URLs are still readable (by dimming the query portion in gray)
* Removes noisy `CROP: https://...` lines from console output

### Example output

![image](https://user-images.githubusercontent.com/409245/44788390-ca062800-ab4e-11e8-8393-50642bdc2634.png)