### PR TITLE
chore: Remove unnecessary default arguments that affect coverage

### DIFF
--- a/packages/mdc-line-ripple/foundation.js
+++ b/packages/mdc-line-ripple/foundation.js
@@ -55,7 +55,7 @@ class MDCLineRippleFoundation extends MDCFoundation {
   /**
    * @param {!MDCLineRippleAdapter=} adapter
    */
-  constructor(adapter = /** @type {!MDCLineRippleAdapter} */ ({})) {
+  constructor(adapter) {
     super(Object.assign(MDCLineRippleFoundation.defaultAdapter, adapter));
 
     /** @private {function(!Event): undefined} */

--- a/packages/mdc-list/foundation.js
+++ b/packages/mdc-list/foundation.js
@@ -57,7 +57,10 @@ class MDCListFoundation extends MDCFoundation {
     });
   }
 
-  constructor(adapter = /** @type {!MDCListFoundation} */ ({})) {
+  /**
+   * @param {!MDCListAdapter=} adapter
+   */
+  constructor(adapter) {
     super(Object.assign(MDCListFoundation.defaultAdapter, adapter));
     /** {boolean} */
     this.wrapFocus_ = false;


### PR DESCRIPTION
This solves the mystery in https://github.com/material-components/material-components-web/pull/3516#discussion_r215364312.

All of our foundation constructors follow the pattern of calling `super(Object.assign(MDCFooFoundation.defaultAdapter, adapter))`, but two components in particular (three if you include the Dialog prototype) were also assigning an empty object as the default value, which caused coverage to decrease due to the default "branch" never being taken. The default assignment is not necessary, since `Object.assign` effectively no-ops on `undefined` sources anyway.