### PR TITLE
chore(infrastructure): Render important info in bold in log output

### DIFF
--- a/test/screenshot/infra/lib/cli.js
+++ b/test/screenshot/infra/lib/cli.js
@@ -75,7 +75,7 @@ class Cli {
     return url.replace(/^([^?]+)(\?.*)?$/, (substring, resourcePlain, queryPlain) => {
       const resourceColor = CliColor.reset(resourcePlain);
       if (queryPlain) {
-        const queryColor = CliColor.gray(queryPlain);
+        const queryColor = CliColor.dim(queryPlain);
         return `${resourceColor}${queryColor}`;
       }
       return resourceColor;


### PR DESCRIPTION
### What it does

- Colorizes log output:
    - URL params: dimmer
    - User agent alias: bold + italic
    - Image dimensions: bold
- Changes `FAILED` to `ERROR` (shown when an error is thrown during a Selenium session)
- Refactors `SeleniumApi.takeScreenshotWithRetries_()` into `logRetry_()`

### Example output

#### Before:

![screenshot of terminal with this PR](https://user-images.githubusercontent.com/409245/44960784-5cddf400-aeba-11e8-8597-f023e790e095.png)

#### After:

![screenshot of terminal with this PR](https://user-images.githubusercontent.com/409245/44960715-07edae00-aeb9-11e8-87f0-8eb78e2cc9fb.png)