### PR TITLE
chore(infrastructure): Retry failed CBT HTTP requests

### DIFF
--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -464,10 +464,11 @@ https://crossbrowsertesting.com/account
    * @param {string} method
    * @param {string} endpoint
    * @param {!Object=} body
+   * @param {number=} retryCount
    * @return {!Promise<!Object<string, *>|!Array<*>>}
    * @private
    */
-  async sendRequest_(stackTrace, method, endpoint, body = undefined) {
+  async sendRequest_(stackTrace, method, endpoint, body = undefined, retryCount = 0) {
     const uri = `${REST_API_BASE_URL}${endpoint}`;
 
     if (this.cli_.isOffline()) {
@@ -490,6 +491,16 @@ https://crossbrowsertesting.com/account
         json: true, // Automatically stringify the request body and parse the response body as JSON
       });
     } catch (err) {
+      const MAX_RETRIES = 5;
+      if (retryCount < MAX_RETRIES) {
+        console.error('');
+        console.error(`CBT API request failed: ${method} ${uri}:\n${stackTrace}`);
+        console.error(err);
+        console.error('');
+        console.error(`Retrying request (attempt ${retryCount + 1} of ${MAX_RETRIES})...`);
+        console.error('');
+        return this.sendRequest_(stackTrace, method, endpoint, body, retryCount + 1);
+      }
       throw new VError(err, `CBT API request failed: ${method} ${uri}:\n${stackTrace}`);
     }
   }

--- a/test/screenshot/infra/lib/constants.js
+++ b/test/screenshot/infra/lib/constants.js
@@ -55,6 +55,12 @@ module.exports = {
   CBT_CONCURRENCY_MAX_WAIT_MS: 10 * 60 * 1000, // 10 minutes
 
   /**
+   * Maximum number of times to retry a failed HTTP request to CBT.
+   * @type {number}
+   */
+  CBT_HTTP_MAX_RETRIES: 5,
+
+  /**
    * Number of milliseconds a Selenium test should wait to receive commands before being considered "stalled".
    * @type {number}
    */


### PR DESCRIPTION
### What it does

- Retries failed CBT HTTP requests up to 5 times
    - Mitigates CBT's and Travis CI's intermittent network flakiness
- Kills stalled Selenium sessions that have not received any commands

### Example output

![image](https://user-images.githubusercontent.com/409245/46135923-3bdb9b00-c1fb-11e8-8dd6-ccd9950f0333.png)