### PR TITLE
feat(base): Add generic type signatures to listen/unlisten/emit

### DIFF
--- a/packages/mdc-base/component.ts
+++ b/packages/mdc-base/component.ts
@@ -22,6 +22,7 @@
  */
 
 import MDCFoundation from './foundation';
+import {CustomEventListener, EventType, SpecificEventListener} from './types';
 
 class MDCComponent<FoundationType extends MDCFoundation> {
 
@@ -82,6 +83,8 @@ class MDCComponent<FoundationType extends MDCFoundation> {
    * Wrapper method to add an event listener to the component's root element. This is most useful when
    * listening for custom events.
    */
+  listen<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
+  listen<E extends Event>(evtType: string, handler: CustomEventListener<E>): void;
   listen(evtType: string, handler: EventListener) {
     this.root_.addEventListener(evtType, handler);
   }
@@ -90,6 +93,8 @@ class MDCComponent<FoundationType extends MDCFoundation> {
    * Wrapper method to remove an event listener to the component's root element. This is most useful when
    * unlistening for custom events.
    */
+  unlisten<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
+  unlisten<E extends Event>(evtType: string, handler: CustomEventListener<E>): void;
   unlisten(evtType: string, handler: EventListener) {
     this.root_.removeEventListener(evtType, handler);
   }
@@ -98,10 +103,10 @@ class MDCComponent<FoundationType extends MDCFoundation> {
    * Fires a cross-browser-compatible custom event from the component root of the given type,
    * with the given data.
    */
-  emit(evtType: string, evtData: object, shouldBubble = false) {
-    let evt;
+  emit<T extends object>(evtType: string, evtData: T, shouldBubble = false) {
+    let evt: CustomEvent<T>;
     if (typeof CustomEvent === 'function') {
-      evt = new CustomEvent(evtType, {
+      evt = new CustomEvent<T>(evtType, {
         bubbles: shouldBubble,
         detail: evtData,
       });

--- a/packages/mdc-base/index.ts
+++ b/packages/mdc-base/index.ts
@@ -23,5 +23,6 @@
 
 import MDCComponent from './component';
 import MDCFoundation from './foundation';
+import {CustomEventListener, EventType, SpecificEventListener} from './types';
 
-export {MDCFoundation, MDCComponent};
+export {MDCFoundation, MDCComponent, CustomEventListener, EventType, SpecificEventListener};

--- a/packages/mdc-base/types.ts
+++ b/packages/mdc-base/types.ts
@@ -23,3 +23,4 @@
 
 export type EventType = keyof GlobalEventHandlersEventMap;
 export type SpecificEventListener<K extends EventType> = (evt: GlobalEventHandlersEventMap[K]) => void;
+export type CustomEventListener<E extends Event> = (evt: E) => void;

--- a/packages/mdc-checkbox/adapter.ts
+++ b/packages/mdc-checkbox/adapter.ts
@@ -22,22 +22,12 @@
  */
 
 /**
- * Adapter for MDC Checkbox. Provides an interface for managing
- * - classes
- * - dom
- * - event handlers
- *
- * Additionally, provides type information for the adapter to the Closure
- * compiler.
- *
+ * Defines the shape of the adapter expected by the foundation.
  * Implement this adapter for your framework of choice to delegate updates to
  * the component in your framework of choice. See architecture documentation
  * for more details.
  * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
- *
- * @record
  */
-
 interface MDCCheckboxAdapter {
   addClass(className: string): void;
   forceLayout(): void;
@@ -46,13 +36,7 @@ interface MDCCheckboxAdapter {
   isChecked(): boolean;
   isIndeterminate(): boolean;
   removeClass(className: string): void;
-  /**
-   * Removes an attribute from the input element.
-   */
   removeNativeControlAttr(attr: string): void;
-  /**
-   * Sets an attribute with a given value on the input element.
-   */
   setNativeControlAttr(attr: string, value: string): void;
   setNativeControlDisabled(disabled: boolean): void;
 }

--- a/packages/mdc-checkbox/index.ts
+++ b/packages/mdc-checkbox/index.ts
@@ -23,7 +23,7 @@
 
 import {getCorrectEventName} from '@material/animation/index';
 import MDCComponent from '@material/base/component';
-import {EventType, SpecificEventListener} from '@material/base/types';
+import {EventType, SpecificEventListener} from '@material/base/index';
 import {MDCRipple, MDCRippleFoundation, RippleCapableSurface, util} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';
 

--- a/packages/mdc-checkbox/index.ts
+++ b/packages/mdc-checkbox/index.ts
@@ -23,7 +23,7 @@
 
 import {getCorrectEventName} from '@material/animation/index';
 import MDCComponent from '@material/base/component';
-import {EventType, SpecificEventListener} from '@material/dom/index';
+import {EventType, SpecificEventListener} from '@material/base/types';
 import {MDCRipple, MDCRippleFoundation, RippleCapableSurface, util} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';
 

--- a/packages/mdc-checkbox/package.json
+++ b/packages/mdc-checkbox/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@material/animation": "^0.41.0",
     "@material/base": "^0.41.0",
-    "@material/dom": "^0.41.0",
     "@material/ripple": "^0.44.0",
     "@material/rtl": "^0.42.0",
     "@material/selection-control": "^0.44.0",

--- a/packages/mdc-dom/index.ts
+++ b/packages/mdc-dom/index.ts
@@ -21,7 +21,6 @@
  * THE SOFTWARE.
  */
 
-import {EventType, SpecificEventListener} from './events';
 import * as ponyfill from './ponyfill';
 
-export {ponyfill, EventType, SpecificEventListener};
+export {ponyfill};

--- a/packages/mdc-form-field/adapter.ts
+++ b/packages/mdc-form-field/adapter.ts
@@ -30,9 +30,7 @@
  * the component in your framework of choice. See architecture documentation
  * for more details.
  * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
- *
  */
-
 interface MDCFormFieldAdapter {
   activateInputRipple(): void;
   deactivateInputRipple(): void;

--- a/packages/mdc-icon-button/adapter.js
+++ b/packages/mdc-icon-button/adapter.js
@@ -24,16 +24,7 @@
 /* eslint no-unused-vars: [2, {"args": "none"}] */
 
 /**
- * Adapter for MDC Icon Button Toggle. Provides an interface for managing
- * - classes
- * - dom
- * - inner text
- * - event handlers
- * - event dispatch
- *
- * Additionally, provides type information for the adapter to the Closure
- * compiler.
- *
+ * Defines the shape of the adapter expected by the foundation.
  * Implement this adapter for your framework of choice to delegate updates to
  * the component in your framework of choice. See architecture documentation
  * for more details.

--- a/packages/mdc-linear-progress/adapter.ts
+++ b/packages/mdc-linear-progress/adapter.ts
@@ -21,6 +21,13 @@
  * THE SOFTWARE.
  */
 
+/**
+ * Defines the shape of the adapter expected by the foundation.
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
+ */
 interface MDCLinearProgressAdapter {
   addClass(className: string): void;
   getBuffer(): HTMLElement | null;

--- a/packages/mdc-menu-surface/adapter.ts
+++ b/packages/mdc-menu-surface/adapter.ts
@@ -24,6 +24,7 @@
 import {MenuDimensions, MenuDistance, MenuPoint} from './types';
 
 /**
+ * Defines the shape of the adapter expected by the foundation.
  * Implement this adapter for your framework of choice to delegate updates to
  * the component in your framework of choice. See architecture documentation
  * for more details.

--- a/packages/mdc-menu-surface/index.ts
+++ b/packages/mdc-menu-surface/index.ts
@@ -22,7 +22,7 @@
  */
 
 import MDCComponent from '@material/base/component';
-import {SpecificEventListener} from '@material/base/types';
+import {SpecificEventListener} from '@material/base/index';
 import {Corner, CornerBit, cssClasses, strings} from './constants';
 import {MDCMenuSurfaceFoundation} from './foundation';
 import {MenuDimensions, MenuDistance, MenuPoint} from './types';

--- a/packages/mdc-menu-surface/index.ts
+++ b/packages/mdc-menu-surface/index.ts
@@ -22,7 +22,7 @@
  */
 
 import MDCComponent from '@material/base/component';
-import {SpecificEventListener} from '@material/dom/index';
+import {SpecificEventListener} from '@material/base/types';
 import {Corner, CornerBit, cssClasses, strings} from './constants';
 import {MDCMenuSurfaceFoundation} from './foundation';
 import {MenuDimensions, MenuDistance, MenuPoint} from './types';

--- a/packages/mdc-menu-surface/package.json
+++ b/packages/mdc-menu-surface/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@material/animation": "^0.41.0",
     "@material/base": "^0.41.0",
-    "@material/dom": "^0.41.0",
     "@material/elevation": "^0.44.0",
     "@material/rtl": "^0.42.0",
     "@material/shape": "^0.43.0",

--- a/packages/mdc-radio/adapter.ts
+++ b/packages/mdc-radio/adapter.ts
@@ -22,15 +22,12 @@
  */
 
 /**
- * Adapter for MDC Radio. Provides an interface for managing
- *
+ * Defines the shape of the adapter expected by the foundation.
  * Implement this adapter for your framework of choice to delegate updates to
  * the component in your framework of choice. See architecture documentation
  * for more details.
  * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
- *
  */
-
 interface MDCRadioAdapter {
   addClass(className: string): void;
   removeClass(className: string): void;

--- a/packages/mdc-radio/index.ts
+++ b/packages/mdc-radio/index.ts
@@ -22,7 +22,7 @@
  */
 
 import MDCComponent from '@material/base/component';
-import {EventType, SpecificEventListener} from '@material/dom/index';
+import {EventType, SpecificEventListener} from '@material/base/types';
 import {RippleCapableSurface} from '@material/ripple/index';
 import {MDCRipple, MDCRippleFoundation} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';

--- a/packages/mdc-radio/index.ts
+++ b/packages/mdc-radio/index.ts
@@ -22,7 +22,7 @@
  */
 
 import MDCComponent from '@material/base/component';
-import {EventType, SpecificEventListener} from '@material/base/types';
+import {EventType, SpecificEventListener} from '@material/base/index';
 import {RippleCapableSurface} from '@material/ripple/index';
 import {MDCRipple, MDCRippleFoundation} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';

--- a/packages/mdc-radio/package.json
+++ b/packages/mdc-radio/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@material/animation": "^0.41.0",
     "@material/base": "^0.41.0",
-    "@material/dom": "^0.41.0",
     "@material/ripple": "^0.44.0",
     "@material/selection-control": "^0.44.0",
     "@material/theme": "^0.43.0"

--- a/packages/mdc-ripple/adapter.ts
+++ b/packages/mdc-ripple/adapter.ts
@@ -41,7 +41,7 @@
  * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
  *
  */
-import {EventType, SpecificEventListener} from '@material/dom/index';
+import {EventType, SpecificEventListener} from '@material/base/types';
 
 interface Point {
   x: number;

--- a/packages/mdc-ripple/adapter.ts
+++ b/packages/mdc-ripple/adapter.ts
@@ -68,4 +68,4 @@ interface MDCRippleAdapter {
   getWindowPageOffset(): Point;
 }
 
-export {MDCRippleAdapter as default, Point};
+export {MDCRippleAdapter as default, MDCRippleAdapter, Point};

--- a/packages/mdc-ripple/adapter.ts
+++ b/packages/mdc-ripple/adapter.ts
@@ -22,13 +22,10 @@
  */
 
 import {EventType, SpecificEventListener} from '@material/base/types';
-
-interface Point {
-  x: number;
-  y: number;
-}
+import {Point} from './types';
 
 /**
+ * Defines the shape of the adapter expected by the foundation.
  * Implement this adapter for your framework of choice to delegate updates to
  * the component in your framework of choice. See architecture documentation
  * for more details.
@@ -61,11 +58,11 @@ interface MDCRippleAdapter {
 
   deregisterResizeHandler(handler: SpecificEventListener<'resize'>): void;
 
-  updateCssVariable(varName: string, value: string|null): void;
+  updateCssVariable(varName: string, value: string | null): void;
 
   computeBoundingRect(): ClientRect;
 
   getWindowPageOffset(): Point;
 }
 
-export {MDCRippleAdapter as default, MDCRippleAdapter, Point};
+export {MDCRippleAdapter as default, MDCRippleAdapter};

--- a/packages/mdc-ripple/adapter.ts
+++ b/packages/mdc-ripple/adapter.ts
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {EventType, SpecificEventListener} from '@material/base/types';
+import {EventType, SpecificEventListener} from '@material/base/index';
 import {Point} from './types';
 
 /**

--- a/packages/mdc-ripple/foundation.ts
+++ b/packages/mdc-ripple/foundation.ts
@@ -22,8 +22,9 @@
  */
 
 import MDCFoundation from '@material/base/foundation';
-import MDCRippleAdapter, {Point} from './adapter';
+import MDCRippleAdapter from './adapter';
 import {cssClasses, numbers, strings} from './constants';
+import {Point} from './types';
 import {getNormalizedEventCoords} from './util';
 
 interface ActivationStateType {

--- a/packages/mdc-ripple/package.json
+++ b/packages/mdc-ripple/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@material/animation": "^0.41.0",
-    "@material/dom": "^0.41.0",
     "@material/base": "^0.41.0",
     "@material/feature-targeting": "^0.44.0",
     "@material/theme": "^0.43.0"

--- a/packages/mdc-ripple/types.ts
+++ b/packages/mdc-ripple/types.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2019 Google Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,33 +21,7 @@
  * THE SOFTWARE.
  */
 
-/**
- * Defines the shape of the adapter expected by the foundation.
- * Implement this adapter for your framework of choice to delegate updates to
- * the component in your framework of choice. See architecture documentation
- * for more details.
- * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
- */
-interface MDCSwitchAdapter {
-  /**
-   * Adds a CSS class to the root element.
-   */
-  addClass(className: string): void;
-
-  /**
-   * Removes a CSS class from the root element.
-   */
-  removeClass(className: string): void;
-
-  /**
-   * Sets checked state of the native HTML control underlying the switch.
-   */
-  setNativeControlChecked(checked: boolean): void;
-
-  /**
-   * Sets the disabled state of the native HTML control underlying the switch.
-   */
-  setNativeControlDisabled(disabled: boolean): void;
+export interface Point {
+  x: number;
+  y: number;
 }
-
-export {MDCSwitchAdapter as default, MDCSwitchAdapter};

--- a/packages/mdc-ripple/util.ts
+++ b/packages/mdc-ripple/util.ts
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import {Point} from './adapter';
+import {Point} from './types';
 
 /**
  * Stores result from supportsCssVariables to avoid redundant processing to


### PR DESCRIPTION
Also moves `mdc-dom/events.ts` to `mdc-base/types.ts`
and adds `CustomEventListener<E extends Event>` type.