### PR TITLE
fix(snackbar): Rename action/dismiss classes and revise docs/tests

### DIFF
--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -48,8 +48,7 @@ npm install @material/snackbar
       Can't send photo. Retry in 5 seconds.
     </div>
     <div class="mdc-snackbar__actions">
-      <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-      <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+      <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
     </div>
   </div>
 </div>
@@ -135,8 +134,8 @@ CSS Class | Description
 `mdc-snackbar` | Mandatory. Container for the snackbar elements.
 `mdc-snackbar__label` | Mandatory. Message text.
 `mdc-snackbar__actions` | Optional. Wraps the action button/icon elements, if present.
-`mdc-snackbar__action-button` | Optional. The action button.
-`mdc-snackbar__action-icon` | Optional. The dismiss ("X") icon.
+`mdc-snackbar__action` | Optional. The action button.
+`mdc-snackbar__dismiss` | Optional. The dismiss ("X") icon.
 `mdc-snackbar--opening` | Optional. Applied automatically when the snackbar is in the process of animating open.
 `mdc-snackbar--open` | Optional. Indicates that the snackbar is open and visible.
 `mdc-snackbar--closing` | Optional. Applied automatically when the snackbar is in the process of animating closed.
@@ -158,7 +157,7 @@ Mixin | Description
 `mdc-snackbar-position-leading()` | Positions the snackbar on the leading edge of the screen (left in LTR, right in RTL) instead of centered.
 `mdc-snackbar-layout-stacked()` | Positions the action button/icon below the label instead of alongside it.
 
-> **NOTE**: The `mdc-snackbar__action-button` and `mdc-snackbar__action-icon` elements can be customized with [`mdc-button`](../mdc-button) and [`mdc-icon-button`](../mdc-icon-button) mixins.
+> **NOTE**: The `mdc-snackbar__action` and `mdc-snackbar__dismiss` elements can be further customized with [`mdc-button`](../mdc-button) and [`mdc-icon-button`](../mdc-icon-button) mixins.
 
 ## JavaScript API
 
@@ -228,8 +227,8 @@ When wrapping the Snackbar foundation, the following events must be bound to the
 Event | Target | Foundation Handler | Register | Deregister
 --- | --- | --- | --- | ---
 `keydown` | `.mdc-snackbar` | `handleKeyDown` | During initialization | During destruction
-`click` | `.mdc-snackbar__action-button` | `handleActionButtonClick` | During initialization | During destruction
-`click` | `.mdc-snackbar__action-icon` | `handleActionIconClick` | During initialization | During destruction
+`click` | `.mdc-snackbar__action` | `handleActionButtonClick` | During initialization | During destruction
+`click` | `.mdc-snackbar__dismiss` | `handleActionIconClick` | During initialization | During destruction
 
 #### The Util API
 
@@ -267,16 +266,16 @@ macOS VoiceOver is _not_ supported at this time.
 
 ### Dismiss Icon
 
-A dedicated dismiss icon is optional, but **strongly** recommended. If the snackbar gets permanently "stuck" on the screen for any reason (e.g., #1398), the user needs to be able to manually dismiss it.
+Snackbars are intended to dismiss on their own after a few seconds, but a dedicated dismiss icon may be optionally included as well for accessibility purposes.
 
 ### Dismiss Key
 
-Pressing the <kbd>ESC</kbd> key while one of the snackbar's subelements has focus (e.g., the action button) will dismiss the snackbar.
+Pressing the <kbd>ESC</kbd> key while one of the snackbar's child elements has focus (e.g., the action button) will dismiss the snackbar.
 
 To disable this behavior, set `closeOnEscape` to `false`.
 
 ### No JS Ripples
 
-The `mdc-snackbar__action-button` and `mdc-snackbar__action-icon` elements should _**not**_ have JavaScript-enabled [`MDCRipple`](../mdc-ripple) behavior.
+The `mdc-snackbar__action` and `mdc-snackbar__dismiss` elements should _**not**_ have JavaScript-enabled [`MDCRipple`](../mdc-ripple) behavior.
 
 When combined with the snackbar's exit animation, ripples cause too much motion, which can be distracting or disorienting for users.

--- a/packages/mdc-snackbar/_variables.scss
+++ b/packages/mdc-snackbar/_variables.scss
@@ -25,8 +25,8 @@
 
 $mdc-snackbar-fill-color: mix(mdc-theme-prop-value(on-surface), mdc-theme-prop-value(surface), 80%) !default;
 $mdc-snackbar-label-ink-color: rgba(mdc-theme-prop-value(surface), mdc-theme-text-emphasis(high)) !default;
-$mdc-snackbar-action-icon-ink-color: rgba(mdc-theme-prop-value(surface), mdc-theme-text-emphasis(high)) !default;
-$mdc-snackbar-action-button-ink-color: #bb86fc !default;
+$mdc-snackbar-action-ink-color: #bb86fc !default;
+$mdc-snackbar-dismiss-ink-color: rgba(mdc-theme-prop-value(surface), mdc-theme-text-emphasis(high)) !default;
 
 $mdc-snackbar-label-type-scale: body2 !default;
 $mdc-snackbar-action-icon-size: 18px !default;

--- a/packages/mdc-snackbar/_variables.scss
+++ b/packages/mdc-snackbar/_variables.scss
@@ -29,7 +29,7 @@ $mdc-snackbar-action-ink-color: #bb86fc !default;
 $mdc-snackbar-dismiss-ink-color: rgba(mdc-theme-prop-value(surface), mdc-theme-text-emphasis(high)) !default;
 
 $mdc-snackbar-label-type-scale: body2 !default;
-$mdc-snackbar-action-icon-size: 18px !default;
+$mdc-snackbar-dismiss-icon-size: 18px !default;
 $mdc-snackbar-min-width: 344px !default;
 $mdc-snackbar-max-width: 672px !default;
 $mdc-snackbar-mobile-breakpoint: 480px !default;

--- a/packages/mdc-snackbar/constants.js
+++ b/packages/mdc-snackbar/constants.js
@@ -30,8 +30,8 @@ const cssClasses = {
 const strings = {
   SURFACE_SELECTOR: '.mdc-snackbar__surface',
   LABEL_SELECTOR: '.mdc-snackbar__label',
-  ACTION_BUTTON_SELECTOR: '.mdc-snackbar__action-button',
-  ACTION_ICON_SELECTOR: '.mdc-snackbar__action-icon',
+  ACTION_SELECTOR: '.mdc-snackbar__action',
+  DISMISS_SELECTOR: '.mdc-snackbar__dismiss',
 
   OPENING_EVENT: 'MDCSnackbar:opening',
   OPENED_EVENT: 'MDCSnackbar:opened',

--- a/packages/mdc-snackbar/index.js
+++ b/packages/mdc-snackbar/index.js
@@ -28,7 +28,7 @@ import * as util from './util';
 import * as ponyfill from '@material/dom/ponyfill';
 
 const {
-  SURFACE_SELECTOR, LABEL_SELECTOR, ACTION_BUTTON_SELECTOR, ACTION_ICON_SELECTOR,
+  SURFACE_SELECTOR, LABEL_SELECTOR, ACTION_SELECTOR, DISMISS_SELECTOR,
   OPENING_EVENT, OPENED_EVENT, CLOSING_EVENT, CLOSED_EVENT,
 } = strings;
 
@@ -47,7 +47,7 @@ class MDCSnackbar extends MDCComponent {
     this.labelEl_;
 
     /** @type {!HTMLElement} */
-    this.actionButtonEl_;
+    this.actionEl_;
 
     /** @type {function(!HTMLElement, !HTMLElement=): void} */
     this.announce_;
@@ -69,7 +69,7 @@ class MDCSnackbar extends MDCComponent {
   initialSyncWithDOM() {
     this.surfaceEl_ = /** @type {!HTMLElement} */ (this.root_.querySelector(SURFACE_SELECTOR));
     this.labelEl_ = /** @type {!HTMLElement} */ (this.root_.querySelector(LABEL_SELECTOR));
-    this.actionButtonEl_ = /** @type {!HTMLElement} */ (this.root_.querySelector(ACTION_BUTTON_SELECTOR));
+    this.actionEl_ = /** @type {!HTMLElement} */ (this.root_.querySelector(ACTION_SELECTOR));
 
     this.handleKeyDown_ = (evt) => this.foundation_.handleKeyDown(evt);
     this.handleSurfaceClick_ = (evt) => {
@@ -172,14 +172,14 @@ class MDCSnackbar extends MDCComponent {
    * @return {string}
    */
   get actionButtonText() {
-    return this.actionButtonEl_.textContent;
+    return this.actionEl_.textContent;
   }
 
   /**
    * @param {string} actionButtonText
    */
   set actionButtonText(actionButtonText) {
-    this.actionButtonEl_.textContent = actionButtonText;
+    this.actionEl_.textContent = actionButtonText;
   }
 
   /**
@@ -220,7 +220,7 @@ class MDCSnackbar extends MDCComponent {
    * @private
    */
   isActionButton_(target) {
-    return Boolean(ponyfill.closest(target, ACTION_BUTTON_SELECTOR));
+    return Boolean(ponyfill.closest(target, ACTION_SELECTOR));
   }
 
   /**
@@ -229,7 +229,7 @@ class MDCSnackbar extends MDCComponent {
    * @private
    */
   isActionIcon_(target) {
-    return Boolean(ponyfill.closest(target, ACTION_ICON_SELECTOR));
+    return Boolean(ponyfill.closest(target, DISMISS_SELECTOR));
   }
 }
 

--- a/packages/mdc-snackbar/mdc-snackbar.scss
+++ b/packages/mdc-snackbar/mdc-snackbar.scss
@@ -130,22 +130,22 @@
   box-sizing: border-box;
 }
 
-.mdc-snackbar__action-button {
-  @include mdc-button-ink-color($mdc-snackbar-action-button-ink-color);
-  @include mdc-states($mdc-snackbar-action-button-ink-color);
+.mdc-snackbar__action {
+  @include mdc-button-ink-color($mdc-snackbar-action-ink-color);
+  @include mdc-states($mdc-snackbar-action-ink-color);
 }
 
-.mdc-snackbar__action-icon {
-  @include mdc-icon-button-ink-color($mdc-snackbar-action-icon-ink-color);
+.mdc-snackbar__dismiss {
+  @include mdc-icon-button-ink-color($mdc-snackbar-dismiss-ink-color);
 }
 
 // Two selectors are needed to increase specificity above `.material-icons`.
 // stylelint-disable-next-line selector-class-pattern
-.mdc-snackbar__action-icon.mdc-snackbar__action-icon {
+.mdc-snackbar__dismiss.mdc-snackbar__dismiss {
   @include mdc-icon-button-size($mdc-snackbar-action-icon-size);
 }
 
-.mdc-snackbar__action-button + .mdc-snackbar__action-icon {
+.mdc-snackbar__action + .mdc-snackbar__dismiss {
   @include mdc-rtl-reflexive-property(margin, $mdc-snackbar-padding, 0);
 }
 

--- a/packages/mdc-snackbar/mdc-snackbar.scss
+++ b/packages/mdc-snackbar/mdc-snackbar.scss
@@ -142,7 +142,7 @@
 // Two selectors are needed to increase specificity above `.material-icons`.
 // stylelint-disable-next-line selector-class-pattern
 .mdc-snackbar__dismiss.mdc-snackbar__dismiss {
-  @include mdc-icon-button-size($mdc-snackbar-action-icon-size);
+  @include mdc-icon-button-size($mdc-snackbar-dismiss-icon-size);
 }
 
 .mdc-snackbar__action + .mdc-snackbar__dismiss {

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -1195,30 +1195,30 @@
     }
   },
   "spec/mdc-snackbar/classes/baseline-without-action.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/12/05/21_03_57_990/spec/mdc-snackbar/classes/baseline-without-action.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/baseline-without-action.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/01_26_33_478/spec/mdc-snackbar/classes/baseline-without-action.html.windows_chrome_69.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/02_34_48_408/spec/mdc-snackbar/classes/baseline-without-action.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/12/05/21_03_57_990/spec/mdc-snackbar/classes/baseline-without-action.html.windows_firefox_63.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/01_26_33_478/spec/mdc-snackbar/classes/baseline-without-action.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/baseline-without-action.html.windows_chrome_71.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/baseline-without-action.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/baseline-without-action.html.windows_firefox_63.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/baseline-without-action.html.windows_ie_11.png"
     }
   },
   "spec/mdc-snackbar/classes/leading.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/12/05/21_03_57_990/spec/mdc-snackbar/classes/leading.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/leading.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/01_26_33_478/spec/mdc-snackbar/classes/leading.html.windows_chrome_69.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/02_34_48_408/spec/mdc-snackbar/classes/leading.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/12/05/21_03_57_990/spec/mdc-snackbar/classes/leading.html.windows_firefox_63.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/01_26_33_478/spec/mdc-snackbar/classes/leading.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/leading.html.windows_chrome_71.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/leading.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/leading.html.windows_firefox_63.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/leading.html.windows_ie_11.png"
     }
   },
   "spec/mdc-snackbar/classes/stacked.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/12/05/21_03_57_990/spec/mdc-snackbar/classes/stacked.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/stacked.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/01_26_33_478/spec/mdc-snackbar/classes/stacked.html.windows_chrome_69.png",
-      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/02_34_48_408/spec/mdc-snackbar/classes/stacked.html.windows_edge_17.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/12/05/21_03_57_990/spec/mdc-snackbar/classes/stacked.html.windows_firefox_63.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/11/13/01_26_33_478/spec/mdc-snackbar/classes/stacked.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/stacked.html.windows_chrome_71.png",
+      "desktop_windows_edge@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/stacked.html.windows_edge_17.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/stacked.html.windows_firefox_63.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/kfranqueiro/2018/12/20/16_29_02_542/spec/mdc-snackbar/classes/stacked.html.windows_ie_11.png"
     }
   },
   "spec/mdc-snackbar/mixins/elevation.html": {

--- a/test/screenshot/spec/mdc-snackbar/classes/baseline-with-action.html
+++ b/test/screenshot/spec/mdc-snackbar/classes/baseline-with-action.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/classes/baseline-without-action.html
+++ b/test/screenshot/spec/mdc-snackbar/classes/baseline-without-action.html
@@ -53,9 +53,6 @@
           <div class="mdc-snackbar__label"
                role="status"
                aria-live="polite">Message sent.</div>
-          <div class="mdc-snackbar__actions">
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
-          </div>
         </div>
       </div>
 

--- a/test/screenshot/spec/mdc-snackbar/classes/leading.html
+++ b/test/screenshot/spec/mdc-snackbar/classes/leading.html
@@ -53,8 +53,7 @@
                role="status"
                aria-live="polite">Your photo has been archived.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Undo</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Undo</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/classes/stacked.html
+++ b/test/screenshot/spec/mdc-snackbar/classes/stacked.html
@@ -53,8 +53,7 @@
                role="status"
                aria-live="polite">This item already has the label "travel". You can add a new label.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Add a new label</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Add a new label</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/mixins/elevation.html
+++ b/test/screenshot/spec/mdc-snackbar/mixins/elevation.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/mixins/fill-color.html
+++ b/test/screenshot/spec/mdc-snackbar/mixins/fill-color.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/mixins/label-ink-color.html
+++ b/test/screenshot/spec/mdc-snackbar/mixins/label-ink-color.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/mixins/max-width.html
+++ b/test/screenshot/spec/mdc-snackbar/mixins/max-width.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/mixins/min-width.html
+++ b/test/screenshot/spec/mdc-snackbar/mixins/min-width.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/mixins/shape-radius.html
+++ b/test/screenshot/spec/mdc-snackbar/mixins/shape-radius.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-snackbar/mixins/viewport-margin.html
+++ b/test/screenshot/spec/mdc-snackbar/mixins/viewport-margin.html
@@ -53,8 +53,8 @@
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>

--- a/test/unit/mdc-snackbar/mdc-snackbar.test.js
+++ b/test/unit/mdc-snackbar/mdc-snackbar.test.js
@@ -40,8 +40,8 @@ function getFixture() {
                role="status"
                aria-live="polite">Can't send photo. Retry in 5 seconds.</div>
           <div class="mdc-snackbar__actions">
-            <button type="button" class="mdc-button mdc-snackbar__action-button">Retry</button>
-            <button class="mdc-icon-button mdc-snackbar__action-icon material-icons" title="Dismiss">close</button>
+            <button type="button" class="mdc-button mdc-snackbar__action">Retry</button>
+            <button class="mdc-icon-button mdc-snackbar__dismiss material-icons" title="Dismiss">close</button>
           </div>
         </div>
       </div>
@@ -61,11 +61,11 @@ function getFixture() {
  */
 function setupTest(fixture = getFixture()) {
   const root = fixture.querySelector('.mdc-snackbar');
-  const surface = fixture.querySelector('.mdc-snackbar__surface');
-  const label = fixture.querySelector('.mdc-snackbar__label');
+  const surface = fixture.querySelector(strings.SURFACE_SELECTOR);
+  const label = fixture.querySelector(strings.LABEL_SELECTOR);
   const actions = fixture.querySelector('.mdc-snackbar__actions');
-  const actionButton = fixture.querySelector('.mdc-snackbar__action-button');
-  const actionIcon = fixture.querySelector('.mdc-snackbar__action-icon');
+  const actionButton = fixture.querySelector(strings.ACTION_SELECTOR);
+  const actionIcon = fixture.querySelector(strings.DISMISS_SELECTOR);
   const announce = td.func('announce');
   const component = new MDCSnackbar(root, undefined, () => announce);
   return {component, announce, root, surface, label, actions, actionButton, actionIcon};
@@ -81,11 +81,11 @@ function setupTest(fixture = getFixture()) {
  */
 function setupTestWithMocks(fixture = getFixture()) {
   const root = fixture.querySelector('.mdc-snackbar');
-  const surface = fixture.querySelector('.mdc-snackbar__surface');
-  const label = fixture.querySelector('.mdc-snackbar__label');
+  const surface = fixture.querySelector(strings.SURFACE_SELECTOR);
+  const label = fixture.querySelector(strings.LABEL_SELECTOR);
   const actions = fixture.querySelector('.mdc-snackbar__actions');
-  const actionButton = fixture.querySelector('.mdc-snackbar__action-button');
-  const actionIcon = fixture.querySelector('.mdc-snackbar__action-icon');
+  const actionButton = fixture.querySelector(strings.ACTION_SELECTOR);
+  const actionIcon = fixture.querySelector(strings.DISMISS_SELECTOR);
 
   const MockFoundationCtor = td.constructor(MDCSnackbarFoundation);
 


### PR DESCRIPTION
This revises the names of the action and dismiss elements to make them potentially more indicative and less bound to specifically being a button or icon, for potential future-proofing.

I've also revised our docs' wording a bit after talking to our designer again, who expressed serious reservations about featuring the dismiss icon as prominently as we were, at least until further discussion RE IxD and accessibility on his end.

(I'm not including a breaking change note, because this hasn't been released yet. All the better to revise classnames now.)