### PR TITLE
fix(select): apperance none not working in chromium

### DIFF
--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -293,6 +293,8 @@
     color: inherit; // Override default user agent stylesheet
     white-space: nowrap;
     cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
     appearance: none;
   }
 }


### PR DESCRIPTION
I have to add:
```
-webkit-appearance: none;
```
In order to get rid of the default triangle of the select in chromium (65.0.3325.181).