### PR TITLE
chore(infrastructure): Fix analytics URLs

### DIFF
--- a/test/screenshot/infra/commands/test.js
+++ b/test/screenshot/infra/commands/test.js
@@ -295,7 +295,7 @@ class TestCommand {
     const masterReportPageUrl = this.analytics_.getUrl({
       url: masterReportData.meta.report_html_file.public_url,
       source: 'github',
-      type: 'pr_comment',
+      medium: 'pr_comment',
     });
     const masterScreenshots = masterReportData.screenshots;
     const masterGitRev = masterReportData.meta.golden_diff_base.git_revision;
@@ -361,7 +361,7 @@ ${listMarkdown}
       const htmlFileUrl = this.analytics_.getUrl({
         url: (firstScreenshot.actual_html_file || firstScreenshot.expected_html_file).public_url,
         source: 'github',
-        type: 'pr_comment',
+        medium: 'pr_comment',
       });
 
       return `
@@ -397,7 +397,7 @@ ${listItemMarkdown}
     const linkUrl = this.analytics_.getUrl({
       url: imgFile.public_url,
       source: 'github',
-      type: 'pr_comment',
+      medium: 'pr_comment',
     });
 
     const untrimmed = `
@@ -488,7 +488,7 @@ ${CliColor.bold.red('Skipping screenshot tests.')}
     const reportPageUrl = this.analytics_.getUrl({
       url: reportData.meta.report_html_file.public_url,
       source: 'cli',
-      type: 'test_results',
+      medium: 'test_results',
     });
 
     const headingPlain = 'Screenshot Test Results';

--- a/test/screenshot/infra/lib/analytics.js
+++ b/test/screenshot/infra/lib/analytics.js
@@ -41,7 +41,7 @@ class Analytics {
   getUrl({
     url,
     source,
-    type = undefined,
+    content = undefined,
     campaign = undefined,
     medium = undefined,
     extraParams = undefined,
@@ -49,8 +49,8 @@ class Analytics {
     const [resource, oldQuery] = url.split('?');
     const params = new URLSearchParams(oldQuery);
     params.set('utm_source', source);
-    if (type) {
-      params.set('utm_content', type);
+    if (content) {
+      params.set('utm_content', content);
     }
     if (campaign) {
       params.set('utm_campaign', campaign);

--- a/test/screenshot/infra/lib/github-api.js
+++ b/test/screenshot/infra/lib/github-api.js
@@ -151,7 +151,7 @@ class GitHubApi {
       targetUrl = this.analytics_.getUrl({
         url: reportFileUrl,
         source: 'github',
-        type: 'pr_status',
+        medium: 'pr_status',
       });
     } else {
       const runnableScreenshots = screenshots.runnable_screenshot_list;

--- a/test/screenshot/infra/lib/report-builder.js
+++ b/test/screenshot/infra/lib/report-builder.js
@@ -1011,7 +1011,7 @@ class ReportBuilder {
         const publicUrl = this.analytics_.getUrl({
           url: htmlFile.public_url,
           source: 'cli',
-          type: 'inventory',
+          medium: 'inventory',
         });
         console.log(`  - ${this.cli_.colorizeUrl(publicUrl)} > ${screenshot.user_agent.alias}`);
       }

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -769,7 +769,7 @@ class SeleniumApi {
     const urlWithQsParams = this.analytics_.getUrl({
       url,
       source: 'cbt',
-      type: 'selenium',
+      medium: 'selenium',
       extraParams: {
         font_face_observer_timeout_ms: flakeConfig.font_face_observer_timeout_ms,
         fonts_loaded_reflow_delay_ms: flakeConfig.fonts_loaded_reflow_delay_ms,
@@ -936,7 +936,7 @@ class SeleniumApi {
     const actualHtmlFileUrlPlain = this.analytics_.getUrl({
       url: screenshot.actual_html_file.public_url,
       source: 'cli',
-      type: 'progress',
+      medium: 'progress',
     });
 
     let cropColor = '';
@@ -1001,7 +1001,7 @@ class SeleniumApi {
     const actualHtmlFileUrl = this.analytics_.getUrl({
       url: screenshot.actual_html_file.public_url,
       source: 'cli',
-      type: 'progress',
+      medium: 'progress',
     });
 
     const bold = CliColor.bold;


### PR DESCRIPTION
`utm_medium` is displayed prominently in the Google Analytics console, whereas `utm_content` is harder to find.