### PR TITLE
chore(infrastructure): Reduce font reflow delays

### DIFF
--- a/test/screenshot/diffing.json
+++ b/test/screenshot/diffing.json
@@ -8,11 +8,11 @@
   "flaky_test_config": {
     "global_config": {
       "max_retries": 2,
-      "retry_delay_ms": 500,
       "min_changed_pixel_count": 15,
       "max_changed_pixel_fraction_to_retry": 0.10,
       "font_face_observer_timeout_ms": 3000,
-      "fonts_loaded_reflow_delay_ms": 50
+      "fonts_loaded_reflow_delay_ms": 0,
+      "retry_delay_ms": 500
     },
 
     "config_overrides": [
@@ -23,8 +23,7 @@
           "desktop_windows_ie@11"
         ],
         "custom_config": {
-          "max_retries": 3,
-          "fonts_loaded_reflow_delay_ms": 250
+          "max_retries": 3
         }
       },
       {
@@ -38,7 +37,8 @@
         ],
         "custom_config": {
           "max_retries": 6,
-          "fonts_loaded_reflow_delay_ms": 500
+          "fonts_loaded_reflow_delay_ms": 250,
+          "retry_delay_ms": 1000
         }
       },
       {
@@ -52,17 +52,6 @@
         ],
         "custom_config": {
           "skip_all": true
-        }
-      },
-      {
-        "description": "Wait for dialog entrance animations to finish.",
-        "url_regex_patterns": [
-          "mdc-dialog"
-        ],
-        "custom_config": {
-          "max_retries": 4,
-          "min_changed_pixel_count": 25,
-          "fonts_loaded_reflow_delay_ms": 250
         }
       }
     ]


### PR DESCRIPTION
- Removes global font reflow delay
- Reduces font reflow delay in Edge and IE 11 💩 from `500ms` to `100ms`
- Adds a `1000ms` retry delay on text field pages in Edge and IE 11 💩

This should speed up screenshot tests by about a minute.