### PR TITLE
docs(drawer): Rename icon heading to make more sense contextually

### DIFF
--- a/packages/mdc-drawer/README.md
+++ b/packages/mdc-drawer/README.md
@@ -51,7 +51,7 @@ npm install @material/drawer
 </aside>
 ```
 
-#### Menu Icon
+#### Icons
 
 We recommend using [Material Icons](https://material.io/tools/icons/) from Google Fonts:
 


### PR DESCRIPTION
Resolves a comment on another PR: https://github.com/material-components/material-components-web/pull/3947#discussion_r227064522

It makes more sense to fix this in master rather than hold it back in the side sheet branch.