### PR TITLE
docs(dialog): rename handleClick for mdc-dialog to handleInteraction

### DIFF
--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -396,7 +396,7 @@ Method Signature | Description
 `setScrimClickAction(action: string)` | Sets the action reflected when the scrim is clicked. Setting to `''` disables closing the dialog via scrim click.
 `getAutoStackButtons() => boolean` | Returns whether stacked/unstacked action button layout is automatically handled during layout logic.
 `setAutoStackButtons(autoStack: boolean) => void` | Sets whether stacked/unstacked action button layout is automatically handled during layout logic.
-`handleClick(event: Event)` | Handles `click` events on or within the dialog's root element
+`handleInteraction(event: Event)` | Handles `click` and `keydown` events on or within the dialog's root element
 `handleDocumentKeydown(event: Event)` | Handles `keydown` events on or within the document while the dialog is open
 
 #### Event Handlers
@@ -405,7 +405,7 @@ When wrapping the Dialog foundation, the following events must be bound to the i
 
 Event | Target | Foundation Handler | Register | Deregister
 --- | --- | --- | --- | ---
-`click` | `.mdc-dialog` (root) | `handleClick` | During initialization | During destruction
+`click` | `.mdc-dialog` (root) | `handleInteraction` | During initialization | During destruction
 `keydown` | `document` | `handleDocumentKeydown` | On `MDCDialog:opening` | On `MDCDialog:closing`
 `resize` | `window` | `layout` | On `MDCDialog:opening` | On `MDCDialog:closing`
 `orientationchange` | `window` | `layout` | On `MDCDialog:opening` | On `MDCDialog:closing`


### PR DESCRIPTION
Looks like handleClick was renamed to handleInteraction, but it is not displayed in documentation