### PR TITLE
fix(select): Only add line ripple listeners when line ripple is present

### DIFF
--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -290,9 +290,7 @@ class MDCSelect extends MDCComponent {
     const targetClientRect = evt.target.getBoundingClientRect();
     const xCoordinate = evt.clientX;
     const normalizedX = xCoordinate - targetClientRect.left;
-    if (this.lineRipple_) {
-      this.lineRipple_.setRippleCenter(normalizedX);
-    }
+    this.lineRipple_.setRippleCenter(normalizedX);
   }
 }
 

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -176,9 +176,12 @@ class MDCSelect extends MDCComponent {
     this.nativeControl_.addEventListener('change', this.handleChange_);
     this.nativeControl_.addEventListener('focus', this.handleFocus_);
     this.nativeControl_.addEventListener('blur', this.handleBlur_);
-    ['mousedown', 'touchstart'].forEach((evtType) => {
-      this.nativeControl_.addEventListener(evtType, this.handleClick_);
-    });
+
+    if (this.lineRipple_) {
+      ['mousedown', 'touchstart'].forEach((evtType) => {
+        this.nativeControl_.addEventListener(evtType, this.handleClick_);
+      });
+    }
 
     // Initially sync floating label
     this.foundation_.handleChange();
@@ -287,7 +290,9 @@ class MDCSelect extends MDCComponent {
     const targetClientRect = evt.target.getBoundingClientRect();
     const xCoordinate = evt.clientX;
     const normalizedX = xCoordinate - targetClientRect.left;
-    this.lineRipple_.setRippleCenter(normalizedX);
+    if (this.lineRipple_) {
+      this.lineRipple_.setRippleCenter(normalizedX);
+    }
   }
 }
 

--- a/test/unit/mdc-select/mdc-select.test.js
+++ b/test/unit/mdc-select/mdc-select.test.js
@@ -488,6 +488,19 @@ test('mousedown on the select sets the line ripple origin', () => {
   td.verify(bottomLine.setRippleCenter(200), {times: 1});
 });
 
+test('mousedown on the select does nothing if the it does not have a lineRipple', () => {
+  const hasOutline = true;
+  const {bottomLine, fixture} = setupTest(hasOutline);
+  const event = document.createEvent('MouseEvent');
+  const clientX = 200;
+  const clientY = 200;
+  // IE11 mousedown event.
+  event.initMouseEvent('mousedown', true, true, window, 0, 0, 0, clientX, clientY, false, false, false, false, 0, null);
+  fixture.querySelector('select').dispatchEvent(event);
+
+  td.verify(bottomLine.setRippleCenter(200), {times: 0});
+});
+
 test('#destroy removes the mousedown listener', () => {
   const {bottomLine, component, fixture} = setupTest();
   const event = document.createEvent('MouseEvent');


### PR DESCRIPTION
Modifies the line ripple logic in the `select` to only add the event listeners or updates if the line ripple element exists. 