### PR TITLE
docs: Update stale triage / release cycle docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -58,6 +58,4 @@ submitting a pull request*. You can read more about this in our [contributing do
 
 MDC Web is still under active development. You can see our current progress on [master](https://github.com/material-components/material-components-web/tree/master) as well as an overview of our [architecture and practices](https://github.com/material-components/material-components-web/blob/master/docs/code).
 
-If you're interested in information for a specific component, check out our [component issues](https://github.com/material-components/material-components-web/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Av2-component) to see which milestone it's associated with and subscribe to updates to it. If an issue has the `in-tracker` label, you can also take a look at our [public Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1664011) for a rough estimate of when we'll get to it.
-
 Our team prioritizes responding to as many engineering and user experience questions as possible. We do not support responses to questions outside of these areas at this time.

--- a/docs/open_source/README.md
+++ b/docs/open_source/README.md
@@ -18,15 +18,14 @@ We have several ways of pushing content to external developers:
 
 * Node Modules: the code in an installable form (See Releases section)
 * GitHub Documentation: Explain how to use the Node modules
-* Pivotal Backlog: Detail our priorities for fixing bugs and completing feature requests
+* GitHub Milestones: Detail our priorities for fixing bugs and completing feature requests
 * Catalog: Visualize our components (See Releases section)
 
 GitHub is where we do most of our communication with external developers. The
 GitHub documentation is critical to our external developers understanding how
 to use our Node modules. GitHub is also where they can file bugs and feature
-requests. External developers see these issues prioritized on our Pivotal
-tracker. External developers can view the Backlog and see the time estimate
-until their bug is fixed, or their feature request is complete.
+requests. External developers see these issues prioritized in our release milestones
+on GitHub.
 
 ## Release Cop
 
@@ -44,8 +43,8 @@ release cop for two weeks.
 
 There is a special kind of external developer: the kind that also contributes
 code back to our repository. These external contributors fix GitHub issue we
-mark as “help wanted” in our triage process. This stops the GitHub issue from
-becoming a bug on our pivotal tracker, which saves core contributors from
+mark as “help wanted” in our triage process. This prevents the GitHub issue from
+becoming a bug in our icebox or milestones, which saves core contributors from
 having to fix the bug.
 
 > Our GitHub code must be readable by external contributors. And we must review

--- a/docs/open_source/triage.md
+++ b/docs/open_source/triage.md
@@ -7,8 +7,8 @@
 
 ### Installation Problems
 
-Some installation problems we can help with. For example, @material SASS paths
-in the SASS compiler is expertise we have, and we can help them with this
+Some installation problems we can help with. For example, @material Sass paths
+in the Sass compiler is expertise we have, and we can help them with this
 question. But it is best if the answer to this question is a link to
 documentation.
 
@@ -30,7 +30,7 @@ bigger Material Design journey.
 They are welcome to build this feature request on top of our code, in another
 repository. Then close!
 
-If it is in spec, mirror the issue into Pivotal, add the "in-tracker" label.
+If it is in spec, add the "icebox" label.
 Tell them we've decided this is in spec, and link to the relevant place in spec.
 
 ### Valid Bug
@@ -40,5 +40,5 @@ reasonable grasp on how to solve it. If we know offhand how to solve it, add
 the solution to the response, along with any relevant code samples. Always
 kindly ask for a PR if the issue is labeled "help wanted".
 
-Otherwise, mirror the issue into Pivotal, add the "in-tracker" label. Thank
-them for filing the bug.
+Otherwise, add the "icebox" label, or if it is an immediate priority, add it to a release milestone instead.
+Thank them for filing the bug.

--- a/docs/team/README.md
+++ b/docs/team/README.md
@@ -4,11 +4,11 @@ MDC Web team members write and review code in this repository.
 They work with other Material Design Engineers (Android and iOS)
 and Designers to write design docs.
 
-The APIs across Web, Android, and iOS are expected to match, and the final code
-is expected to match [spec](https://material.io/guidelines).
+The components across Web, Android, iOS, and Flutter are expected to match [spec](https://material.io/design).
 
-MDC Web uses a two week sprint system to prioritize our feature requests and
-tech debt. Tasks are prioritized on our [Pivotal tracker](#pivotal).
+Material Design follows a monthly release cycle. Within those releases, MDC Web uses a 2-3 week sprint system to
+prioritize feature requests and tech debt. Accepted tasks are prioritized within
+[milestones](https://github.com/material-components/material-components-web/milestones).
 
 ![MDC Web Feedback Loops](feedback.jpg?raw=true)
 
@@ -17,19 +17,3 @@ tech debt. Tasks are prioritized on our [Pivotal tracker](#pivotal).
 Contributors submit PRs through GitHub. MDC Web team members review the code
 and documentation before merging it to master. Both code and documentation
 are immediately available on GitHub once it is merged.
-
-### Pivotal
-
-[Pivotal Backlog + Icebox](https://www.pivotaltracker.com/n/projects/1664011)
-
-All feature requests, and chores are filed in the Icebox. Once a week, the
-Scrum Master moves these tasks into the Backlog. A Pivotal
-story can have the following status:
-
-* Unstarted: no branch for this feature
-* Started: there is a branch for this feature
-* Delivered: there is a PR for this feature
-* Accepted: the PR is merged!
-
-Each Pivotal story is pointed before it is included in a sprint.
-Points represent both complexity and ambiguity in completing the story.


### PR DESCRIPTION
Follow-up to #3702 to clean up other Pivotal references, as well as update a few other things that looked outdated.