### PR TITLE
chore: Update karma to run Chrome+FF headless and only IE on SL

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,122 +27,29 @@ const webpackConfig = require('./webpack.config')[0];
 const USING_TRAVISCI = Boolean(process.env.TRAVIS);
 const USING_SL = Boolean(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY);
 
-const LOCAL_LAUNCHERS = {
+const HEADLESS_LAUNCHERS = {
   /** See https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-348248951 */
   'ChromeHeadlessNoSandbox': {
     base: 'ChromeHeadless',
     flags: ['--no-sandbox'],
   },
+  'FirefoxHeadless': {
+    base: 'Firefox',
+    flags: ['-headless'],
+  },
 };
 
 const SAUCE_LAUNCHERS = {
-  /*
-   * Chrome (desktop)
-   */
-
-  'sl-chrome-stable': {
-    base: 'SauceLabs',
-    browserName: 'chrome',
-    version: 'latest',
-    platform: 'macOS 10.12',
-    extendedDebugging: true,
-  },
-  // 'sl-chrome-beta': {
-  //   base: 'SauceLabs',
-  //   browserName: 'chrome',
-  //   version: 'dev',
-  //   platform: 'macOS 10.12',
-  //   extendedDebugging: true,
-  // },
-  // 'sl-chrome-previous': {
-  //   base: 'SauceLabs',
-  //   browserName: 'chrome',
-  //   version: 'latest-1',
-  //   platform: 'macOS 10.12',
-  //   extendedDebugging: true,
-  // },
-
-  /*
-   * Firefox
-   */
-
-  'sl-firefox-stable': {
-    base: 'SauceLabs',
-    browserName: 'firefox',
-    version: 'latest',
-    platform: 'Windows 10',
-    extendedDebugging: true,
-  },
-  // 'sl-firefox-previous': {
-  //   base: 'SauceLabs',
-  //   browserName: 'firefox',
-  //   version: 'latest-1',
-  //   platform: 'Windows 10',
-  //   extendedDebugging: true,
-  // },
-
-  /*
-   * IE
-   */
-
   'sl-ie': {
     base: 'SauceLabs',
     browserName: 'internet explorer',
     version: '11',
     platform: 'Windows 10',
   },
-
-  /*
-   * Edge
-   */
-
-  // TODO(sgomes): Re-enable Edge and Safari after Sauce Labs problems are fixed.
-  // 'sl-edge': {
-  //   base: 'SauceLabs',
-  //   browserName: 'microsoftedge',
-  //   version: 'latest',
-  //   platform: 'Windows 10',
-  // },
-
-  /*
-   * Safari (desktop)
-   */
-
-  // 'sl-safari-stable': {
-  //   base: 'SauceLabs',
-  //   browserName: 'safari',
-  //   version: 'latest',
-  //   platform: 'macOS 10.12',
-  // },
-  // 'sl-safari-previous': {
-  //   base: 'SauceLabs',
-  //   browserName: 'safari',
-  //   version: '9.0',
-  //   platform: 'OS X 10.11',
-  // },
-
-  /*
-   * Safari (mobile)
-   */
-
-  'sl-ios-safari-latest': {
-    base: 'SauceLabs',
-    deviceName: 'iPhone Simulator',
-    platformVersion: '11.0',
-    platformName: 'iOS',
-    browserName: 'Safari',
-  },
-  // 'sl-ios-safari-previous': {
-  //   base: 'SauceLabs',
-  //   deviceName: 'iPhone Simulator',
-  //   platformVersion: '9.3',
-  //   platformName: 'iOS',
-  //   browserName: 'Safari',
-  // },
 };
 
-const getLaunchers = () => USING_SL ? SAUCE_LAUNCHERS : LOCAL_LAUNCHERS;
-const getBrowsers = () => USING_TRAVISCI ? Object.keys(getLaunchers()) : ['Chrome'];
+const customLaunchers = Object.assign({}, USING_SL ? SAUCE_LAUNCHERS : {}, HEADLESS_LAUNCHERS);
+const browsers = USING_TRAVISCI ? Object.keys(customLaunchers) : ['Chrome'];
 
 module.exports = function(config) {
   config.set({
@@ -158,12 +65,12 @@ module.exports = function(config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    browsers: getBrowsers(),
+    browsers: browsers,
     browserDisconnectTimeout: 40000,
     browserNoActivityTimeout: 120000,
     captureTimeout: 240000,
     concurrency: USING_SL ? 4 : Infinity,
-    customLaunchers: getLaunchers(),
+    customLaunchers: customLaunchers,
 
     coverageReporter: {
       dir: 'coverage',


### PR DESCRIPTION
Fixes #4041.

Sending out initially to see what happens on Travis. Tested locally on OS X forcing the travis flag to true.