### PR TITLE
fix(ripple): Deactivate on contextmenu event

### DIFF
--- a/packages/mdc-ripple/foundation.js
+++ b/packages/mdc-ripple/foundation.js
@@ -70,7 +70,7 @@ let PointType;
 const ACTIVATION_EVENT_TYPES = ['touchstart', 'pointerdown', 'mousedown', 'keydown'];
 
 // Deactivation events registered on documentElement when a pointer-related down event occurs
-const POINTER_DEACTIVATION_EVENT_TYPES = ['touchend', 'pointerup', 'mouseup'];
+const POINTER_DEACTIVATION_EVENT_TYPES = ['touchend', 'pointerup', 'mouseup', 'contextmenu'];
 
 // Tracks activations that have occurred on the current frame, to avoid simultaneous nested activations
 /** @type {!Array<!EventTarget>} */

--- a/test/unit/mdc-ripple/foundation-deactivation.test.js
+++ b/test/unit/mdc-ripple/foundation-deactivation.test.js
@@ -81,6 +81,29 @@ testFoundation('runs deactivation UX on pointerup after pointerdown', ({foundati
   clock.uninstall();
 });
 
+testFoundation('runs deactivation UX on contextmenu after pointerdown', ({foundation, adapter, mockRaf}) => {
+  const handlers = captureHandlers(adapter, 'registerInteractionHandler');
+  const documentHandlers = captureHandlers(adapter, 'registerDocumentInteractionHandler');
+  const clock = lolex.install();
+  foundation.init();
+  mockRaf.flush();
+
+  handlers.pointerdown({pageX: 0, pageY: 0});
+  mockRaf.flush();
+
+  documentHandlers.contextmenu();
+  mockRaf.flush();
+  clock.tick(DEACTIVATION_TIMEOUT_MS);
+
+  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
+  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION));
+
+  clock.tick(numbers.FG_DEACTIVATION_MS);
+  td.verify(adapter.removeClass(cssClasses.FG_DEACTIVATION));
+
+  clock.uninstall();
+});
+
 testFoundation('runs deactivation UX on mouseup after mousedown', ({foundation, adapter, mockRaf}) => {
   const handlers = captureHandlers(adapter, 'registerInteractionHandler');
   const documentHandlers = captureHandlers(adapter, 'registerDocumentInteractionHandler');
@@ -92,6 +115,29 @@ testFoundation('runs deactivation UX on mouseup after mousedown', ({foundation, 
   mockRaf.flush();
 
   documentHandlers.mouseup();
+  mockRaf.flush();
+  clock.tick(DEACTIVATION_TIMEOUT_MS);
+
+  td.verify(adapter.removeClass(cssClasses.FG_ACTIVATION), {times: 2});
+  td.verify(adapter.addClass(cssClasses.FG_DEACTIVATION));
+
+  clock.tick(numbers.FG_DEACTIVATION_MS);
+  td.verify(adapter.removeClass(cssClasses.FG_DEACTIVATION));
+
+  clock.uninstall();
+});
+
+testFoundation('runs deactivation UX on contextmenu after mousedown', ({foundation, adapter, mockRaf}) => {
+  const handlers = captureHandlers(adapter, 'registerInteractionHandler');
+  const documentHandlers = captureHandlers(adapter, 'registerDocumentInteractionHandler');
+  const clock = lolex.install();
+  foundation.init();
+  mockRaf.flush();
+
+  handlers.mousedown({pageX: 0, pageY: 0});
+  mockRaf.flush();
+
+  documentHandlers.contextmenu();
   mockRaf.flush();
   clock.tick(DEACTIVATION_TIMEOUT_MS);
 


### PR DESCRIPTION
Fixes #3524.

While testing I wasn't able to get tap-hold to bring up the context menu at all on mobile for some reason... but I confirmed that this fixes the issue for right-click in Chrome and Safari on OS X, which are the only browsers I could reproduce it on.

OS | Browser | Before | After
--- | --- | --- | ---
OS X | Chrome | Buggy | OK
OS X | Safari | Buggy | OK
OS X | Firefox | OK | OK
Win10 | Chrome | OK | OK
Win10 | Firefox | OK | OK
Win10 | Edge | OK | OK

Tested on Win10 with both mouse and touch. IE is N/A because it doesn't use JS for ripple effect.