### PR TITLE
docs(dialog): Fix list item markup in docs and tests

### DIFF
--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -165,7 +165,8 @@ radio buttons (indicating single selection) or checkboxes (indicating multiple s
             </div>
           </span>
           <label id="test-dialog-baseline-confirmation-radio-1-label"
-                 for="test-dialog-baseline-confirmation-radio-1">None</label>
+                 for="test-dialog-baseline-confirmation-radio-1"
+                 class="mdc-list-item__text">None</label>
         </li>
         <!-- ... -->
       </ul>

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -116,7 +116,7 @@ The Simple Dialog contains a list of potential actions. It does not contain butt
  --></h2>
     <section class="mdc-dialog__content" id="my-dialog-content">
       <ul class="mdc-list mdc-list--avatar-list">
-        <li class="mdc-list-item" data-mdc-dialog-action="none">
+        <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="none">
           <span class="mdc-list-item__text">None</span>
         </li>
         <li class="mdc-list-item" data-mdc-dialog-action="callisto">

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
@@ -72,7 +72,7 @@
                         </div>
                       </div>
                     </span>
-                    <label class="test-list-item__label" for="test-dialog-baseline-confirmation-radio-1">Option 1</label>
+                    <label class="mdc-list-item__text test-list-item__label" for="test-dialog-baseline-confirmation-radio-1">Option 1</label>
                   </li>
                   <li class="mdc-list-item" tabindex="0">
                     <span class="mdc-list-item__graphic">
@@ -88,7 +88,7 @@
                         </div>
                       </div>
                     </span>
-                    <label class="test-list-item__label" for="test-dialog-baseline-confirmation-radio-2">Option 2</label>
+                    <label class="mdc-list-item__text test-list-item__label" for="test-dialog-baseline-confirmation-radio-2">Option 2</label>
                   </li>
                 </ul>
               </div>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
@@ -74,7 +74,7 @@
                     </span>
                     <label class="mdc-list-item__text test-list-item__label" for="test-dialog-baseline-confirmation-radio-1">Option 1</label>
                   </li>
-                  <li class="mdc-list-item" tabindex="0">
+                  <li class="mdc-list-item">
                     <span class="mdc-list-item__graphic">
                       <div class="mdc-radio">
                         <input class="mdc-radio__native-control"

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
@@ -59,15 +59,15 @@
                 <ul class="mdc-list mdc-list--avatar-list" aria-orientation="vertical" style="list-style-type: none;">
                   <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="wifi">
                     <i class="material-icons mdc-list-item__graphic">network_wifi</i>
-                    <span class="test-list-item__label">Wi-Fi</span>
+                    <span class="mdc-list-item__text test-list-item__label">Wi-Fi</span>
                   </li>
                   <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="bluetooth">
                     <i class="material-icons mdc-list-item__graphic">bluetooth</i>
-                    <span class="test-list-item__label">Bluetooth</span>
+                    <span class="mdc-list-item__text test-list-item__label">Bluetooth</span>
                   </li>
                   <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="data">
                     <i class="material-icons mdc-list-item__graphic">data_usage</i>
-                    <span class="test-list-item__label">Data usage</span>
+                    <span class="mdc-list-item__text test-list-item__label">Data usage</span>
                   </li>
                 </ul>
               </div>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
@@ -61,11 +61,11 @@
                     <i class="material-icons mdc-list-item__graphic">network_wifi</i>
                     <span class="mdc-list-item__text test-list-item__label">Wi-Fi</span>
                   </li>
-                  <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="bluetooth">
+                  <li class="mdc-list-item" data-mdc-dialog-action="bluetooth">
                     <i class="material-icons mdc-list-item__graphic">bluetooth</i>
                     <span class="mdc-list-item__text test-list-item__label">Bluetooth</span>
                   </li>
-                  <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="data">
+                  <li class="mdc-list-item" data-mdc-dialog-action="data">
                     <i class="material-icons mdc-list-item__graphic">data_usage</i>
                     <span class="mdc-list-item__text test-list-item__label">Data usage</span>
                   </li>


### PR DESCRIPTION
* add `mdc-list-item__text` where missing
* remove extra tabindex attributes