### PR TITLE
fix(dialog): Wait for rAF/timeout to apply open class

### DIFF
--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -331,7 +331,6 @@ Method Signature | Description
 `addBodyClass(className: string) => void` | Adds a class to the `<body>`.
 `removeBodyClass(className: string) => void` | Removes a class from the `<body>`.
 `eventTargetMatches(target: !EventTarget, selector: string) => void` | Returns `true` if the target element matches the given CSS selector, otherwise `false`.
-`computeBoundingRect()`: Forces the component to recalculate its layout; in the vanilla DOM implementation, this calls `computeBoundingClientRect`.
 `trapFocus() => void` | Sets up the DOM such that keyboard navigation is restricted to focusable elements within the dialog surface (see [Handling Focus Trapping](#handling-focus-trapping) below for more details).
 `releaseFocus() => void` | Removes any effects of focus trapping on the dialog surface (see [Handling Focus Trapping](#handling-focus-trapping) below for more details).
 `isContentScrollable() => boolean` | Returns `true` if `mdc-dialog__content` can be scrolled by the user, otherwise `false`.

--- a/packages/mdc-dialog/adapter.js
+++ b/packages/mdc-dialog/adapter.js
@@ -65,9 +65,6 @@ class MDCDialogAdapter {
    */
   eventTargetMatches(target, selector) {}
 
-  /** @return {!ClientRect} */
-  computeBoundingRect() {}
-
   trapFocus() {}
   releaseFocus() {}
 

--- a/packages/mdc-dialog/foundation.js
+++ b/packages/mdc-dialog/foundation.js
@@ -46,7 +46,6 @@ class MDCDialogFoundation extends MDCFoundation {
       addBodyClass: (/* className: string */) => {},
       removeBodyClass: (/* className: string */) => {},
       eventTargetMatches: (/* target: !EventTarget, selector: string */) => {},
-      computeBoundingRect: () => {},
       trapFocus: () => {},
       releaseFocus: () => {},
       isContentScrollable: () => {},
@@ -69,6 +68,9 @@ class MDCDialogFoundation extends MDCFoundation {
 
     /** @private {boolean} */
     this.isOpen_ = false;
+
+    /** @ private {number} */
+    this.animationFrame_ = 0;
 
     /** @private {number} */
     this.animationTimer_ = 0;
@@ -100,6 +102,10 @@ class MDCDialogFoundation extends MDCFoundation {
       this.close(strings.DESTROY_ACTION);
     }
 
+    if (this.animationFrame_) {
+      cancelAnimationFrame(this.animationFrame_);
+    }
+
     if (this.animationTimer_) {
       clearTimeout(this.animationTimer_);
       this.handleAnimationTimerEnd_();
@@ -116,19 +122,19 @@ class MDCDialogFoundation extends MDCFoundation {
     this.adapter_.notifyOpening();
     this.adapter_.addClass(cssClasses.OPENING);
 
-    // Force redraw now that display is no longer "none", to establish basis for animation
-    this.adapter_.computeBoundingRect();
-    this.adapter_.addClass(cssClasses.OPEN);
-    this.adapter_.addBodyClass(cssClasses.SCROLL_LOCK);
+    // Wait a frame once display is no longer "none", to establish basis for animation
+    this.runNextAnimationFrame_(() => {
+      this.adapter_.addClass(cssClasses.OPEN);
+      this.adapter_.addBodyClass(cssClasses.SCROLL_LOCK);
 
-    this.layout();
+      this.layout();
 
-    clearTimeout(this.animationTimer_);
-    this.animationTimer_ = setTimeout(() => {
-      this.handleAnimationTimerEnd_();
-      this.adapter_.trapFocus();
-      this.adapter_.notifyOpened();
-    }, numbers.DIALOG_ANIMATION_OPEN_TIME_MS);
+      this.animationTimer_ = setTimeout(() => {
+        this.handleAnimationTimerEnd_();
+        this.adapter_.trapFocus();
+        this.adapter_.notifyOpened();
+      }, numbers.DIALOG_ANIMATION_OPEN_TIME_MS);
+    });
   }
 
   /**
@@ -268,6 +274,20 @@ class MDCDialogFoundation extends MDCFoundation {
     this.animationTimer_ = 0;
     this.adapter_.removeClass(cssClasses.OPENING);
     this.adapter_.removeClass(cssClasses.CLOSING);
+  }
+
+  /**
+   * Runs the given logic on the next animation frame, using setTimeout to factor in Firefox reflow behavior.
+   * @param {Function} callback
+   * @private
+   */
+  runNextAnimationFrame_(callback) {
+    cancelAnimationFrame(this.animationFrame_);
+    this.animationFrame_ = requestAnimationFrame(() => {
+      this.animationFrame_ = 0;
+      clearTimeout(this.animationTimer_);
+      this.animationTimer_ = setTimeout(callback, 0);
+    });
   }
 }
 

--- a/packages/mdc-dialog/foundation.js
+++ b/packages/mdc-dialog/foundation.js
@@ -69,7 +69,7 @@ class MDCDialogFoundation extends MDCFoundation {
     /** @private {boolean} */
     this.isOpen_ = false;
 
-    /** @ private {number} */
+    /** @private {number} */
     this.animationFrame_ = 0;
 
     /** @private {number} */

--- a/packages/mdc-dialog/index.js
+++ b/packages/mdc-dialog/index.js
@@ -182,7 +182,6 @@ class MDCDialog extends MDCComponent {
       addBodyClass: (className) => document.body.classList.add(className),
       removeBodyClass: (className) => document.body.classList.remove(className),
       eventTargetMatches: (target, selector) => matches(target, selector),
-      computeBoundingRect: () => this.root_.getBoundingClientRect(),
       trapFocus: () => this.focusTrap_.activate(),
       releaseFocus: () => this.focusTrap_.deactivate(),
       isContentScrollable: () => !!this.content_ && util.isScrollable(/** @type {!Element} */ (this.content_)),

--- a/test/unit/mdc-dialog/mdc-dialog.test.js
+++ b/test/unit/mdc-dialog/mdc-dialog.test.js
@@ -302,17 +302,6 @@ test('adapter#eventTargetMatches returns whether or not the target matches the s
   assert.isFalse(adapter.eventTargetMatches(target, '.non-existent-class'));
 });
 
-test('adapter#computeBoundingRect calls getBoundingClientRect() on root', () => {
-  const {root, component} = setupTest();
-  document.body.appendChild(root);
-
-  try {
-    assert.deepEqual(component.getDefaultFoundation().adapter_.computeBoundingRect(), root.getBoundingClientRect());
-  } finally {
-    document.body.removeChild(root);
-  }
-});
-
 test(`adapter#notifyOpening emits ${strings.OPENING_EVENT}`, () => {
   const {component} = setupTest();
 


### PR DESCRIPTION
Fixes #3676 for Dialog.

Firefox needs a rAF + setTimeout to animate properly (possibly related [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=731974) and [docs](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Performance_best_practices_for_Firefox_fe_engineers#How_do_I_avoid_triggering_uninterruptible_reflow)).