### PR TITLE
chore(infrastructure): Set timezone & fix date calc

### DIFF
--- a/scripts/travis-env-vars.sh
+++ b/scripts/travis-env-vars.sh
@@ -21,7 +21,8 @@ function log_warning() {
 
 function print_travis_env_vars() {
   echo
-  date
+  echo "Shell date: $(date)"
+  echo "Node date: $(echo 'console.log(new Date().toString())' | node)"
   echo
   env | grep -E -e 'TRAVIS' -e '^(LANG|TERM|TZ)=' | sort
   echo

--- a/scripts/travis-env-vars.sh
+++ b/scripts/travis-env-vars.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# https://stackoverflow.com/a/27052708/467582
+export TZ=America/Los_Angeles
+
 CHANGED_FILE_PATHS=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
 
 if [[ -n "$CHANGED_FILE_PATHS" ]]; then
@@ -18,7 +21,9 @@ function log_warning() {
 
 function print_travis_env_vars() {
   echo
-  env | grep TRAVIS
+  date
+  echo
+  env | grep -E -e 'TRAVIS' -e '^(LANG|TERM|TZ)=' | sort
   echo
 }
 

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -982,8 +982,8 @@ class SeleniumApi {
    * @private
    */
   isBusinessHours_() {
-    const MORNING_HOUR = 9; // 9am
-    const EVENING_HOUR = 18; // 6pm
+    const MORNING_HOUR = 6; // 6am PT = 9am ET
+    const EVENING_HOUR = 18; // 6pm PT = 9pm ET
     const SATURDAY = 6;
     const SUNDAY = 0;
 

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -982,16 +982,17 @@ class SeleniumApi {
    * @private
    */
   isBusinessHours_() {
-    const MORNING_UTC_HOURS = 13; // 1pm UTC === 9am EST
-    const EVENING_UTC_HOURS = 1; // 1am UTC === 6pm PST
-    const SATURDAY = 7;
+    const MORNING_HOUR = 9; // 9am
+    const EVENING_HOUR = 18; // 6pm
+    const SATURDAY = 6;
     const SUNDAY = 0;
 
+    // Travis CI runs in the Pacific Time Zone (America/Los_Angeles). See scripts/travis-env-vars.sh.
     const nowDate = new Date();
-    const nowUtcHours = nowDate.getUTCHours();
+    const nowHour = nowDate.getHours();
 
     const isWeekDay = nowDate.getDay() > SUNDAY || nowDate.getDay() < SATURDAY;
-    const is9to5 = nowUtcHours > MORNING_UTC_HOURS || nowUtcHours < EVENING_UTC_HOURS;
+    const is9to5 = nowHour > MORNING_HOUR || nowHour < EVENING_HOUR;
 
     return isWeekDay && is9to5;
   }


### PR DESCRIPTION
Fixes oversights in #3652:

* Fixes `SATURDAY` value
* Explicitly sets timezone in Travis CI by adding `export TZ=America/Los_Angeles` to `scripts/travis-env-vars.sh`
* Prints current date and timezone to terminal in `scripts/travis-env-vars.sh`