### PR TITLE
fix(fab): Separate mixins for regular FAB and Extended FAB

### DIFF
--- a/packages/mdc-drawer/common.scss
+++ b/packages/mdc-drawer/common.scss
@@ -106,10 +106,6 @@
   }
 }
 
-.mdc-drawer--open {
-  transition: mdc-animation-standard(transform, $mdc-drawer-animation-enter);
-}
-
 .mdc-drawer--animate {
   transform: translateX(-100%);
 

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -129,7 +129,8 @@ Mixin | Description
 `mdc-fab-ink-color($color)` | Sets the ink color to the given color
 `mdc-fab-extended-padding($icon-padding, $label-padding)` | Sets the padding on both sides of the icon, and between the label and the edge of the FAB. In cases where there is no icon, `$label-padding` will apply to both sides.
 `mdc-fab-extended-label-padding($label-padding)` | Sets the label side padding for Extended FAB. Useful when styling an Extended FAB with no icon.
-`mdc-fab-shape-radius($radius, $rtl-reflexive)` | Sets rounded shape to all FAB variants with given radius size. Set `$rtl-reflexive` to true to flip radius values in RTL context, defaults to false.
+`mdc-fab-shape-radius($radius, $rtl-reflexive)` | Sets rounded shape to only regular & mini FAB variants with given radius size. Set `$rtl-reflexive` to true to flip radius values in RTL context, defaults to false.
+`mdc-fab-extended-shape-radius($radius, $rtl-reflexive)` | Sets rounded shape to only Extended FAB variant with given radius size. Set `$rtl-reflexive` to true to flip radius values in RTL context, defaults to false.
 
 The ripple effect for the FAB component is styled using [MDC Ripple](../mdc-ripple) mixins.
 

--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -89,17 +89,13 @@
 }
 
 @mixin mdc-fab-shape-radius($radius, $rtl-reflexive: false) {
-  @include mdc-shape-radius($radius, $rtl-reflexive);
-
-  &.mdc-fab--mini {
+  &:not(.mdc-fab--extended) {
     @include mdc-shape-radius($radius, $rtl-reflexive);
   }
 }
 
 @mixin mdc-fab-extended-shape-radius($radius, $rtl-reflexive: false) {
-  &.mdc-fab--extended {
-    @include mdc-shape-radius(mdc-shape-resolve-percentage-radius($mdc-fab-extended-height, $radius), $rtl-reflexive);
-  }
+  @include mdc-shape-radius(mdc-shape-resolve-percentage-radius($mdc-fab-extended-height, $radius), $rtl-reflexive);
 }
 
 $mdc-fab-icon-enter-delay_: 90ms;

--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -89,12 +89,14 @@
 }
 
 @mixin mdc-fab-shape-radius($radius, $rtl-reflexive: false) {
-  @include mdc-shape-radius(mdc-shape-resolve-percentage-radius($mdc-fab-height, $radius), $rtl-reflexive);
+  @include mdc-shape-radius($radius, $rtl-reflexive);
 
   &.mdc-fab--mini {
-    @include mdc-shape-radius(mdc-shape-resolve-percentage-radius($mdc-fab-mini-height, $radius), $rtl-reflexive);
+    @include mdc-shape-radius($radius, $rtl-reflexive);
   }
+}
 
+@mixin mdc-fab-extended-shape-radius($radius, $rtl-reflexive: false) {
   &.mdc-fab--extended {
     @include mdc-shape-radius(mdc-shape-resolve-percentage-radius($mdc-fab-extended-height, $radius), $rtl-reflexive);
   }
@@ -174,6 +176,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
 
 @mixin mdc-fab--extended_ {
   @include mdc-typography(button);
+  @include mdc-fab-extended-shape-radius(50%);
   @include mdc-fab-extended-padding(
     $mdc-fab-extended-icon-padding,
     $mdc-fab-extended-label-padding);

--- a/packages/mdc-shape/_functions.scss
+++ b/packages/mdc-shape/_functions.scss
@@ -173,11 +173,6 @@
 
 @function mdc-shape-is-valid-radius-value_($radius) {
   $is-number: type-of($radius) == "number";
-  $is-percentage: $is-number and unit($radius) == "%";
 
-  @if $is-percentage {
-    @return false;
-  } @else {
-    @return $is-number or str_index($radius, "var(") or str_index($radius, "calc(");
-  }
+  @return $is-number or str_index($radius, "var(") or str_index($radius, "calc(");
 }

--- a/packages/mdc-snackbar/package-lock.json
+++ b/packages/mdc-snackbar/package-lock.json
@@ -1,0 +1,11 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@material/shape": {
+			"version": "0.40.1",
+			"resolved": "https://registry.npmjs.org/@material/shape/-/shape-0.40.1.tgz",
+			"integrity": "sha512-o1pw5+s/jWqsKbUAkCCaEcB8XLqJ4FlZhYfSvxZ88WRw9zoWOt9iQMMP82wLWhUX1DSzpNRI8BAD7aNLK6yRlA=="
+		}
+	}
+}

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -681,6 +681,24 @@
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/07/17/22_50_36_536/spec/mdc-fab/mixins/extended-padding.html.windows_ie_11.png"
     }
   },
+  "spec/mdc-fab/mixins/extended-shape-radius.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/extended-shape-radius.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/extended-shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/extended-shape-radius.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/extended-shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/extended-shape-radius.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-fab/mixins/shape-radius.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/shape-radius.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/shape-radius.html.windows_chrome_69.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/shape-radius.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/shape-radius.html.windows_firefox_62.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/13/20_59_35_867/spec/mdc-fab/mixins/shape-radius.html.windows_ie_11.png"
+    }
+  },
   "spec/mdc-icon-button/classes/baseline-icon-button-toggle.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/13/15_39_02_591/spec/mdc-icon-button/classes/baseline-icon-button-toggle.html?utm_source=golden_json",
     "screenshots": {

--- a/test/screenshot/spec/mdc-fab/fixture.scss
+++ b/test/screenshot/spec/mdc-fab/fixture.scss
@@ -43,3 +43,11 @@
 .custom-fab--extended-label-padding {
   @include mdc-fab-extended-label-padding(24px);
 }
+
+.custom-fab-shape-radius {
+  @include mdc-fab-shape-radius(50% 0 0 0);
+}
+
+.custom-fab-extended-shape-radius {
+  @include mdc-fab-extended-shape-radius(25%);
+}

--- a/test/screenshot/spec/mdc-fab/mixins/extended-shape-radius.html
+++ b/test/screenshot/spec/mdc-fab/mixins/extended-shape-radius.html
@@ -23,7 +23,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>extended-padding FAB Mixin - MDC Web Screenshot Test</title>
+    <title>extended-shape-radius FAB Mixin - MDC Web Screenshot Test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../../out/mdc.fab.css">
     <link rel="stylesheet" href="../../../out/spec/fixture.css">

--- a/test/screenshot/spec/mdc-fab/mixins/extended-shape-radius.html
+++ b/test/screenshot/spec/mdc-fab/mixins/extended-shape-radius.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>extended-padding FAB Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.fab.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-fab/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--fab-extended">
+          <button class="mdc-fab mdc-fab--extended custom-fab-extended-shape-radius" aria-label="Create">
+            <span class="material-icons mdc-fab__icon">add</span>
+            <span class="mdc-fab__label">Create</span>
+          </button>
+        </div>
+        <div class="test-cell test-cell--fab-extended">
+          <button class="mdc-fab mdc-fab--extended custom-fab-extended-shape-radius" aria-label="Create">
+            <span class="mdc-fab__label">Create</span>
+            <span class="material-icons mdc-fab__icon">add</span>
+          </button>
+        </div>
+        <div class="test-cell test-cell--fab-extended">
+          <button class="mdc-fab mdc-fab--extended custom-fab-extended-shape-radius" aria-label="Create">
+            <span class="mdc-fab__label">Create</span>
+          </button>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-fab/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-fab/mixins/shape-radius.html
+++ b/test/screenshot/spec/mdc-fab/mixins/shape-radius.html
@@ -23,7 +23,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Baseline FAB (Floating Action Button) - MDC Web Screenshot Test</title>
+    <title>shape-radius FAB mixin - MDC Web Screenshot Test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../../out/mdc.fab.css">
     <link rel="stylesheet" href="../../../out/spec/fixture.css">

--- a/test/screenshot/spec/mdc-fab/mixins/shape-radius.html
+++ b/test/screenshot/spec/mdc-fab/mixins/shape-radius.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Baseline FAB (Floating Action Button) - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.fab.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-fab/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--fab">
+          <button class="mdc-fab custom-fab-shape-radius" aria-label="Favorite">
+            <span class="mdc-fab__icon material-icons">favorite_border</span>
+          </button>
+        </div>
+        <div class="test-cell test-cell--fab">
+          <button class="mdc-fab custom-fab-shape-radius" aria-label="Favorite">
+            <svg xmlns="http://www.w3.org/2000/svg" class="mdc-fab__icon" viewBox="0 0 24 24" fill="#000000">
+              <path fill="none" d="M0 0h24v24H0z"/>
+              <path d="M23 12c0-6.07-4.93-11-11-11S1 5.93 1 12s4.93 11 11 11 11-4.93 11-11zM5 17.64C3.75 16.1 3 14.14 3 12c0-2.13.76-4.08 2-5.63v11.27zM17.64 5H6.36C7.9 3.75 9.86 3 12 3s4.1.75 5.64 2zM12 14.53L8.24 7h7.53L12 14.53zM17 9v8h-4l4-8zm-6 8H7V9l4 8zm6.64 2c-1.55 1.25-3.51 2-5.64 2s-4.1-.75-5.64-2h11.28zM21 12c0 2.14-.75 4.1-2 5.64V6.37c1.24 1.55 2 3.5 2 5.63z"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-fab/fixture.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
BREAKING CHANGE: Fab now has 2 separate mixins - `mdc-fab-shape-radius` for regular & mini Fab variants & `mdc-fab-extended-shape-radius` for Extended FAB variant. 

Before:
```
mdc-fab-shape-radius(50%) => border-radius: 28px;
```

After:
```
mdc-fab-shape-radius(50%) => border-radius: 50%;
```

Where, `mdc-fab-shape-radius` doesn't resolve percentage to absolute value.

- `mdc-fab-shape-radius` sets rounded shape to regular & mini FAB.
- `mdc-fab-extended-shape-radius`sets rounded shape to only Extended FAB.

Fixes #3989