### PR TITLE
fix(shape): Add noflip comments, fix RTL for categories

### DIFF
--- a/packages/mdc-shape/_mixins.scss
+++ b/packages/mdc-shape/_mixins.scss
@@ -24,11 +24,19 @@
 @import "./functions";
 
 @mixin mdc-shape-radius($radius, $rtl-reflexive: false) {
+  // Even if $rtl-reflexive is true, only emit RTL styles if we can't easily tell that the given radius is symmetrical
+  $needs-flip: $rtl-reflexive and length($radius) > 1;
+
+  @if ($needs-flip) {
+    /* @noflip */
+  }
+
   border-radius: mdc-shape-prop-value($radius);
 
-  @if ($rtl-reflexive) {
+  @if ($needs-flip) {
     @include mdc-rtl {
-      border-radius: mdc-shape-flip-radius($radius);
+      /* @noflip */
+      border-radius: mdc-shape-flip-radius(mdc-shape-prop-value($radius));
     }
   }
 }


### PR DESCRIPTION
This has 3 changes/fixes:

* Don't bother emitting separate RTL styles when we can easily tell it's identical to LTR
* Add `@noflip` annotations to both the LTR and RTL emitted styles when both are emitted
* Fix RTL emitted styles to resolve shape category names (this caused a bug in drawer's RTL styles previously)