### PR TITLE
fix(notched-outline): Auto position the notch and floating label based on corner size

### DIFF
--- a/packages/mdc-notched-outline/README.md
+++ b/packages/mdc-notched-outline/README.md
@@ -80,6 +80,13 @@ Mixin | Description
 `mdc-notched-outline-shape-radius($radius, $rtl-reflexive)` | Sets the rounded shape to notched outline element with given radius size. Set `$rtl-reflexive` to true to flip radius values in RTL context, defaults to false.
 `mdc-notched-outline-idle-shape-radius($radius, $rtl-reflexive)` | Sets the rounded shape to notched outline element in idle state with given radius size. Set `$rtl-reflexive` to true to flip radius values in RTL context, defaults to false.
 
+
+### Sass Functions
+
+Function | Description
+--- | ---
+`mdc-notched-outline-get-notch-padded-position($cornerSize)` | Returns the notch padded position based on given radius. This is 'x' position where the floating label starts.
+
 #### Calling Mixins with Parent Selectors
 
 Because notched-outline has sibling elements, you need to call the "idle" Sass mixins with parent selectors.

--- a/packages/mdc-notched-outline/_functions.scss
+++ b/packages/mdc-notched-outline/_functions.scss
@@ -20,9 +20,9 @@
 // THE SOFTWARE.
 //
 
-$mdc-notched-outline-transition-duration: 150ms;
-// Keep this in sync with constants.numbers.MIN_LEADING_STROKE_EDGE_POSITION
-$mdc-notched-outline-leading-notch-edge-position: 12px;
-// The gap between the stroke end and floating label
-// Keep this in sync with constants.numbers.NOTCH_GUTTER_SIZE
-$mdc-notched-outline-notch-gutter-size: 4px;
+@import "./variables";
+
+@function mdc-notched-outline-get-notch-padded-position($cornerSize) {
+  $leadingStrokeLength: max(0, $mdc-notched-outline-leading-notch-edge-position - $cornerSize);
+  @return $cornerSize + $leadingStrokeLength + $mdc-notched-outline-notch-gutter-size + 1.2;
+}

--- a/packages/mdc-notched-outline/_functions.scss
+++ b/packages/mdc-notched-outline/_functions.scss
@@ -22,6 +22,13 @@
 
 @import "./variables";
 
+//
+// Returns the notch padded position based on given radius. This is 'x' position where the floating label starts.
+//
+// Examples:
+//
+// mdc-notched-outline-get-notch-padded-position(4px) => 21.2px
+//
 @function mdc-notched-outline-get-notch-padded-position($cornerSize) {
   $leadingStrokeLength: max(0, $mdc-notched-outline-leading-notch-edge-position - $cornerSize - 1.2);
   @return $cornerSize + $leadingStrokeLength + $mdc-notched-outline-notch-gutter-size + 1.2;

--- a/packages/mdc-notched-outline/_functions.scss
+++ b/packages/mdc-notched-outline/_functions.scss
@@ -23,6 +23,6 @@
 @import "./variables";
 
 @function mdc-notched-outline-get-notch-padded-position($cornerSize) {
-  $leadingStrokeLength: max(0, $mdc-notched-outline-leading-notch-edge-position - $cornerSize);
+  $leadingStrokeLength: max(0, $mdc-notched-outline-leading-notch-edge-position - $cornerSize - 1.2);
   @return $cornerSize + $leadingStrokeLength + $mdc-notched-outline-notch-gutter-size + 1.2;
 }

--- a/packages/mdc-notched-outline/_functions.scss
+++ b/packages/mdc-notched-outline/_functions.scss
@@ -30,6 +30,6 @@
 // mdc-notched-outline-get-notch-padded-position(4px) => 21.2px
 //
 @function mdc-notched-outline-get-notch-padded-position($cornerSize) {
-  $leadingStrokeLength: max(0, $mdc-notched-outline-leading-notch-edge-position - $cornerSize - 1.2);
+  $leadingStrokeLength: max(0, $mdc-notched-outline-min-leading-stroke-edge-position - $cornerSize - 1.2);
   @return $cornerSize + $leadingStrokeLength + $mdc-notched-outline-notch-gutter-size + 1.2;
 }

--- a/packages/mdc-notched-outline/_variables.scss
+++ b/packages/mdc-notched-outline/_variables.scss
@@ -21,3 +21,8 @@
 //
 
 $mdc-notched-outline-transition-duration: 150ms;
+// Keep this in sync with constants.numbers.LEADING_STROKE_LENGTH
+$mdc-notched-outline-leading-notch-length: 8px;
+// The gap between the stroke end and floating label
+// Keep this in sync with constants.numbers.NOTCH_GUTTER_SIZE
+$mdc-notched-outline-notch-gutter-size: 4px;

--- a/packages/mdc-notched-outline/_variables.scss
+++ b/packages/mdc-notched-outline/_variables.scss
@@ -22,7 +22,7 @@
 
 $mdc-notched-outline-transition-duration: 150ms;
 // Keep this in sync with constants.numbers.MIN_LEADING_STROKE_EDGE_POSITION
-$mdc-notched-outline-leading-notch-edge-position: 12px;
+$mdc-notched-outline-min-leading-stroke-edge-position: 12px;
 // The gap between the stroke end and floating label
 // Keep this in sync with constants.numbers.NOTCH_GUTTER_SIZE
 $mdc-notched-outline-notch-gutter-size: 4px;

--- a/packages/mdc-notched-outline/constants.js
+++ b/packages/mdc-notched-outline/constants.js
@@ -34,7 +34,7 @@ const cssClasses = {
 
 /** @enum {number} */
 const numbers = {
-  FLOATING_LABEL_SIDE_PADDING: 4,
+  NOTCH_GUTTER_SIZE: 4,
   LEADING_STROKE_LENGTH: 8,
 };
 

--- a/packages/mdc-notched-outline/constants.js
+++ b/packages/mdc-notched-outline/constants.js
@@ -32,4 +32,10 @@ const cssClasses = {
   OUTLINE_NOTCHED: 'mdc-notched-outline--notched',
 };
 
-export {cssClasses, strings};
+/** @enum {number} */
+const numbers = {
+  FLOATING_LABEL_SIDE_PADDING: 4,
+  LEADING_STROKE_LENGTH: 8,
+};
+
+export {cssClasses, strings, numbers};

--- a/packages/mdc-notched-outline/constants.js
+++ b/packages/mdc-notched-outline/constants.js
@@ -35,7 +35,7 @@ const cssClasses = {
 /** @enum {number} */
 const numbers = {
   NOTCH_GUTTER_SIZE: 4,
-  LEADING_STROKE_LENGTH: 8,
+  MIN_LEADING_STROKE_EDGE_POSITION: 12,
 };
 
 export {cssClasses, strings, numbers};

--- a/packages/mdc-notched-outline/foundation.js
+++ b/packages/mdc-notched-outline/foundation.js
@@ -125,7 +125,7 @@ class MDCNotchedOutlineFoundation extends MDCFoundation {
       path = 'M' + (width - cornerWidth - leadingStrokeLength) + ',' + 1
         + 'h' + leadingStrokeLength
         + pathMiddle
-        + 'h' + (width - (2 * cornerWidth) - paddedNotchWidth - leadingStrokeLength + 12);
+        + 'h' + (width - (2 * cornerWidth) - paddedNotchWidth - leadingStrokeLength);
     }
 
     this.adapter_.setOutlinePathAttr(path);

--- a/packages/mdc-notched-outline/foundation.js
+++ b/packages/mdc-notched-outline/foundation.js
@@ -23,7 +23,7 @@
 
 import MDCFoundation from '@material/base/foundation';
 import MDCNotchedOutlineAdapter from './adapter';
-import {cssClasses, strings} from './constants';
+import {cssClasses, strings, numbers} from './constants';
 
 /**
  * @extends {MDCFoundation<!MDCNotchedOutlineAdapter>}
@@ -98,12 +98,12 @@ class MDCNotchedOutlineFoundation extends MDCFoundation {
     const width = this.adapter_.getWidth();
     const height = this.adapter_.getHeight();
     const cornerWidth = radius + 1.2;
-    const leadingStrokeLength = Math.abs(12 - cornerWidth);
+    const leadingStrokeLength = numbers.LEADING_STROKE_LENGTH;
 
     // If the notchWidth is 0, the the notched outline doesn't need to add padding.
     let paddedNotchWidth = 0;
     if (notchWidth > 0) {
-      paddedNotchWidth = notchWidth + 8;
+      paddedNotchWidth = notchWidth + 2 * numbers.FLOATING_LABEL_SIDE_PADDING;
     }
 
     // The right, bottom, and left sides of the outline follow the same SVG path.
@@ -125,7 +125,7 @@ class MDCNotchedOutlineFoundation extends MDCFoundation {
       path = 'M' + (width - cornerWidth - leadingStrokeLength) + ',' + 1
         + 'h' + leadingStrokeLength
         + pathMiddle
-        + 'h' + (width - (2 * cornerWidth) - paddedNotchWidth - leadingStrokeLength);
+        + 'h' + (width - (2 * cornerWidth) - paddedNotchWidth - leadingStrokeLength + 12);
     }
 
     this.adapter_.setOutlinePathAttr(path);

--- a/packages/mdc-notched-outline/foundation.js
+++ b/packages/mdc-notched-outline/foundation.js
@@ -40,6 +40,11 @@ class MDCNotchedOutlineFoundation extends MDCFoundation {
     return cssClasses;
   }
 
+  /** @return enum {number} */
+  static get numbers() {
+    return numbers;
+  }
+
   /**
    * {@see MDCNotchedOutlineAdapter} for typing information on parameters and return
    * types.
@@ -103,7 +108,7 @@ class MDCNotchedOutlineFoundation extends MDCFoundation {
     // If the notchWidth is 0, the the notched outline doesn't need to add padding.
     let paddedNotchWidth = 0;
     if (notchWidth > 0) {
-      paddedNotchWidth = notchWidth + 2 * numbers.FLOATING_LABEL_SIDE_PADDING;
+      paddedNotchWidth = notchWidth + 2 * numbers.NOTCH_GUTTER_SIZE;
     }
 
     // The right, bottom, and left sides of the outline follow the same SVG path.

--- a/packages/mdc-notched-outline/foundation.js
+++ b/packages/mdc-notched-outline/foundation.js
@@ -103,7 +103,7 @@ class MDCNotchedOutlineFoundation extends MDCFoundation {
     const width = this.adapter_.getWidth();
     const height = this.adapter_.getHeight();
     const cornerWidth = radius + 1.2;
-    const leadingStrokeLength = numbers.LEADING_STROKE_LENGTH;
+    const leadingStrokeLength = numbers.LEADING_STROKE_LENGTH - 1.2;
 
     // If the notchWidth is 0, the the notched outline doesn't need to add padding.
     let paddedNotchWidth = 0;

--- a/packages/mdc-notched-outline/foundation.js
+++ b/packages/mdc-notched-outline/foundation.js
@@ -103,7 +103,7 @@ class MDCNotchedOutlineFoundation extends MDCFoundation {
     const width = this.adapter_.getWidth();
     const height = this.adapter_.getHeight();
     const cornerWidth = radius + 1.2;
-    const leadingStrokeLength = numbers.LEADING_STROKE_LENGTH - 1.2;
+    const leadingStrokeLength = Math.max(0, numbers.MIN_LEADING_STROKE_EDGE_POSITION - radius - 1.2);
 
     // If the notchWidth is 0, the the notched outline doesn't need to add padding.
     let paddedNotchWidth = 0;

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -26,6 +26,7 @@
 @import "@material/shape/functions";
 @import "@material/line-ripple/mixins";
 @import "@material/notched-outline/mixins";
+@import "@material/notched-outline/variables";
 @import "./variables";
 
 // Public
@@ -112,15 +113,21 @@
   // this is because .mdc-notched-outline and .mdc-notched-outline__idle
   // are siblings. .mdc-notched-outline__idle needs to be a child of
   // .mdc-notched-outline in order to remedy this issue.
+  $resolved-radius: mdc-shape-resolve-percentage-radius($mdc-select-height, $radius);
   .mdc-notched-outline {
-    @include mdc-notched-outline-shape-radius(mdc-shape-resolve-percentage-radius($mdc-select-height, $radius), $rtl-reflexive);
+    @include mdc-notched-outline-shape-radius($resolved-radius, $rtl-reflexive);
   }
 
-  @include mdc-notched-outline-idle-shape-radius(mdc-shape-resolve-percentage-radius($mdc-select-height, $radius), $rtl-reflexive);
+  @include mdc-notched-outline-idle-shape-radius($resolved-radius, $rtl-reflexive);
 
   &__native-control {
-    @include mdc-shape-radius(mdc-shape-resolve-percentage-radius($mdc-select-height, $radius), $rtl-reflexive);
+    @include mdc-shape-radius($resolved-radius, $rtl-reflexive);
   }
+
+  $cornerSize: mdc-shape-prop-value($resolved-radius);
+  $positionX: $cornerSize + $mdc-notched-outline-leading-notch-length + $mdc-notched-outline-notch-gutter-size;
+  $labelPositionOffset: - $mdc-select-outline-label-offset + $positionX;
+  @include mdc-floating-label-float-position($mdc-select-outlined-label-position-y, -1 * ($labelPositionOffset));
 }
 
 // Private
@@ -198,7 +205,7 @@
 
 @mixin mdc-select-floating-label_ {
   .mdc-floating-label {
-    @include mdc-rtl-reflexive-position(left, 16px);
+    @include mdc-rtl-reflexive-position(left, $mdc-select-outline-label-offset);
 
     bottom: 12px;
     line-height: 1.75rem;

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -26,7 +26,7 @@
 @import "@material/shape/functions";
 @import "@material/line-ripple/mixins";
 @import "@material/notched-outline/mixins";
-@import "@material/notched-outline/variables";
+@import "@material/notched-outline/functions";
 @import "./variables";
 
 // Public
@@ -125,7 +125,7 @@
   }
 
   $cornerSize: mdc-shape-prop-value($resolved-radius);
-  $positionX: $cornerSize + $mdc-notched-outline-leading-notch-length + $mdc-notched-outline-notch-gutter-size;
+  $positionX: mdc-notched-outline-get-notch-padded-position($cornerSize);
   $labelPositionOffset: - $mdc-select-outline-label-offset + $positionX;
   @include mdc-floating-label-float-position($mdc-select-outlined-label-position-y, -1 * ($labelPositionOffset));
 }

--- a/packages/mdc-select/_variables.scss
+++ b/packages/mdc-select/_variables.scss
@@ -49,5 +49,6 @@ $mdc-select-outlined-disabled-border: rgba(mdc-theme-prop-value(on-surface), .16
 $mdc-select-outlined-hover-border: rgba(mdc-theme-prop-value(on-surface), .87);
 
 $mdc-select-label-position-y: 40%;
+$mdc-select-outline-label-offset: 16px;
 $mdc-select-outlined-label-position-y: 130%;
 $mdc-select-outlined-dense-label-position-y: 110%;

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -121,7 +121,6 @@
   @include mdc-select-outline-color($mdc-select-outlined-idle-border);
   @include mdc-select-hover-outline-color($mdc-select-outlined-hover-border);
   @include mdc-select-focused-outline-color(primary);
-  @include mdc-floating-label-float-position($mdc-select-outlined-label-position-y);
   @include mdc-floating-label-shake-animation(text-field-outlined);
   @include mdc-select-outline-shape-radius(medium);
   @include mdc-states-base-color(transparent);

--- a/packages/mdc-shape/README.md
+++ b/packages/mdc-shape/README.md
@@ -64,6 +64,7 @@ Function | Description
 `mdc-shape-flip-radius($radius)` | Flips the radius values in RTL context. `$radius` is list of 2-4 corner values.
 `mdc-shape-resolve-percentage-radius($component-height, $radius)` | Calculates the absolute radius value based on its component height. Use this for fixed height components only.
 `mdc-shape-mask-radius($radius, $masked-corners)` | Accepts radius number or list of 2-4 radius values and returns 4 value list with masked corners as mentioned in `$masked-corners`.
+`mdc-shape-prop-value($radius)` | Returns $radius value of shape category - `large`, `medium` or `small`. Otherwise, it returns the $radius itself if valid. $radius can be a single value or list of up to 4.
 
 ### Additional Information
 

--- a/packages/mdc-shape/README.md
+++ b/packages/mdc-shape/README.md
@@ -64,7 +64,7 @@ Function | Description
 `mdc-shape-flip-radius($radius)` | Flips the radius values in RTL context. `$radius` is list of 2-4 corner values.
 `mdc-shape-resolve-percentage-radius($component-height, $radius)` | Calculates the absolute radius value based on its component height. Use this for fixed height components only.
 `mdc-shape-mask-radius($radius, $masked-corners)` | Accepts radius number or list of 2-4 radius values and returns 4 value list with masked corners as mentioned in `$masked-corners`.
-`mdc-shape-prop-value($radius)` | Returns $radius value of shape category - `large`, `medium` or `small`. Otherwise, it returns the $radius itself if valid. $radius can be a single value or list of up to 4.
+`mdc-shape-prop-value($radius)` | Returns `$radius` value of shape category - `large`, `medium` or `small`. Otherwise, it returns the `$radius` itself if valid. `$radius` can be a single value or list of up to 4.
 
 ### Additional Information
 

--- a/packages/mdc-shape/_functions.scss
+++ b/packages/mdc-shape/_functions.scss
@@ -104,9 +104,9 @@
 //
 // Examples:
 //
-// mdc-shape-prop-value_(small) => 4px
+// mdc-shape-prop-value(small) => 4px
 //
-@function mdc-shape-prop-value_($radius) {
+@function mdc-shape-prop-value($radius) {
   @if type-of($radius) == "list" {
     @if length($radius) > 4 {
       @error "Invalid radius: '#{$radius}' is more than 4 values";

--- a/packages/mdc-shape/_mixins.scss
+++ b/packages/mdc-shape/_mixins.scss
@@ -24,7 +24,7 @@
 @import "./functions";
 
 @mixin mdc-shape-radius($radius, $rtl-reflexive: false) {
-  border-radius: mdc-shape-prop-value_($radius);
+  border-radius: mdc-shape-prop-value($radius);
 
   @if ($rtl-reflexive) {
     @include mdc-rtl {

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -23,6 +23,7 @@
 @import "@material/floating-label/mixins";
 @import "@material/line-ripple/mixins";
 @import "@material/notched-outline/mixins";
+@import "@material/notched-outline/variables";
 @import "@material/theme/mixins";
 @import "@material/shape/mixins";
 @import "@material/shape/functions";
@@ -247,8 +248,8 @@
 
   @include mdc-notched-outline-idle-shape-radius($resolved-radius, $rtl-reflexive);
 
-  $cornerSize: mdc-shape-prop-value_($resolved-radius);
-  $positionX: $cornerSize + $mdc-text-field-outline-leading-notch-length + $mdc-text-field-outline-float-label-padding;
+  $cornerSize: mdc-shape-prop-value($resolved-radius);
+  $positionX: $cornerSize + $mdc-notched-outline-leading-notch-length + $mdc-notched-outline-notch-gutter-size;
   $labelPositionOffset: - $mdc-text-field-outline-label-offset + $positionX;
   @include mdc-floating-label-float-position($mdc-text-field-outlined-label-position-y, -1 * ($labelPositionOffset));
 }

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -246,13 +246,19 @@
   }
 
   @include mdc-notched-outline-idle-shape-radius($resolved-radius, $rtl-reflexive);
+
+  $cornerSize: mdc-shape-prop-value_($resolved-radius);
+  $positionX: $cornerSize + $mdc-text-field-outline-leading-notch-length + $mdc-text-field-outline-float-label-padding;
+  $labelPositionOffset: - $mdc-text-field-outline-label-offset + $positionX;
+  @include mdc-floating-label-float-position($mdc-text-field-outlined-label-position-y, -1 * ($labelPositionOffset));
 }
 
 @mixin mdc-text-field-floating-label_ {
   .mdc-floating-label {
-    @include mdc-rtl-reflexive-position(left, 16px);
+    @include mdc-rtl-reflexive-position(left, 12px);
 
     bottom: 20px;
+    pointer-events: none;
   }
 
   &:not(.mdc-text-field--outlined):not(.mdc-text-field--textarea) {
@@ -307,7 +313,6 @@
   @include mdc-text-field-outline-color($mdc-text-field-outlined-idle-border);
   @include mdc-text-field-hover-outline-color($mdc-text-field-outlined-hover-border);
   @include mdc-text-field-focused-outline-color(primary);
-  @include mdc-floating-label-float-position($mdc-text-field-outlined-label-position-y);
   @include mdc-floating-label-shake-animation(text-field-outlined);
   @include mdc-text-field-outline-shape-radius(small);
   @include mdc-states-base-color(transparent);
@@ -329,7 +334,7 @@
   }
 
   .mdc-floating-label {
-    @include mdc-rtl-reflexive-position(left, 16px);
+    @include mdc-rtl-reflexive-position(left, $mdc-text-field-outline-label-offset);
 
     width: auto;
   }

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -23,7 +23,7 @@
 @import "@material/floating-label/mixins";
 @import "@material/line-ripple/mixins";
 @import "@material/notched-outline/mixins";
-@import "@material/notched-outline/variables";
+@import "@material/notched-outline/functions";
 @import "@material/theme/mixins";
 @import "@material/shape/mixins";
 @import "@material/shape/functions";
@@ -249,7 +249,7 @@
   @include mdc-notched-outline-idle-shape-radius($resolved-radius, $rtl-reflexive);
 
   $cornerSize: mdc-shape-prop-value($resolved-radius);
-  $positionX: $cornerSize + $mdc-notched-outline-leading-notch-length + $mdc-notched-outline-notch-gutter-size;
+  $positionX: mdc-notched-outline-get-notch-padded-position($cornerSize);
   $labelPositionOffset: - $mdc-text-field-outline-label-offset + $positionX;
   @include mdc-floating-label-float-position($mdc-text-field-outlined-label-position-y, -1 * ($labelPositionOffset));
 }

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -54,10 +54,6 @@ $mdc-textarea-disabled-background: rgba(249, 249, 249, 1);
 $mdc-text-field-height: 56px;
 $mdc-text-field-label-position-y: 50%;
 $mdc-text-field-outline-label-offset: 16px;
-// Keep this in sync with mdc-notched-outline:constants.numbers.LEADING_STROKE_LENGTH
-$mdc-text-field-outline-leading-notch-length: 8px;
-// Keep this in sync with mdc-notched-outline:constants.numbers.FLOATING_LABEL_SIDE_PADDING
-$mdc-text-field-outline-float-label-padding: 4px;
 $mdc-text-field-dense-label-position-y: 70%;
 $mdc-text-field-dense-label-scale: .923;
 $mdc-text-field-outlined-label-position-y: 130%;

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -53,6 +53,11 @@ $mdc-textarea-disabled-background: rgba(249, 249, 249, 1);
 
 $mdc-text-field-height: 56px;
 $mdc-text-field-label-position-y: 50%;
+$mdc-text-field-outline-label-offset: 16px;
+// Keep this in sync with mdc-notched-outline:constants.numbers.LEADING_STROKE_LENGTH
+$mdc-text-field-outline-leading-notch-length: 8px;
+// Keep this in sync with mdc-notched-outline:constants.numbers.FLOATING_LABEL_SIDE_PADDING
+$mdc-text-field-outline-float-label-padding: 4px;
 $mdc-text-field-dense-label-position-y: 70%;
 $mdc-text-field-dense-label-scale: .923;
 $mdc-text-field-outlined-label-position-y: 130%;

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -74,13 +74,6 @@
   height: $mdc-text-field-height;
   overflow: hidden;
   will-change: opacity, transform, color;
-
-  // stylelint-disable-next-line plugin/selector-bem-pattern
-  .mdc-floating-label {
-    @include mdc-rtl-reflexive-position(left, 12px);
-
-    pointer-events: none;
-  }
 }
 
 .mdc-text-field__input {

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -863,12 +863,12 @@
     }
   },
   "spec/mdc-select/mixins/shape-radius.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-select/mixins/shape-radius.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_chrome_69.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/24/15_50_35_891/spec/mdc-select/mixins/shape-radius.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-select/mixins/shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-select/mixins/shape-radius.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-select/mixins/shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-select/mixins/shape-radius.html.windows_ie_11.png"
     }
   },
   "spec/mdc-switch/classes/baseline.html": {
@@ -1297,6 +1297,15 @@
       "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_edge_17.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_firefox_62.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/01/23_31_41_483/spec/mdc-textfield/issues/3332.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-textfield/mixins/outline-shape-radius.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-textfield/mixins/outline-shape-radius.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-textfield/mixins/outline-shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-textfield/mixins/outline-shape-radius.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-textfield/mixins/outline-shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/18/16_27_05_631/spec/mdc-textfield/mixins/outline-shape-radius.html.windows_ie_11.png"
     }
   },
   "spec/mdc-typography/classes/baseline-large.html": {

--- a/test/screenshot/spec/mdc-select/fixture.scss
+++ b/test/screenshot/spec/mdc-select/fixture.scss
@@ -45,7 +45,7 @@
 }
 
 .custom-select-shape-radius {
-  @include mdc-select-shape-radius(10px);
+  @include mdc-select-shape-radius(50%);
 }
 
 .custom-select-outline-color {
@@ -53,5 +53,5 @@
 }
 
 .custom-select-outline-shape-radius {
-  @include mdc-select-outline-shape-radius(10px);
+  @include mdc-select-outline-shape-radius(50%);
 }

--- a/test/screenshot/spec/mdc-textfield/fixture.scss
+++ b/test/screenshot/spec/mdc-textfield/fixture.scss
@@ -32,6 +32,14 @@
   @include test-cell-size(301, 181);
 }
 
+.test-shaped-text-field {
+  @include mdc-text-field-shape-radius(50%);
+}
+
+.test-shaped-text-field--outline {
+  @include mdc-text-field-outline-shape-radius(50%);
+}
+
 // Work around MS Edge rendering bug.
 // TODO(acdvorak): Create and link to GitHub issue
 @supports (-ms-ime-align:auto) {

--- a/test/screenshot/spec/mdc-textfield/mixins/outline-shape-radius.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/outline-shape-radius.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Baseline Text Field Element - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.textfield.css">
+    <link rel="stylesheet" href="../../../out/mdc.typography.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-textfield/fixture.css">
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--textfield">
+          <div class="mdc-text-field test-shaped-text-field">
+            <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
+            <label class="mdc-floating-label" for="filled-text-field">Label</label>
+            <div class="mdc-line-ripple"></div>
+          </div>
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent" aria-hidden="true">Helper Text</p>
+        </div>
+
+        <div class="test-cell test-cell--textfield">
+          <div class="mdc-text-field mdc-text-field--outlined test-shaped-text-field--outline">
+            <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
+            <label for="outlined-text-field" class="mdc-floating-label">Label</label>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent" aria-hidden="true">Helper Text</p>
+        </div>
+
+        <div class="test-cell test-cell--textfield">
+          <div class="mdc-text-field test-shaped-text-field">
+            <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
+            <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
+            <div class="mdc-line-ripple"></div>
+          </div>
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent" aria-hidden="true">Helper Text</p>
+        </div>
+
+        <div class="test-cell test-cell--textfield">
+          <div class="mdc-text-field mdc-text-field--outlined test-shaped-text-field--outline">
+            <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
+            <label for="outlined-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
+            <div class="mdc-notched-outline">
+              <svg>
+                <path class="mdc-notched-outline__path"/>
+              </svg>
+            </div>
+            <div class="mdc-notched-outline__idle"></div>
+          </div>
+          <p class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent" aria-hidden="true">Helper Text</p>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-textfield/fixture.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This change fixes the issue where notched outline overlaps with floating label on text field & select components.

Notch position is calculated based on the corner size of notched outline and accordingly the shape mixins in text field and select components sets the floating label position based on radius size.

The leading stroke length is calculated with: `Math.max(0, numbers.MIN_LEADING_STROKE_EDGE_POSITION - radius - 1.2)` which gets shrunk when large radius is used.

The floating label position calculation with: `$cornerSize + $leadingStrokeLength + $mdc-notched-outline-notch-gutter-size + 1.2` where `$leadingStrokeLength` is the stroke length that applies the same formula as above.

Fixes #3158, #3936