### PR TITLE
feat(side-sheet): Make mixins more consistent with Drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
           "rtl",
           "select",
           "selection-control",
+          "side-sheet",
           "shape",
           "slider",
           "snackbar",

--- a/packages/mdc-side-sheet/README.md
+++ b/packages/mdc-side-sheet/README.md
@@ -86,7 +86,7 @@ Dismissible side sheets are by default hidden off screen, and can slide into vie
 ```
 
 > The main content of your page/app should reside in a `mdc-side-sheet-app-content` sibling element after the side sheet,
-> in order to adjust appropriately when the drawer opens and closes.
+> in order to adjust appropriately when the side sheet opens and closes.
 
 #### Usage with Top App Bar
 

--- a/packages/mdc-side-sheet/README.md
+++ b/packages/mdc-side-sheet/README.md
@@ -85,7 +85,8 @@ Dismissible side sheets are by default hidden off screen, and can slide into vie
 </body>
 ```
 
-> Apply the `mdc-side-sheet-app-content` class to a subsequent sibling element after the side-sheet for the open/close animations to work.\
+> The main content of your page/app should reside in a `mdc-side-sheet-app-content` sibling element after the side sheet,
+> in order to adjust appropriately when the drawer opens and closes.
 
 #### Usage with Top App Bar
 
@@ -201,7 +202,7 @@ Mixin | Description
 `mdc-side-sheet-surface-fill-color($color)` | Sets the background color of `mdc-side-sheet`.
 `mdc-side-sheet-surface-fill-color-accessible($color)` | Sets the fill color to `$color`, and text ink color to an accessible color relative to `$color`.
 `mdc-side-sheet-scrim-fill-color($color)` | Sets the fill color of `mdc-side-sheet-scrim`.
-`mdc-side-sheet-stroke-color($color)` | Sets border color of `mdc-side-sheet` surface.
+`mdc-side-sheet-outline-color($color)` | Sets border color of `mdc-side-sheet` surface.
 `mdc-side-sheet-shape-radius($radius)` | Sets the rounded shape to side sheet with given radius size. `$radius` can be single radius or list of 2 radius values for trailing-top and trailing-bottom. Automatically flips the radius values in RTL context.
 `mdc-side-sheet-z-index($value)` | Sets the z index of side sheet. Side Sheet stays on top of top app bar except for clipped variant of side sheet.
 `mdc-side-sheet-width($width)` | Sets the width of the side sheet. In the case of the dismissible variant, also sets margin required for `mdc-side-sheet-app-content`.

--- a/packages/mdc-side-sheet/_mixins.scss
+++ b/packages/mdc-side-sheet/_mixins.scss
@@ -22,6 +22,7 @@
 
 @import "@material/animation/functions";
 @import "@material/animation/variables";
+@import "@material/elevation/mixins";
 @import "@material/rtl/mixins";
 @import "@material/shape/mixins";
 @import "@material/theme/mixins";
@@ -32,8 +33,8 @@
 // Public
 //
 
-@mixin mdc-side-sheet-stroke-color($color, $opacity: $mdc-side-sheet-stroke-opacity) {
-  $value: rgba(mdc-theme-prop-value($color), $opacity);
+@mixin mdc-side-sheet-outline-color($color) {
+  $value: rgba(mdc-theme-prop-value($color), $mdc-side-sheet-outline-opacity);
 
   @include mdc-theme-prop(border-color, $value);
 }
@@ -64,24 +65,22 @@
   @include mdc-shape-radius($radius, $rtl-reflexive: true);
 }
 
-@mixin mdc-side-sheet-scrim-fill-color($color, $opacity: $mdc-side-sheet-modal-scrim-opacity) {
-  $value: rgba(mdc-theme-prop-value($color), $opacity);
+@mixin mdc-side-sheet-scrim-fill-color($color) {
+  $value: rgba(mdc-theme-prop-value($color), $mdc-side-sheet-modal-scrim-opacity);
 
   ~ .mdc-side-sheet-scrim {
     @include mdc-theme-prop(background-color, $value);
   }
 }
 
-@mixin mdc-side-sheet-ink-color($color, $opacity: $mdc-side-sheet-ink-opacity) {
-  $value: rgba(mdc-theme-prop-value($color), $opacity);
+@mixin mdc-side-sheet-ink-color($color) {
+  $value: rgba(mdc-theme-prop-value($color), $mdc-side-sheet-ink-opacity);
 
   @include mdc-theme-prop(color, $value);
 }
 
 @mixin mdc-side-sheet-surface-fill-color($color) {
-  $value: mdc-theme-prop-value($color);
-
-  @include mdc-theme-prop(background-color, $value);
+  @include mdc-theme-prop(background-color, $color);
 }
 
 @mixin mdc-side-sheet-surface-fill-color-accessible($color) {
@@ -98,14 +97,8 @@
 @mixin mdc-side-sheet-width($width, $side: trailing) {
   width: $width;
 
-  &.mdc-side-sheet--open:not(.mdc-side-sheet--closing) ~ .mdc-side-sheet-app-content {
-    @if $side == leading {
-      @include mdc-rtl-reflexive-box(margin, left, $width);
-    } @else if $side == trailing {
-      @include mdc-rtl-reflexive-box(margin, right, $width);
-    } @else {
-      @error "mdc-side-sheet-width() mixin: $side must be 'leading' or 'trailing', but got '#{$side}'";
-    }
+  &.mdc-side-sheet--open:not(&--closing) ~ .mdc-side-sheet-app-content {
+    @include mdc-side-sheet-app-content-margin_($width, $side);
   }
 }
 
@@ -113,21 +106,12 @@
 // Private
 //
 
-@mixin mdc-side-sheet-base_($side: trailing) {
+@mixin mdc-side-sheet-base_() {
   @include mdc-typography-base;
-
-  $flexOrder: if($side == leading, 0, 1);
-  $xFactor: if($side == leading, 1, -1);
 
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-
-  // Scrim and app content styles rely on the CSS sibling selector (~), which means the side sheet element needs to come
-  // first in the source order. Unfortunately, this causes permanent side sheets to be displayed on the leading side of
-  // the page instead of the trailing side. Setting `order` corrects the visual layout of the page; however,
-  // screen readers and tab order are unaffected by this property, so we need to find a better long term solution.
-  order: $flexOrder;
 
   // stylelint-disable-next-line declaration-empty-line-before
   box-sizing: border-box;
@@ -140,6 +124,10 @@
   &--open {
     transition: mdc-animation-standard(transform, $mdc-side-sheet-animation-enter);
   }
+}
+
+@mixin mdc-side-sheet-transitions_($side: trailing) {
+  $xFactor: if($side == leading, 1, -1);
 
   &--animate {
     transform: translateX(-100% * $xFactor);
@@ -188,6 +176,8 @@
 }
 
 @mixin mdc-side-sheet-modal_($rootClass, $side: trailing) {
+  @include mdc-elevation($mdc-side-sheet-modal-elevation);
+
   display: none;
   position: fixed;
 
@@ -201,6 +191,16 @@
     @include mdc-rtl-reflexive-position(right, 0);
   } @else {
     @error "mdc-side-sheet-modal_() mixin: $side must be 'leading' or 'trailing', but got '#{$side}'";
+  }
+}
+
+@mixin mdc-side-sheet-app-content-margin_($width, $side) {
+  @if $side == leading {
+    @include mdc-rtl-reflexive-box(margin, left, $width);
+  } @else if $side == trailing {
+    @include mdc-rtl-reflexive-box(margin, right, $width);
+  } @else {
+    @error "$side must be 'leading' or 'trailing', but got '#{$side}'";
   }
 }
 
@@ -219,6 +219,7 @@
   height: 100%;
   transition-property: opacity;
   transition-timing-function: $mdc-animation-standard-curve-timing-function;
+  z-index: $mdc-side-sheet-z-index - 1;
 
   .#{$rootClass}--open ~ & {
     display: block;
@@ -239,46 +240,40 @@
   }
 }
 
-@mixin mdc-side-sheet-app-content_($side: trailing) {
+@mixin mdc-side-sheet-app-content_() {
   position: relative;
-
-  @if $side == leading {
-    @include mdc-rtl-reflexive-box(margin, left, 0);
-  } @else if $side == trailing {
-    @include mdc-rtl-reflexive-box(margin, right, 0);
-  } @else {
-    @error "mdc-side-sheet-app-content_() mixin: $side must be 'leading' or 'trailing', but got '#{$side}'";
-  }
+  margin-left: 0;
+  margin-right: 0;
 }
 
-@mixin mdc-side-sheet-stroke-right_($width) {
+@mixin mdc-side-sheet-outline-right_($width) {
   border-right-width: $width;
   border-left-width: 0;
   border-right-style: solid;
   border-left-style: none;
 }
 
-@mixin mdc-side-sheet-stroke-left_($width) {
+@mixin mdc-side-sheet-outline-left_($width) {
   border-right-width: 0;
   border-left-width: $width;
   border-right-style: none;
   border-left-style: solid;
 }
 
-@mixin mdc-side-sheet-stroke-width_($width, $side: trailing) {
+@mixin mdc-side-sheet-outline-width_($width, $side: trailing) {
   @if $side == leading {
-    @include mdc-side-sheet-stroke-right_($width);
+    @include mdc-side-sheet-outline-right_($width);
 
     @include mdc-rtl {
-      @include mdc-side-sheet-stroke-left_($width);
+      @include mdc-side-sheet-outline-left_($width);
     }
   } @else if $side == trailing {
-    @include mdc-side-sheet-stroke-left_($width);
+    @include mdc-side-sheet-outline-left_($width);
 
     @include mdc-rtl {
-      @include mdc-side-sheet-stroke-right_($width);
+      @include mdc-side-sheet-outline-right_($width);
     }
   } @else {
-    @error "mdc-side-sheet-stroke_() mixin: $side must be 'leading' or 'trailing', but got '#{$side}'";
+    @error "mdc-side-sheet-outline-width_() mixin: $side must be 'leading' or 'trailing', but got '#{$side}'";
   }
 }

--- a/packages/mdc-side-sheet/_variables.scss
+++ b/packages/mdc-side-sheet/_variables.scss
@@ -25,11 +25,11 @@
 // Colors
 $mdc-side-sheet-surface-fill-color: mdc-theme-prop-value(surface);
 $mdc-side-sheet-ink-color: mdc-theme-prop-value(on-surface);
-$mdc-side-sheet-stroke-color: mdc-theme-prop-value(on-surface);
+$mdc-side-sheet-outline-color: mdc-theme-prop-value(on-surface);
 
 // Opacity
 $mdc-side-sheet-ink-opacity: mdc-theme-text-emphasis(high);
-$mdc-side-sheet-stroke-opacity: .12;
+$mdc-side-sheet-outline-opacity: .12;
 
 // Widths
 $mdc-side-sheet-width: 256px;

--- a/packages/mdc-side-sheet/mdc-side-sheet.scss
+++ b/packages/mdc-side-sheet/mdc-side-sheet.scss
@@ -20,7 +20,6 @@
 // THE SOFTWARE.
 //
 
-@import "@material/elevation/mixins";
 @import "./mixins";
 @import "./variables";
 
@@ -28,12 +27,23 @@
 
 .mdc-side-sheet {
   @include mdc-side-sheet-base_;
-  @include mdc-side-sheet-stroke-width_(1px);
-  @include mdc-side-sheet-stroke-color($mdc-side-sheet-stroke-color);
+  @include mdc-side-sheet-transitions_;
+  @include mdc-side-sheet-outline-width_(1px);
+  @include mdc-side-sheet-outline-color($mdc-side-sheet-outline-color);
   @include mdc-side-sheet-surface-fill-color($mdc-side-sheet-surface-fill-color);
   @include mdc-side-sheet-shape-radius(large);
   @include mdc-side-sheet-z-index($mdc-side-sheet-z-index);
   @include mdc-side-sheet-width($mdc-side-sheet-width);
+
+  // Scrim and app content styles rely on the CSS sibling selector (~), which means the side sheet element needs to come
+  // first in the source order. Unfortunately, this causes permanent side sheets to be displayed on the leading side of
+  // the page instead of the trailing side. Setting `order` corrects the visual layout of the page; however,
+  // screen readers and tab order are unaffected by this property, so we need to find a better long term solution.
+  order: 1;
+}
+
+.mdc-side-sheet__content {
+  @include mdc-side-sheet-content_;
 }
 
 .mdc-side-sheet--dismissible {
@@ -43,20 +53,14 @@
 .mdc-side-sheet--modal {
   @include mdc-side-sheet-modal_("mdc-side-sheet");
   @include mdc-side-sheet-scrim-fill-color($mdc-side-sheet-modal-scrim-color);
-  @include mdc-elevation($mdc-side-sheet-modal-elevation);
-}
-
-.mdc-side-sheet__content {
-  @include mdc-side-sheet-content_;
-}
-
-.mdc-side-sheet-scrim {
-  @include mdc-side-sheet-scrim_("mdc-side-sheet");
-  @include mdc-side-sheet-z-index($mdc-side-sheet-z-index - 1);
 }
 
 .mdc-side-sheet-app-content {
   @include mdc-side-sheet-app-content_;
+}
+
+.mdc-side-sheet-scrim {
+  @include mdc-side-sheet-scrim_("mdc-side-sheet");
 }
 
 // postcss-bem-linter: end

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -920,11 +920,11 @@
     }
   },
   "spec/mdc-side-sheet/mixins/stroke-color.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/17/17_34_32_221/spec/mdc-side-sheet/mixins/stroke-color.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/24/18_09_10_610/spec/mdc-side-sheet/mixins/stroke-color.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/17/17_34_32_221/spec/mdc-side-sheet/mixins/stroke-color.html.windows_chrome_69.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/17/17_34_32_221/spec/mdc-side-sheet/mixins/stroke-color.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/10/17/17_34_32_221/spec/mdc-side-sheet/mixins/stroke-color.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/24/18_09_10_610/spec/mdc-side-sheet/mixins/stroke-color.html.windows_chrome_69.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/24/18_09_10_610/spec/mdc-side-sheet/mixins/stroke-color.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/10/24/18_09_10_610/spec/mdc-side-sheet/mixins/stroke-color.html.windows_ie_11.png"
     }
   },
   "spec/mdc-side-sheet/mixins/surface-fill-color-accessible.html": {

--- a/test/screenshot/spec/mdc-side-sheet/fixture.scss
+++ b/test/screenshot/spec/mdc-side-sheet/fixture.scss
@@ -81,8 +81,8 @@ $custom-side-sheet-color: $material-color-red-600;
   @include mdc-side-sheet-shape-radius(40px);
 }
 
-.custom-side-sheet--stroke-color {
-  @include mdc-side-sheet-stroke-color($custom-side-sheet-color, 1);
+.custom-side-sheet--outline-color {
+  @include mdc-side-sheet-outline-color($custom-side-sheet-color);
 }
 
 .custom-side-sheet--surface-fill-color {

--- a/test/screenshot/spec/mdc-side-sheet/mixins/stroke-color.html
+++ b/test/screenshot/spec/mdc-side-sheet/mixins/stroke-color.html
@@ -43,7 +43,7 @@
 
   <body class="test-container test-container--edge-fonts">
     <div class="test-viewport test-viewport--side-sheet">
-      <aside class="mdc-side-sheet mdc-side-sheet--dismissible mdc-side-sheet--open test-side-sheet custom-side-sheet--stroke-color">
+      <aside class="mdc-side-sheet mdc-side-sheet--dismissible mdc-side-sheet--open test-side-sheet custom-side-sheet--outline-color">
         <div class="mdc-side-sheet__content test-side-sheet__content">
           <button class="test-side-sheet-toggle-button" autofocus>Close</button>
           <p>


### PR DESCRIPTION
Refs #3742.

This removes opacity parameters to match how drawer's mixin APIs are currently exposed (with the reasoning that it's easier to add later than remove), and reorganizes some styles to make them reusable between side sheet and drawer.