### PR TITLE
fix(list): Always call followHref regardless of single-selection mode

### DIFF
--- a/packages/mdc-list/foundation.js
+++ b/packages/mdc-list/foundation.js
@@ -195,10 +195,12 @@ class MDCListFoundation extends MDCFoundation {
       this.preventDefaultEvent_(evt);
       this.focusLastElement();
     } else if (isEnter || isSpace) {
-      if (this.isSingleSelectionList_ && isRootListItem) {
-        // Check if the space key was pressed on the list item or a child element.
-        this.setSelectedIndex(currentIndex);
-        this.preventDefaultEvent_(evt);
+      if (isRootListItem) {
+        if (this.isSingleSelectionList_) {
+          // Check if the space key was pressed on the list item or a child element.
+          this.setSelectedIndex(currentIndex);
+          this.preventDefaultEvent_(evt);
+        }
 
         // Explicitly activate links, since we're preventing default on Enter, and Space doesn't activate them.
         this.adapter_.followHref(currentIndex);

--- a/test/unit/mdc-list/foundation.test.js
+++ b/test/unit/mdc-list/foundation.test.js
@@ -416,10 +416,30 @@ test('#handleKeydown space/enter key does not cause event.preventDefault when si
   td.when(mockAdapter.toggleCheckbox(0)).thenReturn(false);
   foundation.setSingleSelection(false);
   foundation.handleKeydown(event, true, 0);
-  event.key = 'Enter';
+  event.key = 'Space';
   foundation.handleKeydown(event, true, 0);
 
   td.verify(preventDefault(), {times: 0});
+});
+
+test('#handleKeydown space/enter key call adapter.followHref regardless of singleSelection', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const target = {classList: ['mdc-list-item']};
+  const event = {key: 'Enter', target, preventDefault: () => {}};
+
+  td.when(mockAdapter.getFocusedElementIndex()).thenReturn(0);
+  td.when(mockAdapter.getListItemCount()).thenReturn(3);
+  td.when(mockAdapter.toggleCheckbox(0)).thenReturn(false);
+  foundation.setSingleSelection(false);
+  foundation.handleKeydown(event, true, 0);
+  foundation.setSingleSelection(true);
+  foundation.handleKeydown(event, true, 0);
+  event.key = 'Space';
+  foundation.handleKeydown(event, true, 0);
+  foundation.setSingleSelection(false);
+  foundation.handleKeydown(event, true, 0);
+
+  td.verify(mockAdapter.followHref(0), {times: 4});
 });
 
 test('#handleKeydown space key does not cause preventDefault to be called if singleSelection=false', () => {


### PR DESCRIPTION
I encountered this issue while attempting some approaches for lists in dialogs.

Currently, if single-selection mode isn't enabled, links don't get followed. I'm pretty sure they ought to be followed regardless.

I also noticed another test was accidentally testing the enter key twice instead of enter and space.