### PR TITLE
doc(typography): Fix styles examples

### DIFF
--- a/packages/mdc-typography/README.md
+++ b/packages/mdc-typography/README.md
@@ -145,13 +145,14 @@ $mdc-typography-font-family: "Arial, Helvetica, sans-serif";
 @import ...
 ```
 
-Example: Overriding the `font-family` property for `headline1` and `headline2`.
+Example: Overriding the `font-family` property for `headline1` and `font-family` and `font-size` for `headline2`.
 ```scss
 $mdc-typography-styles-headline1: (
-  font-family: "Arial, Helvetica, sans-serif";
+  font-family: unquote("Arial, Helvetica, sans-serif")
 );
 $mdc-typography-styles-headline2: (
-  font-family: "Arial, Helvetica, sans-serif";
+  font-family: unquote("Arial, Helvetica, sans-serif"),
+  font-size: 3.25rem
 );
 
 ...


### PR DESCRIPTION
Map items are separated with comma and not semicolon, quotes should be unquoted.

```
$map: (key1: value1, key2: value2, key3: value3);
```

https://sass-lang.com/documentation/file.SASS_REFERENCE.html#maps