### PR TITLE
docs(drawer): Improve continuity between examples

### DIFF
--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -348,8 +348,8 @@ It is recommended to shift focus to the first focusable element in the main cont
 Restore focus to the first focusable element when a list item is activated or after the drawer closes. Do not close the drawer upon item activation, since it should be up to the user when to show/hide the dismissible drawer.
 
 ```js
-const listEl = drawerEl.querySelector('.mdc-drawer .mdc-list');
-const mainContentEl = document.body.querySelector('.main-content');
+const listEl = document.querySelector('.mdc-drawer .mdc-list');
+const mainContentEl = document.querySelector('.main-content');
 
 listEl.addEventListener('click', (event) => {
   mainContentEl.querySelector('input, button').focus();
@@ -365,8 +365,8 @@ document.body.addEventListener('MDCDrawer:closed', () => {
 Close the drawer when an item is activated in order to dismiss the modal as soon as the user performs an action. Only restore focus to the first focusable element in the main content after the drawer is closed, since it's being closed automatically.
 
 ```js
-const listEl = drawerEl.querySelector('.mdc-drawer .mdc-list');
-const mainContentEl = document.body.querySelector('.main-content');
+const listEl = document.querySelector('.mdc-drawer .mdc-list');
+const mainContentEl = document.querySelector('.main-content');
 
 listEl.addEventListener('click', (event) => {
   drawer.open = false;


### PR DESCRIPTION
Someone on Discord ended up confused trying to apply our drawer examples because the focus examples reference `drawerEl` but that's never defined in our JS initialization example.

Given that our initialization example already assumes a single drawer, I just changed the other examples to use `document.querySelector` since they're otherwise already using specific enough selectors to work. I also changed `document.body.querySelector` to just `document.querySelector` for consistency.