### PR TITLE
chore(infrastructure): Only try resolving PR ID on Travis CBT runs

### DIFF
--- a/test/screenshot/infra/lib/diff-base-parser.js
+++ b/test/screenshot/infra/lib/diff-base-parser.js
@@ -101,7 +101,7 @@ class DiffBaseParser {
     const parsedDiffBase = await this.parseDiffBase_(rawDiffBase);
     const parsedBranch = parsedDiffBase.git_revision ? parsedDiffBase.git_revision.branch : null;
 
-    if (isOnline && isRealBranch(parsedBranch)) {
+    if (isOnline && isRealBranch(parsedBranch) && process.env.TRAVIS) {
       const prNumber = await this.gitHubApi_.getPullRequestNumber(parsedBranch);
       if (prNumber) {
         parsedDiffBase.git_revision.pr_number = prNumber;


### PR DESCRIPTION
This avoids needlessly querying GitHub APIs for local screenshot test runs, which is very likely to hit rate limits for anonymous requests. Getting the associated PR ID is typically not useful (or not even applicable) when running screenshot tests locally, so we certainly don't want to fail on it.