### PR TITLE
fix(top-app-bar): Move scroll target initialization; improve test

### DIFF
--- a/packages/mdc-top-app-bar/index.js
+++ b/packages/mdc-top-app-bar/index.js
@@ -63,6 +63,8 @@ class MDCTopAppBar extends MDCComponent {
       ripple.unbounded = true;
       return ripple;
     });
+
+    this.scrollTarget_ = window;
   }
 
   destroy() {
@@ -118,8 +120,6 @@ class MDCTopAppBar extends MDCComponent {
         this.root_.querySelectorAll(strings.ACTION_ITEM_SELECTOR).length,
     })
     );
-
-    this.scrollTarget_ = window;
 
     /** @type {!MDCTopAppBarBaseFoundation} */
     let foundation;

--- a/test/unit/mdc-top-app-bar/mdc-top-app-bar.test.js
+++ b/test/unit/mdc-top-app-bar/mdc-top-app-bar.test.js
@@ -290,10 +290,10 @@ test('adapter#getViewportScrollY returns scroll distance', () => {
 });
 
 test('adapter#getViewportScrollY returns scroll distance when scrollTarget_ is not window', () => {
-  const {component, fixture} = setupTest();
-  const content = {addEventListener: () => {}, scrollTop: 20};
-  component.setScrollTarget(content);
-  assert.equal(component.getDefaultFoundation().adapter_.getViewportScrollY(), content.scrollTop);
+  const {component} = setupTest();
+  const mockContent = {addEventListener: () => {}, scrollTop: 20};
+  component.setScrollTarget(mockContent);
+  assert.equal(component.getDefaultFoundation().adapter_.getViewportScrollY(), mockContent.scrollTop);
 });
 
 test('adapter#getTotalActionItems returns the number of action items on the opposite side of the menu', () => {

--- a/test/unit/mdc-top-app-bar/mdc-top-app-bar.test.js
+++ b/test/unit/mdc-top-app-bar/mdc-top-app-bar.test.js
@@ -62,7 +62,6 @@ function getFixture(removeIcon) {
       </header>
       <main class="mdc-top-app-bar-fixed-adjust">
       </main>
-      <div class="content">Content</div>
     </div>
   `;
 
@@ -292,8 +291,8 @@ test('adapter#getViewportScrollY returns scroll distance', () => {
 
 test('adapter#getViewportScrollY returns scroll distance when scrollTarget_ is not window', () => {
   const {component, fixture} = setupTest();
-  const content = fixture.querySelector('.content');
-  component.scrollTarget_ = content;
+  const content = {addEventListener: () => {}, scrollTop: 20};
+  component.setScrollTarget(content);
   assert.equal(component.getDefaultFoundation().adapter_.getViewportScrollY(), content.scrollTop);
 });
 


### PR DESCRIPTION
This resolves the test failure discovered in #4046.

The `getViewportScrollY` adapter unit test was coincidentally passing because the page's scroll offset and the scroll offset of the content element were typically both 0. This only ended up not being the case when I tried running our unit tests via headless Firefox on Travis.

The test as written actually should never have passed, because `getDefaultFoundation` in the Top App Bar component had the side effect of resetting the scroll target, effectively undoing the test's setup.

This fixes the component to initialize the scroll target in `initialize` rather than `getDefaultFoundation`, and fixes the test to use a mock object to guarantee a distinguishable expected value.