### PR TITLE
feat(menu): Expose handleSelection API to public

### DIFF
--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -232,6 +232,7 @@ Method Signature | Description
 --- | ---
 `handleKeydown(evt: Event) => void` | Event handler for the `keydown` events within the menu.
 `handleClick(evt: Event) => void` | Event handler for the `click` events within the menu.
+`handleSelection(listItem: Element) => void` | Handler for a selected list item. Use this instead of `handleClick` when you don't have access to list item click event.
 
 ### Events
 

--- a/packages/mdc-menu/foundation.js
+++ b/packages/mdc-menu/foundation.js
@@ -113,7 +113,7 @@ class MDCMenuFoundation extends MDCFoundation {
   handleAction_(evt) {
     const listItem = this.getListItem_(/** @type {HTMLElement} */ (evt.target));
     if (listItem) {
-      this.handleSelection_(listItem);
+      this.handleSelection(listItem);
       this.preventDefaultEvent_(evt);
     }
   }
@@ -121,9 +121,8 @@ class MDCMenuFoundation extends MDCFoundation {
   /**
    * Handler for a selected list item.
    * @param {?HTMLElement} listItem
-   * @private
    */
-  handleSelection_(listItem) {
+  handleSelection(listItem) {
     const index = this.adapter_.getElementIndex(listItem);
     if (index < 0) {
       return;

--- a/test/unit/mdc-menu/menu.foundation.test.js
+++ b/test/unit/mdc-menu/menu.foundation.test.js
@@ -484,3 +484,14 @@ test('Click event inside of a child element of a selection group (but not a list
     {times: 0});
   clock.uninstall();
 });
+
+test('#handleSelection: should invoke notifySelected on selected item.', () => {
+  const {foundation, mockAdapter} = setupTest();
+  const event = {target: 'My Element', preventDefault: td.func('preventDefault')};
+  td.when(mockAdapter.elementContainsClass(event.target, listClasses.LIST_ITEM_CLASS)).thenReturn(true);
+  td.when(mockAdapter.getElementIndex(event.target)).thenReturn(2);
+
+  foundation.handleSelection(event.target);
+
+  td.verify(mockAdapter.notifySelected({index: 2}), {times: 1});
+});


### PR DESCRIPTION
Exposing `handleSelection` to public for web frameworks which doesn't have access to events triggered by inner child component such as list component.

- `handleSelection_(listItem: Element)` => `handleSelection(listItem: Element)`