### PR TITLE
fix(feature-targeting): prevent accidental nesting of mdc-feature-targets mixin

### DIFF
--- a/packages/mdc-feature-targeting/_mixins.scss
+++ b/packages/mdc-feature-targeting/_mixins.scss
@@ -28,7 +28,7 @@ $mdc-feature-targets-context_: false;
 // Mixin that annotates the contained styles as applying to specific cross-cutting features
 // indicated by the given list of feature targets.
 @mixin mdc-feature-targets($feature-targets...) {
-  // Prevent accidnetal nesting of this mixin, which could lead to unexpected results.
+  // Prevent accidental nesting of this mixin, which could lead to unexpected results.
   @if $mdc-feature-targets-context_ {
     @error "mdc-feature-targets must not be used inside of another mdc-feature-targets block";
   }

--- a/packages/mdc-feature-targeting/_mixins.scss
+++ b/packages/mdc-feature-targeting/_mixins.scss
@@ -22,12 +22,23 @@
 
 @import "./functions";
 
+// Tracks whether the current context is inside a `mdc-feature-targets` mixin.
+$mdc-feature-targets-context_: false;
+
 // Mixin that annotates the contained styles as applying to specific cross-cutting features
 // indicated by the given list of feature targets.
 @mixin mdc-feature-targets($feature-targets...) {
+  // Prevent accidnetal nesting of this mixin, which could lead to unexpected results.
+  @if $mdc-feature-targets-context_ {
+    @error "mdc-feature-targets must not be used inside of another mdc-feature-targets block";
+  }
+
+  $mdc-feature-targets-context_: true !global;
   $parsed-targets: mdc-feature-parse-targets($feature-targets);
 
   @if mdc-feature-is-query-satisfied_(map-get($parsed-targets, query), map-get($parsed-targets, available)) {
     @content;
   }
+
+  $mdc-feature-targets-context_: false !global;
 }


### PR DESCRIPTION
Nesting this mixin could lead to unexpected results. (e.g. the following property would not get emitted if the color styles were requested)

```scss
@include mdc-feature-targets($feat-structure) {
  @include mdc-feature-targets($feat-color) {
    color: red;
  }
}
```

This PR makes the above pattern an error by using a global variable to track when we're inside the mixin and raise an error if the mixin is included again in that context.