### PR TITLE
fix(chips): Use required pixel value

### DIFF
--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -82,7 +82,7 @@
   }
 }
 
-@mixin mdc-chip-outline($width: 1, $style: solid, $color: mdc-theme-prop-value(on-surface)) {
+@mixin mdc-chip-outline($width: 1px, $style: solid, $color: mdc-theme-prop-value(on-surface)) {
   @include mdc-chip-outline-width($width);
   @include mdc-chip-outline-style($style);
   @include mdc-chip-outline-color($color);


### PR DESCRIPTION
`border-width` requires a unit and has a weird default value: https://jsfiddle.net/04j5sqzw/1/. This change fixes that behavior.