### PR TITLE
chore: Support cherry-picking from tags not in master

### DIFF
--- a/scripts/cherry-pick-patch-commits.js
+++ b/scripts/cherry-pick-patch-commits.js
@@ -41,6 +41,16 @@ const {spawnSync} = require('child_process');
 
 const CONFLICT_MESSAGE = 'after resolving the conflicts, mark the corrected paths';
 
+// simple-git defaults to only including subject + tag/branch (%s%d) in message, which adds noise and is not useful
+// for finding BREAKING CHANGEs (which are in body, %b).
+const logFormat = {
+  hash: '%H', // Contains full hash only, for cherry-picking
+  message: '%s\n\n%b', // Contains subject + body for passing to conventional-commits-parser
+  oneline: '%h %s', // Contains abbreviated hash + subject for summary lists
+};
+// Use a splitter that is very unlikely to be included in commit descriptions, to be used with the above format
+const logSplitter = ';;;';
+
 // Resolves to the most recent non-pre-release git tag.
 async function getMostRecentTag() {
   const tags = await simpleGit.tags();
@@ -49,23 +59,44 @@ async function getMostRecentTag() {
   return filteredTags[filteredTags.length - 1];
 }
 
+async function isCommitInHistory(commit) {
+  const branchSummary = await simpleGit.branch([
+    '--points-at', 'HEAD',
+    '--contains', commit,
+    '-v', // simpleGit.branch seems to require -v in order to work
+  ]);
+  return Object.keys(branchSummary.branches).some((key) => branchSummary.branches[key].current);
+}
+
+async function resolveCherryPick(tag) {
+  const info = await simpleGit.show(['--format=hash:%H', '-s', tag]);
+  const tagCommit = info.slice(info.indexOf('hash:') + 5).trim();
+
+  const cherryPickLog = await simpleGit.log({
+    format: logFormat,
+    splitter: logSplitter,
+    '--grep': `cherry picked from commit ${tagCommit}`,
+  });
+
+  if (cherryPickLog.all.length !== 1) {
+    throw new Error(`Unable to resolve a single cherry-pick commit from ${tag}`);
+  }
+
+  const resolvedCommit = cherryPickLog.all[0].hash;
+  console.log(`Resolved ${tag} to cherry-picked commit ${resolvedCommit} on current branch`);
+  return resolvedCommit;
+}
+
 // Resolves to an array of commits after the given tag, from earliest to latest (for proper cherry-picking).
-async function getCommitsAfterTag(tag) {
+async function getCommitsAfter(commit) {
   if (!args.includes('--no-fetch')) {
     await simpleGit.fetch();
   }
   const log = await simpleGit.log({
-    from: tag,
+    from: commit,
     to: 'origin/master',
-    // simple-git defaults to only including subject + tag/branch (%s%d) in message, which adds noise and is not useful
-    // for finding BREAKING CHANGEs (which are in body, %b).
-    format: {
-      hash: '%H', // Contains full hash only, for cherry-picking
-      message: '%s\n\n%b', // Contains subject + body for passing to conventional-commits-parser
-      oneline: '%h %s', // Contains abbreviated hash + subject for summary lists
-    },
-    // Use a splitter that is very unlikely to be included in commit descriptions
-    splitter: ';;;',
+    format: logFormat,
+    splitter: logSplitter,
   });
   return log.all.reverse();
 }
@@ -128,9 +159,14 @@ function logSingleLineCommit(logLine) {
 
 async function run() {
   const tag = args.find((arg) => arg[0] === 'v') || await getMostRecentTag();
-  const list = await getCommitsAfterTag(tag);
-  console.log(`Found ${list.length} commits after tag ${tag}`);
+  const isInHistory = await isCommitInHistory(tag);
+  const commit = isInHistory ? tag : await resolveCherryPick(tag);
+  const list = await getCommitsAfter(commit);
+  console.log(`Found ${list.length} commits after ${commit}`);
 
+  // Always cherry-pick on top of the last tag.
+  // If we used the cherry-picked master commit as base in the case of subsequent patches, we'd inherit
+  // non-patch commits from master between the last .0 release and the previous patch release.
   const results = await attemptCherryPicks(tag, list);
 
   console.log('');

--- a/scripts/cherry-pick-patch-commits.js
+++ b/scripts/cherry-pick-patch-commits.js
@@ -73,8 +73,8 @@ async function resolveCherryPick(tag) {
   const tagCommit = info.slice(info.indexOf('hash:') + 5).trim();
 
   const cherryPickLog = await simpleGit.log({
-    format: logFormat,
-    splitter: logSplitter,
+    'format': logFormat,
+    'splitter': logSplitter,
     '--grep': `cherry picked from commit ${tagCommit}`,
   });
 

--- a/test/screenshot/report/report.scss
+++ b/test/screenshot/report/report.scss
@@ -31,6 +31,7 @@
 html {
   box-sizing: border-box;
 }
+
 *, *:before, *:after { // stylelint-disable-line
   box-sizing: inherit;
 }


### PR DESCRIPTION
This fixes the cherry-pick-patch-commits script to work when the last release tag is off-master (which typically happens when there was a previous patch release).

If you run the current script on master right now, you'll immediately see odd errors with cherry-picks. What's happening is the script attempts to cherry-pick things that were already cherry-picked, because attempting to log commits between an off-master patch release and master results in listing all commits since the two references diverged, which is typically the last .0 release.

The fix involves the following:

* Detect when the last release is off-branch (by checking if `git branch --points-at HEAD --contains <tag>` returns the current branch)
* For off-branch patch tags, resolve to the equivalent commit in history (this is enabled by the fact that we pass `-x` to `git cherry-pick` which references the original commit hash, when cherry-picking the release commits from the patch tag into master)
* Read the list of commits since the identified point in history, and apply them on top of the _patch tag_ (not master, since that would end up inheriting non-patch-friendly commits between the last .0 release and the last patch release, which we don't want for subsequent patch releases)

For reference, here's the resulting commit list since v0.39.1 with this update applied:

```
6441256747dd17e9e9704ed541b307ecdb50b44d (HEAD) test(icon-button): Add focus to baseline screenshot test pages (#3523)
4f1debf46727f42c7d7fec5f2750067d658e647d chore: Remove unnecessary default arguments that affect coverage (#3522)
955ff2349ed8e5d50e333da88b7213cdd0dc4f44 chore: Add bem-linter comments where they were missing (#3504)
471770dd855d1bafdda181dcd96457ac69c12748 docs(drawer): Fix typos in README.md (#3493)
b4bd2285a11b1eb3541d21c03ff107e01b18fae5 chore(infrastructure): Skip browsers excluded by URL patterns (#3503)
9615c23b896e2355bc686340078ac6523f13e9ae chore(infrastructure): Upload captured images to `master` report (#3501)
abb812f415cd12a85fbeab77aa52e990c0966fe3 chore(infrastructure): Run 2 parallel browsers by default instead of 3 (#3500)
a1e424926ecca2b85068b8f97b0e80240c603ef0 chore(infrastructure): Render important info in bold in log output (#3499)
f0fb3ad601bf4d8ead1111dffaedde48e138e1fc chore(infrastructure): Workaround for Edge autofocus bug (#3498)
dddb5761abc151268fa3c79486e53bec43cb3b32 docs(mdc-menu-surface): README typo (#3491)
```

(Worth noting: it had to skip 2 select fix commits due to conflicts.)