### PR TITLE
fix(text-field): Update closure type for rippleFactory

### DIFF
--- a/packages/mdc-textfield/index.js
+++ b/packages/mdc-textfield/index.js
@@ -76,7 +76,7 @@ class MDCTextField extends MDCComponent {
   }
 
   /**
-   * @param {(function(!Element): !MDCRipple)=} rippleFactory A function which
+   * @param {(function(!Element, MDCRippleFoundation): !MDCRipple)=} rippleFactory A function which
    * creates a new MDCRipple.
    * @param {(function(!Element): !MDCLineRipple)=} lineRippleFactory A function which
    * creates a new MDCLineRipple.


### PR DESCRIPTION
The function takes 2 parameters but the jsdoc only documented one.