### PR TITLE
Fix discrepency in mdc-base readme

### DIFF
--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -244,11 +244,11 @@ Where `./util` could look like:
 
 ```javascript
 export function toggleClass(element, className) {
-  if (root.classList.contains(className)) {
-    root.classList.remove(className);
+  if (element.classList.contains(className)) {
+    element.classList.remove(className);
     return;
   }
-  root.classList.add(className);
+  element.classList.add(className);
 }
 ```
 


### PR DESCRIPTION
Fixed a seeming typo, I believe root should be element here considering the overall code context and the function parameters.