### PR TITLE
chore: Skip comparing against master screenshots

### DIFF
--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -86,14 +86,15 @@ class TestCommand {
       return localExitCode;
     }
 
-    if (isTravisPr) {
-      /** @type {!mdc.proto.ReportData} */
-      const masterReportData = await this.diffAgainstMaster_({localReportData, snapshotGitRev});
+    // Temporarily disabled, see https://github.com/material-components/material-components-web/issues/3555
+    // if (isTravisPr) {
+    //   /** @type {!mdc.proto.ReportData} */
+    //   const masterReportData = await this.diffAgainstMaster_({localReportData, snapshotGitRev});
+    //   this.logTestResults_(localReportData);
+    //   this.logTestResults_(masterReportData);
+    // } else {
       this.logTestResults_(localReportData);
-      this.logTestResults_(masterReportData);
-    } else {
-      this.logTestResults_(localReportData);
-    }
+    // }
 
     // Diffs against master shouldn't fail the Travis job.
     return ExitCode.OK;

--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -26,7 +26,7 @@
 const VError = require('verror');
 
 const mdcProto = require('../proto/mdc.pb').mdc.proto;
-const GitRevision = mdcProto.GitRevision;
+// const GitRevision = mdcProto.GitRevision;
 const InclusionType = mdcProto.Screenshot.InclusionType;
 const ReportData = mdcProto.ReportData;
 
@@ -67,9 +67,9 @@ class TestCommand {
 
     /** @type {!mdc.proto.DiffBase} */
     const snapshotDiffBase = await this.diffBaseParser_.parseGoldenDiffBase();
-    const snapshotGitRev = snapshotDiffBase.git_revision;
+    // const snapshotGitRev = snapshotDiffBase.git_revision;
 
-    const isTravisPr = snapshotGitRev && snapshotGitRev.type === GitRevision.Type.TRAVIS_PR;
+    // const isTravisPr = snapshotGitRev && snapshotGitRev.type === GitRevision.Type.TRAVIS_PR;
     const shouldExit = process.env.HAS_TESTABLE_FILES === 'false';
 
     if (shouldExit) {
@@ -93,7 +93,7 @@ class TestCommand {
     //   this.logTestResults_(localReportData);
     //   this.logTestResults_(masterReportData);
     // } else {
-      this.logTestResults_(localReportData);
+    this.logTestResults_(localReportData);
     // }
 
     // Diffs against master shouldn't fail the Travis job.


### PR DESCRIPTION
This should at least enable the screenshot CI task to pass again.

Refs #3555.