### PR TITLE
chore(infrastructure): Add screenshot tests for high contrast & RTL

### DIFF
--- a/test/screenshot/browser.json
+++ b/test/screenshot/browser.json
@@ -1,8 +1,12 @@
 {
   "user_agent_aliases": [
     "desktop_windows_chrome@latest",
+    "desktop_windows_chrome@latest_rtl",
     "desktop_windows_firefox@latest",
+    "desktop_windows_firefox@latest_highcontrast",
     "desktop_windows_edge@latest",
-    "desktop_windows_ie@11"
+    "desktop_windows_edge@latest_highcontrast",
+    "desktop_windows_ie@11",
+    "desktop_windows_ie@11_rtl"
   ]
 }

--- a/test/screenshot/diffing.json
+++ b/test/screenshot/diffing.json
@@ -41,6 +41,19 @@
         }
       },
       {
+        "description": "Edge in highcontrast mode frequently fails to load the Roboto font, especially on fullscreen pages",
+        "browser_regex_patterns": [
+          "desktop_windows_edge@latest_highcontrast"
+        ],
+        "url_regex_patterns": [
+          "mdc-dialog",
+          "mdc-drawer"
+        ],
+        "custom_config": {
+          "skip_all": true
+        }
+      },
+      {
         "description": "Edge flakes so frequently on certain pages that it needs to be disabled entirely",
         "browser_regex_patterns": [
           "desktop_windows_edge@latest"

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -1,1318 +1,1875 @@
 {
   "spec/mdc-button/classes/baseline-button-with-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-with-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-button-with-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-with-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-button-with-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-with-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-button-with-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-with-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-with-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-button-with-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-with-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-button-with-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/classes/baseline-button-without-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-without-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-button-without-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-without-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-button-without-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-without-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-button-without-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-without-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-without-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-button-without-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-button-without-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-button-without-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/classes/baseline-link-with-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-with-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-link-with-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-with-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-link-with-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-with-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-link-with-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-with-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-with-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-link-with-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-with-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-link-with-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/classes/baseline-link-without-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-without-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-link-without-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-without-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-link-without-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-without-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-link-without-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-without-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-without-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/baseline-link-without-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/baseline-link-without-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/baseline-link-without-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/classes/dense-button-with-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-with-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-button-with-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-with-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-button-with-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-with-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-button-with-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-with-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-with-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-button-with-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-with-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-button-with-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/classes/dense-button-without-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-without-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-button-without-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-without-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-button-without-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-without-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-button-without-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-without-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-without-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-button-without-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-button-without-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-button-without-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/classes/dense-link-with-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-with-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-link-with-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-with-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-link-with-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-with-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-link-with-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-with-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-with-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-link-with-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-with-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-link-with-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/classes/dense-link-without-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-without-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-link-without-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-without-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-link-without-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-without-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-link-without-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-without-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-without-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/classes/dense-link-without-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/classes/dense-link-without-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/classes/dense-link-without-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/container-fill-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/container-fill-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/container-fill-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/container-fill-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/container-fill-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/container-fill-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/container-fill-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/container-fill-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/container-fill-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/container-fill-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/container-fill-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/container-fill-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/filled-accessible.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/filled-accessible.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/filled-accessible.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/filled-accessible.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/filled-accessible.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/filled-accessible.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/filled-accessible.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/filled-accessible.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/filled-accessible.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/filled-accessible.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/filled-accessible.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/filled-accessible.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/horizontal-padding-baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/horizontal-padding-baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/horizontal-padding-baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/horizontal-padding-dense.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-dense.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/horizontal-padding-dense.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/horizontal-padding-dense.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/icon-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/icon-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/icon-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/icon-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/icon-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/icon-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/icon-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/icon-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/icon-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/icon-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/icon-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/icon-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/ink-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/ink-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/ink-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/ink-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/shape-radius.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/17/20_33_17_975/spec/mdc-button/mixins/shape-radius.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/shape-radius.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/17/20_33_17_975/spec/mdc-button/mixins/shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/shape-radius.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/17/20_33_17_975/spec/mdc-button/mixins/shape-radius.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/shape-radius.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/17/20_33_17_975/spec/mdc-button/mixins/shape-radius.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/17/20_33_17_975/spec/mdc-button/mixins/shape-radius.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/17/20_33_17_975/spec/mdc-button/mixins/shape-radius.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/shape-radius.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/stroke-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/stroke-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/stroke-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/stroke-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/stroke-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/stroke-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-button/mixins/stroke-width.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-width.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/stroke-width.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-width.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/stroke-width.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-width.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/stroke-width.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-width.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-width.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-button/mixins/stroke-width.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/13/21_47_32_548/spec/mdc-button/mixins/stroke-width.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-button/mixins/stroke-width.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-card/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/baseline.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-card/classes/media.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/media.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/classes/media.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/media.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/classes/media.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/media.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/classes/media.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/media.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/media.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/classes/media.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/classes/media.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/classes/media.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-card/mixins/color-and-shape.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/color-and-shape.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/mixins/color-and-shape.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/color-and-shape.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/mixins/color-and-shape.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/color-and-shape.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/mixins/color-and-shape.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/color-and-shape.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/color-and-shape.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/mixins/color-and-shape.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/color-and-shape.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/mixins/color-and-shape.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-card/mixins/media-aspect-ratio.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/media-aspect-ratio.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/mixins/media-aspect-ratio.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/media-aspect-ratio.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/mixins/media-aspect-ratio.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/media-aspect-ratio.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/mixins/media-aspect-ratio.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/media-aspect-ratio.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/media-aspect-ratio.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-card/mixins/media-aspect-ratio.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-card/mixins/media-aspect-ratio.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-card/mixins/media-aspect-ratio.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-checkbox/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/mattgoo/2018/07/18/19_29_49_289/spec/mdc-checkbox/classes/baseline.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/mattgoo/2018/07/18/19_29_49_289/spec/mdc-checkbox/classes/baseline.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/mattgoo/2018/07/18/19_29_49_289/spec/mdc-checkbox/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-checkbox/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/mattgoo/2018/07/18/19_29_49_289/spec/mdc-checkbox/classes/baseline.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/mattgoo/2018/07/18/19_29_49_289/spec/mdc-checkbox/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-checkbox/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/mattgoo/2018/07/18/19_29_49_289/spec/mdc-checkbox/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-checkbox/mixins/container-colors.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/mixins/container-colors.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/mixins/container-colors.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-checkbox/mixins/container-colors.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-checkbox/mixins/container-colors.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-checkbox/mixins/ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/mixins/ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/mixins/ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-checkbox/mixins/ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-checkbox/mixins/ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/31/03_19_25_902/spec/mdc-checkbox/mixins/ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-checkbox/mixins/ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/classes/action.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/action.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/action.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/action.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/action.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/action.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/action.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/action.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/action.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/action.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/action.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/action.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/classes/choice.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/choice.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/choice.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/choice.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/choice.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/choice.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/choice.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/choice.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/choice.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/choice.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/choice.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/choice.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/classes/filter.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/filter.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/filter.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/filter.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/filter.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/filter.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/filter.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/filter.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/filter.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/filter.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/filter.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/filter.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/classes/input.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/input.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/input.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/input.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/input.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/input.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/input.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/input.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/input.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/classes/input.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/classes/input.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/classes/input.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/chip-set-spacing.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/chip-set-spacing.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/chip-set-spacing.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/chip-set-spacing.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/chip-set-spacing.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/chip-set-spacing.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/chip-set-spacing.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/chip-set-spacing.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/chip-set-spacing.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/chip-set-spacing.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/chip-set-spacing.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/chip-set-spacing.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/fill-color-accessible.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color-accessible.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/fill-color-accessible.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color-accessible.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/fill-color-accessible.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color-accessible.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/fill-color-accessible.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color-accessible.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color-accessible.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/fill-color-accessible.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color-accessible.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/fill-color-accessible.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/fill-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/fill-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/fill-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/fill-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/fill-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/fill-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/fill-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/height.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/height.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/height.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/height.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/height.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/height.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/height.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/height.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/height.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/height.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/height.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/height.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/horizontal-padding.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/horizontal-padding.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/horizontal-padding.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/horizontal-padding.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/horizontal-padding.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/horizontal-padding.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/horizontal-padding.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/horizontal-padding.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/horizontal-padding.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/horizontal-padding.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/horizontal-padding.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/horizontal-padding.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/ink-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/ink-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/ink-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/ink-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/leading-icon-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/leading-icon-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/leading-icon-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/leading-icon-margin.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/17/18_18_41_165/spec/mdc-chips/mixins/leading-icon-margin.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-margin.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/17/18_18_41_165/spec/mdc-chips/mixins/leading-icon-margin.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-margin.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/17/18_18_41_165/spec/mdc-chips/mixins/leading-icon-margin.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/leading-icon-margin.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/17/18_18_41_165/spec/mdc-chips/mixins/leading-icon-margin.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/17/18_18_41_165/spec/mdc-chips/mixins/leading-icon-margin.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/leading-icon-margin.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/17/18_18_41_165/spec/mdc-chips/mixins/leading-icon-margin.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-margin.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/leading-icon-size.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-size.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-size.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-size.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-size.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-size.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/leading-icon-size.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-size.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-size.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/leading-icon-size.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/leading-icon-size.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/leading-icon-size.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/outline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/outline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/outline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/outline.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/outline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/outline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/outline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/outline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/outline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/outline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/outline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/outline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/selected-ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/selected-ink-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/selected-ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/selected-ink-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/selected-ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/selected-ink-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/selected-ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/selected-ink-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/selected-ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/selected-ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/selected-ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/selected-ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/shape-radius.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-chips/mixins/shape-radius.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/shape-radius.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-chips/mixins/shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/shape-radius.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-chips/mixins/shape-radius.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/shape-radius.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-chips/mixins/shape-radius.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-chips/mixins/shape-radius.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-chips/mixins/shape-radius.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/shape-radius.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/trailing-icon-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/trailing-icon-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/trailing-icon-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/trailing-icon-margin.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/trailing-icon-margin.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-margin.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/22_36_05_454/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-margin.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-chips/mixins/trailing-icon-size.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-size.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-size.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-size.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-size.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-size.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/trailing-icon-size.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-size.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-size.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-chips/mixins/trailing-icon-size.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/rlfriedman/2018/09/13/20_54_11_470/spec/mdc-chips/mixins/trailing-icon-size.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-chips/mixins/trailing-icon-size.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/baseline-alert-above-drawer.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-above-drawer.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert-above-drawer.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert-above-drawer.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/baseline-alert-with-title.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-with-title.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert-with-title.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert-with-title.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/baseline-alert.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/baseline-alert.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-alert.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-alert.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/baseline-confirmation.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-confirmation.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-confirmation.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-confirmation.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-confirmation.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-confirmation.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-confirmation.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-confirmation.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/baseline-confirmation.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-confirmation.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-confirmation.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/baseline-simple.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-simple.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-simple.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-simple.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-simple.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-simple.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-simple.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-simple.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/baseline-simple.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/baseline-simple.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/baseline-simple.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/manual-window-resize.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/manual-window-resize.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/manual-window-resize.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/manual-window-resize.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/manual-window-resize.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/manual-window-resize.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/manual-window-resize.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/manual-window-resize.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/manual-window-resize.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/manual-window-resize.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/manual-window-resize.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/overflow-accessible-font-size.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/overflow-accessible-font-size.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-accessible-font-size.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-accessible-font-size.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/overflow-bottom.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/overflow-bottom.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-bottom.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-bottom.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-bottom.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/overflow-bottom.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-bottom.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-bottom.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/overflow-bottom.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-bottom.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-bottom.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/classes/overflow-top.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/overflow-top.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-top.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-top.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-top.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/classes/overflow-top.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-top.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-top.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/classes/overflow-top.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/classes/overflow-top.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/classes/overflow-top.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/container-fill-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/container-fill-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/container-fill-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/container-fill-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/container-fill-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/container-fill-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/container-fill-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/container-fill-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/container-fill-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/container-fill-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/container-fill-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/content-ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/content-ink-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/content-ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/content-ink-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/content-ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/content-ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/content-ink-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/content-ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/content-ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/content-ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/content-ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/max-height.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/max-height.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/max-height.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-height.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/max-height.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/max-height.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-height.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-height.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/max-height.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-height.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/max-height.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/max-width.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/max-width.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/max-width.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-width.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/max-width.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/max-width.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-width.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-width.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/max-width.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/max-width.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/max-width.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/min-width.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/min-width.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/min-width.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/min-width.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/min-width.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/min-width.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/min-width.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/min-width.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/min-width.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/min-width.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/min-width.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/scrim-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/scrim-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/scrim-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scrim-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/scrim-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/scrim-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scrim-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scrim-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/scrim-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scrim-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/scrim-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/scroll-divider-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/scroll-divider-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/scroll-divider-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/scroll-divider-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/shape-radius.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/17_17_41_724/spec/mdc-dialog/mixins/shape-radius.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/shape-radius.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/21/22_25_39_766/spec/mdc-dialog/mixins/shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/shape-radius.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/17_17_41_724/spec/mdc-dialog/mixins/shape-radius.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/21/22_25_39_766/spec/mdc-dialog/mixins/shape-radius.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/21/22_25_39_766/spec/mdc-dialog/mixins/shape-radius.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2018/09/21/22_25_39_766/spec/mdc-dialog/mixins/shape-radius.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/shape-radius.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-dialog/mixins/title-ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/title-ink-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/title-ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/title-ink-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/title-ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/23_10_20_654/spec/mdc-dialog/mixins/title-ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/title-ink-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/title-ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-dialog/mixins/title-ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/21/16_50_45_748/spec/mdc-dialog/mixins/title-ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-dialog/mixins/title-ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-drawer/classes/dismissible.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/dismissible.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/dismissible.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/dismissible.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/dismissible.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/dismissible.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/dismissible.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/dismissible.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-drawer/classes/dismissible.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/dismissible.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/dismissible.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-drawer/classes/modal.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/modal.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/modal.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/modal.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/modal.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/modal.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/modal.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/modal.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-drawer/classes/modal.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/modal.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/modal.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-drawer/classes/permanent.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/permanent.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/permanent.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/permanent.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/permanent.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/permanent.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/permanent.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/permanent.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-drawer/classes/permanent.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/classes/permanent.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/classes/permanent.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-drawer/mixins/fill-color-accessible.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color-accessible.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/fill-color-accessible.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/fill-color-accessible.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-drawer/mixins/fill-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/fill-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/fill-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-drawer/mixins/fill-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/fill-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/fill-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-drawer/mixins/width.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/width.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/width.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/width.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/width.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/width.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/width.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/width.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-drawer/mixins/width.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-drawer/mixins/width.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-drawer/mixins/width.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-elevation/classes/baseline-large.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-large.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/classes/baseline-large.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-large.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/classes/baseline-large.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-large.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-elevation/classes/baseline-large.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-large.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-large.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-elevation/classes/baseline-large.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-large.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/classes/baseline-large.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-elevation/classes/baseline-small.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-small.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/classes/baseline-small.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-small.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/classes/baseline-small.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-small.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-elevation/classes/baseline-small.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-small.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-small.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-elevation/classes/baseline-small.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/classes/baseline-small.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/classes/baseline-small.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-elevation/mixins/mixins.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/mixins/mixins.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/mixins/mixins.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/mixins/mixins.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/mixins/mixins.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/mixins/mixins.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-elevation/mixins/mixins.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/mixins/mixins.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/mixins/mixins.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-elevation/mixins/mixins.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-elevation/mixins/mixins.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-elevation/mixins/mixins.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-fab/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/baseline.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/baseline.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/baseline.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-fab/classes/extended.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/extended.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/extended.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/extended.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/extended.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/extended.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/classes/extended.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/extended.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/extended.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/classes/extended.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/extended.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/extended.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-fab/classes/mini.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/mini.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/mini.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/mini.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/mini.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/mini.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/classes/mini.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/mini.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/mini.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/classes/mini.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/classes/mini.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/classes/mini.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-fab/mixins/extended-padding.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/mixins/extended-padding.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/mixins/extended-padding.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/mixins/extended-padding.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-fab/mixins/extended-padding.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-fab/mixins/extended-padding.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-icon-button/classes/baseline-icon-button-toggle.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/15_39_02_591/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/15_39_02_591/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/20_29_19_047/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/20_29_19_047/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/20_29_19_047/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-icon-button/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-icon-button/classes/baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/20_29_19_047/spec/mdc-icon-button/classes/baseline.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/20_29_19_047/spec/mdc-icon-button/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-icon-button/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/20_29_19_047/spec/mdc-icon-button/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/20_29_19_047/spec/mdc-icon-button/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-icon-button/mixins/icon-size.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-icon-button/mixins/icon-size.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/mixins/icon-size.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/icon-size.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/mixins/icon-size.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/icon-size.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/mixins/icon-size.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-icon-button/mixins/icon-size.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/icon-size.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/mixins/icon-size.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/icon-size.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/mixins/icon-size.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-icon-button/mixins/ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-icon-button/mixins/ink-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/mixins/ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/ink-color.html.windows_chrome_67.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/mixins/ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/ink-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/mixins/ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-icon-button/mixins/ink-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-icon-button/mixins/ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-icon-button/mixins/ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-icon-button/mixins/ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-image-list/classes/standard-with-text-protection.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard-with-text-protection.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/classes/standard-with-text-protection.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/classes/standard-with-text-protection.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-image-list/classes/standard.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/classes/standard.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/classes/standard.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/classes/standard.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/classes/standard.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/classes/standard.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/classes/standard.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-image-list/mixins/standard-shape-radius.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-shape-radius.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/mixins/standard-shape-radius.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/mixins/standard-shape-radius.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-image-list/mixins/standard-with-text-protection-shape-radius.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-linear-progress/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/classes/baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/classes/baseline.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-linear-progress/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-linear-progress/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-linear-progress/mixins/bar-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/bar-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/mixins/bar-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/bar-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/mixins/bar-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/bar-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-linear-progress/mixins/bar-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/bar-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/bar-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-linear-progress/mixins/bar-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/bar-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/mixins/bar-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-linear-progress/mixins/buffer-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/buffer-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/mixins/buffer-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/buffer-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/mixins/buffer-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/buffer-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-linear-progress/mixins/buffer-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/buffer-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/buffer-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-linear-progress/mixins/buffer-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/26/06_08_27_877/spec/mdc-linear-progress/mixins/buffer-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-linear-progress/mixins/buffer-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-radio/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-radio/classes/baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-radio/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/classes/baseline.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-radio/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-radio/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-radio/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-radio/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-radio/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-radio/mixins/mixins.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/17_45_53_712/spec/mdc-radio/mixins/mixins.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-radio/mixins/mixins.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/17_45_53_712/spec/mdc-radio/mixins/mixins.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-radio/mixins/mixins.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/mixins/mixins.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-radio/mixins/mixins.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-radio/mixins/mixins.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/mixins/mixins.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-radio/mixins/mixins.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/mixins/mixins.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-radio/mixins/mixins.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/classes/baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/16_06_43_039/spec/mdc-select/classes/baseline.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/classes/disabled.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/01_27_31_830/spec/mdc-select/classes/disabled.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/classes/disabled.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/01_27_31_830/spec/mdc-select/classes/disabled.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/classes/disabled.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/01_27_31_830/spec/mdc-select/classes/disabled.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/classes/disabled.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/01_27_31_830/spec/mdc-select/classes/disabled.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/01_27_31_830/spec/mdc-select/classes/disabled.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/classes/disabled.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/01_27_31_830/spec/mdc-select/classes/disabled.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/classes/disabled.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/issues/3230-3496.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/09/05/22_23_12_480/spec/mdc-select/issues/3230-3496.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/issues/3230-3496.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/09/05/22_23_12_480/spec/mdc-select/issues/3230-3496.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/issues/3230-3496.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/09/05/22_23_12_480/spec/mdc-select/issues/3230-3496.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/issues/3230-3496.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/05/07_46_19_171/spec/mdc-select/issues/3230-3496.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/09/05/22_23_12_480/spec/mdc-select/issues/3230-3496.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/issues/3230-3496.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/williamernest/2018/09/05/22_23_12_480/spec/mdc-select/issues/3230-3496.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/issues/3230-3496.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/mixins/bottom-line-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/bottom-line-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/bottom-line-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/bottom-line-color.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/bottom-line-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/bottom-line-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/bottom-line-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/bottom-line-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/bottom-line-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/bottom-line-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/bottom-line-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/bottom-line-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/mixins/container-fill-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/container-fill-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/container-fill-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/container-fill-color.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/container-fill-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/container-fill-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/container-fill-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/container-fill-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/container-fill-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/container-fill-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/04/02_57_26_240/spec/mdc-select/mixins/container-fill-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/container-fill-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/mixins/ink-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/ink-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/ink-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/16_06_43_039/spec/mdc-select/mixins/ink-color.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/ink-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/ink-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/ink-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/ink-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/ink-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/ink-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/ink-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/ink-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/mixins/label-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/label-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/label-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/16_06_43_039/spec/mdc-select/mixins/label-color.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/label-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/label-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/label-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-select/mixins/label-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/label-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/label-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/label-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/label-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/mixins/outline-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/16_06_43_039/spec/mdc-select/mixins/outline-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/outline-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/16_06_43_039/spec/mdc-select/mixins/outline-color.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/outline-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/outline-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/outline-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/16_06_43_039/spec/mdc-select/mixins/outline-color.html.windows_firefox_61.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/outline-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/outline-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/05/14_55_40_222/spec/mdc-select/mixins/outline-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/outline-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-select/mixins/shape-radius.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/shape-radius.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/shape-radius.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/shape-radius.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-select/mixins/shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-select/mixins/shape-radius.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-switch/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-switch/classes/baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/classes/baseline.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-switch/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-switch/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-switch/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-switch/mixins/thumb-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-switch/mixins/thumb-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/mixins/thumb-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/mixins/thumb-color.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/mixins/thumb-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/mixins/thumb-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-switch/mixins/thumb-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-switch/mixins/thumb-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/mixins/thumb-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-switch/mixins/thumb-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/mixins/thumb-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/mixins/thumb-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-switch/mixins/track-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/17_45_53_712/spec/mdc-switch/mixins/track-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/mixins/track-color.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/17_45_53_712/spec/mdc-switch/mixins/track-color.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/mixins/track-color.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/mixins/track-color.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-switch/mixins/track-color.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-switch/mixins/track-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/mixins/track-color.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-switch/mixins/track-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/21_25_57_424/spec/mdc-switch/mixins/track-color.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-switch/mixins/track-color.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-persistent-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-helper-text-persistent.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text-persistent.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-persistent.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-persistent.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-helper-text.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-helper-text.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-helper-text.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-helper-text.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-helper-text.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-leading-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-leading-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-leading-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-leading-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-leading-trailing-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-trailing-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-trailing-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-trailing-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline-trailing-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/baseline.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/baseline.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/baseline.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-persistent-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled-helper-text-persistent.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-persistent.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-persistent.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled-helper-text.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-helper-text.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-helper-text.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-helper-text.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled-leading-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-leading-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-leading-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-leading-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled-leading-trailing-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/12/19_39_12_819/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/12/19_39_12_819/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/12/19_39_12_819/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/12/19_39_12_819/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/12/19_39_12_819/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/12/19_39_12_819/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled-trailing-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-trailing-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-trailing-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled-trailing-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/disabled.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/disabled.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/20_52_13_406/spec/mdc-textfield/classes/disabled.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/disabled.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-persistent-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused-helper-text-persistent.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text-persistent.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-persistent.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-persistent.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused-helper-text-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused-helper-text.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-helper-text.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-helper-text.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-helper-text.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-helper-text.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused-leading-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-leading-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-leading-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-leading-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-leading-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-leading-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-leading-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-leading-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-leading-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-leading-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-leading-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-leading-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused-leading-trailing-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/focused-leading-trailing-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-leading-trailing-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-leading-trailing-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused-trailing-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-trailing-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-trailing-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused-trailing-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/focused.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/focused.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/focused.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/focused.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/focused.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-persistent.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused-helper-text.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-helper-text.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused-leading-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-leading-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-leading-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-leading-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused-trailing-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-focused.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-focused.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-focused.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-focused.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-focused.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-persistent-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-helper-text-persistent.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text-persistent.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-persistent.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-persistent.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text-validation-msg.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-helper-text.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-helper-text.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-helper-text.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-helper-text.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-helper-text.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-leading-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-leading-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-leading-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-leading-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-leading-trailing-icons.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/11/21_26_44_558/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/28/20_00_10_516/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid-trailing-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-trailing-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-trailing-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid-trailing-icon.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/invalid.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/invalid.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/invalid.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/invalid.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/invalid.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/textarea-disabled.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea-disabled.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-disabled.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-disabled.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-disabled.html.windows_chrome_69_rtl.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea-disabled.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-disabled.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/textarea-disabled.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-disabled.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-disabled.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/textarea-focused.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea-focused.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-focused.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-focused.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-focused.html.windows_chrome_69_rtl.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea-focused.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-focused.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/textarea-focused.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-focused.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-focused.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/textarea-invalid.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea-invalid.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-invalid.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-invalid.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-invalid.html.windows_chrome_69_rtl.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea-invalid.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-invalid.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/textarea-invalid.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea-invalid.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea-invalid.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/classes/textarea.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea.html.windows_chrome_69_rtl.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-textfield/classes/textarea.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/classes/textarea.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/08/23/20_10_17_804/spec/mdc-textfield/classes/textarea.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/classes/textarea.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-textfield/issues/3332.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/issues/3332.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_chrome_69.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/issues/3332.html.windows_chrome_69_rtl.png",
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_edge_17.png",
+      "desktop_windows_edge@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/issues/3332.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-textfield/issues/3332.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-textfield/issues/3332.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-typography/classes/baseline-large.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-typography/classes/baseline-large.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/classes/baseline-large.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/classes/baseline-large.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/classes/baseline-large.html.windows_chrome_69_rtl.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-typography/classes/baseline-large.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/classes/baseline-large.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-typography/classes/baseline-large.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/classes/baseline-large.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/classes/baseline-large.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-typography/classes/baseline-small.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-typography/classes/baseline-small.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/classes/baseline-small.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/classes/baseline-small.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/classes/baseline-small.html.windows_chrome_69_rtl.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-typography/classes/baseline-small.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/classes/baseline-small.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-typography/classes/baseline-small.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/classes/baseline-small.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/classes/baseline-small.html.windows_ie_11_rtl.png"
     }
   },
   "spec/mdc-typography/mixins/mixins.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-typography/mixins/mixins.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/mixins/mixins.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/mixins/mixins.html.windows_chrome_68.png",
+      "desktop_windows_chrome@latest_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/mixins/mixins.html.windows_chrome_69_rtl.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-typography/mixins/mixins.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/mixins/mixins.html.windows_ie_11.png"
+      "desktop_windows_firefox@latest_highcontrast": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/06_22_25_725/spec/mdc-typography/mixins/mixins.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/08/08/08_47_39_000/spec/mdc-typography/mixins/mixins.html.windows_ie_11.png",
+      "desktop_windows_ie@11_rtl": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/08_31_18_498/spec/mdc-typography/mixins/mixins.html.windows_ie_11_rtl.png"
     }
   }
 }


### PR DESCRIPTION
### What it does

- Adds screenshot tests for high contrast mode and RTL

    - _Doubles_ the number of screenshot images from `557` to `1,114`

    - _Doubles_ test execution time to around `40 minutes` when nobody else is running tests \
        (`--parallels=2`), and _quadruples_ it to about `80 minutes` when other people are running tests (`--parallels=1`)  😱😱😱

    - _Doubles_ `report.json`'s file size to around `6.5 MB` 😱

    - Exceeds Travis CI's limit of 10,000 log lines 😱

        > This log is too long to be displayed. Please reduce the verbosity of your build or download the raw log.

        ![image](https://user-images.githubusercontent.com/409245/46473506-3e0e9e00-c795-11e8-9a18-692d7be655b1.png)


### Example output

[https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/09_14_45_974/report/report.html](https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/04/09_14_45_974/report/report.html?utm_source=github&utm_medium=pr_description)

![image](https://user-images.githubusercontent.com/409245/46465590-dac54180-c77d-11e8-8229-d89aece688bb.png)