### PR TITLE
fix(ripple): Transition background-color to avoid flashes

### DIFF
--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -46,7 +46,10 @@
   }
 
   &::before {
-    transition: opacity $mdc-states-wash-duration linear;
+    // Also transition background-color to avoid unnatural color flashes when toggling activated/selected state
+    transition:
+      opacity $mdc-states-wash-duration linear,
+      background-color $mdc-states-wash-duration linear;
     z-index: 1; // Ensure that the ripple wash for hover/focus states is displayed on top of positioned child elements
   }
 


### PR DESCRIPTION
Context: https://github.com/material-components/material-components-web-codelabs/pull/66#pullrequestreview-160820735

Reproducible within MDC Web using the drawer screenshot pages or demos/list.html. (Slowing down animations to 25% or 10% helps.)