### PR TITLE
docs(shape): Remove obsolete image

### DIFF
--- a/packages/mdc-shape/README.md
+++ b/packages/mdc-shape/README.md
@@ -7,12 +7,6 @@ path: /catalog/shape/
 -->
 
 # Shape
-<!--<div class="article__asset">
-  <a class="article__asset-link"
-     href="https://material-components.github.io/material-components-web-catalog/#/component/shape">
-    <img src="{{ site.rootpath }}/images/mdc_web_screenshots/shape.png" width="159" alt="Shape screenshot">
-  </a>
-</div>-->
 
 Shapes direct attention, identify components, communicate state, and express brand.
 


### PR DESCRIPTION
This image was left over from the previous mdc-shape package contents.