### PR TITLE
chore(infrastructure): Fix zombie detection

### DIFF
--- a/test/screenshot/diffing.json
+++ b/test/screenshot/diffing.json
@@ -41,6 +41,19 @@
         }
       },
       {
+        "description": "Edge frequently fails to load the Roboto font, especially on fullscreen pages and in highcontrast mode",
+        "browser_regex_patterns": [
+          "desktop_windows_edge@latest"
+        ],
+        "url_regex_patterns": [
+          "mdc-dialog",
+          "mdc-drawer"
+        ],
+        "custom_config": {
+          "skip_all": true
+        }
+      },
+      {
         "description": "Edge flakes so frequently on certain pages that it needs to be disabled entirely",
         "browser_regex_patterns": [
           "desktop_windows_edge@latest"

--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -407,7 +407,7 @@ https://crossbrowsertesting.com/account
       'GET', '/selenium?active=true&num=100'
     );
 
-    const activeSeleniumTestIds = listResponse.selenium.map((test) => test.selenium_test_id);
+    const activeSeleniumTestIds = listResponse.selenium.map((test) => test.selenium_session_id);
 
     /** @type {!Array<!CbtSeleniumInfoResponse>} */
     const infoResponses = await Promise.all(activeSeleniumTestIds.map((seleniumTestId) => {
@@ -415,27 +415,26 @@ https://crossbrowsertesting.com/account
       return this.sendRequest_(infoStackTrace, 'GET', `/selenium/${seleniumTestId}`);
     }));
 
-    const stalledSeleniumTestIds = [];
+    const stalledSeleniumSessionIds = [];
 
     for (const infoResponse of infoResponses) {
       const lastCommand = infoResponse.commands[infoResponse.commands.length - 1];
+      let timestampMs = null;
 
-      // At least one Selenium command was received
       if (lastCommand) {
-        const commandTimestampMs = new Date(lastCommand.date_issued).getTime();
-        if (Duration.hasElapsed(SELENIUM_ZOMBIE_SESSION_DURATION_MS, commandTimestampMs)) {
-          stalledSeleniumTestIds.push(infoResponse.selenium_test_id);
-        }
+        // At least one Selenium command was received.
+        timestampMs = new Date(lastCommand.date_issued).getTime();
+      } else {
+        // No Selenium commands have been received yet.
+        timestampMs = new Date(infoResponse.start_date || infoResponse.startup_finish_date).getTime();
       }
 
-      // No Selenium commands have been received
-      const startTimestampMs = new Date(infoResponse.start_date || infoResponse.startup_finish_date).getTime();
-      if (Duration.hasElapsed(SELENIUM_ZOMBIE_SESSION_DURATION_MS, startTimestampMs)) {
-        stalledSeleniumTestIds.push(infoResponse.selenium_test_id);
+      if (timestampMs > 0 && Duration.hasElapsed(SELENIUM_ZOMBIE_SESSION_DURATION_MS, timestampMs)) {
+        stalledSeleniumSessionIds.push(infoResponse.selenium_session_id);
       }
     }
 
-    await this.killSeleniumTests(stalledSeleniumTestIds);
+    await this.killSeleniumTests(stalledSeleniumSessionIds);
   }
 
   /**

--- a/test/screenshot/infra/lib/report-writer.js
+++ b/test/screenshot/infra/lib/report-writer.js
@@ -389,7 +389,10 @@ class ReportWriter {
   getFilteredCountMarkup_(numRunnable, numSkipped) {
     const numTotal = numRunnable + numSkipped;
     if (numSkipped > 0) {
-      return new Handlebars.SafeString(`${numRunnable} of ${numTotal} (skipped ${numSkipped})`);
+      const strRunnable = numRunnable.toLocaleString();
+      const strTotal = numTotal.toLocaleString();
+      const strSkipped = numSkipped.toLocaleString();
+      return new Handlebars.SafeString(`${strRunnable} of ${strTotal} (skipped ${strSkipped})`);
     }
     return new Handlebars.SafeString(numRunnable);
   }

--- a/test/screenshot/infra/lib/selenium-api.js
+++ b/test/screenshot/infra/lib/selenium-api.js
@@ -1068,16 +1068,21 @@ class SeleniumApi {
 
     const pending = this.numPending_;
     const completed = this.numCompleted_;
+    const changed = this.numChanged_;
     const total = pending + completed;
     const percent = (total === 0 ? 0 : (100 * completed / total).toFixed(1));
 
+    const plainDiffs = `${changed.toLocaleString()} diff${(changed === 1 ? '' : 's')}`;
+    const colorDiffs = changed > 0 ? ` - ${CliColor.bold.red(plainDiffs)}` : '';
     const colorCaptured = CliStatuses.CAPTURED.color(CliStatuses.CAPTURED.name.toUpperCase());
-    const colorCompleted = CliColor.bold.white(completed.toLocaleString());
-    const colorTotal = CliColor.bold.white(total.toLocaleString());
+    const colorCompleted = completed.toLocaleString();
+    const colorTotal = total.toLocaleString();
     const colorPercent = CliColor.bold.white(`${percent}%`);
 
     const isTravis = process.env.TRAVIS === 'true';
-    const colorProgressTravis = isTravis ? ` [${colorCompleted} of ${colorTotal} = ${colorPercent} complete]` : '';
+    const colorProgressTravis = isTravis
+      ? ` [${colorCompleted} of ${colorTotal} - ${colorPercent}${colorDiffs}]`
+      : '';
     console.log(eraseCurrentLine + paddingSpaces + status.color(statusName) + colorProgressTravis + ':', ...args);
 
     if (this.isKillRequested_) {
@@ -1088,7 +1093,7 @@ class SeleniumApi {
 
     if (!isTravis) {
       process.stdout.write(
-        `${colorCaptured}: ${colorCompleted} of ${colorTotal} screenshots (${colorPercent} complete)`
+        `${colorCaptured}: ${colorCompleted} of ${colorTotal} screenshots (${colorPercent} complete)${colorDiffs}`
       );
     }
   }


### PR DESCRIPTION
### What it does

- Fixes bug in detection of stalled/zombie Selenium sessions
    - Adds missing `else` statement
- Disables Dialog and Drawer test pages in Edge until font loading flakiness is resolved
- Formats # of screenshots on diff report page (e.g., "1234" -> "1,234")
- Adds # of diffs to CLI output

### Example output

#### Local machine:

![image](https://user-images.githubusercontent.com/409245/46469883-99d32a00-c789-11e8-87ae-52df9efd4e24.png)

#### Travis CI:

![image](https://user-images.githubusercontent.com/409245/46469839-6e503f80-c789-11e8-827c-417c83d343bb.png)