### PR TITLE
refactor(tab-scroller): Fix a Closure type declaration in the Tab Scroller util.

### DIFF
--- a/packages/mdc-tab-scroller/util.js
+++ b/packages/mdc-tab-scroller/util.js
@@ -56,7 +56,7 @@ function computeHorizontalScrollbarHeight(documentObj, shouldCacheResult = true)
 
 /**
  * @param {!Object} HTMLElementPrototype
- * @return {!Array<string>}
+ * @return {string}
  */
 function getMatchesProperty(HTMLElementPrototype) {
   return [


### PR DESCRIPTION
getMatchesProperty returns Array.pop() from an Array of strings, so the return value should be string.