### PR TITLE
docs(select): Update module format used in JS example

### DIFF
--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -73,7 +73,9 @@ For the native select, you can simply include the `mdc-select` Sass file.
 ### JavaScript Instantiation
 
 ```js
-const select = new mdc.select.MDCSelect(document.querySelector('.mdc-select'));
+import {MDCSelect} from '@material/select';
+
+const select = new MDCSelect(document.querySelector('.mdc-select'));
 
 select.listen('MDCSelect:change', () => {
   alert(`Selected option at index ${select.selectedIndex} with value "${select.value}"`);


### PR DESCRIPTION
Our Select JS example was using global namespace syntax, inconsistent with the rest of our READMEs.

(This was already the case prior to the enhanced select work, and went unnoticed during that.)

Fixes #3995.