### PR TITLE
chore: Remove reference to appspot demo server.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -10,8 +10,8 @@ skip_files:
 
 handlers:
 - url: /
-  static_files: demos/index.html
-  upload: demos/index.html
+  static_files: demos/redirect.html
+  upload: demos/redirect.html
 
 - url: /assets/(.*)
   static_files: build/\1

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,6 @@
-# Demonstrations 
+# Demonstrations
 
-MDC Web's collection of components. Demonstrated in idiomatic JavaScript/CSS/HTML. A hosted version of this folder can be found [here](http://material-components-web.appspot.com/).
+MDC Web's collection of components. Demonstrated in idiomatic JavaScript/CSS/HTML.
 
 ## Installation
 

--- a/demos/redirect.html
+++ b/demos/redirect.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='https://material-components.github.io/material-components-web-catalog/'" />

--- a/docs/code/readme_template.md
+++ b/docs/code/readme_template.md
@@ -17,7 +17,7 @@ Copy the snippet and replace the following
   * `ICON_ID`: id for the icon representing the component
   * `SCREENSHOT_NAME`: name of the screenshot image of the component
   * `SCREENSHOT_WIDTH`: width of the screenshot image of the component
-  * `LINK_TO_CATALOG_SERVER`: link to the component page on [Demo Catalog](https://material-components-web.appspot.com/)
+  * `LINK_TO_CATALOG_SERVER`: link to the component page on [Catalog](https://material-components.github.io/material-components-web-catalog/)
 * Usage sections
   * `BASIC_USAGE_SECTION`: see [README standards on Basic Usage](readme_standards.md#basic-usage)
   * `VARIANTS_SECTION`: see [README standards on Variants](readme_standards.md#variants)

--- a/docs/open_source/README.md
+++ b/docs/open_source/README.md
@@ -57,7 +57,7 @@ having to fix the bug.
 
 Our code is released as Node modules. External developers install these modules.
 
-[Catalog Server](https://material-components-web.appspot.com/)
+[Catalog Server](https://material-components.github.io/material-components-web-catalog/)
 
 Our catalog server is where we visually display the components to our external
 developers.
@@ -67,4 +67,3 @@ developers.
 [Discord channel](https://discordapp.com/invite/material-components)
 
 Our Discord channel is where we can talk with external developers in realtime.
-

--- a/docs/open_source/release-process.md
+++ b/docs/open_source/release-process.md
@@ -246,12 +246,3 @@ MDC React repository, with the "required for sync" label.
 Our markdown documentation is transformed and mirrored to the Develop section of material.io.
 
 Currently, this requires some manual work by the Tools team, so we need to notify them to update the site content.
-
-## (Deprecated) Deploy Catalog Server
-
-> Note: We now promote the [MDC Web Catalog](https://github.com/material-components/material-components-web-catalog)
-> instead. The old catalog server is no longer linked from our documentation.
-
-`MDC_ENV=development npm run build:demos && gcloud app deploy`
-
-[Double check it is live](https://material-components-web.appspot.com/)


### PR DESCRIPTION
[Appspot](http://material-components-web.appspot.com/) demo page now redirects to [catalog](https://material-components.github.io/material-components-web-catalog/) demo page.