### PR TITLE
Adding label setter to MDCTextField

### DIFF
--- a/packages/mdc-floating-label/adapter.js
+++ b/packages/mdc-floating-label/adapter.js
@@ -53,6 +53,12 @@ class MDCFloatingLabelAdapter {
   getWidth() {}
 
   /**
+   * Sets the text content for the label element.
+   * @param {string} content
+   */
+  setContent(content) { }
+
+  /**
    * Registers an event listener on the root element for a given event.
    * @param {string} evtType
    * @param {function(!Event): undefined} handler

--- a/packages/mdc-floating-label/foundation.js
+++ b/packages/mdc-floating-label/foundation.js
@@ -45,6 +45,7 @@ class MDCFloatingLabelFoundation extends MDCFoundation {
       addClass: () => {},
       removeClass: () => {},
       getWidth: () => {},
+      setContent: () => {},
       registerInteractionHandler: () => {},
       deregisterInteractionHandler: () => {},
     });
@@ -74,6 +75,14 @@ class MDCFloatingLabelFoundation extends MDCFoundation {
    */
   getWidth() {
     return this.adapter_.getWidth();
+  }
+
+  /**
+   * Sets the content of the label field.
+   * @param {string} content
+   */
+  setContent(content) {
+    this.adapter_.setContent(content);
   }
 
   /**

--- a/packages/mdc-floating-label/index.js
+++ b/packages/mdc-floating-label/index.js
@@ -71,6 +71,9 @@ class MDCFloatingLabel extends MDCComponent {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
       getWidth: () => this.root_.scrollWidth,
+      setContent: (content) => {
+        this.root_.textContent = content;
+      },
       registerInteractionHandler: (evtType, handler) => this.root_.addEventListener(evtType, handler),
       deregisterInteractionHandler: (evtType, handler) => this.root_.removeEventListener(evtType, handler),
     });

--- a/packages/mdc-textfield/adapter.js
+++ b/packages/mdc-textfield/adapter.js
@@ -24,6 +24,7 @@
 /* eslint-disable no-unused-vars */
 import MDCTextFieldHelperTextFoundation from './helper-text/foundation';
 import MDCTextFieldIconFoundation from './icon/foundation';
+import MDCFloatingLabelFoundation from '@material/floating-label/index';
 
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
@@ -43,6 +44,7 @@ let NativeInputType;
 /**
  * @typedef {{
  *   helperText: (!MDCTextFieldHelperTextFoundation|undefined),
+ *   label: (!MDCFloatingLabelFoundation|undefined,)
  *   leadingIcon: (!MDCTextFieldIconFoundation|undefined),
  *   trailingIcon: (!MDCTextFieldIconFoundation|undefined),
  * }}

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -30,7 +30,6 @@ import MDCFloatingLabelFoundation from '@material/floating-label/index';
 import {MDCTextFieldAdapter, NativeInputType, FoundationMapType} from './adapter';
 import {cssClasses, strings, numbers, VALIDATION_ATTR_WHITELIST, ALWAYS_FLOAT_TYPES} from './constants';
 
-
 /**
  * @extends {MDCFoundation<!MDCTextFieldAdapter>}
  * @final
@@ -107,7 +106,6 @@ class MDCTextFieldFoundation extends MDCFoundation {
    */
   constructor(adapter, foundationMap = /** @type {!FoundationMapType} */ ({})) {
     super(Object.assign(MDCTextFieldFoundation.defaultAdapter, adapter));
-
     /** @type {!MDCTextFieldHelperTextFoundation|undefined} */
     this.helperText_ = foundationMap.helperText;
     /** @type {!MDCFloatingLabelFoundation|undefined} */

--- a/packages/mdc-textfield/foundation.js
+++ b/packages/mdc-textfield/foundation.js
@@ -25,9 +25,11 @@ import MDCFoundation from '@material/base/foundation';
 /* eslint-disable no-unused-vars */
 import MDCTextFieldHelperTextFoundation from './helper-text/foundation';
 import MDCTextFieldIconFoundation from './icon/foundation';
+import MDCFloatingLabelFoundation from '@material/floating-label/index';
 /* eslint-enable no-unused-vars */
 import {MDCTextFieldAdapter, NativeInputType, FoundationMapType} from './adapter';
 import {cssClasses, strings, numbers, VALIDATION_ATTR_WHITELIST, ALWAYS_FLOAT_TYPES} from './constants';
+
 
 /**
  * @extends {MDCFoundation<!MDCTextFieldAdapter>}
@@ -108,6 +110,8 @@ class MDCTextFieldFoundation extends MDCFoundation {
 
     /** @type {!MDCTextFieldHelperTextFoundation|undefined} */
     this.helperText_ = foundationMap.helperText;
+    /** @type {!MDCFloatingLabelFoundation|undefined} */
+    this.label_ = foundationMap.label;
     /** @type {!MDCTextFieldIconFoundation|undefined} */
     this.leadingIcon_ = foundationMap.leadingIcon;
     /** @type {!MDCTextFieldIconFoundation|undefined} */
@@ -356,6 +360,15 @@ class MDCTextFieldFoundation extends MDCFoundation {
   setHelperTextContent(content) {
     if (this.helperText_) {
       this.helperText_.setContent(content);
+    }
+  }
+
+  /**
+   * @param {string} content Sets the content of the label.
+   */
+  setLabelContent(content) {
+    if (this.label_) {
+      this.label_.setContent(content);
     }
   }
 

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -370,6 +370,14 @@ class MDCTextField extends MDCComponent {
   }
 
   /**
+   * Sets the label element content.
+   * @param {string} content
+   */
+  set labelContent(content) {
+    this.foundation_.setLabelContent(content);
+  }
+
+  /**
    * Focuses the input element.
    */
   focus() {

--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -502,9 +502,10 @@ class MDCTextField extends MDCComponent {
    */
   getFoundationMap_() {
     return {
-      helperText: this.helperText_ ? this.helperText_.foundation : undefined,
-      leadingIcon: this.leadingIcon_ ? this.leadingIcon_.foundation : undefined,
-      trailingIcon: this.trailingIcon_ ? this.trailingIcon_.foundation : undefined,
+      helperText: this.helperText_ ? this.helperText_.foundation_ : undefined,
+      label: this.label_ ? this.label_.foundation_ : undefined,
+      leadingIcon: this.leadingIcon_ ? this.leadingIcon_.foundation_ : undefined,
+      trailingIcon: this.trailingIcon_ ? this.trailingIcon_.foundation_ : undefined,
     };
   }
 }

--- a/test/unit/mdc-floating-label/mdc-floating-label-foundation.test.js
+++ b/test/unit/mdc-floating-label/mdc-floating-label-foundation.test.js
@@ -40,7 +40,7 @@ test('exports cssClasses', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCFloatingLabelFoundation, [
-    'addClass', 'removeClass', 'getWidth',
+    'addClass', 'removeClass', 'getWidth', 'setContent',
     'registerInteractionHandler', 'deregisterInteractionHandler',
   ]);
 });

--- a/test/unit/mdc-floating-label/mdc-floating-label.test.js
+++ b/test/unit/mdc-floating-label/mdc-floating-label.test.js
@@ -81,3 +81,10 @@ test('#adapter.getWidth returns the width of the label element', () => {
   const {root, component} = setupTest();
   assert.equal(component.getDefaultFoundation().adapter_.getWidth(), root.offsetWidth);
 });
+
+test('#adapter.setContent sets the content of the label element', () => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setContent('foo');
+  assert.equal(root.textContent, 'foo');
+});
+

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -63,6 +63,14 @@ const setupTest = () => {
     showToScreenReader: () => {},
     setValidity: () => {},
   });
+  const label = td.object({
+    addClass: () => {},
+    removeClass: () => {},
+    getWidth: () => {},
+    setContent: () => {},
+    registerInteractionHandler: () => {},
+    deregisterInteractionHandler: () => {},
+  });
   const leadingIcon = td.object({
     setDisabled: () => {},
     setAriaLabel: () => {},
@@ -81,11 +89,12 @@ const setupTest = () => {
   });
   const foundationMap = {
     helperText,
+    label,
     leadingIcon,
     trailingIcon,
   };
   const foundation = new MDCTextFieldFoundation(mockAdapter, foundationMap);
-  return {foundation, mockAdapter, helperText, leadingIcon, trailingIcon};
+  return {foundation, mockAdapter, helperText, label, leadingIcon, trailingIcon};
 };
 
 test('#constructor sets disabled to false', () => {
@@ -402,6 +411,12 @@ test('#setHelperTextContent sets the content of the helper text element', () => 
   const {foundation, helperText} = setupTest();
   foundation.setHelperTextContent('foo');
   td.verify(helperText.setContent('foo'));
+});
+
+test('#setLabelContent sets the content of the label element', () => {
+  const {foundation, label} = setupTest();
+  foundation.setLabelContent('foo');
+  td.verify(label.setContent('foo'));
 });
 
 test('#setLeadingIconAriaLabel sets the aria-label of the leading icon element', () => {

--- a/test/unit/mdc-textfield/mdc-text-field.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field.test.js
@@ -325,6 +325,13 @@ test('set iconContent has no effect when no icon element is present', () => {
   });
 });
 
+test('set labelContent has no effect when no label element is present', () => {
+  const {component} = setupTest();
+  assert.doesNotThrow(() => {
+    component.labelContent = 'foo';
+  });
+});
+
 test('#adapter.addClass adds a class to the root element', () => {
   const {root, component} = setupTest();
   component.getDefaultFoundation().adapter_.addClass('foo');
@@ -468,6 +475,12 @@ test('get/set valid', () => {
   td.verify(mockFoundation.isValid());
   component.valid = true;
   td.verify(mockFoundation.setValid(true));
+});
+
+test('get/set label content', () => {
+  const {component, mockFoundation} = setupMockFoundationTest();
+  component.labelContent = 'foo';
+  td.verify(mockFoundation.setLabelContent('foo'));
 });
 
 test('get/set required', () => {


### PR DESCRIPTION
Taking a stab at #2258
* Added `setLabelContent()` to MDCTextfield and foundation
* Added `setContent()` to MDCFloatingLabel
* Fixed bug in `getFoundationMap_()` where `foundation_` was missing the trailing underscore, resulting in `undefined` fields