### PR TITLE
fix(ripple): Clean deactivation timer and CSS when interrupted

### DIFF
--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -225,8 +225,13 @@ class MDCRippleFoundation extends MDCFoundation {
       if (this.activationTimer_) {
         clearTimeout(this.activationTimer_);
         this.activationTimer_ = 0;
-        const {FG_ACTIVATION} = MDCRippleFoundation.cssClasses;
-        this.adapter_.removeClass(FG_ACTIVATION);
+        this.adapter_.removeClass(MDCRippleFoundation.cssClasses.FG_ACTIVATION);
+      }
+
+      if (this.fgDeactivationRemovalTimer_) {
+        clearTimeout(this.fgDeactivationRemovalTimer_);
+        this.fgDeactivationRemovalTimer_ = 0;
+        this.adapter_.removeClass(MDCRippleFoundation.cssClasses.FG_DEACTIVATION);
       }
 
       const {ROOT, UNBOUNDED} = MDCRippleFoundation.cssClasses;

--- a/test/unit/mdc-ripple/foundation.test.js
+++ b/test/unit/mdc-ripple/foundation.test.js
@@ -170,7 +170,18 @@ testFoundation(`#destroy removes ${cssClasses.FG_ACTIVATION} if activation is in
     foundation.destroy();
     mockRaf.flush();
 
+    assert.equal(foundation.activationTimer_, 0);
     td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION));
+  });
+
+testFoundation(`#destroy removes ${cssClasses.FG_DEACTIVATION} if deactivation is interrupted`,
+  ({foundation, adapter, mockRaf}) => {
+    foundation.fgDeactivationRemovalTimer_ = 1;
+    foundation.destroy();
+    mockRaf.flush();
+
+    assert.equal(foundation.fgDeactivationRemovalTimer_, 0);
+    td.verify(adapter.removeClass(cssClasses.FG_DEACTIVATION));
   });
 
 testFoundation('#destroy removes all CSS variables', ({foundation, adapter, mockRaf}) => {


### PR DESCRIPTION
This is analogous to #2490, except for the deactivation timer rather than the activation timer.

Fixes #3527.