### PR TITLE
fix(shape): Remove reference from MCW package

### DIFF
--- a/packages/material-components-web/material-components-web.scss
+++ b/packages/material-components-web/material-components-web.scss
@@ -44,7 +44,6 @@
 @import "@material/radio/mdc-radio";
 @import "@material/ripple/mdc-ripple";
 @import "@material/select/mdc-select";
-@import "@material/shape/mdc-shape";
 @import "@material/slider/mdc-slider";
 @import "@material/snackbar/mdc-snackbar";
 @import "@material/switch/mdc-switch";


### PR DESCRIPTION
I could've sworn I saw this in one of the other shape PRs originally, but we somehow missed removing this reference from material-components-web.scss, which breaks the build/dist targets for the all-in-one package, because there are no longer any emitted shape styles OOTB.