### PR TITLE
chore(infrastructure): Reduce dialog flakiness by avoiding reflow

### DIFF
--- a/scripts/travis-env-vars.sh
+++ b/scripts/travis-env-vars.sh
@@ -92,5 +92,5 @@ fi
 
 if [[ "$TEST_SUITE" == 'screenshot' ]]; then
   # Only run screenshot tests if package JS/Sass files, non-Markdown screenshot test files, or image files changed.
-  check_for_testable_files '^packages/.+\.(js|css|scss)$' '^test/screenshot/.+[^m][^d]$' '\.(png|jpg|jpeg|gif|svg)$'
+  check_for_testable_files '^packages/.+\.(js|css|scss)$' '^test/screenshot/' '\.(png|jpg|jpeg|gif|svg)$'
 fi

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -422,11 +422,11 @@
     }
   },
   "spec/mdc-dialog/classes/overflow-bottom.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/18/18_18_22_548/spec/mdc-dialog/classes/overflow-bottom.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/21/11_20_28_699/spec/mdc-dialog/classes/overflow-bottom.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/18/18_18_22_548/spec/mdc-dialog/classes/overflow-bottom.html.windows_chrome_69.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/17/15_33_59_538/spec/mdc-dialog/classes/overflow-bottom.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/18/18_18_22_548/spec/mdc-dialog/classes/overflow-bottom.html.windows_firefox_62.png"
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/21/11_20_28_699/spec/mdc-dialog/classes/overflow-bottom.html.windows_firefox_62.png"
     }
   },
   "spec/mdc-dialog/classes/overflow-top.html": {

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
@@ -34,25 +34,25 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
-           aria-hidden="true"
-           aria-describedby="test-dialog__content--alert"
+           aria-labelledby="test-dialog__title"
+           aria-describedby="test-dialog__content"
            id="test-dialog">
         <div class="mdc-dialog__scrim"></div>
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
-            <h2 class="mdc-dialog__title test-dialog__title test-dialog__title--3-line" id="test-dialog__title"><!--
+            <h2 class="mdc-dialog__title test-dialog__title" id="test-dialog__title"><!--
             -->Alert title<!--
           --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content--alert">
-              <div class="test-dialog__content-rect">Alert description</div>
+            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+              <div class="test-dialog__content-rect"><p>Alert description</p></div>
             </section>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="cancel">

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
@@ -34,21 +34,21 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
-           aria-describedby="test-dialog__content--alert"
+           aria-describedby="test-dialog__content"
            id="test-dialog">
         <div class="mdc-dialog__scrim"></div>
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content--alert">
-              <div class="test-dialog__content-rect">Alert</div>
+            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+              <div class="test-dialog__content-rect"><p>Alert</p></div>
             </section>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="cancel">

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--confirmation"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -72,8 +72,7 @@
                         </div>
                       </div>
                     </span>
-                    <label id="test-dialog-baseline-confirmation-radio-1-label"
-                           for="test-dialog-baseline-confirmation-radio-1">Option 1</label>
+                    <label class="test-list-item__label" for="test-dialog-baseline-confirmation-radio-1">Option 1</label>
                   </li>
                   <li class="mdc-list-item" tabindex="0">
                     <span class="mdc-list-item__graphic">
@@ -89,8 +88,7 @@
                         </div>
                       </div>
                     </span>
-                    <label id="test-dialog-baseline-confirmation-radio-2-label"
-                           for="test-dialog-baseline-confirmation-radio-2">Option 2</label>
+                    <label class="test-list-item__label" for="test-dialog-baseline-confirmation-radio-2">Option 2</label>
                   </li>
                 </ul>
               </div>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--simple"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title--simple"

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--simple"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title--simple"
@@ -58,13 +58,16 @@
                 -->
                 <ul class="mdc-list" aria-orientation="vertical" style="list-style-type: none;">
                   <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="wifi">
-                    <i class="material-icons mdc-list-item__graphic">network_wifi</i> Wi-Fi
+                    <i class="material-icons mdc-list-item__graphic">network_wifi</i>
+                    <span class="test-list-item__label">Wi-Fi</span>
                   </li>
                   <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="bluetooth">
-                    <i class="material-icons mdc-list-item__graphic">bluetooth</i> Bluetooth
+                    <i class="material-icons mdc-list-item__graphic">bluetooth</i>
+                    <span class="test-list-item__label">Bluetooth</span>
                   </li>
                   <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="data">
-                    <i class="material-icons mdc-list-item__graphic">data_usage</i> Data usage
+                    <i class="material-icons mdc-list-item__graphic">data_usage</i>
+                    <span class="test-list-item__label">Data usage</span>
                   </li>
                 </ul>
               </div>

--- a/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
+++ b/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts test-container--large-font">
+  <body class="test-container test-container--edge-fonts test-container--large-font mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--scroll-to-bottom"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-to-bottom"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/fixture.js
+++ b/test/screenshot/spec/mdc-dialog/fixture.js
@@ -49,7 +49,7 @@ window.mdc.testFixture.fontsLoaded.then(() => {
       };
 
       const handleOpenEvent = () => {
-        for (let ms = 0; ms < 500; i += 50) {
+        for (let ms = 0; ms < 500; ms += 50) {
           setTimeout(scrollToBottom, ms);
         }
       };

--- a/test/screenshot/spec/mdc-dialog/fixture.js
+++ b/test/screenshot/spec/mdc-dialog/fixture.js
@@ -43,8 +43,8 @@ window.mdc.testFixture.fontsLoaded.then(() => {
       const scrollToBottom = () => {
         const tryToScroll = () => {
           contentEl.scrollTop = contentEl.scrollHeight;
-          if (contentEl.scrollTop === 0) {
-            requestAnimationFrame(tryToScroll);
+          if (contentEl.scrollHeight > contentEl.scrollTop + contentEl.offsetHeight) {
+            setTimeout(tryToScroll);
           }
         };
         tryToScroll();

--- a/test/screenshot/spec/mdc-dialog/fixture.js
+++ b/test/screenshot/spec/mdc-dialog/fixture.js
@@ -41,11 +41,11 @@ window.mdc.testFixture.fontsLoaded.then(() => {
     const shouldScrollToBottom = dialogEl.classList.contains('test-dialog--scroll-to-bottom');
     if (contentEl && shouldScrollToBottom) {
       const scrollToBottom = () => {
-        contentEl.scrollTop = contentEl.scrollHeight;
         const lastChild = contentEl.children[contentEl.children.length - 1];
         if (lastChild && lastChild.scrollIntoView) {
           lastChild.scrollIntoView(/* topAligned */ false);
         }
+        contentEl.scrollTop = contentEl.scrollHeight;
       };
 
       const handleOpenEvent = () => {

--- a/test/screenshot/spec/mdc-dialog/fixture.js
+++ b/test/screenshot/spec/mdc-dialog/fixture.js
@@ -40,14 +40,9 @@ window.mdc.testFixture.fontsLoaded.then(() => {
     const contentEl = dialogEl.querySelector('.mdc-dialog__content');
     const shouldScrollToBottom = dialogEl.classList.contains('test-dialog--scroll-to-bottom');
     if (contentEl && shouldScrollToBottom) {
-      const handleOpenEvent = () => {
-        for (let ms = 0; ms < 500; ms += 50) {
-          setTimeout(() => contentEl.scrollTop = contentEl.scrollHeight, ms);
-        }
-      };
-
-      dialog.listen(strings.OPENING_EVENT, handleOpenEvent);
-      dialog.listen(strings.OPENED_EVENT, handleOpenEvent);
+      const scrollToTop = () => setTimeout(() => contentEl.scrollTop = contentEl.scrollHeight);
+      dialog.listen(strings.OPENING_EVENT, scrollToTop);
+      dialog.listen(strings.OPENED_EVENT, scrollToTop);
     }
 
     const openButtonEl = dialogEl.id ? document.querySelector(`[data-test-dialog-id="${dialogEl.id}"]`) : null;

--- a/test/screenshot/spec/mdc-dialog/fixture.js
+++ b/test/screenshot/spec/mdc-dialog/fixture.js
@@ -40,17 +40,9 @@ window.mdc.testFixture.fontsLoaded.then(() => {
     const contentEl = dialogEl.querySelector('.mdc-dialog__content');
     const shouldScrollToBottom = dialogEl.classList.contains('test-dialog--scroll-to-bottom');
     if (contentEl && shouldScrollToBottom) {
-      const scrollToBottom = () => {
-        const lastChild = contentEl.children[contentEl.children.length - 1];
-        if (lastChild && lastChild.scrollIntoView) {
-          lastChild.scrollIntoView(/* topAligned */ false);
-        }
-        contentEl.scrollTop = contentEl.scrollHeight;
-      };
-
       const handleOpenEvent = () => {
         for (let ms = 0; ms < 500; ms += 50) {
-          setTimeout(scrollToBottom, ms);
+          setTimeout(() => contentEl.scrollTop = contentEl.scrollHeight, ms);
         }
       };
 

--- a/test/screenshot/spec/mdc-dialog/fixture.js
+++ b/test/screenshot/spec/mdc-dialog/fixture.js
@@ -41,16 +41,21 @@ window.mdc.testFixture.fontsLoaded.then(() => {
     const shouldScrollToBottom = dialogEl.classList.contains('test-dialog--scroll-to-bottom');
     if (contentEl && shouldScrollToBottom) {
       const scrollToBottom = () => {
-        const tryToScroll = () => {
-          contentEl.scrollTop = contentEl.scrollHeight;
-          if (contentEl.scrollHeight > contentEl.scrollTop + contentEl.offsetHeight) {
-            setTimeout(tryToScroll);
-          }
-        };
-        tryToScroll();
+        contentEl.scrollTop = contentEl.scrollHeight;
+        const lastChild = contentEl.children[contentEl.children.length - 1];
+        if (lastChild && lastChild.scrollIntoView) {
+          lastChild.scrollIntoView(/* topAligned */ false);
+        }
       };
-      dialog.listen(strings.OPENING_EVENT, scrollToBottom);
-      dialog.listen(strings.OPENED_EVENT, scrollToBottom);
+
+      const handleOpenEvent = () => {
+        for (let ms = 0; ms < 500; i += 50) {
+          setTimeout(scrollToBottom, ms);
+        }
+      };
+
+      dialog.listen(strings.OPENING_EVENT, handleOpenEvent);
+      dialog.listen(strings.OPENED_EVENT, handleOpenEvent);
     }
 
     const openButtonEl = dialogEl.id ? document.querySelector(`[data-test-dialog-id="${dialogEl.id}"]`) : null;

--- a/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--container-fill-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--container-fill-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--content-ink-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--content-ink-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--corner-radius"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--corner-radius"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/mixins/max-height.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-height.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--max-height"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-height"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/mixins/max-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-width.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--max-width"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-width"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -48,9 +48,11 @@
         <div class="mdc-dialog__scrim"></div>
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
-            <h2 class="mdc-dialog__title test-dialog__title test-dialog__title--5-line" id="test-dialog__title">“The Count of Monte Cristo” by Alexandre Dumas.<br>
+            <h2 class="mdc-dialog__title test-dialog__title test-dialog__title--5-line" id="test-dialog__title"><!--
+           -->“The Count of Monte Cristo” by Alexandre Dumas.<br>
               Published in 1844 and translated by Robin Buss.<br>
-              Public domain.</h2>
+              Public domain.<!--
+         --></h2>
             <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde

--- a/test/screenshot/spec/mdc-dialog/mixins/min-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/min-width.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--min-width"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--min-width"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -51,7 +51,7 @@
             <h2 class="mdc-dialog__title test-dialog__title" id="test-dialog__title">Title</h2>
             <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
-                Content
+                <p>Content</p>
               </div>
             </section>
             <footer class="mdc-dialog__actions">

--- a/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--scrim-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scrim-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--scroll-divider-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-divider-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"

--- a/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
@@ -34,12 +34,12 @@
     <link rel="stylesheet" href="../../../out/spec/mdc-dialog/fixture.css">
   </head>
 
-  <body class="test-container test-container--edge-fonts">
+  <body class="test-container test-container--edge-fonts mdc-dialog-scroll-lock">
     <main class="test-viewport test-viewport--center">
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog test-dialog test-dialog--title-ink-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--title-ink-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"


### PR DESCRIPTION
- Reduces text rendering flakiness on dialog pages in IE 11 💩, Edge, and Firefox
- Avoids reflow by adding CSS classes directly to the HTML:
    - `mdc-dialog--open`
    - `mdc-dialog-scroll-lock` (without this, scrollbars flicker in IE 11 💩 and Edge)
- Fixes a broken regex that caused screenshot tests to be skipped on PRs that only have HTML or YAML file changes 😞 