### PR TITLE
fix(select): Enhanced select doesn't wrap focus

### DIFF
--- a/packages/mdc-menu/README.md
+++ b/packages/mdc-menu/README.md
@@ -194,6 +194,7 @@ Property | Value Type | Description
 `open` | Boolean | Proxies to the menu surface's `open` property.
 `items` | Array<Element> | Proxies to the list to query for all `.mdc-list-item` elements.
 `quickOpen` | Boolean | Proxies to the menu surface `quickOpen` property.
+`wrapFocus` | Boolean | Proxies to list's `wrapFocus` property.
 
 Method Signature | Description
 --- | ---

--- a/packages/mdc-menu/index.js
+++ b/packages/mdc-menu/index.js
@@ -99,6 +99,16 @@ class MDCMenu extends MDCComponent {
     this.menuSurface_.open = value;
   }
 
+  /** @return {boolean} */
+  get wrapFocus() {
+    return this.list_.wrapFocus;
+  }
+
+  /** @param {boolean} value */
+  set wrapFocus(value) {
+    this.list_.wrapFocus = value;
+  }
+
   /**
    * @param {!Corner} corner Default anchor corner alignment of top-left
    *     menu corner.

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -304,6 +304,7 @@ class MDCSelect extends MDCComponent {
     this.menu_.hoistMenuToBody();
     this.menu_.setAnchorElement(/** @type {!HTMLElement} */ (this.root_));
     this.menu_.setAnchorCorner(menuSurfaceConstants.Corner.BOTTOM_START);
+    this.menu_.wrapFocus = false;
   }
 
   /**

--- a/test/unit/mdc-menu/mdc-menu.test.js
+++ b/test/unit/mdc-menu/mdc-menu.test.js
@@ -52,6 +52,7 @@ class FakeList {
     this.root = root;
     this.destroy = td.func('.destroy');
     this.itemsContainer = td.func('.root_');
+    this.wrapFocus = true;
     this.listElements = [].slice.call(root.querySelectorAll('.mdc-list-item'));
   }
 }
@@ -156,6 +157,15 @@ test('get/set open', () => {
 
   component.open = false;
   assert.isFalse(menuSurface.open);
+});
+
+test('wrapFocus proxies to MDCList#wrapFocus property', () => {
+  const {component, list} = setupTestWithFakes();
+
+  assert.isTrue(component.wrapFocus);
+
+  component.wrapFocus = false;
+  assert.isFalse(list.wrapFocus);
 });
 
 test('setAnchorCorner proxies to the MDCMenuSurface#setAnchorCorner method', () => {


### PR DESCRIPTION
Added new API to menu to set list's `wrapFocus` property. Enhanced select uses this new API to set it to `false` since select component doesn't wrap focus.

Fixes #3733