### PR TITLE
docs(list): Document how to instantiate ripples

### DIFF
--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -70,9 +70,7 @@ fully-upgraded ripple effect on list items, you must instantiate `MDCRipple` on 
 ```js
 import {MDCRipple} from '@material/ripple';
 
-[].forEach.call(document.querySelectorAll('.mdc-list-item'), function(listItemEl) {
-  MDCRipple.attachTo(listItemEl);
-});
+const listItemRipples = list.listElements.map((listItemEl) => new MDCRipple(listItemEl));
 ```
 
 ## Variants
@@ -207,7 +205,7 @@ single list item to become selected and any other previous selected element to b
 ```
 
 ```js
-var list = new MDCList(document.getElementById('my-list'));
+const list = new MDCList(document.getElementById('my-list'));
 list.singleSelection = true;
 ```
 
@@ -232,7 +230,7 @@ creating the list.
 ```
 
 ```js
-var list = new MDCList(document.getElementById('my-list'));
+const list = new MDCList(document.getElementById('my-list'));
 list.singleSelection = true;
 ```
 

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -52,6 +52,29 @@ npm install @material/list
 </ul>
 ```
 
+### JavaScript
+
+MDC List includes an optional JavaScript component which can be used for keyboard interaction and accessibility.
+
+```js
+import {MDCList} from '@material/list';
+
+const list = new MDCList(document.querySelector('.mdc-list'));
+```
+
+> See [Importing the JS component](../../docs/importing-js.md) for more information on how to import JavaScript.
+
+Note that the JS component does _not_ automatically instantiate ripples on list items. If you wish to include the
+fully-upgraded ripple effect on list items, you must instantiate `MDCRipple` on each item:
+
+```js
+import {MDCRipple} from '@material/ripple';
+
+[].forEach.call(document.querySelectorAll('.mdc-list-item'), function(listItemEl) {
+  MDCRipple.attachTo(listItemEl);
+});
+```
+
 ## Variants
 
 ### Two-Line List
@@ -184,8 +207,7 @@ single list item to become selected and any other previous selected element to b
 ```
 
 ```js
-var listEle = document.getElementById('my-list');
-var list = new mdc.list.MDCList(listEle);
+var list = new MDCList(document.getElementById('my-list'));
 list.singleSelection = true;
 ```
 
@@ -210,8 +232,7 @@ creating the list.
 ```
 
 ```js
-var listEle = document.getElementById('my-list');
-var list = new mdc.list.MDCList(listEle);
+var list = new MDCList(document.getElementById('my-list'));
 list.singleSelection = true;
 ```
 


### PR DESCRIPTION
Fixes #4031.

Also updates all JS examples to use ES2015+ syntax consistent with other readmes, and links to the importing JS docs.