### PR TITLE
chore(infrastructure): Wait for DOM/animations to finish before capture

### DIFF
--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -782,7 +782,8 @@ class SeleniumApi {
     const fontLoadTimeoutMs = isOnline ? flakeConfig.font_face_observer_timeout_ms : 500;
 
     await driver.get(urlWithQsParams);
-    await driver.wait(until.elementLocated(By.css('[data-fonts-loaded]')), fontLoadTimeoutMs).catch(() => 0);
+    const domReadyCssSelector = '[data-fonts-loaded][data-animations-settled][data-dom-ready]';
+    await driver.wait(until.elementLocated(By.css(domReadyCssSelector)), fontLoadTimeoutMs).catch(() => {});
 
     const delayMs = flakeConfig.retry_delay_ms;
     if (delayMs > 0) {

--- a/test/screenshot/spec/mdc-button/classes/baseline-button-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-button-with-icons.html
@@ -176,6 +176,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/classes/baseline-button-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-button-without-icons.html
@@ -87,6 +87,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/classes/baseline-link-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-link-with-icons.html
@@ -112,6 +112,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/classes/baseline-link-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-link-without-icons.html
@@ -74,6 +74,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/classes/dense-button-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-button-with-icons.html
@@ -192,6 +192,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/classes/dense-button-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-button-without-icons.html
@@ -87,6 +87,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/classes/dense-link-with-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-link-with-icons.html
@@ -120,6 +120,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/classes/dense-link-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/dense-link-without-icons.html
@@ -74,6 +74,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/fixture.js
+++ b/test/screenshot/spec/mdc-button/fixture.js
@@ -22,9 +22,5 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-switch'), (el) => {
-    mdc.switchControl.MDCSwitch.attachTo(el);
-  });
-
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-button/mixins/container-fill-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/container-fill-color.html
@@ -58,6 +58,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/corner-radius.html
+++ b/test/screenshot/spec/mdc-button/mixins/corner-radius.html
@@ -73,6 +73,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/filled-accessible.html
+++ b/test/screenshot/spec/mdc-button/mixins/filled-accessible.html
@@ -85,6 +85,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/horizontal-padding-baseline.html
+++ b/test/screenshot/spec/mdc-button/mixins/horizontal-padding-baseline.html
@@ -116,6 +116,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/horizontal-padding-dense.html
+++ b/test/screenshot/spec/mdc-button/mixins/horizontal-padding-dense.html
@@ -116,6 +116,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/icon-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/icon-color.html
@@ -109,6 +109,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/ink-color.html
@@ -121,6 +121,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/stroke-color.html
+++ b/test/screenshot/spec/mdc-button/mixins/stroke-color.html
@@ -58,6 +58,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-button/mixins/stroke-width.html
+++ b/test/screenshot/spec/mdc-button/mixins/stroke-width.html
@@ -121,6 +121,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-card/classes/baseline.html
+++ b/test/screenshot/spec/mdc-card/classes/baseline.html
@@ -107,6 +107,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-card/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-card/fixture.js
+++ b/test/screenshot/spec/mdc-card/fixture.js
@@ -22,9 +22,5 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-switch'), (el) => {
-    mdc.switchControl.MDCSwitch.attachTo(el);
-  });
-
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-card/mixins/mixins.html
+++ b/test/screenshot/spec/mdc-card/mixins/mixins.html
@@ -85,6 +85,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-card/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-checkbox/classes/baseline.html
+++ b/test/screenshot/spec/mdc-checkbox/classes/baseline.html
@@ -156,6 +156,7 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
     <script src="../../../out/spec/mdc-checkbox/fixture.js"></script>
   </body>

--- a/test/screenshot/spec/mdc-checkbox/fixture.js
+++ b/test/screenshot/spec/mdc-checkbox/fixture.js
@@ -1,2 +1,27 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 document.getElementById('checkbox-indeterminate').indeterminate = true;
 document.getElementById('checkbox-indeterminate-disabled').indeterminate = true;
+
+window.mdc.testFixture.notifyDomReady();

--- a/test/screenshot/spec/mdc-checkbox/mixins/container-colors.html
+++ b/test/screenshot/spec/mdc-checkbox/mixins/container-colors.html
@@ -156,6 +156,7 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
     <script src="../../../out/spec/mdc-checkbox/fixture.js"></script>
   </body>

--- a/test/screenshot/spec/mdc-checkbox/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-checkbox/mixins/ink-color.html
@@ -156,6 +156,7 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
     <script src="../../../out/spec/mdc-checkbox/fixture.js"></script>
   </body>

--- a/test/screenshot/spec/mdc-chips/classes/action.html
+++ b/test/screenshot/spec/mdc-chips/classes/action.html
@@ -88,5 +88,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/classes/choice.html
+++ b/test/screenshot/spec/mdc-chips/classes/choice.html
@@ -84,5 +84,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/classes/filter.html
+++ b/test/screenshot/spec/mdc-chips/classes/filter.html
@@ -186,5 +186,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/classes/input.html
+++ b/test/screenshot/spec/mdc-chips/classes/input.html
@@ -114,5 +114,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/fixture.js
+++ b/test/screenshot/spec/mdc-chips/fixture.js
@@ -22,9 +22,5 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-switch'), (el) => {
-    mdc.switchControl.MDCSwitch.attachTo(el);
-  });
-
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-chips/mixins/chip-set-spacing.html
+++ b/test/screenshot/spec/mdc-chips/mixins/chip-set-spacing.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--chip-set-spacing mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/corner-radius.html
+++ b/test/screenshot/spec/mdc-chips/mixins/corner-radius.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--corner-radius mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/fill-color-accessible.html
+++ b/test/screenshot/spec/mdc-chips/mixins/fill-color-accessible.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--fill-color-accessible mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/fill-color.html
+++ b/test/screenshot/spec/mdc-chips/mixins/fill-color.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--fill-color mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/height.html
+++ b/test/screenshot/spec/mdc-chips/mixins/height.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--height mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/horizontal-padding.html
+++ b/test/screenshot/spec/mdc-chips/mixins/horizontal-padding.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--horizontal-padding mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-chips/mixins/ink-color.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--ink-color mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/leading-icon-color.html
+++ b/test/screenshot/spec/mdc-chips/mixins/leading-icon-color.html
@@ -62,7 +62,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--leading-icon-color" tabindex="0">
@@ -137,5 +137,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/leading-icon-margin.html
+++ b/test/screenshot/spec/mdc-chips/mixins/leading-icon-margin.html
@@ -62,7 +62,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--leading-icon-margin" tabindex="0">
@@ -215,5 +215,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/leading-icon-size.html
+++ b/test/screenshot/spec/mdc-chips/mixins/leading-icon-size.html
@@ -62,7 +62,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--leading-icon-size" tabindex="0">
@@ -137,5 +137,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/outline.html
+++ b/test/screenshot/spec/mdc-chips/mixins/outline.html
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
- 
+
         <div class="test-cell test-cell--chip">
           <div class="mdc-chip-set mdc-chip-set--filter">
             <div class="mdc-chip custom-chip custom-chip--outline mdc-chip--selected" tabindex="0">
@@ -150,5 +150,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/selected-ink-color.html
+++ b/test/screenshot/spec/mdc-chips/mixins/selected-ink-color.html
@@ -104,5 +104,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/trailing-icon-color.html
+++ b/test/screenshot/spec/mdc-chips/mixins/trailing-icon-color.html
@@ -75,5 +75,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/trailing-icon-margin.html
+++ b/test/screenshot/spec/mdc-chips/mixins/trailing-icon-margin.html
@@ -75,5 +75,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-chips/mixins/trailing-icon-size.html
+++ b/test/screenshot/spec/mdc-chips/mixins/trailing-icon-size.html
@@ -75,5 +75,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
     <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-chips/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-dialog/fixture.js
+++ b/test/screenshot/spec/mdc-dialog/fixture.js
@@ -64,6 +64,10 @@ window.mdc.testFixture.fontsLoaded.then(() => {
       dialog.listen(strings.OPENED_EVENT, () => list.layout());
     }
 
+    dialog.listen(strings.OPENED_EVENT, () => {
+      window.mdc.testFixture.notifyDomReady();
+    });
+
     /* Commenting out redlines for now due to unexplained flakes
 
     dialog.listen(strings.CLOSING_EVENT, () => {

--- a/test/screenshot/spec/mdc-drawer/classes/permanent.html
+++ b/test/screenshot/spec/mdc-drawer/classes/permanent.html
@@ -224,6 +224,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-drawer/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-drawer/fixture.js
+++ b/test/screenshot/spec/mdc-drawer/fixture.js
@@ -21,4 +21,7 @@
  * THE SOFTWARE.
  */
 
-mdc.drawer.MDCDrawer.attachTo(document.querySelector('.mdc-drawer'));
+window.mdc.testFixture.fontsLoaded.then(() => {
+  mdc.drawer.MDCDrawer.attachTo(document.querySelector('.mdc-drawer'));
+  window.mdc.testFixture.notifyDomReady();
+});

--- a/test/screenshot/spec/mdc-drawer/mixins/fill-color-accessible.html
+++ b/test/screenshot/spec/mdc-drawer/mixins/fill-color-accessible.html
@@ -224,6 +224,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-drawer/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-drawer/mixins/fill-color.html
+++ b/test/screenshot/spec/mdc-drawer/mixins/fill-color.html
@@ -224,6 +224,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-drawer/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-elevation/classes/baseline-large.html
+++ b/test/screenshot/spec/mdc-elevation/classes/baseline-large.html
@@ -62,6 +62,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-elevation/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-elevation/classes/baseline-small.html
+++ b/test/screenshot/spec/mdc-elevation/classes/baseline-small.html
@@ -62,6 +62,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-elevation/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-elevation/fixture.js
+++ b/test/screenshot/spec/mdc-elevation/fixture.js
@@ -22,9 +22,5 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-switch'), (el) => {
-    mdc.switchControl.MDCSwitch.attachTo(el);
-  });
-
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-elevation/mixins/mixins.html
+++ b/test/screenshot/spec/mdc-elevation/mixins/mixins.html
@@ -52,6 +52,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-elevation/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-fab/classes/baseline.html
+++ b/test/screenshot/spec/mdc-fab/classes/baseline.html
@@ -62,6 +62,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-fab/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-fab/classes/extended.html
+++ b/test/screenshot/spec/mdc-fab/classes/extended.html
@@ -66,6 +66,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-fab/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-fab/classes/mini.html
+++ b/test/screenshot/spec/mdc-fab/classes/mini.html
@@ -62,6 +62,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-fab/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-fab/fixture.js
+++ b/test/screenshot/spec/mdc-fab/fixture.js
@@ -22,9 +22,5 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-switch'), (el) => {
-    mdc.switchControl.MDCSwitch.attachTo(el);
-  });
-
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-fab/mixins/extended-padding.html
+++ b/test/screenshot/spec/mdc-fab/mixins/extended-padding.html
@@ -66,6 +66,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-fab/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-icon-button/classes/baseline.html
+++ b/test/screenshot/spec/mdc-icon-button/classes/baseline.html
@@ -92,6 +92,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-icon-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-icon-button/fixture.js
+++ b/test/screenshot/spec/mdc-icon-button/fixture.js
@@ -1,7 +1,32 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 mdc.testFixture.fontsLoaded.then(() => {
   const firstToggleButton = document.querySelector('.mdc-icon-button[aria-pressed]');
   if (firstToggleButton) {
     mdc.iconButton.MDCIconButtonToggle.attachTo(firstToggleButton);
     firstToggleButton.focus();
   }
+
+  window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-icon-button/mixins/icon-size.html
+++ b/test/screenshot/spec/mdc-icon-button/mixins/icon-size.html
@@ -92,6 +92,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-icon-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-icon-button/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-icon-button/mixins/ink-color.html
@@ -92,6 +92,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-icon-button/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-linear-progress/fixture.js
+++ b/test/screenshot/spec/mdc-linear-progress/fixture.js
@@ -69,3 +69,5 @@ enableAnimationCheckboxEl.addEventListener('change', (evt) => {
 window.addEventListener('popstate', checkUrlParams);
 
 checkUrlParams();
+
+window.mdc.testFixture.notifyDomReady();

--- a/test/screenshot/spec/mdc-radio/classes/baseline.html
+++ b/test/screenshot/spec/mdc-radio/classes/baseline.html
@@ -96,6 +96,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-radio/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-radio/fixture.js
+++ b/test/screenshot/spec/mdc-radio/fixture.js
@@ -22,9 +22,5 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-switch'), (el) => {
-    mdc.switchControl.MDCSwitch.attachTo(el);
-  });
-
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-radio/mixins/mixins.html
+++ b/test/screenshot/spec/mdc-radio/mixins/mixins.html
@@ -198,6 +198,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-radio/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-select/fixture.js
+++ b/test/screenshot/spec/mdc-select/fixture.js
@@ -25,4 +25,6 @@ window.mdc.testFixture.fontsLoaded.then(() => {
   [].forEach.call(document.querySelectorAll('.mdc-select'), (el) => {
     mdc.select.MDCSelect.attachTo(el);
   });
+
+  window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-textfield/fixture.js
+++ b/test/screenshot/spec/mdc-textfield/fixture.js
@@ -1,5 +1,30 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 window.mdc.testFixture.fontsLoaded.then(() => {
   [].forEach.call(document.querySelectorAll('.mdc-text-field'), (el) => {
     mdc.textField.MDCTextField.attachTo(el);
   });
+
+  window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-typography/classes/baseline-large.html
+++ b/test/screenshot/spec/mdc-typography/classes/baseline-large.html
@@ -58,6 +58,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-typography/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-typography/classes/baseline-small.html
+++ b/test/screenshot/spec/mdc-typography/classes/baseline-small.html
@@ -79,6 +79,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-typography/fixture.js"></script>
   </body>
 </html>

--- a/test/screenshot/spec/mdc-typography/fixture.js
+++ b/test/screenshot/spec/mdc-typography/fixture.js
@@ -22,9 +22,5 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
-  [].forEach.call(document.querySelectorAll('.mdc-switch'), (el) => {
-    mdc.switchControl.MDCSwitch.attachTo(el);
-  });
-
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-typography/mixins/mixins.html
+++ b/test/screenshot/spec/mdc-typography/mixins/mixins.html
@@ -57,6 +57,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
     <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-typography/fixture.js"></script>
   </body>
 </html>


### PR DESCRIPTION
- Attempts to reduce test flakiness by waiting to take a screenshot until the DOM has been initialized by the component JS and all CSS animations/transitions have finished
- Adds a test fixture JS file to every test page