### PR TITLE
feat(select): Add leading icon support

### DIFF
--- a/demos/menu-surface.html
+++ b/demos/menu-surface.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="/assets/menu-surface.css">
   </head>
-  <body class="mdc-typography">
+  <body class="mdc-typography" style="width: 200vw">
     <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">

--- a/demos/menu-surface.html
+++ b/demos/menu-surface.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="/assets/menu-surface.css">
   </head>
-  <body class="mdc-typography" style="width: 200vw">
+  <body class="mdc-typography">
     <header class="mdc-toolbar mdc-toolbar--fixed demo-header-toolbar">
       <div class="mdc-toolbar__row">
         <section class="mdc-toolbar__section mdc-toolbar__section--align-start">

--- a/demos/select.html
+++ b/demos/select.html
@@ -89,7 +89,7 @@
           <section class="example">
             <h2 class="mdc-typography--headline6">Fully-Featured Native Component</h2>
             <section id="native-demo-wrapper">
-              <div id="native-select" class="mdc-select">
+              <div id="native-select" class="mdc-select mdc-select--with-leading-icon">
                 <i class="material-icons mdc-select__icon">code</i>
                 <i class="mdc-select__dropdown-icon"></i>
                 <select class="mdc-select__native-control" id="native-full-func-select">
@@ -146,7 +146,7 @@
           <section class="example">
             <h2 class="mdc-typography--headline6">Fully-Featured Enhanced Component</h2>
             <section id="enhanced-demo-wrapper">
-              <div id="enhanced-select" class="mdc-select demo-enhanced-select">
+              <div id="enhanced-select" class="mdc-select demo-enhanced-select mdc-select--with-leading-icon">
                 <i class="material-icons mdc-select__icon">code</i>
                 <div class="mdc-select__selected-text" role="combobox"></div>
                 <i class="mdc-select__dropdown-icon"></i>
@@ -209,7 +209,7 @@
           <section class="example">
           <h2 class="mdc-typography--headline6">Outlined Select</h2>
           <section>
-            <div id="outline-js-select" class="mdc-select mdc-select--outlined">
+            <div id="outline-js-select" class="mdc-select mdc-select--outlined mdc-select--with-leading-icon">
               <i class="material-icons mdc-select__icon">code</i>
               <i class="mdc-select__dropdown-icon"></i>
               <select class="mdc-select__native-control" id="outlined-select">
@@ -271,7 +271,7 @@
           <section class="example">
           <h2 class="mdc-typography--headline6">Outlined Select</h2>
           <section>
-            <div id="outline-select-enhanced" class="mdc-select mdc-select--outlined demo-enhanced-select">
+            <div id="outline-select-enhanced" class="mdc-select mdc-select--outlined demo-enhanced-select mdc-select--with-leading-icon">
               <i class="material-icons mdc-select__icon">code</i>
               <div class="mdc-select__selected-text" role="combobox"></div>
               <i class="mdc-select__dropdown-icon"></i>

--- a/demos/select.html
+++ b/demos/select.html
@@ -38,7 +38,7 @@
       }
 
       .example {
-        max-width: 400px;
+        max-width: 600px;
         margin: 24px;
         padding: 24px;
       }
@@ -90,6 +90,7 @@
             <h2 class="mdc-typography--headline6">Fully-Featured Native Component</h2>
             <section id="native-demo-wrapper">
               <div id="native-select" class="mdc-select">
+                <i class="material-icons mdc-select__icon">code</i>
                 <i class="mdc-select__dropdown-icon"></i>
                 <select class="mdc-select__native-control" id="native-full-func-select">
                   <option value="" disabled selected>
@@ -146,6 +147,7 @@
             <h2 class="mdc-typography--headline6">Fully-Featured Enhanced Component</h2>
             <section id="enhanced-demo-wrapper">
               <div id="enhanced-select" class="mdc-select demo-enhanced-select">
+                <i class="material-icons mdc-select__icon">code</i>
                 <div class="mdc-select__selected-text" role="combobox"></div>
                 <i class="mdc-select__dropdown-icon"></i>
                 <div class="mdc-select__menu mdc-menu demo-enhanced-menu mdc-menu-surface" role="listbox">
@@ -208,6 +210,7 @@
           <h2 class="mdc-typography--headline6">Outlined Select</h2>
           <section>
             <div id="outline-js-select" class="mdc-select mdc-select--outlined">
+              <i class="material-icons mdc-select__icon">code</i>
               <i class="mdc-select__dropdown-icon"></i>
               <select class="mdc-select__native-control" id="outlined-select">
                 <option value="" disabled selected>
@@ -269,6 +272,7 @@
           <h2 class="mdc-typography--headline6">Outlined Select</h2>
           <section>
             <div id="outline-select-enhanced" class="mdc-select mdc-select--outlined demo-enhanced-select">
+              <i class="material-icons mdc-select__icon">code</i>
               <div class="mdc-select__selected-text" role="combobox"></div>
               <i class="mdc-select__dropdown-icon"></i>
               <div class="mdc-menu demo-enhanced-menu mdc-menu-surface mdc-select__menu" role="listbox" id="outlined-select-selected-text">

--- a/demos/select.scss
+++ b/demos/select.scss
@@ -72,11 +72,10 @@
 }
 
 .demo-enhanced-select {
-  width: 400px;
+  width: 450px;
 }
 
 .demo-enhanced-menu {
-  width: 400px;
-  max-width: 400px;
+  width: 450px;
 }
 // stylelint-enable selector-class-pattern

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -291,6 +291,11 @@ programmatically select a disabled list item in the enhanced select.
 </div>
 ```
 
+### Select with Leading  Icons
+
+Leading icons can be added within the default or outlined variant of MDC Select as visual indicators as
+well as interaction targets. See [here](icon/) for more information on using icons.
+
 ## Style Customization
 
 #### CSS Classes
@@ -300,10 +305,12 @@ programmatically select a disabled list item in the enhanced select.
 | `mdc-select` | Mandatory. |
 | `mdc-select__menu` | Mandatory when using the enhanced select. This class should be placed on the `mdc-menu` element within the `mdc-select` element. |
 | `mdc-select__dropdown-icon` | Mandatory. Should be placed on an `i` element within the `mdc-select` element. Used for the dropdown arrow svg and animation.
+| `mdc-select__icon` | Optional. Should be placed on an `i` or `svg` element within the `mdc-select` element. Used for the leading icon. 
 | `mdc-select--disabled` | Optional. Styles the select as disabled. This class should be applied to the root element when the `disabled` attribute is applied to the `<select>` element. |
 | `mdc-select--outlined` | Optional. Styles the select as outlined select. |
 | `mdc-select__native-control` | Mandatory for the native select. The native `<select>` element. |
 | `mdc-select__selected-text` | Mandatory for the enhanced select. This class should be placed on a `div` within the `mdc-select` element. |
+| `mdc-select--with-leading-icon` | Styles the select as a select with a leading icon. |
 
 > Note: To further customize the [MDCMenu](./../mdc-menu) or the [MDCList](./../mdc-list) component contained within the select, please refer to their respective documentation.
 
@@ -334,9 +341,11 @@ The `MDCSelect` component API is modeled after a subset of the `HTMLSelectElemen
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `value` | `string` | The `value`/`data-value` of the currently selected option. |
-| `selectedIndex` | `number` | The index of the currently selected option. Set to -1 if no option is currently selected. Changing this property will update the select element. |
-| `disabled` | `boolean` | Whether or not the component is disabled. Settings this sets the disabled state on the component. |
+| `value` | string | The `value`/`data-value` of the currently selected option. |
+| `selectedIndex` | number | The index of the currently selected option. Set to -1 if no option is currently selected. Changing this property will update the select element. |
+| `disabled` | boolean | Whether or not the component is disabled. Settings this sets the disabled state on the component. |
+| `leadingIconAriaLabel` | string (write-only) | Proxies to the foundation's `setLeadingIconAriaLabel` method. |
+| `leadingIconContent` | string (write-only) | Proxies to the foundation's `setLeadingIconContent` method. |
 
 ### Events
 
@@ -386,9 +395,13 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 | `setValue(value: string) => void` | Handles setting the value through the adapter and causes the label to float and outline to notch if needed. |
 | `getValue() => string` | Handles getting the value through the adapter. |
 | `layout() => void` | Handles determining if the notched outline should be notched. |
+| `setLeadingIconAriaLabel(label: string) => void` | Sets the aria label of the leading icon. |
+| `setLeadingIconContent(content: string) => void` | Sets the text content of the leading icon. |
 
 ### Events
 
 Event Name | Data | Description
 --- | --- | ---
 `MDCSelect:change` | `{value: string, index: number}` | Used to indicate when an element has been selected. This event also includes the value of the item and the index.
+
+`MDCTextFieldFoundation` supports an optional icon sub-element. The foundation of the icon must be passed in as constructor arguments to `MDCSelectFoundation`.

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -26,6 +26,7 @@
 @import "@material/shape/functions";
 @import "@material/line-ripple/mixins";
 @import "@material/notched-outline/mixins";
+@import "./icon/mixins";
 @import "./variables";
 
 // Public
@@ -192,7 +193,6 @@
   &:not(.mdc-select--focused) .mdc-select__selected-text:hover ~ {
     @include mdc-notched-outline-idle-color($color);
 
-    // stylelint-disable-next-line selector-max-specificity
     .mdc-notched-outline {
       @include mdc-notched-outline-color($color);
     }
@@ -219,24 +219,8 @@
   }
 }
 
-@mixin mdc-select-leading-icon-layout_ ($position, $padding) {
-  .mdc-select__icon {
-    @include mdc-rtl-reflexive-position(left, $position);
-  }
-
-  // Move the input's position, to allow room for the icon
-  .mdc-select__native-control,
-  .mdc-select__selected-text {
-    @include mdc-rtl-reflexive-property(padding, $padding /* left-value */, 32px /* right-value */);
-  }
-
-  .mdc-floating-label {
-    @include mdc-rtl-reflexive-position(left, $padding);
-  }
-}
-
 @mixin mdc-select-with-leading-icon_ {
-  @include mdc-select-leading-icon-layout_(16px, 48px);
+  @include mdc-select-icon-horizontal-position_(16px, 48px);
 
   &.mdc-select--outlined {
     @include mdc-floating-label-float-position($mdc-select-outlined-label-position-y, $mdc-select-outlined-with-leading-icon-label-position-x);
@@ -249,16 +233,6 @@
 
   &.mdc-select__menu .mdc-list-item__text {
     @include mdc-rtl-reflexive-property(padding, 32px /* left-value */, 32px /* right-value */);
-  }
-}
-
-@mixin mdc-select-icon_ {
-  .mdc-select__icon {
-    @include mdc-theme-prop(color, $mdc-select-icon-color);
-
-    position: absolute;
-    bottom: 16px;
-    cursor: pointer;
   }
 }
 
@@ -287,7 +261,6 @@
       text-indent: -2px;
     }
 
-    // stylelint-disable-next-line selector-max-type, plugin/selector-bem-pattern
     > option {
       @include mdc-theme-prop(background-color, surface);
 
@@ -321,7 +294,6 @@
     @include mdc-select-dd-arrow-svg-bg_($mdc-select-dropdown-color, $mdc-select-disabled-dropdown-opacity);
   }
 
-  // stylelint-disable-next-line plugin/selector-bem-pattern
   .mdc-line-ripple {
     display: none;
   }
@@ -330,11 +302,11 @@
     @include mdc-theme-prop(color, $mdc-select-disabled-icon-color);
   }
 
-  // stylelint-disable-next-line plugin/selector-bem-pattern
   .mdc-select__native-control,
   .mdc-select__selected-text {
+    @include mdc-theme-prop(color, $mdc-select-disabled-ink-color);
+
     border-bottom-style: dotted;
-    color: $mdc-select-disabled-ink-color;
   }
 
   .mdc-select__selected-text {
@@ -344,7 +316,6 @@
   &.mdc-select--outlined {
     @include mdc-select-container-fill-color_(transparent);
 
-    // stylelint-disable-next-line plugin/selector-bem-pattern
     .mdc-select__native-control,
     .mdc-select__selected-text {
       border-bottom-style: none;
@@ -387,7 +358,10 @@
     padding-top: 14px;
   }
 
-  // stylelint-disable-next-line plugin/selector-bem-pattern
+  .mdc-select__icon {
+    z-index: 2;
+  }
+
   .mdc-floating-label {
     bottom: 20px;
     line-height: 1.15rem;

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -218,3 +218,179 @@
     pointer-events: none;
   }
 }
+
+@mixin mdc-select-leading-icon-layout_ ($position, $padding) {
+  .mdc-select__icon {
+    @include mdc-rtl-reflexive-position(left, $position);
+  }
+
+  // Move the input's position, to allow room for the icon
+  .mdc-select__native-control,
+  .mdc-select__selected-text {
+    @include mdc-rtl-reflexive-property(padding, $padding /* left-value */, 32px /* right-value */);
+  }
+
+  .mdc-floating-label {
+    @include mdc-rtl-reflexive-position(left, $padding);
+  }
+}
+
+@mixin mdc-select-with-leading-icon_ {
+  @include mdc-select-leading-icon-layout_(16px, 48px);
+
+  &.mdc-select--outlined {
+    @include mdc-floating-label-float-position($mdc-select-outlined-label-position-y, $mdc-select-outlined-with-leading-icon-label-position-x);
+    @include mdc-floating-label-shake-animation(text-field-outlined-leading-icon);
+
+    @include mdc-rtl {
+      @include mdc-floating-label-shake-animation(text-field-outlined-leading-icon-rtl);
+    }
+  }
+
+  &.mdc-select__menu .mdc-list-item__text {
+    @include mdc-rtl-reflexive-property(padding, 32px /* left-value */, 32px /* right-value */);
+  }
+}
+
+@mixin mdc-select-icon_ {
+  .mdc-select__icon {
+    @include mdc-theme-prop(color, $mdc-select-icon-color);
+
+    position: absolute;
+    bottom: 16px;
+    cursor: pointer;
+  }
+}
+
+@mixin mdc-select-text-and-control_ {
+  .mdc-select__selected-text {
+    min-width: 200px;
+    padding-top: 22px;
+  }
+
+  .mdc-select__native-control,
+  .mdc-select__selected-text {
+    @include mdc-rtl-reflexive-property(padding, $mdc-select-label-padding, $mdc-select-arrow-padding);
+    @include mdc-typography(subtitle1);
+
+    &::-ms-expand {
+      display: none;
+    }
+
+    &::-ms-value {
+      background-color: transparent;
+      color: inherit;
+    }
+
+    // counteracts the extra text padding that Firefox adds by default
+    @-moz-document url-prefix("") {
+      text-indent: -2px;
+    }
+
+    // stylelint-disable-next-line selector-max-type, plugin/selector-bem-pattern
+    > option {
+      @include mdc-theme-prop(background-color, surface);
+
+      color: inherit; // Override default user agent stylesheet
+    }
+
+    box-sizing: border-box;
+    width: 100%;
+    height: $mdc-select-height;
+    padding-top: 20px;
+    padding-bottom: 4px;
+    border: none;
+    border-bottom: 1px solid;
+    outline: none;
+    background-color: transparent;
+    color: inherit; // Override default user agent stylesheet
+    white-space: nowrap;
+    cursor: pointer;
+    appearance: none;
+  }
+}
+
+@mixin mdc-select-disabled_ {
+  @include mdc-select-container-fill-color_($mdc-select-disabled-fill-color);
+
+  .mdc-floating-label {
+    @include mdc-floating-label-ink-color($mdc-select-disabled-label-color);
+  }
+
+  .mdc-select__dropdown-icon {
+    @include mdc-select-dd-arrow-svg-bg_($mdc-select-dropdown-color, $mdc-select-disabled-dropdown-opacity);
+  }
+
+  // stylelint-disable-next-line plugin/selector-bem-pattern
+  .mdc-line-ripple {
+    display: none;
+  }
+
+  .mdc-select__icon {
+    @include mdc-theme-prop(color, $mdc-select-disabled-icon-color);
+  }
+
+  // stylelint-disable-next-line plugin/selector-bem-pattern
+  .mdc-select__native-control,
+  .mdc-select__selected-text {
+    border-bottom-style: dotted;
+    color: $mdc-select-disabled-ink-color;
+  }
+
+  .mdc-select__selected-text {
+    pointer-events: none;
+  }
+
+  &.mdc-select--outlined {
+    @include mdc-select-container-fill-color_(transparent);
+
+    // stylelint-disable-next-line plugin/selector-bem-pattern
+    .mdc-select__native-control,
+    .mdc-select__selected-text {
+      border-bottom-style: none;
+    }
+
+    @include mdc-select-outline-color_($mdc-select-outlined-disabled-border);
+  }
+
+  cursor: default;
+  pointer-events: none;
+}
+
+@mixin mdc-select-outlined_ {
+  @include mdc-select-container-fill-color(transparent);
+  @include mdc-select-outline-color($mdc-select-outlined-idle-border);
+  @include mdc-select-hover-outline-color($mdc-select-outlined-hover-border);
+  @include mdc-select-focused-outline-color(primary);
+  @include mdc-floating-label-float-position($mdc-select-outlined-label-position-y);
+  @include mdc-floating-label-shake-animation(text-field-outlined);
+  @include mdc-select-outline-shape-radius(medium);
+  @include mdc-states-base-color(transparent);
+  @include mdc-select-container-fill-color(transparent);
+
+  border: none;
+  overflow: visible;
+
+  .mdc-select__native-control,
+  .mdc-select__selected-text {
+    @include mdc-rtl-reflexive-property(padding, $mdc-select-label-padding, $mdc-select-arrow-padding);
+
+    display: flex;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border: none;
+    background-color: transparent;
+    z-index: 1;
+  }
+
+  .mdc-select__selected-text {
+    padding-top: 14px;
+  }
+
+  // stylelint-disable-next-line plugin/selector-bem-pattern
+  .mdc-floating-label {
+    bottom: 20px;
+    line-height: 1.15rem;
+    pointer-events: auto;
+  }
+}

--- a/packages/mdc-select/_variables.scss
+++ b/packages/mdc-select/_variables.scss
@@ -28,21 +28,23 @@ $mdc-select-height: 56px;
 
 $mdc-select-ink-color: rgba(mdc-theme-prop-value(on-surface), .87);
 $mdc-select-dropdown-color: mdc-theme-prop-value(on-surface);
-$mdc-select-disabled-ink-color: rgba(mdc-theme-prop-value(on-surface), .37);
-$mdc-select-dropdown-opacity: .54;
-$mdc-select-disabled-dropdown-opacity: .37;
-
+$mdc-select-icon-color: rgba(mdc-theme-prop-value(on-surface), .54);
 $mdc-select-label-color: rgba(mdc-theme-prop-value(on-surface), .6);
 $mdc-select-focused-label-color: rgba(mdc-theme-prop-value(primary), .87);
-$mdc-select-disabled-label-color: rgba(mdc-theme-prop-value(on-surface), .37);
-
 $mdc-select-bottom-line-idle-color: rgba(mdc-theme-prop-value(on-surface), .42);
 $mdc-select-bottom-line-hover-color: rgba(mdc-theme-prop-value(on-surface), .87);
 
-$mdc-select-box-fill-color: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 4%);
-$mdc-select-box-disabled-fill-color: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 2%);
+$mdc-select-fill-color: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 4%);
 
 $mdc-select-outlined-idle-border: rgba(mdc-theme-prop-value(on-surface), .24);
+$mdc-select-dropdown-opacity: .54;
+
+/** Disabled Styles **/
+$mdc-select-disabled-label-color: rgba(mdc-theme-prop-value(on-surface), .37);
+$mdc-select-disabled-icon-color: rgba(mdc-theme-prop-value(on-surface), .37);
+$mdc-select-disabled-ink-color: rgba(mdc-theme-prop-value(on-surface), .37);
+$mdc-select-disabled-fill-color: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 2%);
+$mdc-select-disabled-dropdown-opacity: .37;
 
 // should be .06 after mdc-select opacity is applied
 $mdc-select-outlined-disabled-border: rgba(mdc-theme-prop-value(on-surface), .16);
@@ -51,5 +53,6 @@ $mdc-select-outlined-hover-border: rgba(mdc-theme-prop-value(on-surface), .87);
 $mdc-select-label-position-y: 40%;
 $mdc-select-outlined-label-position-y: 130%;
 $mdc-select-outlined-dense-label-position-y: 110%;
+$mdc-select-outlined-with-leading-icon-label-position-x: 32px;
 
 $mdc-select-dropdown-transition-duration: 150ms;

--- a/packages/mdc-select/adapter.js
+++ b/packages/mdc-select/adapter.js
@@ -23,6 +23,14 @@
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
+
+/**
+ * @typedef {{
+ *   leadingIcon: (!MDCSelectIconFoundation|undefined),
+ * }}
+ */
+let FoundationMapType;
+
 /**
  * Adapter for MDC Select. Provides an interface for managing
  * - classes
@@ -162,4 +170,4 @@ class MDCSelectAdapter {
   notifyChange(evtData) {}
 }
 
-export default MDCSelectAdapter;
+export {MDCSelectAdapter, FoundationMapType};

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -126,8 +126,12 @@ class MDCSelectFoundation extends MDCFoundation {
   handleChange(didChange) {
     const value = this.getValue();
     const optionHasValue = value.length > 0;
-    this.adapter_.floatLabel(optionHasValue);
     this.notchOutline(optionHasValue);
+
+    if (!this.adapter_.hasClass(cssClasses.FOCUSED)) {
+      this.adapter_.floatLabel(optionHasValue);
+    }
+
     if (didChange) {
       this.adapter_.notifyChange({value});
     }

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -174,13 +174,14 @@ class MDCSelectFoundation extends MDCFoundation {
     if (!this.adapter_.hasOutline()) {
       return;
     }
+    const isFocused = this.adapter_.hasClass(cssClasses.FOCUSED);
 
     if (openNotch) {
       const labelScale = numbers.LABEL_SCALE;
       const labelWidth = this.adapter_.getLabelWidth() * labelScale;
       const isRtl = this.adapter_.isRtl();
       this.adapter_.notchOutline(labelWidth, isRtl);
-    } else {
+    } else if (!isFocused) {
       this.adapter_.closeOutline();
     }
   }

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -23,7 +23,7 @@
 
 import {MDCFoundation} from '@material/base/index';
 /* eslint-disable no-unused-vars */
-import MDCSelectAdapter from './adapter';
+import {MDCSelectAdapter, FoundationMapType} from './adapter';
 /* eslint-enable no-unused-vars */
 import {cssClasses, strings, numbers} from './constants';
 
@@ -79,9 +79,13 @@ class MDCSelectFoundation extends MDCFoundation {
 
   /**
    * @param {!MDCSelectAdapter} adapter
+   * @param {!FoundationMapType=} foundationMap Map from subcomponent names to their subfoundations.
    */
-  constructor(adapter) {
+  constructor(adapter, foundationMap = /** @type {!FoundationMapType} */ ({})) {
     super(Object.assign(MDCSelectFoundation.defaultAdapter, adapter));
+
+    /** @type {!MDCSelectIconFoundation|undefined} */
+    this.leadingIcon_ = foundationMap.leadingIcon;
   }
 
   setSelectedIndex(index) {
@@ -105,6 +109,10 @@ class MDCSelectFoundation extends MDCFoundation {
     isDisabled ? this.adapter_.addClass(cssClasses.DISABLED) : this.adapter_.removeClass(cssClasses.DISABLED);
     this.adapter_.setDisabled(isDisabled);
     this.adapter_.closeMenu();
+
+    if (this.leadingIcon_) {
+      this.leadingIcon_.setDisabled(isDisabled);
+    }
   }
 
   layout() {
@@ -183,6 +191,26 @@ class MDCSelectFoundation extends MDCFoundation {
       this.adapter_.notchOutline(labelWidth, isRtl);
     } else if (!isFocused) {
       this.adapter_.closeOutline();
+    }
+  }
+
+  /**
+   * Sets the aria label of the leading icon.
+   * @param {string} label
+   */
+  setLeadingIconAriaLabel(label) {
+    if (this.leadingIcon_) {
+      this.leadingIcon_.setAriaLabel(label);
+    }
+  }
+
+  /**
+   * Sets the text content of the leading icon.
+   * @param {string} content
+   */
+  setLeadingIconContent(content) {
+    if (this.leadingIcon_) {
+      this.leadingIcon_.setContent(content);
     }
   }
 }

--- a/packages/mdc-select/icon/README.md
+++ b/packages/mdc-select/icon/README.md
@@ -1,0 +1,125 @@
+<!--docs:
+title: "Select Icon"
+layout: detail
+section: components
+excerpt: "Icons describe the type of input a select requires"
+iconId: text_field
+path: /catalog/input-controls/select/icon/
+-->
+
+# Select Icon
+
+Icons describe the type of input a select requires. They can also be interaction targets.
+
+## Design & API Documentation
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--spec">
+    <a href="https://material.io/go/design-selects#selects-layout">Material Design guidelines: Text Fields Layout</a>
+  </li>
+</ul>
+
+## Basic Usage
+
+### HTML Structure
+
+```html
+<i class="material-icons mdc-select__icon" tabindex="0" role="button">event</i>
+```
+
+#### Icon Set
+
+We recommend using [Material Icons](https://material.io/tools/icons/) from Google Fonts:
+
+```html
+<head>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+</head>
+```
+
+However, you can also use SVG, [Font Awesome](https://fontawesome.com/), or any other icon library you wish.
+
+### Styles
+
+```scss
+@import "@material/select/icon/mdc-select-icon";
+```
+
+### JavaScript Instantiation
+
+```js
+import {MDCSelectIcon} from '@material/select/icon';
+
+const icon = new MDCSelectIcon(document.querySelector('.mdc-select__icon'));
+```
+
+## Variants
+
+Leading icons can be applied to default or `mdc-select--outlined` Selects. To add an icon, add the relevant class (`mdc-select--with-leading-icon` and/or `mdc-select--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-select__icon`.
+
+> **NOTE:** if you would like to display un-clickable icons, simply omit `tabindex="0"` and `role="button"`, and the CSS will ensure the cursor is set to default, and that interacting with an icon doesn't do anything unexpected.
+
+### Leading icon
+
+In select:
+
+```html
+<div class="mdc-select mdc-select--with-leading-icon">
+  <i class="material-icons mdc-select__icon" tabindex="0" role="button">event</i>
+  <!-- The rest of the select markup. -->
+</div>
+```
+
+In outlined select:
+
+```html
+<div class="mdc-select mdc-select--outlined mdc-select--with-leading-icon">
+  <i class="material-icons mdc-select__icon" tabindex="0" role="button">event</i>
+  <!-- The rest of the select markup. -->
+</div>
+```
+
+## Style Customization
+
+### CSS Classes
+
+CSS Class | Description
+--- | ---
+`mdc-select__icon` | Mandatory.
+
+### Sass Mixins
+
+Mixin | Description
+--- | ---
+`mdc-select-icon-color($color)` | Customizes the color for the leading icon.
+
+## `MDCSelectIcon` Properties and Methods
+
+Property | Value Type | Description
+--- | --- | ---
+`foundation` | `MDCSelectIconFoundation` | Returns the icon's foundation. This allows the parent `MDCSelect` component to access the public methods on the `MDCSelectIconFoundation` class.
+
+## Usage Within Frameworks
+
+If you are using a JavaScript framework, such as React or Angular, you can create a Select Icon for your framework. Depending on your needs, you can use the _Simple Approach: Wrapping MDC Web Vanilla Components_, or the _Advanced Approach: Using Foundations and Adapters_. Please follow the instructions [here](../../../docs/integrating-into-frameworks.md).
+
+### `MDCSelectIconAdapter`
+
+Method Signature | Description
+--- | ---
+`getAttr(attr: string) => string` | Gets the value of an attribute on the icon element.
+`setAttr(attr: string, value: string) => void` | Sets an attribute with a given value on the icon element.
+`removeAttr(attr: string) => void` | Removes an attribute from the icon element.
+`setContent(content: string) => void` | Sets the text content of the icon element.
+`registerInteractionHandler(evtType: string, handler: EventListener) => void` | Registers an event listener for a given event.
+`deregisterInteractionHandler(evtType: string, handler: EventListener) => void` | Deregisters an event listener for a given event.
+`notifyIconAction() => void` | Emits a custom event "MDCSelect:icon" denoting a user has clicked the icon, which bubbles to the top-level select element.
+
+### `MDCSelectIconFoundation`
+
+Method Signature | Description
+--- | ---
+`setDisabled(disabled: boolean) => void` | Updates the icon's disabled state.
+`setAriaLabel(label: string) => void` | Updates the icon's aria-label.
+`setContent(content: string) => void` | Updates the icon's text content.
+`handleInteraction(evt: Event) => void` | Handles a select interaction event.

--- a/packages/mdc-select/icon/_mixins.scss
+++ b/packages/mdc-select/icon/_mixins.scss
@@ -1,0 +1,75 @@
+//  Copyright 2018 Google Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:/
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software./
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@import "@material/theme/mixins";
+@import "./variables";
+
+// Public mixins
+
+@mixin mdc-select-icon-color_($color) {
+  .mdc-select__icon {
+    @include mdc-theme-prop(color, $color);
+  }
+}
+
+@mixin mdc-select-icon-color($color) {
+  &:not(.mdc-select--disabled) {
+    @include mdc-select-icon-color_($color);
+  }
+}
+
+@mixin mdc-select-icon_ {
+  @include mdc-select-icon-color(on-surface);
+
+  .mdc-select__icon {
+    display: inline-block;
+    position: absolute;
+    bottom: 16px;
+    box-sizing: border-box;
+    width: $mdc-select-icon-size;
+    height: $mdc-select-icon-size;
+    border: none;
+    background-color: transparent;
+    fill: currentColor;
+    opacity: $mdc-select-icon-opacity;
+    text-decoration: none;
+    cursor: pointer;
+    user-select: none;
+  }
+}
+
+// Private mixins
+
+@mixin mdc-select-icon-horizontal-position_($iconPosition, $inputPadding) {
+  .mdc-select__icon {
+    @include mdc-rtl-reflexive-position(left, $iconPosition);
+  }
+
+  // Move the input's position, to allow room for the icon
+  .mdc-select__native-control,
+  .mdc-select__selected-text {
+    @include mdc-rtl-reflexive-property(padding, $inputPadding /* left */, $mdc-select-icon-right-padding /* right */);
+  }
+
+  .mdc-floating-label {
+    @include mdc-rtl-reflexive-position(left, $inputPadding);
+  }
+}

--- a/packages/mdc-select/icon/_variables.scss
+++ b/packages/mdc-select/icon/_variables.scss
@@ -1,0 +1,25 @@
+//  Copyright 2018 Google Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:/
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software./
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+$mdc-select-icon-size: 24px !default;
+$mdc-select-icon-opacity: .54 !default;
+$mdc-select-icon-color: on-surface !default;
+$mdc-select-icon-right-padding: 32px !default;

--- a/packages/mdc-select/icon/adapter.js
+++ b/packages/mdc-select/icon/adapter.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/* eslint no-unused-vars: [2, {"args": "none"}] */
+
+/**
+ * Adapter for MDC Select Icon.
+ *
+ * Defines the shape of the adapter expected by the foundation. Implement this
+ * adapter to integrate the select icon into your framework. See
+ * https://github.com/material-components/material-components-web/blob/master/docs/authoring-components.md
+ * for more information.
+ *
+ * @record
+ */
+class MDCSelectIconAdapter {
+  /**
+   * Gets the value of an attribute on the icon element.
+   * @param {string} attr
+   * @return {string}
+   */
+  getAttr(attr) {}
+
+  /**
+   * Sets an attribute on the icon element.
+   * @param {string} attr
+   * @param {string} value
+   */
+  setAttr(attr, value) {}
+
+  /**
+   * Removes an attribute from the icon element.
+   * @param {string} attr
+   */
+  removeAttr(attr) {}
+
+  /**
+   * Sets the text content of the icon element.
+   * @param {string} content
+   */
+  setContent(content) {}
+
+  /**
+   * Registers an event listener on the icon element for a given event.
+   * @param {string} evtType
+   * @param {function(!Event): undefined} handler
+   */
+  registerInteractionHandler(evtType, handler) {}
+
+  /**
+   * Deregisters an event listener on the icon element for a given event.
+   * @param {string} evtType
+   * @param {function(!Event): undefined} handler
+   */
+  deregisterInteractionHandler(evtType, handler) {}
+
+  /**
+   * Emits a custom event "MDCSelect:icon" denoting a user has clicked the icon.
+   */
+  notifyIconAction() {}
+}
+
+export default MDCSelectIconAdapter;

--- a/packages/mdc-select/icon/constants.js
+++ b/packages/mdc-select/icon/constants.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2016 Google Inc.
+ * Copyright 2018 Google Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,33 +22,9 @@
  */
 
 /** @enum {string} */
-const cssClasses = {
-  DISABLED: 'mdc-select--disabled',
-  ROOT: 'mdc-select',
-  OUTLINED: 'mdc-select--outlined',
-  FOCUSED: 'mdc-select--focused',
-  SELECTED_ITEM_CLASS: 'mdc-list-item--selected',
-  WITH_LEADING_ICON: 'mdc-select--with-leading-icon',
-};
-
-/** @enum {string} */
 const strings = {
-  CHANGE_EVENT: 'MDCSelect:change',
-  SELECTED_ITEM_SELECTOR: `.${cssClasses.SELECTED_ITEM_CLASS}`,
-  LEADING_ICON_SELECTOR: '.mdc-select__icon',
-  SELECTED_TEXT_SELECTOR: '.mdc-select__selected-text',
-  MENU_SELECTOR: '.mdc-select__menu',
-  LINE_RIPPLE_SELECTOR: '.mdc-line-ripple',
-  LABEL_SELECTOR: '.mdc-floating-label',
-  NATIVE_CONTROL_SELECTOR: '.mdc-select__native-control',
-  OUTLINE_SELECTOR: '.mdc-notched-outline',
-  ENHANCED_VALUE_ATTR: 'data-value',
-  ARIA_SELECTED_ATTR: 'aria-selected',
+  ICON_EVENT: 'MDCSelect:icon',
+  ICON_ROLE: 'button',
 };
 
-/** @enum {number} */
-const numbers = {
-  LABEL_SCALE: 0.75,
-};
-
-export {cssClasses, strings, numbers};
+export {strings};

--- a/packages/mdc-select/icon/foundation.js
+++ b/packages/mdc-select/icon/foundation.js
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import MDCFoundation from '@material/base/foundation';
+import MDCSelectIconAdapter from './adapter';
+import {strings} from './constants';
+
+
+/**
+ * @extends {MDCFoundation<!MDCSelectIconAdapter>}
+ * @final
+ */
+class MDCSelectIconFoundation extends MDCFoundation {
+  /** @return enum {string} */
+  static get strings() {
+    return strings;
+  }
+
+  /**
+   * {@see MDCSelectIconAdapter} for typing information on parameters and return
+   * types.
+   * @return {!MDCSelectIconAdapter}
+   */
+  static get defaultAdapter() {
+    return /** @type {!MDCSelectIconAdapter} */ ({
+      getAttr: () => {},
+      setAttr: () => {},
+      removeAttr: () => {},
+      setContent: () => {},
+      registerInteractionHandler: () => {},
+      deregisterInteractionHandler: () => {},
+      notifyIconAction: () => {},
+    });
+  }
+
+  /**
+   * @param {!MDCSelectIconAdapter} adapter
+   */
+  constructor(adapter) {
+    super(Object.assign(MDCSelectIconFoundation.defaultAdapter, adapter));
+
+    /** @private {string?} */
+    this.savedTabIndex_ = null;
+
+    /** @private {function(!Event): undefined} */
+    this.interactionHandler_ = (evt) => this.handleInteraction(evt);
+  }
+
+  init() {
+    this.savedTabIndex_ = this.adapter_.getAttr('tabindex');
+
+    ['click', 'keydown'].forEach((evtType) => {
+      this.adapter_.registerInteractionHandler(evtType, this.interactionHandler_);
+    });
+  }
+
+  destroy() {
+    ['click', 'keydown'].forEach((evtType) => {
+      this.adapter_.deregisterInteractionHandler(evtType, this.interactionHandler_);
+    });
+  }
+
+  /** @param {boolean} disabled */
+  setDisabled(disabled) {
+    if (!this.savedTabIndex_) {
+      return;
+    }
+
+    if (disabled) {
+      this.adapter_.setAttr('tabindex', '-1');
+      this.adapter_.removeAttr('role');
+    } else {
+      this.adapter_.setAttr('tabindex', this.savedTabIndex_);
+      this.adapter_.setAttr('role', strings.ICON_ROLE);
+    }
+  }
+
+  /** @param {string} label */
+  setAriaLabel(label) {
+    this.adapter_.setAttr('aria-label', label);
+  }
+
+  /** @param {string} content */
+  setContent(content) {
+    this.adapter_.setContent(content);
+  }
+
+  /**
+   * Handles an interaction event
+   * @param {!Event} evt
+   */
+  handleInteraction(evt) {
+    if (evt.type === 'click' || evt.key === 'Enter' || evt.keyCode === 13) {
+      this.adapter_.notifyIconAction();
+    }
+  }
+}
+
+export default MDCSelectIconFoundation;

--- a/packages/mdc-select/icon/index.js
+++ b/packages/mdc-select/icon/index.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import MDCComponent from '@material/base/component';
+
+import MDCSelectIconAdapter from './adapter';
+import MDCSelectIconFoundation from './foundation';
+
+/**
+ * @extends {MDCComponent<!MDCSelectIconFoundation>}
+ * @final
+ */
+class MDCSelectIcon extends MDCComponent {
+  /**
+   * @param {!Element} root
+   * @return {!MDCSelectIcon}
+   */
+  static attachTo(root) {
+    return new MDCSelectIcon(root);
+  }
+
+  /**
+   * @return {!MDCSelectIconFoundation}
+   */
+  get foundation() {
+    return this.foundation_;
+  }
+
+  /**
+   * @return {!MDCSelectIconFoundation}
+   */
+  getDefaultFoundation() {
+    return new MDCSelectIconFoundation(/** @type {!MDCSelectIconAdapter} */ (Object.assign({
+      getAttr: (attr) => this.root_.getAttribute(attr),
+      setAttr: (attr, value) => this.root_.setAttribute(attr, value),
+      removeAttr: (attr) => this.root_.removeAttribute(attr),
+      setContent: (content) => {
+        this.root_.textContent = content;
+      },
+      registerInteractionHandler: (evtType, handler) => this.root_.addEventListener(evtType, handler),
+      deregisterInteractionHandler: (evtType, handler) => this.root_.removeEventListener(evtType, handler),
+      notifyIconAction: () => this.emit(
+        MDCSelectIconFoundation.strings.ICON_EVENT, {} /* evtData */, true /* shouldBubble */),
+    })));
+  }
+}
+
+export {MDCSelectIcon, MDCSelectIconFoundation};

--- a/packages/mdc-select/icon/mdc-select-icon.scss
+++ b/packages/mdc-select/icon/mdc-select-icon.scss
@@ -1,0 +1,32 @@
+//  Copyright 2018 Google Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:/
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software./
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@import "./mixins";
+
+.mdc-select--with-leading-icon {
+  @include mdc-select-icon_;
+}
+
+.mdc-select__icon:not([tabindex]),
+.mdc-select__icon[tabindex="-1"] {
+  cursor: default;
+  pointer-events: none;
+}

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -176,6 +176,11 @@ class MDCSelect extends MDCComponent {
       this.outline_ = outlineFactory(outlineElement);
     }
 
+    const leadingIcon = this.root_.classList.contains('mdc-select--with-leading-icon');
+    if (leadingIcon && this.menuElement_) {
+      this.menuElement_.classList.add('mdc-select--with-leading-icon');
+    }
+
     if (!this.root_.classList.contains(cssClasses.OUTLINED)) {
       this.ripple = this.initRipple_();
     }

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -337,7 +337,8 @@ class MDCSelect extends MDCComponent {
         this.getCommonAdapterMethods_(),
         this.getOutlineAdapterMethods_(),
         this.getLabelAdapterMethods_())
-      )
+      ),
+      this.getFoundationMap_()
     );
   }
 

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -29,7 +29,8 @@ import {MDCRipple, MDCRippleFoundation} from '@material/ripple/index';
 import {MDCNotchedOutline} from '@material/notched-outline/index';
 
 import MDCSelectFoundation from './foundation';
-import MDCSelectAdapter from './adapter';
+import {MDCSelectAdapter} from './adapter';
+import {MDCSelectIcon} from './icon/index';
 import {cssClasses, strings} from './constants';
 // Closure has issues with {this as that} syntax.
 import * as menuSurfaceConstants from '@material/menu-surface/constants';
@@ -48,6 +49,8 @@ class MDCSelect extends MDCComponent {
     this.nativeControl_;
     /** @private {?Element} */
     this.selectedText_;
+    /** @private {?MDCSelectIcon} */
+    this.leadingIcon_;
     /** @private {?Element} */
     this.menuElement_;
     /** @type {?MDCMenu} */
@@ -139,6 +142,22 @@ class MDCSelect extends MDCComponent {
   }
 
   /**
+   * Sets the aria label of the leading icon.
+   * @param {string} label
+   */
+  set leadingIconAriaLabel(label) {
+    this.foundation_.setLeadingIconAriaLabel(label);
+  }
+
+  /**
+   * Sets the text content of the leading icon.
+   * @param {string} content
+   */
+  set leadingIconContent(content) {
+    this.foundation_.setLeadingIconContent(content);
+  }
+
+  /**
    * Recomputes the outline SVG path for the outline element.
    */
   layout() {
@@ -151,12 +170,14 @@ class MDCSelect extends MDCComponent {
    * @param {(function(!Element): !MDCFloatingLabel)=} labelFactory A function which creates a new MDCFloatingLabel.
    * @param {(function(!Element): !MDCNotchedOutline)=} outlineFactory A function which creates a new MDCNotchedOutline.
    * @param {(function(!Element): !MDCMenu)=} menuFactory A function which creates a new MDCMenu.
+   * @param {(function(!Element): !MDCSelectIcon)=} iconFactory A function which creates a new MDCSelectIcon.
    */
   initialize(
     labelFactory = (el) => new MDCFloatingLabel(el),
     lineRippleFactory = (el) => new MDCLineRipple(el),
     outlineFactory = (el) => new MDCNotchedOutline(el),
-    menuFactory = (el) => new MDCMenu(el)) {
+    menuFactory = (el) => new MDCMenu(el),
+    iconFactory = (el) => new MDCSelectIcon(el)) {
     this.nativeControl_ = /** @type {HTMLElement} */ (this.root_.querySelector(strings.NATIVE_CONTROL_SELECTOR));
     this.selectedText_ = /** @type {HTMLElement} */ (this.root_.querySelector(strings.SELECTED_TEXT_SELECTOR));
 
@@ -176,9 +197,14 @@ class MDCSelect extends MDCComponent {
       this.outline_ = outlineFactory(outlineElement);
     }
 
-    const leadingIcon = this.root_.classList.contains('mdc-select--with-leading-icon');
-    if (leadingIcon && this.menuElement_) {
-      this.menuElement_.classList.add('mdc-select--with-leading-icon');
+    const leadingIcon = this.root_.querySelector(strings.LEADING_ICON_SELECTOR);
+    if (leadingIcon) {
+      this.root_.classList.add(cssClasses.WITH_LEADING_ICON);
+      this.leadingIcon_ = iconFactory(leadingIcon);
+
+      if (this.menuElement_) {
+        this.menuElement_.classList.add(cssClasses.WITH_LEADING_ICON);
+      }
     }
 
     if (!this.root_.classList.contains(cssClasses.OUTLINED)) {
@@ -491,6 +517,16 @@ class MDCSelect extends MDCComponent {
     const targetClientRect = evt.target.getBoundingClientRect();
     const xCoordinate = evt.clientX;
     return xCoordinate - targetClientRect.left;
+  }
+
+  /**
+   * Returns a map of all subcomponents to subfoundations.
+   * @return {!FoundationMapType}
+   */
+  getFoundationMap_() {
+    return {
+      leadingIcon: this.leadingIcon_ ? this.leadingIcon_.foundation : undefined,
+    };
   }
 }
 

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -34,7 +34,7 @@
 
 // postcss-bem-linter: define select
 .mdc-select {
-  @include mdc-select-container-fill-color($mdc-select-box-fill-color);
+  @include mdc-select-container-fill-color($mdc-select-fill-color);
   @include mdc-ripple-surface;
   @include mdc-ripple-radius-bounded;
   // Select intentionally omits press ripple, so each state needs to be specified individually.
@@ -45,6 +45,7 @@
   @include mdc-select-label-color($mdc-select-label-color);
   @include mdc-select-bottom-line-color($mdc-select-bottom-line-idle-color);
   @include mdc-select-shape-radius(medium);
+  @include mdc-select-icon_;
 
   // Focused state colors
   @include mdc-select-focused-bottom-line-color(primary);
@@ -184,7 +185,7 @@
 }
 
 .mdc-select--disabled {
-  @include mdc-select-container-fill-color_($mdc-select-box-disabled-fill-color);
+  @include mdc-select-container-fill-color_($mdc-select-disabled-fill-color);
 
   .mdc-floating-label {
     @include mdc-floating-label-ink-color($mdc-select-disabled-label-color);
@@ -224,6 +225,15 @@
 
   cursor: default;
   pointer-events: none;
+}
+
+.mdc-select--with-leading-icon {
+  @include mdc-select-with-leading-icon_;
+}
+
+.mdc-select__menu .mdc-list .mdc-list-item--selected {
+  @include mdc-theme-prop(color, on-surface);
+  @include mdc-states;
 }
 
 .mdc-select__menu .mdc-list .mdc-list-item--selected {

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -31,6 +31,7 @@
 @import "@material/ripple/common";
 @import "@material/ripple/mixins";
 @import "@material/rtl/mixins";
+@import "./icon/mdc-select-icon";
 
 // postcss-bem-linter: define select
 .mdc-select {
@@ -45,7 +46,6 @@
   @include mdc-select-label-color($mdc-select-label-color);
   @include mdc-select-bottom-line-color($mdc-select-bottom-line-idle-color);
   @include mdc-select-shape-radius(medium);
-  @include mdc-select-icon_;
 
   // Focused state colors
   @include mdc-select-focused-bottom-line-color(primary);
@@ -84,52 +84,8 @@
     }
   }
 
-  &__selected-text {
-    min-width: 200px;
-    padding-top: 22px;
-  }
-
   &__native-control {
     padding-top: 20px;
-  }
-
-  &__native-control,
-  &__selected-text {
-    @include mdc-rtl-reflexive-property(padding, $mdc-select-label-padding, $mdc-select-arrow-padding);
-    @include mdc-typography(subtitle1);
-
-    &::-ms-expand {
-      display: none;
-    }
-
-    &::-ms-value {
-      background-color: transparent;
-      color: inherit;
-    }
-
-    // counteracts the extra text padding that Firefox adds by default
-    @-moz-document url-prefix("") {
-      text-indent: -2px;
-    }
-
-    // stylelint-disable-next-line selector-max-type, plugin/selector-bem-pattern
-    > option {
-      @include mdc-theme-prop(background-color, surface);
-
-      color: inherit; // Override default user agent stylesheet
-    }
-
-    box-sizing: border-box;
-    width: 100%;
-    padding-bottom: 4px;
-    border: none;
-    border-bottom: 1px solid;
-    outline: none;
-    background-color: transparent;
-    color: inherit; // Override default user agent stylesheet
-    white-space: nowrap;
-    cursor: pointer;
-    appearance: none;
   }
 
   @include mdc-select-focused-line-ripple_ {
@@ -141,42 +97,10 @@
 }
 
 .mdc-select--outlined {
-  @include mdc-select-container-fill-color(transparent);
-  @include mdc-select-outline-color($mdc-select-outlined-idle-border);
-  @include mdc-select-hover-outline-color($mdc-select-outlined-hover-border);
-  @include mdc-select-focused-outline-color(primary);
-  @include mdc-floating-label-float-position($mdc-select-outlined-label-position-y);
-  @include mdc-floating-label-shake-animation(text-field-outlined);
-  @include mdc-select-outline-shape-radius(medium);
-  @include mdc-states-base-color(transparent);
-  @include mdc-select-container-fill-color(transparent);
-
-  border: none;
-  overflow: visible;
-
-  .mdc-select__native-control,
-  .mdc-select__selected-text {
-    @include mdc-rtl-reflexive-property(padding, $mdc-select-label-padding, $mdc-select-arrow-padding);
-
-    display: flex;
-    padding-top: 12px;
-    padding-bottom: 12px;
-    border: none;
-    background-color: transparent;
-    z-index: 1;
-  }
-
-  .mdc-select__selected-text {
-    padding-top: 14px;
-  }
-
-  // stylelint-disable-next-line plugin/selector-bem-pattern
-  .mdc-floating-label {
-    bottom: 20px;
-    line-height: 1.15rem;
-    pointer-events: auto;
-  }
+  @include mdc-select-outlined_;
 }
+
+@include mdc-select-text-and-control_
 
 .mdc-select--focused {
   .mdc-select__dropdown-icon {
@@ -185,46 +109,7 @@
 }
 
 .mdc-select--disabled {
-  @include mdc-select-container-fill-color_($mdc-select-disabled-fill-color);
-
-  .mdc-floating-label {
-    @include mdc-floating-label-ink-color($mdc-select-disabled-label-color);
-  }
-
-  .mdc-select__dropdown-icon {
-    @include mdc-select-dd-arrow-svg-bg_($mdc-select-dropdown-color, $mdc-select-disabled-dropdown-opacity);
-  }
-
-  // stylelint-disable-next-line plugin/selector-bem-pattern
-  .mdc-line-ripple {
-    display: none;
-  }
-
-  // stylelint-disable-next-line plugin/selector-bem-pattern
-  .mdc-select__native-control,
-  .mdc-select__selected-text {
-    border-bottom-style: dotted;
-    color: $mdc-select-disabled-ink-color;
-  }
-
-  .mdc-select__selected-text {
-    pointer-events: none;
-  }
-
-  &.mdc-select--outlined {
-    @include mdc-select-container-fill-color_(transparent);
-
-    // stylelint-disable-next-line plugin/selector-bem-pattern
-    .mdc-select__native-control,
-    .mdc-select__selected-text {
-      border-bottom-style: none;
-    }
-
-    @include mdc-select-outline-color_($mdc-select-outlined-disabled-border);
-  }
-
-  cursor: default;
-  pointer-events: none;
+  @include mdc-select-disabled_;
 }
 
 .mdc-select--with-leading-icon {

--- a/test/screenshot/spec/mdc-select/classes/enhanced-leading-icon-svg.html
+++ b/test/screenshot/spec/mdc-select/classes/enhanced-leading-icon-svg.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Leading Icon (SVG) Enhanced Select - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu-surface.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu.css">
+    <link rel="stylesheet" href="../../../out/mdc.select.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-select/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select custom-enhanced-select-width mdc-select--with-leading-icon">
+            <svg class="mdc-select__icon" tabindex="0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="true">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox"></div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value=""></li>
+                <li class="mdc-list-item" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label">Pick a Food Group</span>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined custom-enhanced-select-width mdc-select--with-leading-icon">
+            <svg class="mdc-select__icon" tabindex="0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="true">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox"></div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value=""></li>
+                <li class="mdc-list-item" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label">Pick a Food Group</span>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select custom-enhanced-select-width mdc-select--with-leading-icon">
+            <svg class="mdc-select__icon" tabindex="0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="true">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox">Bread, Cereal, Rice, and Pasta</div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label mdc-floating-label--float-above">Pick a Food Group</span>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined custom-enhanced-select-width mdc-select--with-leading-icon">
+            <i class="mdc-select__icon" tabindex="0">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="false">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+            </i>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox">Bread, Cereal, Rice, and Pasta</div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label mdc-floating-label--float-above">Pick a Food Group</span>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-select/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-select/classes/enhanced-leading-icon.html
+++ b/test/screenshot/spec/mdc-select/classes/enhanced-leading-icon.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Leading Icon Enhanced Select - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu-surface.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu.css">
+    <link rel="stylesheet" href="../../../out/mdc.select.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-select/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select custom-enhanced-select-width mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon">code</i>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox"></div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value=""></li>
+                <li class="mdc-list-item" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label">Pick a Food Group</span>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined custom-enhanced-select-width mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon">code</i>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox"></div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value=""></li>
+                <li class="mdc-list-item" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label">Pick a Food Group</span>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select custom-enhanced-select-width mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon">code</i>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox">Bread, Cereal, Rice, and Pasta</div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label mdc-floating-label--float-above">Pick a Food Group</span>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined custom-enhanced-select-width mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon">code</i>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-select__selected-text" role="combobox">Bread, Cereal, Rice, and Pasta</div>
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+            <span class="mdc-floating-label mdc-floating-label--float-above">Pick a Food Group</span>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-select/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-select/classes/leading-icon-svg.html
+++ b/test/screenshot/spec/mdc-select/classes/leading-icon-svg.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Leading Icon (SVG) Select - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.select.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-select/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--with-leading-icon">
+              <svg class="mdc-select__icon" tabindex="0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="true">
+                <path fill="none" d="M0 0h24v24H0z"/>
+                <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+              </svg>
+            <select class="mdc-select__native-control" id="my-select">
+              <option selected></option>
+              <option value="grains">
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label" for="my-select">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--with-leading-icon">
+            <svg class="mdc-select__icon" tabindex="0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="true">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+            <select class="mdc-select__native-control" id="my-select2">
+              <option selected></option>
+              <option value="grains">
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label" for="my-select2">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--with-leading-icon">
+            <svg class="mdc-select__icon" tabindex="0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="true">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+            <select class="mdc-select__native-control" id="my-select3">
+              <option value="grains" selected>
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label mdc-floating-label--float-above" for="my-select3">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--with-leading-icon">
+            <svg class="mdc-select__icon" tabindex="0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000" focusable="false">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+            <select class="mdc-select__native-control" id="my-select4">
+              <option value="grains" selected>
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label mdc-floating-label--float-above" for="my-select4">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-select/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-select/classes/leading-icon.html
+++ b/test/screenshot/spec/mdc-select/classes/leading-icon.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Leading Icon Select - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.select.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-select/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon" tabindex="0" role="button">code</i>
+            <select class="mdc-select__native-control" id="my-select">
+              <option selected></option>
+              <option value="grains">
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label" for="my-select">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon" tabindex="0" role="button">code</i>
+            <select class="mdc-select__native-control" id="my-select2">
+              <option selected></option>
+              <option value="grains">
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label" for="my-select2">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon" tabindex="0" role="button">code</i>
+            <select class="mdc-select__native-control" id="my-select3">
+              <option value="grains" selected>
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label mdc-floating-label--float-above" for="my-select3">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--with-leading-icon">
+            <i class="material-icons mdc-select__icon" tabindex="0" role="button">code</i>
+            <select class="mdc-select__native-control" id="my-select4">
+              <option value="grains" selected>
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label mdc-floating-label--float-above" for="my-select4">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-select/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-select/fixture.scss
+++ b/test/screenshot/spec/mdc-select/fixture.scss
@@ -25,7 +25,7 @@
 @import "../mixins";
 
 .test-cell--select {
-  @include test-cell-size(301, 121);
+  @include test-cell-size(321, 121);
 }
 
 .custom-select-ink-color {
@@ -57,5 +57,5 @@
 }
 
 .custom-enhanced-select-width {
-  width: 275px;
+  width: 300px;
 }

--- a/test/unit/mdc-select/foundation.test.js
+++ b/test/unit/mdc-select/foundation.test.js
@@ -24,7 +24,6 @@
 import {assert} from 'chai';
 import td from 'testdouble';
 
-import {setupFoundationTest} from '../helpers/setup';
 import {verifyDefaultAdapter} from '../helpers/foundation';
 
 import MDCSelectFoundation from '../../../packages/mdc-select/foundation';
@@ -52,10 +51,24 @@ test('default adapter returns a complete adapter implementation', () => {
   ]);
 });
 
-function setupTest() {
-  const {mockAdapter, foundation} = setupFoundationTest(MDCSelectFoundation);
+function setupTest(hasLeadingIcon = true) {
+  const mockAdapter = td.object(MDCSelectFoundation.defaultAdapter);
+  const leadingIcon = td.object({
+    setDisabled: () => {},
+    setAriaLabel: () => {},
+    setContent: () => {},
+    registerInteractionHandler: () => {},
+    deregisterInteractionHandler: () => {},
+    handleInteraction: () => {},
+  });
+  const foundationMap = {
+    leadingIcon: hasLeadingIcon ? leadingIcon : undefined,
+  };
+
   td.when(mockAdapter.getValue()).thenReturn('');
-  return {mockAdapter, foundation};
+
+  const foundation = new MDCSelectFoundation(mockAdapter, foundationMap);
+  return {foundation, mockAdapter, leadingIcon};
 }
 
 test('#setDisabled(true) calls adapter.addClass', () => {
@@ -70,6 +83,12 @@ test('#setDisabled(false) calls adapter.removeClass', () => {
   foundation.setDisabled(false);
   td.verify(mockAdapter.setDisabled(false));
   td.verify(mockAdapter.removeClass(cssClasses.DISABLED));
+});
+
+test('#setDisabled sets disabled on leading icon', () => {
+  const {foundation, leadingIcon} = setupTest();
+  foundation.setDisabled(true);
+  td.verify(leadingIcon.setDisabled(true));
 });
 
 test('#notchOutline updates the SVG path of the outline element', () => {
@@ -99,12 +118,21 @@ test('#notchOutline does nothing if no label is present', () => {
 });
 
 test('#notchOutline calls updates notched outline to return to idle state when ' +
-  'openNotch is false', () => {
+  'openNotch is false and not focused', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasOutline()).thenReturn(true);
 
   foundation.notchOutline(false);
   td.verify(mockAdapter.closeOutline());
+});
+
+test('#notchOutline does not close the notch if the select is still focused', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasOutline()).thenReturn(true);
+  td.when(mockAdapter.hasClass(cssClasses.FOCUSED)).thenReturn(true);
+
+  foundation.notchOutline(false);
+  td.verify(mockAdapter.closeOutline(), {times: 0});
 });
 
 test('#handleChange calls adapter.floatLabel(true) when there is a value', () => {
@@ -115,12 +143,21 @@ test('#handleChange calls adapter.floatLabel(true) when there is a value', () =>
   td.verify(mockAdapter.floatLabel(true), {times: 1});
 });
 
-test('#handleChange calls adapter.floatLabel(false) when there is no value', () => {
+test('#handleChange calls adapter.floatLabel(false) when there is no value and the select is not focused', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.getValue()).thenReturn('');
 
   foundation.handleChange();
   td.verify(mockAdapter.floatLabel(false), {times: 1});
+});
+
+test('#handleChange does not call adapter.floatLabel(false) when there is no value if the select is focused', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getValue()).thenReturn('');
+  td.when(mockAdapter.hasClass(cssClasses.FOCUSED)).thenReturn(true);
+
+  foundation.handleChange();
+  td.verify(mockAdapter.floatLabel(false), {times: 0});
 });
 
 test('#handleChange calls foundation.notchOutline(true) when there is a value', () => {
@@ -305,9 +342,34 @@ test('#layout calls notchOutline(true) if value is not an empty string', () => {
 });
 
 test('#layout calls notchOutline(false) if value is an empty string', () => {
-  const {foundation, mockAdapter} = setupTest();
+  const {foundation} = setupTest();
   foundation.notchOutline = td.func();
-  td.when(mockAdapter.getValue()).thenReturn('');
   foundation.layout();
   td.verify(foundation.notchOutline(false), {times: 1});
+});
+
+test('#setLeadingIconAriaLabel sets the aria-label of the leading icon element', () => {
+  const {foundation, leadingIcon} = setupTest();
+  foundation.setLeadingIconAriaLabel('foo');
+  td.verify(leadingIcon.setAriaLabel('foo'), {times: 1});
+});
+
+test('#setLeadingIconContent sets the content of the leading icon element', () => {
+  const {foundation, leadingIcon} = setupTest();
+  foundation.setLeadingIconContent('foo');
+  td.verify(leadingIcon.setContent('foo'), {times: 1});
+});
+
+test('#setLeadingIconAriaLabel does nothing if the leading icon element is undefined', () => {
+  const hasLeadingIcon = false;
+  const {foundation, leadingIcon} = setupTest(hasLeadingIcon);
+  foundation.setLeadingIconAriaLabel('foo');
+  td.verify(leadingIcon.setAriaLabel('foo'), {times: 0});
+});
+
+test('#setLeadingIconContent does nothing if the leading icon element is undefined', () => {
+  const hasLeadingIcon = false;
+  const {foundation, leadingIcon} = setupTest(hasLeadingIcon);
+  foundation.setLeadingIconContent('foo');
+  td.verify(leadingIcon.setContent('foo'), {times: 0});
 });

--- a/test/unit/mdc-select/mdc-select-enhanced.test.js
+++ b/test/unit/mdc-select/mdc-select-enhanced.test.js
@@ -36,6 +36,7 @@ import {MDCMenu, MDCMenuFoundation} from '../../../packages/mdc-menu/index';
 import {MDCMenuSurfaceFoundation} from '../../../packages/mdc-menu-surface/index';
 import MDCSelectFoundation from '../../../packages/mdc-select/foundation';
 import MDCListFoundation from '../../../packages/mdc-list/foundation';
+import {MDCSelectIcon} from '../../../packages/mdc-select/icon';
 
 const LABEL_WIDTH = 100;
 
@@ -76,9 +77,18 @@ class FakeMenu {
   }
 }
 
+class FakeIcon {
+  constructor() {
+    this.destroy = td.func('.destroy');
+    this.foundation = td.func('.foundation');
+    this.setDisabled = td.func('.foundation');
+  }
+}
+
 function getFixture() {
   return bel`
     <div class="mdc-select">
+    <i class="mdc-select__icon material-icons">code</i>
       <div class="mdc-select__selected-text"></div>
       <i class="mdc-select__dropdown-icon"></i>
       <div class="mdc-select__menu mdc-menu mdc-menu-surface">
@@ -101,6 +111,7 @@ function getFixture() {
 function getOutlineFixture() {
   return bel`
     <div class="mdc-select mdc-select--outlined">
+      <i class="mdc-select__icon material-icons">code</i>
       <div class="mdc-select__selected-text"></div>
       <i class="mdc-select__dropdown-icon"></i>
       <div class="mdc-select__menu mdc-menu mdc-menu-surface">
@@ -145,6 +156,7 @@ function setupTest(hasOutline = false, hasLabel = true, hasMockFoundation = fals
   const mockMenu = new FakeMenu();
 
   const outline = new FakeOutline();
+  const icon = new FakeIcon();
 
   if (!hasLabel) {
     fixture.removeChild(labelEl);
@@ -155,10 +167,11 @@ function setupTest(hasOutline = false, hasLabel = true, hasMockFoundation = fals
     () => label,
     () => bottomLine,
     () => outline,
-    hasMockMenu ? () => mockMenu : (el) => new MDCMenu(el));
+    hasMockMenu ? () => mockMenu : (el) => new MDCMenu(el),
+    () => icon);
 
   return {fixture, selectedText, label, labelEl, bottomLine, bottomLineEl, component, outline, menuSurface,
-    mockFoundation, mockMenu};
+    mockFoundation, mockMenu, icon};
 }
 
 function setupWithMockFoundation() {
@@ -192,13 +205,15 @@ test('#get/setSelectedIndex 2x removes previously selected element', () => {
 });
 
 test('#get/set disabled', () => {
-  const {component, fixture} = setupTest();
+  const hasMockFoundation = true;
+  const hasMockMenu = true;
+  const hasOutline = false;
+  const hasLabel = true;
+  const {component, mockFoundation} = setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
   component.disabled = true;
-  assert.isTrue(component.disabled);
-  assert.isTrue(fixture.classList.contains(cssClasses.DISABLED));
+  td.verify(mockFoundation.setDisabled(true), {times: 1});
   component.disabled = false;
-  assert.isFalse(component.disabled);
-  assert.isFalse(fixture.classList.contains(cssClasses.DISABLED));
+  td.verify(mockFoundation.setDisabled(false), {times: 1});
 });
 
 test('#get value', () => {
@@ -243,6 +258,26 @@ test('#set disabled calls foundation.setDisabled', () => {
   const {component, mockFoundation} = setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
   component.disabled = true;
   td.verify(mockFoundation.setDisabled(true), {times: 1});
+});
+
+test('#set leadingIconAriaLabel calls foundation.setLeadingIconAriaLabel', () => {
+  const hasMockFoundation = true;
+  const hasMockMenu = true;
+  const hasOutline = false;
+  const hasLabel = true;
+  const {component, mockFoundation} = setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
+  component.leadingIconAriaLabel = true;
+  td.verify(mockFoundation.setLeadingIconAriaLabel(true), {times: 1});
+});
+
+test('#set leadingIconContent calls foundation.setLeadingIconAriaLabel', () => {
+  const hasMockFoundation = true;
+  const hasMockMenu = true;
+  const hasOutline = false;
+  const hasLabel = true;
+  const {component, mockFoundation} = setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
+  component.leadingIconContent = 'hello_world';
+  td.verify(mockFoundation.setLeadingIconContent('hello_world'), {times: 1});
 });
 
 test('#initialSyncWithDOM sets the selected index if an option has the selected class', () => {
@@ -894,4 +929,14 @@ test('menu surface selected event causes the select to update', () => {
 
   document.body.removeChild(menuSurface);
   document.body.removeChild(fixture);
+});
+
+test('#constructor instantiates a leading icon if an icon element is present', () => {
+  const root = getFixture();
+  const menu = root.querySelector('.mdc-select__menu');
+  const component = new MDCSelect(root);
+  assert.instanceOf(component.leadingIcon_, MDCSelectIcon);
+  assert.isTrue(menu.classList.contains(cssClasses.WITH_LEADING_ICON));
+  assert.isTrue(root.classList.contains(cssClasses.WITH_LEADING_ICON));
+  document.body.removeChild(menu);
 });

--- a/test/unit/mdc-select/mdc-select-icon-foundation.test.js
+++ b/test/unit/mdc-select/mdc-select-icon-foundation.test.js
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * @license
+ * Copyright 2017 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import {assert} from 'chai';
+import td from 'testdouble';
+
+import {verifyDefaultAdapter} from '../helpers/foundation';
+import {setupFoundationTest} from '../helpers/setup';
+import MDCSelectIconFoundation from '../../../packages/mdc-select/icon/foundation';
+import {strings} from '../../../packages/mdc-select/icon/constants';
+
+suite('MDCSelectIconFoundation');
+
+test('exports strings', () => {
+  assert.deepEqual(MDCSelectIconFoundation.strings, strings);
+});
+
+test('defaultAdapter returns a complete adapter implementation', () => {
+  verifyDefaultAdapter(MDCSelectIconFoundation, [
+    'getAttr', 'setAttr', 'removeAttr', 'setContent', 'registerInteractionHandler', 'deregisterInteractionHandler',
+    'notifyIconAction',
+  ]);
+});
+
+const setupTest = () => setupFoundationTest(MDCSelectIconFoundation);
+
+test('#init adds event listeners', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.init();
+
+  td.verify(mockAdapter.registerInteractionHandler('click', td.matchers.isA(Function)));
+  td.verify(mockAdapter.registerInteractionHandler('keydown', td.matchers.isA(Function)));
+});
+
+test('#destroy removes event listeners', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.destroy();
+
+  td.verify(mockAdapter.deregisterInteractionHandler('click', td.matchers.isA(Function)));
+  td.verify(mockAdapter.deregisterInteractionHandler('keydown', td.matchers.isA(Function)));
+});
+
+test('#setDisabled sets icon tabindex to -1 and removes role when set to true if icon initially had a tabindex', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn('1');
+  foundation.init();
+
+  foundation.setDisabled(true);
+  td.verify(mockAdapter.setAttr('tabindex', '-1'));
+  td.verify(mockAdapter.removeAttr('role'));
+});
+
+test('#setDisabled does not change icon tabindex or role when set to true if icon initially had no tabindex', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn(null);
+  foundation.init();
+
+  foundation.setDisabled(true);
+  td.verify(mockAdapter.setAttr('tabindex', td.matchers.isA(String)), {times: 0});
+  td.verify(mockAdapter.removeAttr('role'), {times: 0});
+});
+
+test('#setDisabled restores icon tabindex and role when set to false if icon initially had a tabindex', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const expectedTabIndex = '1';
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn(expectedTabIndex);
+  foundation.init();
+
+  foundation.setDisabled(false);
+  td.verify(mockAdapter.setAttr('tabindex', expectedTabIndex));
+  td.verify(mockAdapter.setAttr('role', strings.ICON_ROLE));
+});
+
+test('#setDisabled does not change icon tabindex or role when set to false if icon initially had no tabindex', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getAttr('tabindex')).thenReturn(null);
+  foundation.init();
+
+  foundation.setDisabled(false);
+  td.verify(mockAdapter.setAttr('tabindex', td.matchers.isA(String)), {times: 0});
+  td.verify(mockAdapter.setAttr('role', td.matchers.isA(String)), {times: 0});
+});
+
+test('#setAriaLabel updates the aria-label', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const ariaLabel = 'Test label';
+  foundation.init();
+
+  foundation.setAriaLabel(ariaLabel);
+  td.verify(mockAdapter.setAttr('aria-label', ariaLabel));
+});
+
+test('#setContent updates the text content', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const content = 'test';
+  foundation.init();
+
+  foundation.setContent(content);
+  td.verify(mockAdapter.setContent(content));
+});
+
+test('on click notifies custom icon event', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const evt = {
+    target: {},
+    type: 'click',
+  };
+  let click;
+
+  td.when(mockAdapter.registerInteractionHandler('click', td.matchers.isA(Function))).thenDo((evtType, handler) => {
+    click = handler;
+  });
+
+  foundation.init();
+  click(evt);
+  td.verify(mockAdapter.notifyIconAction());
+});

--- a/test/unit/mdc-select/mdc-select-icon.test.js
+++ b/test/unit/mdc-select/mdc-select-icon.test.js
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import bel from 'bel';
+import {assert} from 'chai';
+import td from 'testdouble';
+import domEvents from 'dom-events';
+
+import {MDCSelectIcon, MDCSelectIconFoundation} from '../../../packages/mdc-select/icon/index';
+
+const getFixture = () => bel`
+  <div class="mdc-select__icon"></div>
+`;
+
+suite('MDCSelectIcon');
+
+test('attachTo returns an MDCSelectIcon instance', () => {
+  assert.isOk(MDCSelectIcon.attachTo(getFixture()) instanceof MDCSelectIcon);
+});
+
+function setupTest() {
+  const root = getFixture();
+  const component = new MDCSelectIcon(root);
+  return {root, component};
+}
+
+test('#adapter.getAttr returns the value of a given attribute on the element', () => {
+  const {root, component} = setupTest();
+  const expectedAttr = 'tabindex';
+  const expectedValue = '0';
+  root.setAttribute(expectedAttr, expectedValue);
+  assert.equal(component.getDefaultFoundation().adapter_.getAttr(expectedAttr), expectedValue);
+});
+
+test('#adapter.setAttr adds a given attribute to the element', () => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setAttr('aria-label', 'foo');
+  assert.equal(root.getAttribute('aria-label'), 'foo');
+});
+
+test('#adapter.removeAttr removes a given attribute from the element', () => {
+  const {root, component} = setupTest();
+  root.setAttribute('role', 'button');
+  component.getDefaultFoundation().adapter_.removeAttr('role');
+  assert.isFalse(root.hasAttribute('role'));
+});
+
+test('#adapter.setContent sets the text content of the element', () => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setContent('foo');
+  assert.equal(root.textContent, 'foo');
+});
+
+test('#adapter.registerInteractionHandler adds event listener for a given event to the element', () => {
+  const {root, component} = setupTest();
+  const handler = td.func('keydown handler');
+  component.getDefaultFoundation().adapter_.registerInteractionHandler('keydown', handler);
+  domEvents.emit(root, 'keydown');
+
+  td.verify(handler(td.matchers.anything()));
+});
+
+test('#adapter.deregisterInteractionHandler removes event listener for a given event from the element', () => {
+  const {root, component} = setupTest();
+  const handler = td.func('keydown handler');
+
+  root.addEventListener('keydown', handler);
+  component.getDefaultFoundation().adapter_.deregisterInteractionHandler('keydown', handler);
+  domEvents.emit(root, 'keydown');
+
+  td.verify(handler(td.matchers.anything()), {times: 0});
+});
+
+test('#adapter.notifyIconAction emits ' + `${MDCSelectIconFoundation.strings.ICON_EVENT}`, () => {
+  const {component} = setupTest();
+  const handler = td.func('handler');
+
+  component.listen(MDCSelectIconFoundation.strings.ICON_EVENT, handler);
+  component.getDefaultFoundation().adapter_.notifyIconAction();
+
+  td.verify(handler(td.matchers.anything()));
+});

--- a/test/unit/mdc-select/mdc-select.test.js
+++ b/test/unit/mdc-select/mdc-select.test.js
@@ -32,6 +32,8 @@ import {MDCRipple, MDCRippleFoundation} from '../../../packages/mdc-ripple/index
 import {MDCSelect} from '../../../packages/mdc-select/index';
 import {cssClasses} from '../../../packages/mdc-select/constants';
 import {MDCNotchedOutline} from '../../../packages/mdc-notched-outline/index';
+import {MDCTextField, MDCTextFieldIcon} from '../../../packages/mdc-textfield/index';
+import {MDCSelectIcon} from '../../../packages/mdc-select/icon';
 
 const LABEL_WIDTH = 100;
 
@@ -60,10 +62,18 @@ class FakeOutline {
   }
 }
 
+class FakeIcon {
+  constructor() {
+    this.destroy = td.func('.destroy');
+    this.foundation = td.func('.foundation');
+  }
+}
+
 function getFixture() {
   return bel`
     <div class="mdc-select">
-      <select class="mdc-select__native-control">
+     <i class="material-icons mdc-select__icon">code</i>
+     <select class="mdc-select__native-control">
         <option value="" disabled selected></option>
         <option value="orange">
           Orange
@@ -81,6 +91,7 @@ function getFixture() {
 function getOutlineFixture() {
   return bel`
     <div class="mdc-select mdc-select--outlined">
+      <i class="material-icons mdc-select__icon">code</i>
       <select class="mdc-select__native-control">
         <option value="orange">
           Orange
@@ -114,14 +125,16 @@ function setupTest(hasOutline = false, hasLabel = true) {
   const labelEl = fixture.querySelector('.mdc-floating-label');
   const bottomLineEl = fixture.querySelector('.mdc-line-ripple');
   const outline = new FakeOutline();
+  const icon = new FakeIcon();
 
   if (!hasLabel) {
     fixture.removeChild(labelEl);
   }
 
-  const component = new MDCSelect(fixture, /* foundation */ undefined, () => label, () => bottomLine, () => outline);
+  const component = new MDCSelect(fixture, /* foundation */ undefined,
+    () => label, () => bottomLine, () => outline, () => icon);
 
-  return {fixture, nativeControl, label, labelEl, bottomLine, bottomLineEl, component, outline};
+  return {fixture, nativeControl, label, labelEl, bottomLine, bottomLineEl, component, outline, icon};
 }
 
 test('#get/setSelectedIndex', () => {
@@ -172,6 +185,20 @@ test('#set disabled calls foundation.setDisabled', () => {
   component.foundation_.setDisabled = td.func();
   component.disabled = true;
   td.verify(component.foundation_.setDisabled(true), {times: 1});
+});
+
+test('#set leadingIconAriaLabel calls foundation.setLeadingIconAriaLabel', () => {
+  const {component} = setupTest();
+  component.foundation_.setLeadingIconAriaLabel = td.func();
+  component.leadingIconAriaLabel = true;
+  td.verify(component.foundation_.setLeadingIconAriaLabel(true), {times: 1});
+});
+
+test('#set leadingIconContent calls foundation.setLeadingIconAriaLabel', () => {
+  const {component} = setupTest();
+  component.foundation_.setLeadingIconContent = td.func();
+  component.leadingIconContent = 'hello_world';
+  td.verify(component.foundation_.setLeadingIconContent('hello_world'), {times: 1});
 });
 
 test('#initialSyncWithDOM sets the selected index if an option has the selected attr', () => {
@@ -526,4 +553,10 @@ test('keydown is not added to the native select when initialized', () => {
   domEvents.emit(fixture.querySelector('.mdc-select__native-control'), 'keydown');
   td.verify(component.foundation_.handleKeydown(td.matchers.anything()), {times: 0});
   document.body.removeChild(fixture);
+});
+
+test('#constructor instantiates a leading icon if an icon element is present', () => {
+  const root = getFixture();
+  const component = new MDCSelect(root);
+  assert.instanceOf(component.leadingIcon_, MDCSelectIcon);
 });


### PR DESCRIPTION
Adds leading icon support to the `mdc-select` component. The icon JS is largely a copy of the `MDCTextFieldIcon` element to keep the two components nearly identical. The scss has been modified to only accommodate a single icon as well as to support SVG elements as leading icons for the select. 
refs: #3629 