### PR TITLE
chore(infrastructure): Increase max CBT parallels off-hours

### DIFF
--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -392,10 +392,15 @@ class SeleniumApi {
         return Math.min(cliParallels, available);
       }
 
-      // If nobody else is running any tests, run half the number of concurrent tests allowed by our CBT account.
-      // This gives us _some_ parallelism while still allowing other users to run their tests.
+      // Nobody else is running tests
       if (active === 0) {
-        return Math.floor(max / 2);
+        if (this.isBusinessHours_()) {
+          // Run half the number of concurrent tests allowed by our CBT account.
+          // This gives us _some_ parallelism while allowing other users to run their tests.
+          return Math.floor(max / 2);
+        } else {
+          return available;
+        }
       }
 
       // If someone else is already running tests, only run one test at a time.
@@ -970,6 +975,25 @@ class SeleniumApi {
   createUrlAliasMessage_(url, userAgent) {
     const userAgentColor = CliColor.bold.italic;
     return `${this.cli_.colorizeUrl(url)} > ${userAgentColor(userAgent.alias)}`;
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isBusinessHours_() {
+    const MORNING_UTC_HOURS = 13; // 1pm UTC === 9am EST
+    const EVENING_UTC_HOURS = 1; // 1am UTC === 6pm PST
+    const SATURDAY = 7;
+    const SUNDAY = 0;
+
+    const nowDate = new Date();
+    const nowUtcHours = nowDate.getUTCHours();
+
+    const isWeekDay = nowDate.getDay() > SUNDAY || nowDate.getDay() < SATURDAY;
+    const is9to5 = nowUtcHours > MORNING_UTC_HOURS || nowUtcHours < EVENING_UTC_HOURS;
+
+    return isWeekDay && is9to5;
   }
 
   /**


### PR DESCRIPTION
### What it does

Increases the default number of parallel CBT browsers from **`2`** to **`4`** when running outside of \
normal business hours (M–F 9–6).

This saves about 5–10 minutes on each Travis job.

### New defaults

When nobody else is running screenshot tests:

* **Outside of normal business hours** (evenings and weekends):\
    Defaults to **`4`** parallel browsers 🆕
* **During normal business hours** (Monday through Friday, 9am EST to 6pm PST): \
    Defaults to **`2`** parallel browsers (same behavior as before)

When other users are already running screenshot tests:

* **Any day/time**: \
    Defaults to **`1`** parallel browser (same behavior as before)

### CLI overrides

Just like before, you can override the default number of parallels with the `--parallels=N` CLI option:

```bash
npm run screenshot-test -- --parallels=4
```