### PR TITLE
chore: Fix stylelint error code reporting for packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fix:js": "eslint --fix packages test webpack.config.js demos/webpack.config.js karma.conf.js",
     "fix:css": "stylelint --fix \"packages/**/*.scss\"; stylelint --fix --config=test/screenshot/.stylelintrc.yaml \"test/screenshot/**/*.scss\"",
     "fix": "npm-run-all --parallel fix:*",
-    "lint:css": "stylelint \"packages/**/*.scss\"; stylelint --config=test/screenshot/.stylelintrc.yaml \"test/screenshot/**/*.scss\"",
+    "lint:css": "stylelint \"packages/**/*.scss\" && stylelint --config=test/screenshot/.stylelintrc.yaml \"test/screenshot/**/*.scss\"",
     "lint:js": "eslint packages test scripts webpack.config.js demos/webpack.config.js karma.conf.js",
     "lint:html": "find test/screenshot/spec/ -name '*.html' | grep -v 'index.html$' | xargs htmllint",
     "lint:imports": "node scripts/check-imports.js",


### PR DESCRIPTION
Our lint task has not been failing on CI for stylelint failures under `packages` for a few months because of a `;` added to its invocation, because that completely discards the exit code from the first command.