### PR TITLE
docs(dialog): Fix markup in docs and tests

### DIFF
--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -46,17 +46,19 @@ npm install @material/dialog
      aria-labelledby="my-dialog-title"
      aria-describedby="my-dialog-content">
   <div class="mdc-dialog__container">
-    <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
-    <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
-   -->Dialog Title<!--
- --></h2>
-    <section class="mdc-dialog__content" id="my-dialog-content">
-      Dialog body text goes here.
-    </section>
-    <footer class="mdc-dialog__actions">
-      <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no">No</button>
-      <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">Yes</button>
-    </footer>
+    <div class="mdc-dialog__surface">
+      <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
+      <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
+     -->Dialog Title<!--
+   --></h2>
+      <section class="mdc-dialog__content" id="my-dialog-content">
+        Dialog body text goes here.
+      </section>
+      <footer class="mdc-dialog__actions">
+        <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no">No</button>
+        <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">Yes</button>
+      </footer>
+    </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
 </div>
@@ -110,21 +112,23 @@ The Simple Dialog contains a list of potential actions. It does not contain butt
      aria-labelledby="my-dialog-title"
      aria-describedby="my-dialog-content">
   <div class="mdc-dialog__container">
-    <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
-    <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
-   -->Choose a Ringtone<!--
- --></h2>
-    <section class="mdc-dialog__content" id="my-dialog-content">
-      <ul class="mdc-list mdc-list--avatar-list">
-        <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="none">
-          <span class="mdc-list-item__text">None</span>
-        </li>
-        <li class="mdc-list-item" data-mdc-dialog-action="callisto">
-          <span class="mdc-list-item__text">Callisto</span>
-        </li>
-        <!-- ... -->
-      </ul>
-    </section>
+    <div class="mdc-dialog__surface">
+      <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
+      <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
+     -->Choose a Ringtone<!--
+   --></h2>
+      <section class="mdc-dialog__content" id="my-dialog-content">
+        <ul class="mdc-list mdc-list--avatar-list">
+          <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="none">
+            <span class="mdc-list-item__text">None</span>
+          </li>
+          <li class="mdc-list-item" data-mdc-dialog-action="callisto">
+            <span class="mdc-list-item__text">Callisto</span>
+          </li>
+          <!-- ... -->
+        </ul>
+      </section>
+    </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
 </div>
@@ -144,37 +148,39 @@ radio buttons (indicating single selection) or checkboxes (indicating multiple s
      aria-labelledby="my-dialog-title"
      aria-describedby="my-dialog-content">
   <div class="mdc-dialog__container">
-    <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
-    <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
-   -->Choose a Ringtone<!--
- --></h2>
-    <section class="mdc-dialog__content" id="my-dialog-content">
-      <ul class="mdc-list">
-        <li class="mdc-list-item" tabindex="0">
-          <span class="mdc-list-item__graphic">
-            <div class="mdc-radio">
-              <input class="mdc-radio__native-control"
-                     type="radio"
-                     id="test-dialog-baseline-confirmation-radio-1"
-                     name="test-dialog-baseline-confirmation-radio-group"
-                     checked>
-              <div class="mdc-radio__background">
-                <div class="mdc-radio__outer-circle"></div>
-                <div class="mdc-radio__inner-circle"></div>
+    <div class="mdc-dialog__surface">
+      <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
+      <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
+     -->Choose a Ringtone<!--
+   --></h2>
+      <section class="mdc-dialog__content" id="my-dialog-content">
+        <ul class="mdc-list">
+          <li class="mdc-list-item" tabindex="0">
+            <span class="mdc-list-item__graphic">
+              <div class="mdc-radio">
+                <input class="mdc-radio__native-control"
+                       type="radio"
+                       id="test-dialog-baseline-confirmation-radio-1"
+                       name="test-dialog-baseline-confirmation-radio-group"
+                       checked>
+                <div class="mdc-radio__background">
+                  <div class="mdc-radio__outer-circle"></div>
+                  <div class="mdc-radio__inner-circle"></div>
+                </div>
               </div>
-            </div>
-          </span>
-          <label id="test-dialog-baseline-confirmation-radio-1-label"
-                 for="test-dialog-baseline-confirmation-radio-1"
-                 class="mdc-list-item__text">None</label>
-        </li>
-        <!-- ... -->
-      </ul>
-    </section>
-    <footer class="mdc-dialog__actions">
-      <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">Cancel</button>
-      <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="accept">OK</button>
-    </footer>
+            </span>
+            <label id="test-dialog-baseline-confirmation-radio-1-label"
+                   for="test-dialog-baseline-confirmation-radio-1"
+                   class="mdc-list-item__text">None</label>
+          </li>
+          <!-- ... -->
+        </ul>
+      </section>
+      <footer class="mdc-dialog__actions">
+        <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">Cancel</button>
+        <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="accept">OK</button>
+      </footer>
+    </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
 </div>

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -40,7 +40,7 @@ npm install @material/dialog
 ### HTML Structure
 
 ```html
-<aside class="mdc-dialog"
+<div class="mdc-dialog"
      role="alertdialog"
      aria-modal="true"
      aria-labelledby="my-dialog-title"
@@ -61,7 +61,7 @@ npm install @material/dialog
     </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
-</aside>
+</div>
 ```
 
 > *NOTE*: Titles cannot contain leading whitespace due to how `mdc-typography-baseline-top()` works.
@@ -106,7 +106,7 @@ dialog.listen('MDCDialog:opened', () => {
 The Simple Dialog contains a list of potential actions. It does not contain buttons.
 
 ```html
-<aside class="mdc-dialog"
+<div class="mdc-dialog"
      role="alertdialog"
      aria-modal="true"
      aria-labelledby="my-dialog-title"
@@ -131,7 +131,7 @@ The Simple Dialog contains a list of potential actions. It does not contain butt
     </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
-</aside>
+</div>
 ```
 
 > Note the inclusion of the `mdc-list--avatar-list` class, which aligns with the Simple Dialog spec.
@@ -142,7 +142,7 @@ The Confirmation Dialog contains a list of choices, and buttons to confirm or ca
 radio buttons (indicating single selection) or checkboxes (indicating multiple selection).
 
 ```html
-<aside class="mdc-dialog"
+<div class="mdc-dialog"
      role="alertdialog"
      aria-modal="true"
      aria-labelledby="my-dialog-title"
@@ -183,7 +183,7 @@ radio buttons (indicating single selection) or checkboxes (indicating multiple s
     </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
-</aside>
+</div>
 ```
 
 > *NOTE*: In the example above, the Cancel button intentionally has the `close` action to align with the behavior of

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -40,7 +40,7 @@ npm install @material/dialog
 ### HTML Structure
 
 ```html
-<div class="mdc-dialog"
+<aside class="mdc-dialog"
      role="alertdialog"
      aria-modal="true"
      aria-labelledby="my-dialog-title"
@@ -61,7 +61,7 @@ npm install @material/dialog
     </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
-</div>
+</aside>
 ```
 
 > *NOTE*: Titles cannot contain leading whitespace due to how `mdc-typography-baseline-top()` works.
@@ -106,7 +106,7 @@ dialog.listen('MDCDialog:opened', () => {
 The Simple Dialog contains a list of potential actions. It does not contain buttons.
 
 ```html
-<div class="mdc-dialog"
+<aside class="mdc-dialog"
      role="alertdialog"
      aria-modal="true"
      aria-labelledby="my-dialog-title"
@@ -131,7 +131,7 @@ The Simple Dialog contains a list of potential actions. It does not contain butt
     </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
-</div>
+</aside>
 ```
 
 > Note the inclusion of the `mdc-list--avatar-list` class, which aligns with the Simple Dialog spec.
@@ -142,7 +142,7 @@ The Confirmation Dialog contains a list of choices, and buttons to confirm or ca
 radio buttons (indicating single selection) or checkboxes (indicating multiple selection).
 
 ```html
-<div class="mdc-dialog"
+<aside class="mdc-dialog"
      role="alertdialog"
      aria-modal="true"
      aria-labelledby="my-dialog-title"
@@ -183,7 +183,7 @@ radio buttons (indicating single selection) or checkboxes (indicating multiple s
     </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
-</div>
+</aside>
 ```
 
 > *NOTE*: In the example above, the Cancel button intentionally has the `close` action to align with the behavior of

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -51,9 +51,9 @@ npm install @material/dialog
       <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
      -->Dialog Title<!--
    --></h2>
-      <section class="mdc-dialog__content" id="my-dialog-content">
+      <div class="mdc-dialog__content" id="my-dialog-content">
         Dialog body text goes here.
-      </section>
+      </div>
       <footer class="mdc-dialog__actions">
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no">No</button>
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">Yes</button>
@@ -117,7 +117,7 @@ The Simple Dialog contains a list of potential actions. It does not contain butt
       <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
      -->Choose a Ringtone<!--
    --></h2>
-      <section class="mdc-dialog__content" id="my-dialog-content">
+      <div class="mdc-dialog__content" id="my-dialog-content">
         <ul class="mdc-list mdc-list--avatar-list">
           <li class="mdc-list-item" tabindex="0" data-mdc-dialog-action="none">
             <span class="mdc-list-item__text">None</span>
@@ -127,7 +127,7 @@ The Simple Dialog contains a list of potential actions. It does not contain butt
           </li>
           <!-- ... -->
         </ul>
-      </section>
+      </div>
     </div>
   </div>
   <div class="mdc-dialog__scrim"></div>
@@ -153,7 +153,7 @@ radio buttons (indicating single selection) or checkboxes (indicating multiple s
       <h2 class="mdc-dialog__title" id="my-dialog-title"><!--
      -->Choose a Ringtone<!--
    --></h2>
-      <section class="mdc-dialog__content" id="my-dialog-content">
+      <div class="mdc-dialog__content" id="my-dialog-content">
         <ul class="mdc-list">
           <li class="mdc-list-item" tabindex="0">
             <span class="mdc-list-item__graphic">
@@ -175,7 +175,7 @@ radio buttons (indicating single selection) or checkboxes (indicating multiple s
           </li>
           <!-- ... -->
         </ul>
-      </section>
+      </div>
       <footer class="mdc-dialog__actions">
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">Cancel</button>
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="accept">OK</button>

--- a/packages/mdc-dialog/mdc-dialog.scss
+++ b/packages/mdc-dialog/mdc-dialog.scss
@@ -156,7 +156,7 @@
   padding: 6px 0 0; // Top padding balances with title height
 }
 
-// stylelint-disable-next-line plugin/selector-bem-pattern
+// stylelint-disable-next-line plugin/selector-bem-pattern, selector-max-specificity
 .mdc-dialog--scrollable .mdc-dialog__content .mdc-list:first-child:last-child {
   // Override default .mdc-list padding for content consisting exclusively of a MDC List
   padding: 0;

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert-above-drawer.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert-above-drawer.html
@@ -48,9 +48,9 @@
         <div class="mdc-dialog__scrim"></div>
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content--alert">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content--alert">
               <div class="test-dialog__content-rect">Alert</div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="cancel">
                 <span class="test-font--redact-all">Cancel</span>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert-above-drawer.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert-above-drawer.html
@@ -40,7 +40,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-describedby="test-dialog__content--alert"
@@ -61,7 +61,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
       <aside class="mdc-drawer mdc-drawer--dismissible mdc-drawer--open">
         <header class="mdc-drawer__header">

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert-above-drawer.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert-above-drawer.html
@@ -40,7 +40,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-describedby="test-dialog__content--alert"
@@ -61,7 +61,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
       <aside class="mdc-drawer mdc-drawer--dismissible mdc-drawer--open">
         <header class="mdc-drawer__header">

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
@@ -51,9 +51,9 @@
             <h2 class="mdc-dialog__title test-dialog__title" id="test-dialog__title"><!--
             -->Alert title<!--
           --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect"><p>Alert description</p></div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="cancel">
                 <span class="test-font--redact-all">Cancel</span>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -64,7 +64,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert-with-title.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -64,7 +64,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
@@ -47,9 +47,9 @@
         <div class="mdc-dialog__scrim"></div>
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect"><p>Alert</p></div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="cancel">
                 <span class="test-font--redact-all">Cancel</span>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-describedby="test-dialog__content"
@@ -60,7 +60,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-alert.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-describedby="test-dialog__content"
@@ -60,7 +60,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
@@ -49,7 +49,7 @@
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
             <h2 class="mdc-dialog__title test-dialog__title" id="test-dialog__title">Confirmation</h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
 
               <div class="test-dialog__content-rect">
                 <!--
@@ -93,7 +93,7 @@
                 </ul>
               </div>
 
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="cancel">
                 <span class="test-font--redact-all">Cancel</span>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--confirmation"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--confirmation"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -104,7 +104,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-confirmation.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--confirmation"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--confirmation"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -104,7 +104,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
@@ -49,7 +49,7 @@
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
             <h2 class="mdc-dialog__title test-dialog__title" id="test-dialog__title--simple">Simple</h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content--simple">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content--simple">
 
               <div class="test-dialog__content-rect">
                 <!--
@@ -72,7 +72,7 @@
                 </ul>
               </div>
 
-            </section>
+            </div>
           </div>
         </div>
       </aside>

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--simple"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--simple"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title--simple"
@@ -75,7 +75,7 @@
             </div>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
+++ b/test/screenshot/spec/mdc-dialog/classes/baseline-simple.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--simple"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--simple"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title--simple"
@@ -75,7 +75,7 @@
             </section>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
+++ b/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -68,7 +68,7 @@
                   been built, rigged, and laden at the old Phocee docks, and belongs to an
                   owner of the city.</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">Verbose loquacious button text</span>

--- a/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
+++ b/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
+++ b/test/screenshot/spec/mdc-dialog/classes/manual-window-resize.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -273,7 +273,7 @@
                   were known that you had conveyed a packet to the marshal, and had
                   conversed with the emperor, it might bring you into trouble.”</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">This is a really long button for testing purposes only. Button text should be short when at all possible, but l10n can present a challenge.</span>

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-accessible-font-size.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -273,7 +273,7 @@
                   were known that you had conveyed a packet to the marshal, and had
                   conversed with the emperor, it might bring you into trouble.”</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">This is a really long button for testing purposes only. Button text should be short when at all possible, but l10n can present a challenge.</span>

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-to-bottom"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-to-bottom"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-bottom.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-to-bottom"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-to-bottom"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -273,7 +273,7 @@
                   were known that you had conveyed a packet to the marshal, and had
                   conversed with the emperor, it might bring you into trouble.”</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">This is a really long button for testing purposes only. Button text should be short when at all possible, but l10n can present a challenge.</span>

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog"
+      <div class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
+++ b/test/screenshot/spec/mdc-dialog/classes/overflow-top.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -68,7 +68,7 @@
                   been built, rigged, and laden at the old Phocee docks, and belongs to an
                   owner of the city.</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">Verbose loquacious button text</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--container-fill-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--container-fill-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/container-fill-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--container-fill-color"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--container-fill-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -68,7 +68,7 @@
                   been built, rigged, and laden at the old Phocee docks, and belongs to an
                   owner of the city.</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">Verbose loquacious button text</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--content-ink-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--content-ink-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/content-ink-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--content-ink-color"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--content-ink-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -68,7 +68,7 @@
                   been built, rigged, and laden at the old Phocee docks, and belongs to an
                   owner of the city.</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">Verbose loquacious button text</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--corner-radius"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--corner-radius"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/corner-radius.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--corner-radius"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--corner-radius"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/max-height.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-height.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -273,7 +273,7 @@
                   were known that you had conveyed a packet to the marshal, and had
                   conversed with the emperor, it might bring you into trouble.”</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">This is a really long button for testing purposes only. Button text should be short when at all possible, but l10n can present a challenge.</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/max-height.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-height.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-height"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-height"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/max-height.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-height.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-height"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-height"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/max-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-width.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -273,7 +273,7 @@
                   were known that you had conveyed a packet to the marshal, and had
                   conversed with the emperor, it might bring you into trouble.”</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">This is a really long button for testing purposes only. Button text should be short when at all possible, but l10n can present a challenge.</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/max-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-width.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-width"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-width"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/max-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/max-width.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-width"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--max-width"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/min-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/min-width.html
@@ -49,11 +49,11 @@
         <div class="mdc-dialog__container">
           <div class="mdc-dialog__surface">
             <h2 class="mdc-dialog__title test-dialog__title" id="test-dialog__title">Title</h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>Content</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">
                 <span class="test-font--redact-all">OK</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/min-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/min-width.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--min-width"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--min-width"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -61,7 +61,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/min-width.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/min-width.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--min-width"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--min-width"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -61,7 +61,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -68,7 +68,7 @@
                   been built, rigged, and laden at the old Phocee docks, and belongs to an
                   owner of the city.</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">Verbose loquacious button text</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scrim-color"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scrim-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scrim-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scrim-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scrim-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -273,7 +273,7 @@
                   were known that you had conveyed a packet to the marshal, and had
                   conversed with the emperor, it might bring you into trouble.”</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">Verbose loquacious button text</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-divider-color"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-divider-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/scroll-divider-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-divider-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--scroll-divider-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -287,7 +287,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
@@ -53,7 +53,7 @@
               Published in 1844 and translated by Robin Buss.<br>
               Public domain.<!--
          --></h2>
-            <section class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
+            <div class="mdc-dialog__content test-dialog__content" id="test-dialog__content">
               <div class="test-dialog__content-rect">
                 <p>On the <span class="test-font--redact-all">24th</span> of February, 1815, the look-out at Notre-Dame de la Garde
                   signalled the <span class="test-font--redact-all">three-master, the</span> Pharaon from Smyrna, Trieste, and
@@ -68,7 +68,7 @@
                   been built, rigged, and laden at the old Phocee docks, and belongs to an
                   owner of the city.</p>
               </div>
-            </section>
+            </div>
             <footer class="mdc-dialog__actions">
               <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="other">
                 <span class="test-font--redact-all">Verbose loquacious button text</span>

--- a/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--title-ink-color"
+      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--title-ink-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </div>
+      </aside>
 
     </main>
 

--- a/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
+++ b/test/screenshot/spec/mdc-dialog/mixins/title-ink-color.html
@@ -39,7 +39,7 @@
 
       <button class="test-dialog-open-button" data-test-dialog-id="test-dialog" autofocus>Open Dialog</button>
 
-      <aside class="mdc-dialog mdc-dialog--open test-dialog test-dialog--title-ink-color"
+      <div class="mdc-dialog mdc-dialog--open test-dialog test-dialog--title-ink-color"
            role="alertdialog"
            aria-modal="true"
            aria-labelledby="test-dialog__title"
@@ -82,7 +82,7 @@
             </footer>
           </div>
         </div>
-      </aside>
+      </div>
 
     </main>
 


### PR DESCRIPTION
Fixes #3620, #3621.

Also fixes a lint error that somehow snuck through.

Note: View this PR with `?w=1` in the URL to make it easier to see the diff (ignoring indentation changes).