### PR TITLE
style: Remove newlines before CSS annotations

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -4,6 +4,8 @@ plugins:
   - stylelint-scss
   - stylelint-order
 rules:
+  # Override stylelint-config-standard - we only use CSS comments for annotations that don't warrant an empty line
+  comment-empty-line-before: null
   # Follow best practices
   font-family-name-quotes: always-where-recommended
   # https://stackoverflow.com/a/34383157/467582

--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -107,7 +107,6 @@
   height: $mdc-button-height;
   border: none;
   outline: none;
-
   /* @alternate */
   line-height: inherit;
   user-select: none;

--- a/packages/mdc-card/mdc-card.scss
+++ b/packages/mdc-card/mdc-card.scss
@@ -178,7 +178,6 @@
   max-height: none;
   margin: 0;
   padding: 8px 16px;
-
   /* @noflip */
   text-align: left;
 

--- a/packages/mdc-drawer/common.scss
+++ b/packages/mdc-drawer/common.scss
@@ -53,10 +53,8 @@
   height: 100%;
   transition-property: transform;
   transition-timing-function: $mdc-animation-standard-curve-timing-function;
-
   /* @noflip */
   border-right-width: 1px;
-
   /* @noflip */
   border-right-style: solid;
   overflow: hidden;
@@ -64,13 +62,10 @@
   @include mdc-rtl {
     /* @noflip */
     border-right-width: 0;
-
     /* @noflip */
     border-left-width: 1px;
-
     /* @noflip */
     border-right-style: none;
-
     /* @noflip */
     border-left-style: solid;
   }

--- a/packages/mdc-floating-label/mdc-floating-label.scss
+++ b/packages/mdc-floating-label/mdc-floating-label.scss
@@ -37,16 +37,13 @@
 
     position: absolute;
     bottom: 8px;
-
     /* @noflip */
     left: 0;
-
     /* @noflip */
     transform-origin: left top;
     transition:
       transform $mdc-floating-label-transition-duration $mdc-animation-standard-curve-timing-function,
       color $mdc-floating-label-transition-duration $mdc-animation-standard-curve-timing-function;
-
     /* @alternate */
     line-height: 1.15rem;
     text-align: left;
@@ -61,13 +58,10 @@
     @include mdc-rtl {
       /* @noflip */
       right: 0;
-
       /* @noflip */
       left: auto;
-
       /* @noflip */
       transform-origin: right top;
-
       /* @noflip */
       text-align: right;
     }

--- a/packages/mdc-form-field/mdc-form-field.scss
+++ b/packages/mdc-form-field/mdc-form-field.scss
@@ -37,10 +37,8 @@ $mdc-form-field-item-spacing: 4px;
 
   > label {
     order: 0;
-
     /* @noflip */
     margin-right: auto;
-
     /* @noflip */
     padding-left: $mdc-form-field-item-spacing;
   }
@@ -49,7 +47,6 @@ $mdc-form-field-item-spacing: 4px;
     > label {
       /* @noflip */
       margin-left: auto;
-
       /* @noflip */
       padding-right: $mdc-form-field-item-spacing;
     }
@@ -59,10 +56,8 @@ $mdc-form-field-item-spacing: 4px;
 .mdc-form-field--align-end {
   > label {
     order: -1;
-
     /* @noflip */
     margin-left: auto;
-
     /* @noflip */
     padding-right: $mdc-form-field-item-spacing;
   }
@@ -71,7 +66,6 @@ $mdc-form-field-item-spacing: 4px;
     > label {
       /* @noflip */
       margin-right: auto;
-
       /* @noflip */
       padding-left: $mdc-form-field-item-spacing;
     }

--- a/packages/mdc-grid-list/mdc-grid-list.scss
+++ b/packages/mdc-grid-list/mdc-grid-list.scss
@@ -94,7 +94,6 @@ $mdc-grid-list-tile-secondary-icon-size: 24px;
 .mdc-grid-tile {
   display: block;
   position: relative;
-
   /* @alternate */
   width: $mdc-grid-list-tile-width;
   width: var(--mdc-grid-list-tile-width, $mdc-grid-list-tile-width);

--- a/packages/mdc-icon-toggle/mdc-icon-toggle.scss
+++ b/packages/mdc-icon-toggle/mdc-icon-toggle.scss
@@ -47,7 +47,6 @@
   cursor: pointer;
   user-select: none;
   // For some reason, GPU layer promotion makes ripples look terrible on Chrome
-
   /* @alternate */
   will-change: initial;
 

--- a/packages/mdc-list/mdc-list.scss
+++ b/packages/mdc-list/mdc-list.scss
@@ -38,7 +38,6 @@
 
   // According to the mocks and stickersheet, the line-height is adjusted to 24px for text content,
   // same as for body1.
-
   /* @alternate */
   line-height: map-get(map-get($mdc-typography-styles, body1), line-height);
   list-style-type: none;

--- a/packages/mdc-notched-outline/mdc-notched-outline.scss
+++ b/packages/mdc-notched-outline/mdc-notched-outline.scss
@@ -41,7 +41,6 @@
   .mdc-notched-outline {
     transition: opacity $mdc-notched-outline-transition-duration $mdc-animation-standard-curve-timing-function;
     opacity: 0;
-
     /* @noflip */
     text-align: left;
     overflow: hidden;

--- a/packages/mdc-radio/mdc-radio.scss
+++ b/packages/mdc-radio/mdc-radio.scss
@@ -46,7 +46,6 @@
   height: $mdc-radio-touch-area;
   padding: ($mdc-radio-touch-area - $mdc-radio-ui-size) / 2;
   cursor: pointer;
-
   /* @alternate */
   will-change: opacity, transform, border-color, color;
 

--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -61,7 +61,6 @@
 
   &.mdc-ripple-upgraded::after {
     top: 0;
-
     /* @noflip */
     left: 0;
     transform: scale(0);
@@ -70,7 +69,6 @@
 
   &.mdc-ripple-upgraded--unbounded::after {
     top: var(--mdc-ripple-top, 0);
-
     /* @noflip */
     left: var(--mdc-ripple-left, 0);
   }
@@ -189,7 +187,6 @@
   &::before,
   &::after {
     top: calc(50% - #{$radius});
-
     /* @noflip */
     left: calc(50% - #{$radius});
     width: $radius * 2;
@@ -206,7 +203,6 @@
   &::before,
   &::after {
     top: calc(50% - #{$radius / 2});
-
     /* @noflip */
     left: calc(50% - #{$radius / 2});
     width: $radius;
@@ -216,7 +212,6 @@
   &.mdc-ripple-upgraded::before,
   &.mdc-ripple-upgraded::after {
     top: var(--mdc-ripple-top, calc(50% - #{$radius / 2}));
-
     /* @noflip */
     left: var(--mdc-ripple-left, calc(50% - #{$radius / 2}));
     width: var(--mdc-ripple-fg-size, $radius);

--- a/packages/mdc-rtl/_mixins.scss
+++ b/packages/mdc-rtl/_mixins.scss
@@ -258,14 +258,12 @@
 ) {
   /* @noflip */
   #{$left-property}: $left-value;
-
   /* @noflip */
   #{$right-property}: $right-value;
 
   @include mdc-rtl($root-selector) {
     /* @noflip */
     #{$left-property}: $right-value;
-
     /* @noflip */
     #{$right-property}: $left-value;
   }

--- a/packages/mdc-top-app-bar/mdc-top-app-bar.scss
+++ b/packages/mdc-top-app-bar/mdc-top-app-bar.scss
@@ -89,10 +89,8 @@
 
 .mdc-top-app-bar--short {
   top: 0;
-
   /* @noflip */
   right: auto;
-
   /* @noflip */
   left: 0;
   width: 100%;
@@ -101,7 +99,6 @@
   @include mdc-rtl {
     /* @noflip */
     right: 0;
-
     /* @noflip */
     left: auto;
   }

--- a/packages/mdc-typography/_mixins.scss
+++ b/packages/mdc-typography/_mixins.scss
@@ -50,7 +50,6 @@
 @mixin mdc-typography-baseline-top($distance) {
   display: block;
   margin-top: 0;
-
   /* @alternate */
   line-height: normal;
 


### PR DESCRIPTION
This piggybacks on #4117 to override the `stylelint-config-standard` rule that was requiring us to add empty lines before our CSS annotation comments, and remove those newlines. The newlines are kind of confusing since really the annotations simply indicate something about the next line, and there's not actually any logical division from the previous line.

CSS output is identical before/after this change.