### PR TITLE
fix(tab-bar): Remove trailing comma from function.

### DIFF
--- a/packages/mdc-tab-bar/index.js
+++ b/packages/mdc-tab-bar/index.js
@@ -77,8 +77,7 @@ class MDCTabBar extends MDCComponent {
    */
   initialize(
     tabFactory = (el) => new MDCTab(el),
-    tabScrollerFactory = (el) => new MDCTabScroller(el),
-  ) {
+    tabScrollerFactory = (el) => new MDCTabScroller(el)) {
     this.tabFactory_ = tabFactory;
     this.tabScrollerFactory_ = tabScrollerFactory;
 


### PR DESCRIPTION
fixes: #3570 
Trailing commas are not officially supported until ES 2017.