### PR TITLE
fix(drawer): Destroy list in destroy method

### DIFF
--- a/packages/mdc-drawer/index.js
+++ b/packages/mdc-drawer/index.js
@@ -61,6 +61,9 @@ class MDCDrawer extends MDCComponent {
 
     /** @private {?Function} */
     this.handleScrimClick_;
+
+    /** @prviate {MDCList} */
+    this.list_;
   }
 
   /**
@@ -92,10 +95,13 @@ class MDCDrawer extends MDCComponent {
   }
 
   initialize(
-    focusTrapFactory = createFocusTrap) {
+    focusTrapFactory = createFocusTrap,
+    listFactory = (el) => new MDCList(el)) {
     const listEl = /** @type {!Element} */ (this.root_.querySelector(`.${MDCListFoundation.cssClasses.ROOT}`));
-    const list = MDCList.attachTo(listEl);
-    list.wrapFocus = true;
+    if (listEl) {
+      this.list_ = listFactory(listEl);
+      this.list_.wrapFocus = true;
+    }
     this.focusTrapFactory_ = focusTrapFactory;
   }
 
@@ -120,6 +126,10 @@ class MDCDrawer extends MDCComponent {
   destroy() {
     this.root_.removeEventListener('keydown', this.handleKeydown_);
     this.root_.removeEventListener('transitionend', this.handleTransitionEnd_);
+
+    if (this.list_) {
+      this.list_.destroy();
+    }
 
     const {MODAL} = MDCDismissibleDrawerFoundation.cssClasses;
     if (this.root_.classList.contains(MODAL)) {

--- a/packages/mdc-drawer/index.js
+++ b/packages/mdc-drawer/index.js
@@ -62,7 +62,7 @@ class MDCDrawer extends MDCComponent {
     /** @private {?Function} */
     this.handleScrimClick_;
 
-    /** @prviate {MDCList} */
+    /** @private {?MDCList} */
     this.list_;
   }
 

--- a/test/unit/mdc-drawer/mdc-drawer.test.js
+++ b/test/unit/mdc-drawer/mdc-drawer.test.js
@@ -71,8 +71,13 @@ function setupTestWithMocks(variantClass = cssClasses.DISMISSIBLE) {
     activate: () => {},
     deactivate: () => {},
   });
-  const component = new MDCDrawer(drawer, mockFoundation, () => mockFocusTrapInstance);
-  return {root, drawer, component, mockFoundation, mockFocusTrapInstance};
+  const mockList = td.object({
+    wrapFocus: () => {},
+    destroy: () => {},
+  });
+
+  const component = new MDCDrawer(drawer, mockFoundation, () => mockFocusTrapInstance, () => mockList);
+  return {root, drawer, component, mockFoundation, mockFocusTrapInstance, mockList};
 }
 
 suite('MDCDrawer');
@@ -132,6 +137,13 @@ test('#destroy removes transitionend event listener', () => {
 
   domEvents.emit(drawer, 'transitionend');
   td.verify(mockFoundation.handleTransitionEnd(td.matchers.isA(Object)), {times: 0});
+});
+
+test('#destroy calls destroy on list', () => {
+  const {component, mockList} = setupTestWithMocks();
+  component.destroy();
+
+  td.verify(mockList.destroy(), {times: 1});
 });
 
 test('adapter#addClass adds class to drawer', () => {


### PR DESCRIPTION
refs: #3471 
List was being instantiated in the `init` but never destroyed. 