### PR TITLE
fix(notched-outline): Add noflip annotation

### DIFF
--- a/packages/mdc-notched-outline/mdc-notched-outline.scss
+++ b/packages/mdc-notched-outline/mdc-notched-outline.scss
@@ -45,6 +45,7 @@
     overflow: hidden;
 
     @include mdc-rtl {
+      /* @noflip */
       text-align: right;
     }
 


### PR DESCRIPTION
Add the `@noflip` annotation to the notched outline Sass in RTL. This is necessary for closure stylesheets.