### PR TITLE
docs: Improve architecture wording

### DIFF
--- a/docs/code/architecture.md
+++ b/docs/code/architecture.md
@@ -32,18 +32,23 @@ we've only implemented a vanilla JavaScript version of the Adapter.
 ### Foundation
 
 The Foundation contains the business logic that best represents Material Design,
-without actually referring to any HTML elements. This lets us isolate HTML logic
-into the Adapter. Foundation has-a Adapter.
+without actually referring to any DOM elements. The Foundation delegates to Adapter
+methods for any logic requiring DOM manipulation.
 
 ### Adapter
 
 The Adapter is an interface with all the methods the Foundation needs to
 implement Material Design business logic. There can be many implementations of
-the Adapter!
+the Adapter, allowing for interoperability with different frameworks.
 
 ### Vanilla Component
 
 Instantiated with a root [element](https://developer.mozilla.org/en-US/docs/Web/API/Element),
-the Vanilla Component creates a Foundation with a Vanilla Adapter. The Vanilla Adapter implements
-the Adapter and directly references the root element. The Vanilla Component also exposes proxy methods
-for any Foundation methods a developer needs to access.
+the Vanilla Component creates a Foundation instance with a Vanilla Adapter by
+overriding the `getDefaultFoundation` method of `MDCComponent`. The Vanilla Adapter
+implements the Adapter APIs and directly references the root element. The Vanilla
+Component also exposes proxy methods for any Foundation methods a developer needs to access.
+
+Developers who are simply interested in consuming MDC Web (i.e. not providing a
+wrapper library) should only need to interact with the Component. They should not
+need to directly access Foundation or Adapter APIs.


### PR DESCRIPTION
Fixes #4119.

The vanilla component section pretty much already covered the "foundation has-a adapter" bit anyway, so I just tried to clarify things.