### PR TITLE
fix(select): Disabled color and opacity

### DIFF
--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -71,6 +71,11 @@
       text-indent: -2px;
     }
 
+    // stylelint-disable-next-line selector-max-type, plugin/selector-bem-pattern
+    > option {
+      color: inherit; // Override default user agent stylesheet
+    }
+
     width: 100%;
     padding-top: 20px;
     padding-bottom: 4px;
@@ -79,6 +84,7 @@
     border-radius: 0;
     outline: none;
     background-color: transparent;
+    color: inherit; // Override default user agent stylesheet
     white-space: nowrap;
     cursor: pointer;
     appearance: none;
@@ -186,6 +192,7 @@
 
   .mdc-select__native-control {
     border-bottom-style: dotted;
+    color: $mdc-select-disabled-ink-color;
   }
   // stylelint-enable plugin/selector-bem-pattern
 
@@ -202,7 +209,6 @@
     @include mdc-select-outline-color_($mdc-select-outlined-disabled-border);
   }
 
-  opacity: .38;
   cursor: default;
   pointer-events: none;
 }

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -405,12 +405,12 @@
     }
   },
   "spec/mdc-select/classes/disabled.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/01_23_53_100/spec/mdc-select/classes/disabled.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/05/08_47_52_369/spec/mdc-select/classes/disabled.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/29/23_30_54_653/spec/mdc-select/classes/disabled.html.windows_chrome_68.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/29/23_30_54_653/spec/mdc-select/classes/disabled.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/29/23_30_54_653/spec/mdc-select/classes/disabled.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/08/29/23_30_54_653/spec/mdc-select/classes/disabled.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/05/08_47_52_369/spec/mdc-select/classes/disabled.html.windows_chrome_68.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/05/08_47_52_369/spec/mdc-select/classes/disabled.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/05/08_47_52_369/spec/mdc-select/classes/disabled.html.windows_firefox_61.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/05/08_47_52_369/spec/mdc-select/classes/disabled.html.windows_ie_11.png"
     }
   },
   "spec/mdc-select/issues/3230.html": {


### PR DESCRIPTION
### What it does

* Sets disabled `color` directly instead of giving the entire `mdc-select` element `opacity: .38` and relying on the default browser styles for text color.

### Example output

#### Before:

![image](https://user-images.githubusercontent.com/409245/45083325-5c0eb300-b0b0-11e8-8917-957bc0306937.png)

#### After:

![image](https://user-images.githubusercontent.com/409245/45083330-616bfd80-b0b0-11e8-8817-8e96cb59006f.png)