### PR TITLE
chore(infrastructure): Run 2 parallel browsers by default instead of 3

### DIFF
--- a/test/screenshot/infra/lib/cli.js
+++ b/test/screenshot/infra/lib/cli.js
@@ -272,7 +272,7 @@ If a local dev server is not already running, one will be started for the durati
       type: 'integer',
       description: `
 Maximum number of browser VMs to run in parallel (subject to our CBT plan limit and VM availability).
-If no value is specified, the default is to start 3 browsers if nobody else is running tests, or 1 browser if other
+If no value is specified, the default is to start 2 browsers if nobody else is running tests, or 1 browser if other
 tests are already running.
 IMPORTANT: To ensure that multiple developers can run their tests simultaneously, DO NOT set this value during normal
 business hours.

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -395,7 +395,7 @@ class SeleniumApi {
       // If nobody else is running any tests, run half the number of concurrent tests allowed by our CBT account.
       // This gives us _some_ parallelism while still allowing other users to run their tests.
       if (active === 0) {
-        return Math.ceil(max / 2);
+        return Math.floor(max / 2);
       }
 
       // If someone else is already running tests, only run one test at a time.


### PR DESCRIPTION
Running 3 parallel browsers is a waste of resources.

`npm run screenshot:test` captures screenshots in 4 browsers, so it takes the same amount of time to finish whether it run 2 or 3 browsers in parallel.

By only consuming 2 parallels, we free up a VM for someone else to use.

As before, the `--parallels=N` CLI flag can be used to override the default.