### PR TITLE
chore: Run unit tests for PRs that change karma conf

### DIFF
--- a/scripts/travis-env-vars.sh
+++ b/scripts/travis-env-vars.sh
@@ -78,7 +78,7 @@ print_all_changed_files
 
 if [[ "$TEST_SUITE" == 'unit' ]]; then
   # Only run unit tests if JS files changed
-  check_for_testable_files '^packages/.+\.js$' '^test/unit/.+\.js$'
+  check_for_testable_files '^karma\.conf\.js$' '^packages/.+\.js$' '^test/unit/.+\.js$'
 fi
 
 if [[ "$TEST_SUITE" == 'lint' ]]; then


### PR DESCRIPTION
This ensures that PRs that change only karma.conf will re-run unit tests.

Example using the added regexp:

```sh
$ git diff --name-only master...chore/karma-headless-firefox
karma.conf.js
scripts/travis-env-vars.sh
test/unit/mdc-top-app-bar/mdc-top-app-bar.test.js

$ git diff --name-only master...chore/karma-headless-firefox | grep -E '^karma\.conf\.js$'
karma.conf.js
```