### PR TITLE
fix(drawer): Remove unnecessary Closure annotation

### DIFF
--- a/packages/mdc-drawer/modal/foundation.js
+++ b/packages/mdc-drawer/modal/foundation.js
@@ -25,7 +25,7 @@ import MDCDrawerAdapter from '../adapter';
 import MDCDismissibleDrawerFoundation from '../dismissible/foundation';
 
 /**
- * @extends {MDCDismissibleDrawerFoundation<!MDCDrawerAdapter>}
+ * @extends {MDCDismissibleDrawerFoundation}
  */
 class MDCModalDrawerFoundation extends MDCDismissibleDrawerFoundation {
   /**


### PR DESCRIPTION
Modal Drawer extends Dismissible Drawer. There's no need for an adapter generic assignment.