### PR TITLE
fix(drawer): Remove redundant style

### DIFF
--- a/packages/mdc-drawer/dismissible/mdc-drawer-dismissible.scss
+++ b/packages/mdc-drawer/dismissible/mdc-drawer-dismissible.scss
@@ -41,8 +41,4 @@
   @include mdc-rtl-reflexive-box(margin, left, 0);
 
   position: relative;
-
-  .mdc-drawer--closing + & {
-    @include mdc-rtl-reflexive-box(margin, left, 0);
-  }
 }


### PR DESCRIPTION
Realized this was unused while thinking about what would be shared by Side Sheet.

There is already an exclusion for the --closing modifier class within the rest of drawer's styles, so the only thing this is overriding is another 0 margin style.