### PR TITLE
feat(chips): Add a mixin to handle chip elevation transitions

### DIFF
--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -219,6 +219,7 @@ Mixin | Description
 `mdc-chip-trailing-icon-size($size)` | Customizes the size of a trailing icon in a chip
 `mdc-chip-leading-icon-margin($top, $right, $bottom, $left)` | Customizes the margin of a leading icon in a chip
 `mdc-chip-trailing-icon-margin($top, $right, $bottom, $left)` | Customizes the margin of a trailing icon in a chip
+`mdc-chip-elevation-transition-value()` | This should be used instead of `mdc-elevation-transition-value` value when a box shadow transition is desired for a chip
 
 > _NOTE_: `mdc-chip-set-spacing` also sets the amount of space between a chip and the edge of the set it's contained in.
 

--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -219,7 +219,7 @@ Mixin | Description
 `mdc-chip-trailing-icon-size($size)` | Customizes the size of a trailing icon in a chip
 `mdc-chip-leading-icon-margin($top, $right, $bottom, $left)` | Customizes the margin of a leading icon in a chip
 `mdc-chip-trailing-icon-margin($top, $right, $bottom, $left)` | Customizes the margin of a trailing icon in a chip
-`mdc-chip-elevation-transition-value()` | This should be used instead of `mdc-elevation-transition-value` value when a box shadow transition is desired for a chip
+`mdc-chip-elevation-transition()` | This should be used instead of setting transition with `mdc-elevation-transition-value()` when a box shadow transition is desired for a chip
 
 > _NOTE_: `mdc-chip-set-spacing` also sets the amount of space between a chip and the edge of the set it's contained in.
 

--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -219,7 +219,7 @@ Mixin | Description
 `mdc-chip-trailing-icon-size($size)` | Customizes the size of a trailing icon in a chip
 `mdc-chip-leading-icon-margin($top, $right, $bottom, $left)` | Customizes the margin of a leading icon in a chip
 `mdc-chip-trailing-icon-margin($top, $right, $bottom, $left)` | Customizes the margin of a trailing icon in a chip
-`mdc-chip-elevation-transition()` | This should be used instead of setting transition with `mdc-elevation-transition-value()` when a box shadow transition is desired for a chip
+`mdc-chip-elevation-transition()` | Adds a MDC elevation transition to the chip. This should be used instead of setting transition with `mdc-elevation-transition-value()` directly when a box shadow transition is desired for a chip
 
 > _NOTE_: `mdc-chip-set-spacing` also sets the amount of space between a chip and the edge of the set it's contained in.
 

--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 //
 
+@import "@material/elevation/mixins";
 @import "@material/ripple/mixins";
 @import "@material/theme/functions";
 @import "@material/theme/mixins";
@@ -182,5 +183,15 @@
   $left: $mdc-chip-trailing-icon-margin-left) {
   .mdc-chip__icon--trailing {
     margin: $top $right $bottom $left;
+  }
+}
+
+@mixin mdc-chip-elevation-transition-value() {
+  transition: mdc-elevation-transition-value();
+
+  &.mdc-chip--exit {
+    transition:
+      mdc-elevation-transition-value(),
+      $mdc-chip-exit-transition;
   }
 }

--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -186,7 +186,7 @@
   }
 }
 
-@mixin mdc-chip-elevation-transition-value() {
+@mixin mdc-chip-elevation-transition() {
   transition: mdc-elevation-transition-value();
 
   &.mdc-chip--exit {

--- a/packages/mdc-chips/_variables.scss
+++ b/packages/mdc-chips/_variables.scss
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 //
 
+@import "@material/animation/variables";
 @import "@material/theme/variables";
 
 $mdc-chip-border-radius-default: 16px;
@@ -52,3 +53,9 @@ $mdc-chip-trailing-icon-margin-top: 0;
 $mdc-chip-trailing-icon-margin-right: -4px;
 $mdc-chip-trailing-icon-margin-bottom: 0;
 $mdc-chip-trailing-icon-margin-left: 4px;
+
+$mdc-chip-exit-transition:
+  opacity 75ms $mdc-animation-standard-curve-timing-function,
+  width 150ms $mdc-animation-deceleration-curve-timing-function,
+  padding 100ms linear,
+  margin 100ms linear;

--- a/packages/mdc-chips/chip/mdc-chip.scss
+++ b/packages/mdc-chips/chip/mdc-chip.scss
@@ -63,11 +63,7 @@
 }
 
 .mdc-chip--exit {
-  transition:
-    opacity 75ms $mdc-animation-standard-curve-timing-function,
-    width 150ms $mdc-animation-deceleration-curve-timing-function,
-    padding 100ms linear,
-    margin 100ms linear;
+  transition: $mdc-chip-exit-transition;
   opacity: 0;
 }
 


### PR DESCRIPTION
This is necessary for handling the case where an input chip needs to have a box-shadow transition. If mdc-elevation-transition-value() is used on its own without this, it overrides the .mdc-chip--exit transition and input chips don't animate out properly.