### PR TITLE
fix(chips): Flip leading icon margin when used in RTL contexts (#4379)

### DIFF
--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -22,6 +22,7 @@
 
 @import "@material/elevation/mixins";
 @import "@material/ripple/mixins";
+@import "@material/rtl/mixins";
 @import "@material/theme/functions";
 @import "@material/theme/mixins";
 @import "@material/shape/mixins";

--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -174,7 +174,9 @@
   $left: $mdc-chip-leading-icon-margin-left) {
   &.mdc-chip--selected .mdc-chip__checkmark,
   .mdc-chip__icon--leading:not(.mdc-chip__icon--leading-hidden) {
-    margin: $top $right $bottom $left;
+    @include mdc-rtl-reflexive-property(margin, $left, $right);
+    margin-bottom: $bottom;
+    margin-top: $top;
   }
 }
 

--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -175,8 +175,9 @@
   &.mdc-chip--selected .mdc-chip__checkmark,
   .mdc-chip__icon--leading:not(.mdc-chip__icon--leading-hidden) {
     @include mdc-rtl-reflexive-property(margin, $left, $right);
-    margin-bottom: $bottom;
+
     margin-top: $top;
+    margin-bottom: $bottom;
   }
 }
 


### PR DESCRIPTION
This fixes the margin of leading icons inside Chips from being applied to the incorrect side of the icon when the Chip appears in a page with RTL writing mode.

Fixes #4379.