### PR TITLE
chore: Fix base component re-import statements.

### DIFF
--- a/packages/mdc-base/README.md
+++ b/packages/mdc-base/README.md
@@ -62,7 +62,7 @@ MDCFoundation provides the basic mechanisms for implementing foundation classes.
 - Provide `init()` and `destroy()` lifecycle methods
 
 ```javascript
-import {MDCFoundation} from '@material/base';
+import MDCFoundation from '@material/base/foundation';
 
 export default class MyFoundation extends MDCFoundation {
   static get cssClasses() {

--- a/packages/mdc-dialog/foundation.js
+++ b/packages/mdc-dialog/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/foundation';
+import MDCFoundation from '@material/base/foundation';
 import MDCDialogAdapter from './adapter';
 import {cssClasses, numbers, strings} from './constants';
 

--- a/packages/mdc-dialog/foundation.js
+++ b/packages/mdc-dialog/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/index';
+import {MDCFoundation} from '@material/base/foundation';
 import MDCDialogAdapter from './adapter';
 import {cssClasses, numbers, strings} from './constants';
 

--- a/packages/mdc-dialog/index.js
+++ b/packages/mdc-dialog/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/index';
+import {MDCComponent} from '@material/base/component';
 import {MDCRipple} from '@material/ripple/index';
 
 import MDCDialogFoundation from './foundation';

--- a/packages/mdc-dialog/index.js
+++ b/packages/mdc-dialog/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/component';
+import MDCComponent from '@material/base/component';
 import {MDCRipple} from '@material/ripple/index';
 
 import MDCDialogFoundation from './foundation';

--- a/packages/mdc-drawer/index.js
+++ b/packages/mdc-drawer/index.js
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import {MDCComponent} from '@material/base/component';
+import MDCComponent from '@material/base/component';
 import MDCDismissibleDrawerFoundation from './dismissible/foundation';
 import MDCModalDrawerFoundation from './modal/foundation';
 import MDCDrawerAdapter from './adapter';

--- a/packages/mdc-drawer/index.js
+++ b/packages/mdc-drawer/index.js
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import {MDCComponent} from '@material/base/index';
+import {MDCComponent} from '@material/base/component';
 import MDCDismissibleDrawerFoundation from './dismissible/foundation';
 import MDCModalDrawerFoundation from './modal/foundation';
 import MDCDrawerAdapter from './adapter';

--- a/packages/mdc-grid-list/foundation.js
+++ b/packages/mdc-grid-list/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/foundation';
+import MDCFoundation from '@material/base/foundation';
 import {strings} from './constants';
 
 export default class MDCGridListFoundation extends MDCFoundation {

--- a/packages/mdc-grid-list/foundation.js
+++ b/packages/mdc-grid-list/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/index';
+import {MDCFoundation} from '@material/base/foundation';
 import {strings} from './constants';
 
 export default class MDCGridListFoundation extends MDCFoundation {

--- a/packages/mdc-grid-list/index.js
+++ b/packages/mdc-grid-list/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/index';
+import {MDCComponent} from '@material/base/component';
 
 import MDCGridListFoundation from './foundation';
 

--- a/packages/mdc-grid-list/index.js
+++ b/packages/mdc-grid-list/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/component';
+import MDCComponent from '@material/base/component';
 
 import MDCGridListFoundation from './foundation';
 

--- a/packages/mdc-linear-progress/foundation.js
+++ b/packages/mdc-linear-progress/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/index';
+import {MDCFoundation} from '@material/base/foundation';
 import {transformStyleProperties} from '@material/animation/index';
 
 import {cssClasses, strings} from './constants';

--- a/packages/mdc-linear-progress/foundation.js
+++ b/packages/mdc-linear-progress/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/foundation';
+import MDCFoundation from '@material/base/foundation';
 import {transformStyleProperties} from '@material/animation/index';
 
 import {cssClasses, strings} from './constants';

--- a/packages/mdc-linear-progress/index.js
+++ b/packages/mdc-linear-progress/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/component';
+import MDCComponent from '@material/base/component';
 import MDCLinearProgressFoundation from './foundation';
 
 export {MDCLinearProgressFoundation};

--- a/packages/mdc-linear-progress/index.js
+++ b/packages/mdc-linear-progress/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/index';
+import {MDCComponent} from '@material/base/component';
 import MDCLinearProgressFoundation from './foundation';
 
 export {MDCLinearProgressFoundation};

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/foundation';
+import MDCFoundation from '@material/base/foundation';
 /* eslint-disable no-unused-vars */
 import {MDCSelectAdapter, FoundationMapType} from './adapter';
 import {MDCSelectIconFoundation} from './icon/index';

--- a/packages/mdc-select/foundation.js
+++ b/packages/mdc-select/foundation.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCFoundation} from '@material/base/index';
+import {MDCFoundation} from '@material/base/foundation';
 /* eslint-disable no-unused-vars */
 import {MDCSelectAdapter, FoundationMapType} from './adapter';
 import {MDCSelectIconFoundation} from './icon/index';

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/component';
+import MDCComponent from '@material/base/component';
 import {MDCFloatingLabel} from '@material/floating-label/index';
 import {MDCLineRipple} from '@material/line-ripple/index';
 import {MDCMenu} from '@material/menu/index';

--- a/packages/mdc-select/index.js
+++ b/packages/mdc-select/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/index';
+import {MDCComponent} from '@material/base/component';
 import {MDCFloatingLabel} from '@material/floating-label/index';
 import {MDCLineRipple} from '@material/line-ripple/index';
 import {MDCMenu} from '@material/menu/index';

--- a/packages/mdc-snackbar/foundation.js
+++ b/packages/mdc-snackbar/foundation.js
@@ -23,7 +23,7 @@
 
 /* eslint no-unused-vars: ["error", {"argsIgnorePattern": "evt", "varsIgnorePattern": "Adapter$"}] */
 
-import {MDCFoundation} from '@material/base/index';
+import {MDCFoundation} from '@material/base/foundation';
 import MDCSnackbarAdapter from './adapter';
 import {cssClasses, numbers, strings} from './constants';
 

--- a/packages/mdc-snackbar/foundation.js
+++ b/packages/mdc-snackbar/foundation.js
@@ -23,7 +23,7 @@
 
 /* eslint no-unused-vars: ["error", {"argsIgnorePattern": "evt", "varsIgnorePattern": "Adapter$"}] */
 
-import {MDCFoundation} from '@material/base/foundation';
+import MDCFoundation from '@material/base/foundation';
 import MDCSnackbarAdapter from './adapter';
 import {cssClasses, numbers, strings} from './constants';
 

--- a/packages/mdc-snackbar/index.js
+++ b/packages/mdc-snackbar/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/index';
+import {MDCComponent} from '@material/base/component';
 import MDCSnackbarFoundation from './foundation';
 import {strings} from './constants';
 import * as util from './util';

--- a/packages/mdc-snackbar/index.js
+++ b/packages/mdc-snackbar/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/component';
+import MDCComponent from '@material/base/component';
 import MDCSnackbarFoundation from './foundation';
 import {strings} from './constants';
 import * as util from './util';

--- a/packages/mdc-toolbar/index.js
+++ b/packages/mdc-toolbar/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/component';
+import MDCComponent from '@material/base/component';
 import {MDCRipple} from '@material/ripple/index';
 
 import MDCToolbarFoundation from './foundation';

--- a/packages/mdc-toolbar/index.js
+++ b/packages/mdc-toolbar/index.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCComponent} from '@material/base/index';
+import {MDCComponent} from '@material/base/component';
 import {MDCRipple} from '@material/ripple/index';
 
 import MDCToolbarFoundation from './foundation';

--- a/test/unit/mdc-base/component.test.js
+++ b/test/unit/mdc-base/component.test.js
@@ -25,7 +25,7 @@ import {assert} from 'chai';
 import domEvents from 'dom-events';
 import td from 'testdouble';
 
-import {MDCComponent} from '../../../packages/mdc-base/index';
+import MDCComponent from '../../../packages/mdc-base/component';
 
 class FakeComponent extends MDCComponent {
   get root() {

--- a/test/unit/mdc-base/foundation.test.js
+++ b/test/unit/mdc-base/foundation.test.js
@@ -22,7 +22,7 @@
  */
 
 import {assert} from 'chai';
-import {MDCFoundation} from '../../../packages/mdc-base/index';
+import MDCFoundation from '../../../packages/mdc-base/foundation';
 
 class FakeFoundation extends MDCFoundation {
   get adapter() {


### PR DESCRIPTION
As per [closure-compiler](https://github.com/material-components/material-components-web/blob/master/docs/closure-compiler.md#all-import-statements-must-not-use-re-exported-modules) doc, all import statements must not use re-exported modules.

Fixes #4211