### PR TITLE
chore: Remove Object.assign from TS files

### DIFF
--- a/packages/mdc-base/component.ts
+++ b/packages/mdc-base/component.ts
@@ -51,6 +51,7 @@ class MDCComponent<FoundationType extends MDCFoundation> {
     this.initialSyncWithDOM();
   }
 
+  /* istanbul ignore next: method param only exists for typing purposes; it does not need to be unit tested */
   // tslint:disable-next-line:no-any a component can pass in anything it needs to initialize
   initialize(..._args: any[]) {
     // Subclasses can override this to do any additional setup work that would be considered part of a

--- a/packages/mdc-checkbox/foundation.ts
+++ b/packages/mdc-checkbox/foundation.ts
@@ -58,7 +58,7 @@ class MDCCheckboxFoundation extends MDCFoundation<MDCCheckboxAdapter> {
   private animEndLatchTimer_ = 0;
   private enableAnimationEndHandler_ = false;
 
-  constructor(adapter: Partial<MDCCheckboxAdapter> = {}) {
+  constructor(adapter?: Partial<MDCCheckboxAdapter>) {
     super({...MDCCheckboxFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-checkbox/foundation.ts
+++ b/packages/mdc-checkbox/foundation.ts
@@ -58,8 +58,8 @@ class MDCCheckboxFoundation extends MDCFoundation<MDCCheckboxAdapter> {
   private animEndLatchTimer_ = 0;
   private enableAnimationEndHandler_ = false;
 
-  constructor(adapter: MDCCheckboxAdapter) {
-    super(Object.assign(MDCCheckboxFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCCheckboxAdapter> = {}) {
+    super({...MDCCheckboxFoundation.defaultAdapter, ...adapter});
   }
 
   init() {

--- a/packages/mdc-checkbox/index.ts
+++ b/packages/mdc-checkbox/index.ts
@@ -24,11 +24,11 @@
 import {getCorrectEventName} from '@material/animation/index';
 import {MDCComponent} from '@material/base/component';
 import {EventType, SpecificEventListener} from '@material/base/index';
-import {MDCRipple, MDCRippleFoundation, RippleCapableSurface, util} from '@material/ripple/index';
+import {ponyfill} from '@material/dom/index';
+import {MDCRipple, MDCRippleFoundation, RippleCapableSurface} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';
 import {MDCCheckboxFoundation} from './foundation';
 
-const {getMatchesProperty} = util;
 const CB_PROTO_PROPS = ['checked', 'indeterminate'];
 
 class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements MDCSelectionControl, RippleCapableSurface {
@@ -87,18 +87,17 @@ class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements MDCSele
   }
 
   private initRipple_(): MDCRipple {
-    const MATCHES = getMatchesProperty(HTMLElement.prototype);
-    const adapter = Object.assign(MDCRipple.createAdapter(this), {
+    const foundation = new MDCRippleFoundation({
+      ...MDCRipple.createAdapter(this),
       deregisterInteractionHandler:
-        <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-          this.nativeCb_.removeEventListener(type, handler),
-      isSurfaceActive: () => this.nativeCb_[MATCHES as 'matches'](':active'),
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              this.nativeCb_.removeEventListener(type, handler),
+      isSurfaceActive: () => ponyfill.matches(this.nativeCb_, ':active'),
       isUnbounded: () => true,
       registerInteractionHandler:
-        <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-          this.nativeCb_.addEventListener(type, handler),
+          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+              this.nativeCb_.addEventListener(type, handler),
     });
-    const foundation = new MDCRippleFoundation(adapter);
     return new MDCRipple(this.root_, foundation);
   }
 

--- a/packages/mdc-checkbox/index.ts
+++ b/packages/mdc-checkbox/index.ts
@@ -89,14 +89,12 @@ class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements MDCSele
   private initRipple_(): MDCRipple {
     const foundation = new MDCRippleFoundation({
       ...MDCRipple.createAdapter(this),
-      deregisterInteractionHandler:
-          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-              this.nativeCb_.removeEventListener(type, handler),
+      deregisterInteractionHandler: <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
+          this.nativeCb_.removeEventListener(evtType, handler),
       isSurfaceActive: () => ponyfill.matches(this.nativeCb_, ':active'),
       isUnbounded: () => true,
-      registerInteractionHandler:
-          <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-              this.nativeCb_.addEventListener(type, handler),
+      registerInteractionHandler: <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
+          this.nativeCb_.addEventListener(evtType, handler),
     });
     return new MDCRipple(this.root_, foundation);
   }

--- a/packages/mdc-checkbox/package.json
+++ b/packages/mdc-checkbox/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@material/animation": "^0.41.0",
     "@material/base": "^0.41.0",
+    "@material/dom": "^0.41.0",
     "@material/ripple": "^0.44.0",
     "@material/rtl": "^0.42.0",
     "@material/selection-control": "^0.44.0",

--- a/packages/mdc-chips/chip-set/foundation.ts
+++ b/packages/mdc-chips/chip-set/foundation.ts
@@ -47,8 +47,8 @@ class MDCChipSetFoundation extends MDCFoundation<MDCChipSetAdapter> {
    */
   private selectedChipIds_: string[] = [];
 
-  constructor(adapter: MDCChipSetAdapter) {
-    super(Object.assign(MDCChipSetFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCChipSetAdapter> = {}) {
+    super({...MDCChipSetFoundation.defaultAdapter, ...adapter});
   }
 
   /**

--- a/packages/mdc-chips/chip-set/foundation.ts
+++ b/packages/mdc-chips/chip-set/foundation.ts
@@ -47,7 +47,7 @@ class MDCChipSetFoundation extends MDCFoundation<MDCChipSetAdapter> {
    */
   private selectedChipIds_: string[] = [];
 
-  constructor(adapter: Partial<MDCChipSetAdapter> = {}) {
+  constructor(adapter?: Partial<MDCChipSetAdapter>) {
     super({...MDCChipSetFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -68,8 +68,8 @@ class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
    */
   private shouldRemoveOnTrailingIconClick_ = true;
 
-  constructor(adapter: MDCChipAdapter) {
-    super(Object.assign(MDCChipFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCChipAdapter> = {}) {
+    super({...MDCChipFoundation.defaultAdapter, ...adapter});
   }
 
   isSelected() {

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -103,7 +103,7 @@ class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
       // The checkmark's width is initially set to 0, so use the checkmark's height as a proxy since the checkmark
       // should always be square.
       const width = rootRect.width + checkmarkRect.height;
-      return Object.assign({}, rootRect, {width});
+      return {...rootRect, width};
     } else {
       return rootRect;
     }

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -172,7 +172,6 @@ class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
   /**
    * Handles an interaction event on the trailing icon element. This is used to
    * prevent the ripple from activating on interaction with the trailing icon.
-   * @param {!Event} evt
    */
   handleTrailingIconInteraction(evt: MouseEvent | KeyboardEvent) {
     const isEnter = (evt as KeyboardEvent).key === 'Enter' || (evt as KeyboardEvent).keyCode === 13;

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -68,7 +68,7 @@ class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
    */
   private shouldRemoveOnTrailingIconClick_ = true;
 
-  constructor(adapter: Partial<MDCChipAdapter> = {}) {
+  constructor(adapter?: Partial<MDCChipAdapter>) {
     super({...MDCChipFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-chips/chip/index.ts
+++ b/packages/mdc-chips/chip/index.ts
@@ -95,10 +95,10 @@ class MDCChip extends MDCComponent<MDCChipFoundation> implements RippleCapableSu
     this.trailingIcon_ = this.root_.querySelector(strings.TRAILING_ICON_SELECTOR);
     this.checkmark_ = this.root_.querySelector(strings.CHECKMARK_SELECTOR);
 
-    const adapter = Object.assign(MDCRipple.createAdapter(this), {
+    this.ripple_ = rippleFactory(this.root_, new MDCRippleFoundation({
+      ...MDCRipple.createAdapter(this),
       computeBoundingRect: () => this.foundation_.getDimensions(),
-    });
-    this.ripple_ = rippleFactory(this.root_, new MDCRippleFoundation(adapter));
+    }));
   }
 
   initialSyncWithDOM() {

--- a/packages/mdc-dialog/adapter.ts
+++ b/packages/mdc-dialog/adapter.ts
@@ -38,7 +38,7 @@ interface MDCDialogAdapter {
 
   isContentScrollable(): boolean;
   areButtonsStacked(): boolean;
-  getActionFromEvent(event: Event): string | null;
+  getActionFromEvent(evt: Event): string | null;
 
   trapFocus(): void;
   releaseFocus(): void;

--- a/packages/mdc-dialog/foundation.ts
+++ b/packages/mdc-dialog/foundation.ts
@@ -69,8 +69,8 @@ class MDCDialogFoundation extends MDCFoundation<MDCDialogAdapter> {
   private autoStackButtons_ = true;
   private areButtonsStacked_ = false;
 
-  constructor(adapter: MDCDialogAdapter) {
-    super(Object.assign(MDCDialogFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCDialogAdapter> = {}) {
+    super({...MDCDialogFoundation.defaultAdapter, ...adapter});
   }
 
   init() {

--- a/packages/mdc-dialog/foundation.ts
+++ b/packages/mdc-dialog/foundation.ts
@@ -69,7 +69,7 @@ class MDCDialogFoundation extends MDCFoundation<MDCDialogAdapter> {
   private autoStackButtons_ = true;
   private areButtonsStacked_ = false;
 
-  constructor(adapter: Partial<MDCDialogAdapter> = {}) {
+  constructor(adapter?: Partial<MDCDialogAdapter>) {
     super({...MDCDialogFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-dialog/index.ts
+++ b/packages/mdc-dialog/index.ts
@@ -154,11 +154,11 @@ class MDCDialog extends MDCComponent<MDCDialogFoundation> {
       areButtonsStacked: () => util.areTopsMisaligned(this.buttons_),
       clickDefaultButton: () => this.defaultButton_ && this.defaultButton_.click(),
       eventTargetMatches: (target, selector) => target ? matches(target as Element, selector) : false,
-      getActionFromEvent: (event: Event) => {
-        if (!event.target) {
+      getActionFromEvent: (evt: Event) => {
+        if (!evt.target) {
           return '';
         }
-        const element = closest(event.target as Element, `[${strings.ACTION_ATTRIBUTE}]`);
+        const element = closest(evt.target as Element, `[${strings.ACTION_ATTRIBUTE}]`);
         return element && element.getAttribute(strings.ACTION_ATTRIBUTE);
       },
       hasClass: (className) => this.root_.classList.contains(className),

--- a/packages/mdc-dialog/index.ts
+++ b/packages/mdc-dialog/index.ts
@@ -110,11 +110,11 @@ class MDCDialog extends MDCComponent<MDCDialogFoundation> {
 
     const LAYOUT_EVENTS = ['resize', 'orientationchange'];
     this.handleOpening_ = () => {
-      LAYOUT_EVENTS.forEach((type) => window.addEventListener(type, this.handleLayout_));
+      LAYOUT_EVENTS.forEach((evtType) => window.addEventListener(evtType, this.handleLayout_));
       document.addEventListener('keydown', this.handleDocumentKeydown_);
     };
     this.handleClosing_ = () => {
-      LAYOUT_EVENTS.forEach((type) => window.removeEventListener(type, this.handleLayout_));
+      LAYOUT_EVENTS.forEach((evtType) => window.removeEventListener(evtType, this.handleLayout_));
       document.removeEventListener('keydown', this.handleDocumentKeydown_);
     };
 

--- a/packages/mdc-floating-label/adapter.ts
+++ b/packages/mdc-floating-label/adapter.ts
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {EventType, SpecificEventListener} from '@material/base';
+import {EventType, SpecificEventListener} from '@material/base/index';
 
 /**
  * Defines the shape of the adapter expected by the foundation.
@@ -49,12 +49,12 @@ interface MDCFloatingLabelAdapter {
   /**
    * Registers an event listener on the root element for a given event.
    */
-  registerInteractionHandler<E extends EventType>(evtType: E, handler: SpecificEventListener<E>): void;
+  registerInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Deregisters an event listener on the root element for a given event.
    */
-  deregisterInteractionHandler<E extends EventType>(evtType: E, handler: SpecificEventListener<E>): void;
+  deregisterInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 }
 
 export {MDCFloatingLabelAdapter as default, MDCFloatingLabelAdapter};

--- a/packages/mdc-floating-label/foundation.ts
+++ b/packages/mdc-floating-label/foundation.ts
@@ -21,8 +21,8 @@
  * THE SOFTWARE.
  */
 
-import {SpecificEventListener} from '@material/base/index';
 import {MDCFoundation} from '@material/base/foundation';
+import {SpecificEventListener} from '@material/base/index';
 import {MDCFloatingLabelAdapter} from './adapter';
 import {cssClasses} from './constants';
 

--- a/packages/mdc-floating-label/foundation.ts
+++ b/packages/mdc-floating-label/foundation.ts
@@ -48,7 +48,7 @@ class MDCFloatingLabelFoundation extends MDCFoundation<MDCFloatingLabelAdapter> 
 
   private readonly shakeAnimationEndHandler_: SpecificEventListener<'animationend'>;
 
-  constructor(adapter: Partial<MDCFloatingLabelAdapter> = {}) {
+  constructor(adapter?: Partial<MDCFloatingLabelAdapter>) {
     super({...MDCFloatingLabelFoundation.defaultAdapter, ...adapter});
 
     this.shakeAnimationEndHandler_ = () => this.handleShakeAnimationEnd_();

--- a/packages/mdc-floating-label/foundation.ts
+++ b/packages/mdc-floating-label/foundation.ts
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {SpecificEventListener} from '@material/base';
+import {SpecificEventListener} from '@material/base/index';
 import {MDCFoundation} from '@material/base/foundation';
 import {MDCFloatingLabelAdapter} from './adapter';
 import {cssClasses} from './constants';

--- a/packages/mdc-form-field/adapter.ts
+++ b/packages/mdc-form-field/adapter.ts
@@ -33,8 +33,8 @@ import {EventType, SpecificEventListener} from '@material/base/index';
 interface MDCFormFieldAdapter {
   activateInputRipple(): void;
   deactivateInputRipple(): void;
-  deregisterInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
-  registerInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  deregisterInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
+  registerInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 }
 
 export {MDCFormFieldAdapter as default, MDCFormFieldAdapter};

--- a/packages/mdc-form-field/adapter.ts
+++ b/packages/mdc-form-field/adapter.ts
@@ -21,11 +21,10 @@
  * THE SOFTWARE.
  */
 
+import {EventType, SpecificEventListener} from '@material/base/index';
+
 /**
- * Adapter for MDC Form Field. Provides an interface for managing
- * - event handlers
- * - ripple activation
- *
+ * Defines the shape of the adapter expected by the foundation.
  * Implement this adapter for your framework of choice to delegate updates to
  * the component in your framework of choice. See architecture documentation
  * for more details.
@@ -34,12 +33,8 @@
 interface MDCFormFieldAdapter {
   activateInputRipple(): void;
   deactivateInputRipple(): void;
-  deregisterInteractionHandler<K extends keyof GlobalEventHandlersEventMap>(
-    type: K, handler: (evt: GlobalEventHandlersEventMap[K],
-  ) => void): void;
-  registerInteractionHandler<K extends keyof GlobalEventHandlersEventMap>(
-    type: K, handler: (evt: GlobalEventHandlersEventMap[K],
-  ) => void): void;
+  deregisterInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  registerInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
 }
 
 export {MDCFormFieldAdapter as default, MDCFormFieldAdapter};

--- a/packages/mdc-form-field/foundation.ts
+++ b/packages/mdc-form-field/foundation.ts
@@ -43,12 +43,11 @@ class MDCFormFieldFoundation extends MDCFoundation<MDCFormFieldAdapter> {
     };
   }
 
-  private clickHandler_: () => void;
+  private readonly clickHandler_: () => void;
 
-  constructor(adapter: MDCFormFieldAdapter) {
-    super(Object.assign(MDCFormFieldFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCFormFieldAdapter> = {}) {
+    super({...MDCFormFieldFoundation.defaultAdapter, ...adapter});
 
-    /** @private {!EventListener} */
     this.clickHandler_ = () => this.handleClick_();
   }
 

--- a/packages/mdc-form-field/foundation.ts
+++ b/packages/mdc-form-field/foundation.ts
@@ -45,7 +45,7 @@ class MDCFormFieldFoundation extends MDCFoundation<MDCFormFieldAdapter> {
 
   private readonly clickHandler_: () => void;
 
-  constructor(adapter: Partial<MDCFormFieldAdapter> = {}) {
+  constructor(adapter?: Partial<MDCFormFieldAdapter>) {
     super({...MDCFormFieldFoundation.defaultAdapter, ...adapter});
 
     this.clickHandler_ = () => this.handleClick_();

--- a/packages/mdc-form-field/index.ts
+++ b/packages/mdc-form-field/index.ts
@@ -57,8 +57,16 @@ class MDCFormField extends MDCComponent<MDCFormFieldFoundation> {
           this.input_.ripple.deactivate();
         }
       },
-      deregisterInteractionHandler: (type, handler) => this.label_ && this.label_.removeEventListener(type, handler),
-      registerInteractionHandler: (type, handler) => this.label_ && this.label_.addEventListener(type, handler),
+      deregisterInteractionHandler: (evtType, handler) => {
+        if (this.label_) {
+          this.label_.removeEventListener(evtType, handler);
+        }
+      },
+      registerInteractionHandler: (evtType, handler) => {
+        if (this.label_) {
+          this.label_.addEventListener(evtType, handler);
+        }
+      },
     });
   }
 }

--- a/packages/mdc-grid-list/foundation.ts
+++ b/packages/mdc-grid-list/foundation.ts
@@ -44,7 +44,7 @@ class MDCGridListFoundation extends MDCFoundation<MDCGridListAdapter> {
   private readonly resizeHandler_: EventListener;
   private resizeFrame_ = 0;
 
-  constructor(adapter: Partial<MDCGridListAdapter> = {}) {
+  constructor(adapter?: Partial<MDCGridListAdapter>) {
     super({...MDCGridListFoundation.defaultAdapter, ...adapter});
 
     this.resizeHandler_ = this.alignCenter.bind(this);

--- a/packages/mdc-grid-list/foundation.ts
+++ b/packages/mdc-grid-list/foundation.ts
@@ -44,6 +44,7 @@ class MDCGridListFoundation extends MDCFoundation<MDCGridListAdapter> {
   private readonly resizeHandler_: EventListener;
   private resizeFrame_ = 0;
 
+  /* istanbul ignore next: optional argument is not a branch statement */
   constructor(adapter?: Partial<MDCGridListAdapter>) {
     super({...MDCGridListFoundation.defaultAdapter, ...adapter});
 

--- a/packages/mdc-grid-list/foundation.ts
+++ b/packages/mdc-grid-list/foundation.ts
@@ -44,8 +44,9 @@ class MDCGridListFoundation extends MDCFoundation<MDCGridListAdapter> {
   private readonly resizeHandler_: EventListener;
   private resizeFrame_ = 0;
 
-  constructor(adapter: MDCGridListAdapter) {
-    super(Object.assign(MDCGridListFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCGridListAdapter> = {}) {
+    super({...MDCGridListFoundation.defaultAdapter, ...adapter});
+
     this.resizeHandler_ = this.alignCenter.bind(this);
   }
 

--- a/packages/mdc-icon-button/foundation.ts
+++ b/packages/mdc-icon-button/foundation.ts
@@ -44,7 +44,7 @@ class MDCIconButtonToggleFoundation extends MDCFoundation<MDCIconButtonToggleAda
     };
   }
 
-  constructor(adapter: Partial<MDCIconButtonToggleAdapter> = {}) {
+  constructor(adapter?: Partial<MDCIconButtonToggleAdapter>) {
     super({...MDCIconButtonToggleFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-icon-button/foundation.ts
+++ b/packages/mdc-icon-button/foundation.ts
@@ -44,8 +44,8 @@ class MDCIconButtonToggleFoundation extends MDCFoundation<MDCIconButtonToggleAda
     };
   }
 
-  constructor(adapter: MDCIconButtonToggleAdapter) {
-    super(Object.assign(MDCIconButtonToggleFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCIconButtonToggleAdapter> = {}) {
+    super({...MDCIconButtonToggleFoundation.defaultAdapter, ...adapter});
   }
 
   init() {

--- a/packages/mdc-line-ripple/adapter.ts
+++ b/packages/mdc-line-ripple/adapter.ts
@@ -51,12 +51,12 @@ interface MDCLineRippleAdapter {
   /**
    * Registers an event listener on the line ripple element for a given event.
    */
-  registerEventHandler<E extends EventType>(evtType: E, handler: SpecificEventListener<E>): void;
+  registerEventHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Deregisters an event listener on the line ripple element for a given event.
    */
-  deregisterEventHandler<E extends EventType>(evtType: E, handler: SpecificEventListener<E>): void;
+  deregisterEventHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 }
 
 export {MDCLineRippleAdapter as default, MDCLineRippleAdapter};

--- a/packages/mdc-line-ripple/foundation.ts
+++ b/packages/mdc-line-ripple/foundation.ts
@@ -21,8 +21,8 @@
  * THE SOFTWARE.
  */
 
-import {SpecificEventListener} from '@material/base/index';
 import {MDCFoundation} from '@material/base/foundation';
+import {SpecificEventListener} from '@material/base/index';
 import {MDCLineRippleAdapter} from './adapter';
 import {cssClasses} from './constants';
 

--- a/packages/mdc-line-ripple/foundation.ts
+++ b/packages/mdc-line-ripple/foundation.ts
@@ -49,7 +49,7 @@ class MDCLineRippleFoundation extends MDCFoundation<MDCLineRippleAdapter> {
 
   private readonly transitionEndHandler_: SpecificEventListener<'transitionend'>;
 
-  constructor(adapter: Partial<MDCLineRippleAdapter> = {}) {
+  constructor(adapter?: Partial<MDCLineRippleAdapter>) {
     super({...MDCLineRippleFoundation.defaultAdapter, ...adapter});
 
     this.transitionEndHandler_ = (evt) => this.handleTransitionEnd(evt);

--- a/packages/mdc-line-ripple/foundation.ts
+++ b/packages/mdc-line-ripple/foundation.ts
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {SpecificEventListener} from '@material/base';
+import {SpecificEventListener} from '@material/base/index';
 import {MDCFoundation} from '@material/base/foundation';
 import {MDCLineRippleAdapter} from './adapter';
 import {cssClasses} from './constants';

--- a/packages/mdc-list/foundation.ts
+++ b/packages/mdc-list/foundation.ts
@@ -69,8 +69,8 @@ class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
   private isCheckboxList_ = false;
   private isRadioList_ = false;
 
-  constructor(adapter: MDCListAdapter) {
-    super(Object.assign(MDCListFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCListAdapter> = {}) {
+    super({...MDCListFoundation.defaultAdapter, ...adapter});
   }
 
   layout() {

--- a/packages/mdc-list/foundation.ts
+++ b/packages/mdc-list/foundation.ts
@@ -69,7 +69,7 @@ class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
   private isCheckboxList_ = false;
   private isRadioList_ = false;
 
-  constructor(adapter: Partial<MDCListAdapter> = {}) {
+  constructor(adapter?: Partial<MDCListAdapter>) {
     super({...MDCListFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-list/index.ts
+++ b/packages/mdc-list/index.ts
@@ -23,7 +23,7 @@
 
 import {MDCComponent} from '@material/base/component';
 import {SpecificEventListener} from '@material/base/index';
-import * as ponyfill from '@material/dom/ponyfill';
+import {ponyfill} from '@material/dom/index';
 import {cssClasses, strings} from './constants';
 import {MDCListFoundation} from './foundation';
 import {ListActionEventDetail, ListIndex} from './types';

--- a/packages/mdc-menu-surface/foundation.ts
+++ b/packages/mdc-menu-surface/foundation.ts
@@ -105,7 +105,7 @@ class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapter> {
   private dimensions_!: MenuDimensions; // assigned in open()
   private measurements_!: AutoLayoutMeasurements; // assigned in open()
 
-  constructor(adapter: Partial<MDCMenuSurfaceAdapter> = {}) {
+  constructor(adapter?: Partial<MDCMenuSurfaceAdapter>) {
     super({...MDCMenuSurfaceFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-menu-surface/foundation.ts
+++ b/packages/mdc-menu-surface/foundation.ts
@@ -105,8 +105,8 @@ class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapter> {
   private dimensions_!: MenuDimensions; // assigned in open()
   private measurements_!: AutoLayoutMeasurements; // assigned in open()
 
-  constructor(adapter: MDCMenuSurfaceAdapter) {
-    super(Object.assign(MDCMenuSurfaceFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCMenuSurfaceAdapter> = {}) {
+    super({...MDCMenuSurfaceFoundation.defaultAdapter, ...adapter});
   }
 
   init() {

--- a/packages/mdc-menu-surface/index.ts
+++ b/packages/mdc-menu-surface/index.ts
@@ -132,7 +132,9 @@ class MDCMenuSurface extends MDCComponent<MDCMenuSurfaceFoundation> {
     this.setIsHoisted(true);
   }
 
-  /** @param corner Default anchor corner alignment of top-left surface corner. */
+  /**
+   * @param corner Default anchor corner alignment of top-left surface corner.
+   */
   setAnchorCorner(corner: Corner) {
     this.foundation_.setAnchorCorner(corner);
   }

--- a/packages/mdc-menu/foundation.ts
+++ b/packages/mdc-menu/foundation.ts
@@ -58,7 +58,7 @@ class MDCMenuFoundation extends MDCFoundation<MDCMenuAdapter> {
     // tslint:enable:object-literal-sort-keys
   }
 
-  constructor(adapter: Partial<MDCMenuAdapter> = {}) {
+  constructor(adapter?: Partial<MDCMenuAdapter>) {
     super({...MDCMenuFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-menu/foundation.ts
+++ b/packages/mdc-menu/foundation.ts
@@ -58,8 +58,8 @@ class MDCMenuFoundation extends MDCFoundation<MDCMenuAdapter> {
     // tslint:enable:object-literal-sort-keys
   }
 
-  constructor(adapter: MDCMenuAdapter) {
-    super(Object.assign(MDCMenuFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCMenuAdapter> = {}) {
+    super({...MDCMenuFoundation.defaultAdapter, ...adapter});
   }
 
   destroy() {

--- a/packages/mdc-notched-outline/foundation.ts
+++ b/packages/mdc-notched-outline/foundation.ts
@@ -52,7 +52,7 @@ class MDCNotchedOutlineFoundation extends MDCFoundation<MDCNotchedOutlineAdapter
     // tslint:enable:object-literal-sort-keys
   }
 
-  constructor(adapter: Partial<MDCNotchedOutlineAdapter> = {}) {
+  constructor(adapter?: Partial<MDCNotchedOutlineAdapter>) {
     super({...MDCNotchedOutlineFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-radio/index.ts
+++ b/packages/mdc-radio/index.ts
@@ -23,8 +23,7 @@
 
 import {MDCComponent} from '@material/base/component';
 import {EventType, SpecificEventListener} from '@material/base/index';
-import {RippleCapableSurface} from '@material/ripple/index';
-import {MDCRipple, MDCRippleFoundation} from '@material/ripple/index';
+import {MDCRipple, MDCRippleFoundation, RippleCapableSurface} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';
 
 import {MDCRadioFoundation} from './foundation';
@@ -81,18 +80,17 @@ class MDCRadio extends MDCComponent<MDCRadioFoundation> implements RippleCapable
   }
 
   private initRipple_(): MDCRipple {
-    const adapter = Object.assign(MDCRipple.createAdapter(this), {
-      deregisterInteractionHandler:
-        <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
+    const foundation = new MDCRippleFoundation({
+      ...MDCRipple.createAdapter(this),
+      deregisterInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
           this.nativeControl_.removeEventListener(type, handler),
       // Radio buttons technically go "active" whenever there is *any* keyboard interaction. This is not the
       // UI we desire.
       isSurfaceActive: () => false,
       isUnbounded: () => true,
       registerInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-        this.nativeControl_.addEventListener(type, handler),
+          this.nativeControl_.addEventListener(type, handler),
     });
-    const foundation = new MDCRippleFoundation(adapter);
     return new MDCRipple(this.root_, foundation);
   }
 

--- a/packages/mdc-radio/index.ts
+++ b/packages/mdc-radio/index.ts
@@ -82,14 +82,14 @@ class MDCRadio extends MDCComponent<MDCRadioFoundation> implements RippleCapable
   private initRipple_(): MDCRipple {
     const foundation = new MDCRippleFoundation({
       ...MDCRipple.createAdapter(this),
-      deregisterInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-          this.nativeControl_.removeEventListener(type, handler),
+      deregisterInteractionHandler: <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
+          this.nativeControl_.removeEventListener(evtType, handler),
       // Radio buttons technically go "active" whenever there is *any* keyboard interaction. This is not the
       // UI we desire.
       isSurfaceActive: () => false,
       isUnbounded: () => true,
-      registerInteractionHandler: <K extends EventType>(type: K, handler: SpecificEventListener<K>) =>
-          this.nativeControl_.addEventListener(type, handler),
+      registerInteractionHandler: <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
+          this.nativeControl_.addEventListener(evtType, handler),
     });
     return new MDCRipple(this.root_, foundation);
   }

--- a/packages/mdc-radio/index.ts
+++ b/packages/mdc-radio/index.ts
@@ -83,13 +83,13 @@ class MDCRadio extends MDCComponent<MDCRadioFoundation> implements RippleCapable
     const foundation = new MDCRippleFoundation({
       ...MDCRipple.createAdapter(this),
       deregisterInteractionHandler: <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
-          this.nativeControl_.removeEventListener(evtType, handler),
+        this.nativeControl_.removeEventListener(evtType, handler),
       // Radio buttons technically go "active" whenever there is *any* keyboard interaction. This is not the
       // UI we desire.
       isSurfaceActive: () => false,
       isUnbounded: () => true,
       registerInteractionHandler: <K extends EventType>(evtType: K, handler: SpecificEventListener<K>) =>
-          this.nativeControl_.addEventListener(evtType, handler),
+        this.nativeControl_.addEventListener(evtType, handler),
     });
     return new MDCRipple(this.root_, foundation);
   }

--- a/packages/mdc-ripple/foundation.ts
+++ b/packages/mdc-ripple/foundation.ts
@@ -116,7 +116,7 @@ class MDCRippleFoundation extends MDCFoundation<MDCRippleAdapter> {
 
   private previousActivationEvent_?: Event;
 
-  constructor(adapter: Partial<MDCRippleAdapter> = {}) {
+  constructor(adapter?: Partial<MDCRippleAdapter>) {
     super({...MDCRippleFoundation.defaultAdapter, ...adapter});
 
     this.activationState_ = this.defaultActivationState_();

--- a/packages/mdc-ripple/foundation.ts
+++ b/packages/mdc-ripple/foundation.ts
@@ -75,11 +75,11 @@ class MDCRippleFoundation extends MDCFoundation<MDCRippleAdapter> {
     return numbers;
   }
 
-  static get defaultAdapter() {
+  static get defaultAdapter(): MDCRippleAdapter {
     return {
       addClass: () => undefined,
       browserSupportsCssVars: () => true,
-      computeBoundingRect: () => undefined,
+      computeBoundingRect: () => ({top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0}),
       containsEventTarget: () => true,
       deregisterDocumentInteractionHandler: () => undefined,
       deregisterInteractionHandler: () => undefined,
@@ -118,8 +118,8 @@ class MDCRippleFoundation extends MDCFoundation<MDCRippleAdapter> {
   private activationTimerCallback_: () => void;
   private previousActivationEvent_?: Event;
 
-  constructor(adapter: MDCRippleAdapter) {
-    super(Object.assign(MDCRippleFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCRippleAdapter> = {}) {
+    super({...MDCRippleFoundation.defaultAdapter, ...adapter});
 
     this.layoutFrame_ = 0;
     this.frame_ = ({width: 0, height: 0});

--- a/packages/mdc-ripple/index.ts
+++ b/packages/mdc-ripple/index.ts
@@ -45,18 +45,18 @@ class MDCRipple extends MDCComponent<MDCRippleFoundation> implements RippleCapab
       computeBoundingRect: () => instance.root_.getBoundingClientRect(),
       containsEventTarget: (target) => instance.root_.contains(target as Node),
       deregisterDocumentInteractionHandler: (evtType, handler) =>
-          document.documentElement.removeEventListener(evtType, handler, util.applyPassive()),
+        document.documentElement.removeEventListener(evtType, handler, util.applyPassive()),
       deregisterInteractionHandler: (evtType, handler) =>
-          instance.root_.removeEventListener(evtType, handler, util.applyPassive()),
+        instance.root_.removeEventListener(evtType, handler, util.applyPassive()),
       deregisterResizeHandler: (handler) => window.removeEventListener('resize', handler),
       getWindowPageOffset: () => ({x: window.pageXOffset, y: window.pageYOffset}),
       isSurfaceActive: () => ponyfill.matches(instance.root_, ':active'),
       isSurfaceDisabled: () => Boolean(instance.disabled),
       isUnbounded: () => Boolean(instance.unbounded),
       registerDocumentInteractionHandler: (evtType, handler) =>
-          document.documentElement.addEventListener(evtType, handler, util.applyPassive()),
+        document.documentElement.addEventListener(evtType, handler, util.applyPassive()),
       registerInteractionHandler: (evtType, handler) =>
-          instance.root_.addEventListener(evtType, handler, util.applyPassive()),
+        instance.root_.addEventListener(evtType, handler, util.applyPassive()),
       registerResizeHandler: (handler) => window.addEventListener('resize', handler),
       removeClass: (className) => instance.root_.classList.remove(className),
       updateCssVariable: (varName, value) => (instance.root_ as HTMLElement).style.setProperty(varName, value),

--- a/packages/mdc-ripple/index.ts
+++ b/packages/mdc-ripple/index.ts
@@ -46,9 +46,9 @@ class MDCRipple extends MDCComponent<MDCRippleFoundation> implements RippleCapab
       computeBoundingRect: () => instance.root_.getBoundingClientRect(),
       containsEventTarget: (target) => instance.root_.contains(target as Node),
       deregisterDocumentInteractionHandler: (evtType, handler) =>
-        document.documentElement.removeEventListener(evtType, handler, util.applyPassive()),
+          document.documentElement.removeEventListener(evtType, handler, util.applyPassive()),
       deregisterInteractionHandler: (evtType, handler) =>
-        instance.root_.removeEventListener(evtType, handler, util.applyPassive()),
+          instance.root_.removeEventListener(evtType, handler, util.applyPassive()),
       deregisterResizeHandler: (handler) => window.removeEventListener('resize', handler),
       getWindowPageOffset: () => ({x: window.pageXOffset, y: window.pageYOffset}),
       isSurfaceActive: () => {
@@ -58,21 +58,20 @@ class MDCRipple extends MDCComponent<MDCRippleFoundation> implements RippleCapab
       isSurfaceDisabled: () => Boolean(instance.disabled),
       isUnbounded: () => Boolean(instance.unbounded),
       registerDocumentInteractionHandler: (evtType, handler) =>
-        document.documentElement.addEventListener(evtType, handler, util.applyPassive()),
+          document.documentElement.addEventListener(evtType, handler, util.applyPassive()),
       registerInteractionHandler: (evtType, handler) =>
-        instance.root_.addEventListener(evtType, handler, util.applyPassive()),
+          instance.root_.addEventListener(evtType, handler, util.applyPassive()),
       registerResizeHandler: (handler) => window.addEventListener('resize', handler),
       removeClass: (className) => instance.root_.classList.remove(className),
       updateCssVariable: (varName, value) => (instance.root_ as HTMLElement).style.setProperty(varName, value),
     };
   }
 
+  // Public visibility for this property is required by RippleCapableSurface.
+  root_!: Element; // assigned in MDCComponent constructor
+
   disabled = false;
-  /**
-   * this line may seem redundent, but without this the TS compiler does not
-   * think that `this` is of type RippleCapableSurface
-   */
-  root_!: Element;
+
   private unbounded_?: boolean;
 
   get unbounded(): boolean {

--- a/packages/mdc-ripple/index.ts
+++ b/packages/mdc-ripple/index.ts
@@ -22,6 +22,7 @@
  */
 
 import {MDCComponent} from '@material/base/component';
+import {ponyfill} from '@material/dom';
 import {MDCRippleAdapter} from './adapter';
 import {MDCRippleFoundation} from './foundation';
 import {RippleAttachOpts, RippleCapableSurface} from './types';
@@ -38,8 +39,6 @@ class MDCRipple extends MDCComponent<MDCRippleFoundation> implements RippleCapab
   }
 
   static createAdapter(instance: RippleCapableSurface): MDCRippleAdapter {
-    const MATCHES = util.getMatchesProperty(HTMLElement.prototype);
-
     return {
       addClass: (className) => instance.root_.classList.add(className),
       browserSupportsCssVars: () => util.supportsCssVariables(window),
@@ -51,10 +50,7 @@ class MDCRipple extends MDCComponent<MDCRippleFoundation> implements RippleCapab
           instance.root_.removeEventListener(evtType, handler, util.applyPassive()),
       deregisterResizeHandler: (handler) => window.removeEventListener('resize', handler),
       getWindowPageOffset: () => ({x: window.pageXOffset, y: window.pageYOffset}),
-      isSurfaceActive: () => {
-        const root = instance.root_;
-        return root[MATCHES as 'matches'](':active');
-      },
+      isSurfaceActive: () => ponyfill.matches(instance.root_, ':active'),
       isSurfaceDisabled: () => Boolean(instance.disabled),
       isUnbounded: () => Boolean(instance.unbounded),
       registerDocumentInteractionHandler: (evtType, handler) =>

--- a/packages/mdc-ripple/index.ts
+++ b/packages/mdc-ripple/index.ts
@@ -22,7 +22,7 @@
  */
 
 import {MDCComponent} from '@material/base/component';
-import {ponyfill} from '@material/dom';
+import {ponyfill} from '@material/dom/index';
 import {MDCRippleAdapter} from './adapter';
 import {MDCRippleFoundation} from './foundation';
 import {RippleAttachOpts, RippleCapableSurface} from './types';
@@ -109,7 +109,6 @@ class MDCRipple extends MDCComponent<MDCRippleFoundation> implements RippleCapab
   private setUnbounded_() {
     this.foundation_.setUnbounded(Boolean(this.unbounded_));
   }
-
 }
 
 export {MDCRipple as default, MDCRipple, util};

--- a/packages/mdc-ripple/package.json
+++ b/packages/mdc-ripple/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@material/animation": "^0.41.0",
     "@material/base": "^0.41.0",
+    "@material/dom": "^0.41.0",
     "@material/feature-targeting": "^0.44.0",
     "@material/theme": "^0.43.0"
   }

--- a/packages/mdc-ripple/util.ts
+++ b/packages/mdc-ripple/util.ts
@@ -111,11 +111,8 @@ export type VendorMatchesFunctionName = 'webkitMatchesSelector' | 'msMatchesSele
 export type MatchesFunctionName = VendorMatchesFunctionName | 'matches';
 
 export function getMatchesProperty(htmlElementPrototype: {}): MatchesFunctionName {
-  /**
-   * Order is important because we return the first existing method we find.
-   * Do not change the order of the items in the below array.
-   */
-
+  // Order is important because we return the first existing method we find.
+  // Do not change the order of the items in the below array.
   const matchesMethods: MatchesFunctionName[] = ['matches', 'webkitMatchesSelector', 'msMatchesSelector'];
   let method: MatchesFunctionName = 'matches';
   for (const matchesMethod of matchesMethods) {
@@ -128,9 +125,8 @@ export function getMatchesProperty(htmlElementPrototype: {}): MatchesFunctionNam
   return method;
 }
 
-export function getNormalizedEventCoords(
-    ev: Event | undefined, pageOffset: Point, clientRect: ClientRect): Point {
-  if (!ev) {
+export function getNormalizedEventCoords(evt: Event | undefined, pageOffset: Point, clientRect: ClientRect): Point {
+  if (!evt) {
     return {x: 0, y: 0};
   }
   const {x, y} = pageOffset;
@@ -140,12 +136,12 @@ export function getNormalizedEventCoords(
   let normalizedX;
   let normalizedY;
   // Determine touch point relative to the ripple container.
-  if (ev.type === 'touchstart') {
-    const touchEvent = ev as TouchEvent;
+  if (evt.type === 'touchstart') {
+    const touchEvent = evt as TouchEvent;
     normalizedX = touchEvent.changedTouches[0].pageX - documentX;
     normalizedY = touchEvent.changedTouches[0].pageY - documentY;
   } else {
-    const mouseEvent = ev as MouseEvent;
+    const mouseEvent = evt as MouseEvent;
     normalizedX = mouseEvent.pageX - documentX;
     normalizedY = mouseEvent.pageY - documentY;
   }

--- a/packages/mdc-slider/adapter.ts
+++ b/packages/mdc-slider/adapter.ts
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {EventType, SpecificEventListener} from '@material/base';
+import {EventType, SpecificEventListener} from '@material/base/index';
 
 /**
  * Defines the shape of the adapter expected by the foundation.
@@ -74,32 +74,32 @@ interface MDCSliderAdapter {
   /**
    * Registers an event handler on the root element for a given event.
    */
-  registerInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  registerInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Deregisters an event handler on the root element for a given event.
    */
-  deregisterInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  deregisterInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Registers an event handler on the thumb container element for a given event.
    */
-  registerThumbContainerInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  registerThumbContainerInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Deregisters an event handler on the thumb container element for a given event.
    */
-  deregisterThumbContainerInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  deregisterThumbContainerInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Registers an event handler on the body for a given event.
    */
-  registerBodyInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  registerBodyInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Deregisters an event handler on the body for a given event.
    */
-  deregisterBodyInteractionHandler<E extends EventType>(type: E, handler: SpecificEventListener<E>): void;
+  deregisterBodyInteractionHandler<K extends EventType>(evtType: K, handler: SpecificEventListener<K>): void;
 
   /**
    * Registers an event handler for the window resize event

--- a/packages/mdc-slider/foundation.ts
+++ b/packages/mdc-slider/foundation.ts
@@ -128,7 +128,7 @@ class MDCSliderFoundation extends MDCFoundation<MDCSliderAdapter> {
   private readonly blurHandler_: SpecificEventListener<'blur'>;
   private readonly resizeHandler_: SpecificEventListener<'resize'>;
 
-  constructor(adapter: Partial<MDCSliderAdapter> = {}) {
+  constructor(adapter?: Partial<MDCSliderAdapter>) {
     super({...MDCSliderFoundation.defaultAdapter, ...adapter});
 
     this.thumbContainerPointerHandler_ = () => this.handlingThumbTargetEvt_ = true;

--- a/packages/mdc-slider/index.ts
+++ b/packages/mdc-slider/index.ts
@@ -95,16 +95,16 @@ class MDCSlider extends MDCComponent<MDCSliderFoundation> {
       removeAttribute: (name) => this.root_.removeAttribute(name),
       computeBoundingRect: () => this.root_.getBoundingClientRect(),
       getTabIndex: () => this.root_.tabIndex,
-      registerInteractionHandler: (type, handler) => this.root_.addEventListener(type, handler),
-      deregisterInteractionHandler: (type, handler) => this.root_.removeEventListener(type, handler),
-      registerThumbContainerInteractionHandler: (type, handler) => {
-        this.thumbContainer_.addEventListener(type, handler);
+      registerInteractionHandler: (evtType, handler) => this.root_.addEventListener(evtType, handler),
+      deregisterInteractionHandler: (evtType, handler) => this.root_.removeEventListener(evtType, handler),
+      registerThumbContainerInteractionHandler: (evtType, handler) => {
+        this.thumbContainer_.addEventListener(evtType, handler);
       },
-      deregisterThumbContainerInteractionHandler: (type, handler) => {
-        this.thumbContainer_.removeEventListener(type, handler);
+      deregisterThumbContainerInteractionHandler: (evtType, handler) => {
+        this.thumbContainer_.removeEventListener(evtType, handler);
       },
-      registerBodyInteractionHandler: (type, handler) => document.body.addEventListener(type, handler),
-      deregisterBodyInteractionHandler: (type, handler) => document.body.removeEventListener(type, handler),
+      registerBodyInteractionHandler: (evtType, handler) => document.body.addEventListener(evtType, handler),
+      deregisterBodyInteractionHandler: (evtType, handler) => document.body.removeEventListener(evtType, handler),
       registerResizeHandler: (handler) => window.addEventListener('resize', handler),
       deregisterResizeHandler: (handler) => window.removeEventListener('resize', handler),
       notifyInput: () => this.emit(strings.INPUT_EVENT, this),

--- a/packages/mdc-snackbar/foundation.ts
+++ b/packages/mdc-snackbar/foundation.ts
@@ -60,8 +60,8 @@ class MDCSnackbarFoundation extends MDCFoundation<MDCSnackbarAdapter> {
   private autoDismissTimeoutMs_ = numbers.DEFAULT_AUTO_DISMISS_TIMEOUT_MS;
   private closeOnEscape_ = true;
 
-  constructor(adapter?: MDCSnackbarAdapter) {
-    super(Object.assign(MDCSnackbarFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCSnackbarAdapter> = {}) {
+    super({...MDCSnackbarFoundation.defaultAdapter, ...adapter});
   }
 
   destroy() {

--- a/packages/mdc-snackbar/foundation.ts
+++ b/packages/mdc-snackbar/foundation.ts
@@ -60,7 +60,7 @@ class MDCSnackbarFoundation extends MDCFoundation<MDCSnackbarAdapter> {
   private autoDismissTimeoutMs_ = numbers.DEFAULT_AUTO_DISMISS_TIMEOUT_MS;
   private closeOnEscape_ = true;
 
-  constructor(adapter: Partial<MDCSnackbarAdapter> = {}) {
+  constructor(adapter?: Partial<MDCSnackbarAdapter>) {
     super({...MDCSnackbarFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-snackbar/index.ts
+++ b/packages/mdc-snackbar/index.ts
@@ -23,7 +23,7 @@
 
 import {SpecificEventListener} from '@material/base';
 import {MDCComponent} from '@material/base/component';
-import * as ponyfill from '@material/dom/ponyfill';
+import {ponyfill} from '@material/dom/index';
 import {strings} from './constants';
 import {MDCSnackbarFoundation} from './foundation';
 import {Announcer, AnnouncerFactory} from './types';

--- a/packages/mdc-snackbar/index.ts
+++ b/packages/mdc-snackbar/index.ts
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {SpecificEventListener} from '@material/base';
+import {SpecificEventListener} from '@material/base/index';
 import {MDCComponent} from '@material/base/component';
 import {ponyfill} from '@material/dom/index';
 import {strings} from './constants';

--- a/packages/mdc-snackbar/index.ts
+++ b/packages/mdc-snackbar/index.ts
@@ -21,8 +21,8 @@
  * THE SOFTWARE.
  */
 
-import {SpecificEventListener} from '@material/base/index';
 import {MDCComponent} from '@material/base/component';
+import {SpecificEventListener} from '@material/base/index';
 import {ponyfill} from '@material/dom/index';
 import {strings} from './constants';
 import {MDCSnackbarFoundation} from './foundation';

--- a/packages/mdc-switch/foundation.ts
+++ b/packages/mdc-switch/foundation.ts
@@ -52,7 +52,7 @@ class MDCSwitchFoundation extends MDCFoundation<MDCSwitchAdapter> {
     };
   }
 
-  constructor(adapter: Partial<MDCSwitchAdapter> = {}) {
+  constructor(adapter?: Partial<MDCSwitchAdapter>) {
     super({...MDCSwitchFoundation.defaultAdapter, ...adapter});
   }
 

--- a/packages/mdc-switch/foundation.ts
+++ b/packages/mdc-switch/foundation.ts
@@ -52,8 +52,8 @@ class MDCSwitchFoundation extends MDCFoundation<MDCSwitchAdapter> {
     };
   }
 
-  constructor(adapter: MDCSwitchAdapter) {
-    super(Object.assign(MDCSwitchFoundation.defaultAdapter, adapter));
+  constructor(adapter: Partial<MDCSwitchAdapter> = {}) {
+    super({...MDCSwitchFoundation.defaultAdapter, ...adapter});
   }
 
   /** Sets the checked state of the switch. */

--- a/packages/mdc-switch/index.ts
+++ b/packages/mdc-switch/index.ts
@@ -26,6 +26,7 @@ import {ponyfill} from '@material/dom/index';
 import {MDCRipple, MDCRippleFoundation, RippleCapableSurface} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';
 import {MDCSwitchFoundation} from './foundation';
+import {EventType} from '@material/base/index';
 
 /**
  * An implementation of the switch component defined by the Material Design spec.
@@ -94,21 +95,23 @@ class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCSelectio
     const {RIPPLE_SURFACE_SELECTOR} = MDCSwitchFoundation.strings;
     const rippleSurface = this.root_.querySelector(RIPPLE_SURFACE_SELECTOR) as HTMLElement;
 
-    const adapter = Object.assign(MDCRipple.createAdapter(this), {
+    return new MDCRipple(this.root_, new MDCRippleFoundation({
+      ...MDCRipple.createAdapter(this),
       addClass: (className: string) => rippleSurface.classList.add(className),
       computeBoundingRect: () => rippleSurface.getBoundingClientRect(),
-      deregisterInteractionHandler: (type: string, handler: EventListener) =>
-          this.nativeControl_.removeEventListener(type, handler),
+      deregisterInteractionHandler: (evtType: EventType, handler: EventListener) => {
+        this.nativeControl_.removeEventListener(evtType, handler);
+      },
       isSurfaceActive: () => ponyfill.matches(this.nativeControl_, ':active'),
       isUnbounded: () => true,
-      registerInteractionHandler: (type: string, handler: EventListener) =>
-          this.nativeControl_.addEventListener(type, handler),
+      registerInteractionHandler: (evtType: EventType, handler: EventListener) => {
+        this.nativeControl_.addEventListener(evtType, handler);
+      },
       removeClass: (className: string) => rippleSurface.classList.remove(className),
-      updateCssVariable: (varName: string, value: string) =>
-          rippleSurface.style.setProperty(varName, value),
-    });
-    const foundation = new MDCRippleFoundation(adapter);
-    return new MDCRipple(this.root_, foundation);
+      updateCssVariable: (varName: string, value: string) => {
+        rippleSurface.style.setProperty(varName, value);
+      },
+    }));
   }
 
   private get nativeControl_() {

--- a/packages/mdc-switch/index.ts
+++ b/packages/mdc-switch/index.ts
@@ -22,11 +22,11 @@
  */
 
 import {MDCComponent} from '@material/base/component';
+import {EventType} from '@material/base/index';
 import {ponyfill} from '@material/dom/index';
 import {MDCRipple, MDCRippleFoundation, RippleCapableSurface} from '@material/ripple/index';
 import {MDCSelectionControl} from '@material/selection-control/index';
 import {MDCSwitchFoundation} from './foundation';
-import {EventType} from '@material/base/index';
 
 /**
  * An implementation of the switch component defined by the Material Design spec.

--- a/packages/mdc-switch/index.ts
+++ b/packages/mdc-switch/index.ts
@@ -22,8 +22,8 @@
  */
 
 import {MDCComponent} from '@material/base/component';
+import {ponyfill} from '@material/dom/index';
 import {MDCRipple, MDCRippleFoundation, RippleCapableSurface} from '@material/ripple/index';
-import {getMatchesProperty} from '@material/ripple/util';
 import {MDCSelectionControl} from '@material/selection-control/index';
 import {MDCSwitchFoundation} from './foundation';
 
@@ -33,7 +33,6 @@ import {MDCSwitchFoundation} from './foundation';
  * https://material.io/design/components/selection-controls.html#switches
  */
 class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCSelectionControl, RippleCapableSurface {
-  /** Creates an instance of MDCSwitch bound to the given root element. */
   static attachTo(root: HTMLElement) {
     return new MDCSwitch(root);
   }
@@ -95,13 +94,12 @@ class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCSelectio
     const {RIPPLE_SURFACE_SELECTOR} = MDCSwitchFoundation.strings;
     const rippleSurface = this.root_.querySelector(RIPPLE_SURFACE_SELECTOR) as HTMLElement;
 
-    const MATCHES = getMatchesProperty(HTMLElement.prototype);
     const adapter = Object.assign(MDCRipple.createAdapter(this), {
       addClass: (className: string) => rippleSurface.classList.add(className),
       computeBoundingRect: () => rippleSurface.getBoundingClientRect(),
       deregisterInteractionHandler: (type: string, handler: EventListener) =>
           this.nativeControl_.removeEventListener(type, handler),
-      isSurfaceActive: () => this.nativeControl_[MATCHES]!(':active'),
+      isSurfaceActive: () => ponyfill.matches(this.nativeControl_, ':active'),
       isUnbounded: () => true,
       registerInteractionHandler: (type: string, handler: EventListener) =>
           this.nativeControl_.addEventListener(type, handler),

--- a/packages/mdc-switch/index.ts
+++ b/packages/mdc-switch/index.ts
@@ -38,8 +38,8 @@ class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCSelectio
     return new MDCSwitch(root);
   }
 
-  // Initialized in super class constructor, re-declared as public to fulfill to the `RippleCapableSurface` interface.
-  root_!: Element;
+  // Public visibility for this property is required by RippleCapableSurface.
+  root_!: Element; // assigned in MDCComponent constructor
 
   private ripple_ = this.initRipple_();
 
@@ -62,7 +62,6 @@ class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCSelectio
     this.checked = this.checked;
   }
 
-  /** Gets the default Foundation for this switch. */
   getDefaultFoundation() {
     return new MDCSwitchFoundation({
       addClass: (className: string) => this.root_.classList.add(className),
@@ -72,23 +71,22 @@ class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCSelectio
     });
   }
 
-  /** The MDCRipple associated with this switch. */
   get ripple() {
     return this.ripple_;
   }
 
-  /** The checked state of this switch. */
   get checked() {
     return this.nativeControl_.checked;
   }
+
   set checked(checked) {
     this.foundation_.setChecked(checked);
   }
 
-  /** The disabled state of this switch. */
   get disabled() {
     return this.nativeControl_.disabled;
   }
+
   set disabled(disabled) {
     this.foundation_.setDisabled(disabled);
   }
@@ -115,7 +113,6 @@ class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCSelectio
     return new MDCRipple(this.root_, foundation);
   }
 
-  /** Returns the state of the native control element. */
   private get nativeControl_() {
     const {NATIVE_CONTROL_SELECTOR} = MDCSwitchFoundation.strings;
     return this.root_.querySelector(NATIVE_CONTROL_SELECTOR) as HTMLInputElement;

--- a/packages/mdc-switch/package.json
+++ b/packages/mdc-switch/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@material/animation": "^0.41.0",
     "@material/base": "^0.41.0",
+    "@material/dom": "^0.41.0",
     "@material/elevation": "^0.44.0",
     "@material/ripple": "^0.44.0",
     "@material/rtl": "^0.42.0",

--- a/test/unit/mdc-ripple/mdc-ripple.test.js
+++ b/test/unit/mdc-ripple/mdc-ripple.test.js
@@ -115,7 +115,7 @@ test('adapter#browserSupportsCssVars delegates to util', () => {
 test('adapter#isUnbounded delegates to unbounded getter', () => {
   const {component} = setupTest();
   component.unbounded = true;
-  assert.isOk(component.getDefaultFoundation().adapter_.isUnbounded());
+  assert.isTrue(component.getDefaultFoundation().adapter_.isUnbounded());
 });
 
 test('adapter#isSurfaceActive calls the correct :matches API method on the root element', () => {
@@ -126,7 +126,7 @@ test('adapter#isSurfaceActive calls the correct :matches API method on the root 
   ponyfill.matches = fakeMatches;
 
   try {
-    assert.isOk(component.getDefaultFoundation().adapter_.isSurfaceActive());
+    assert.isTrue(component.getDefaultFoundation().adapter_.isSurfaceActive());
   } finally {
     ponyfill.matches = realMatches;
   }
@@ -141,14 +141,14 @@ test('adapter#isSurfaceDisabled delegates to component\'s disabled getter', () =
 test('adapter#addClass adds a class to the root', () => {
   const {root, component} = setupTest();
   component.getDefaultFoundation().adapter_.addClass('foo');
-  assert.isOk(root.classList.contains('foo'));
+  assert.isTrue(root.classList.contains('foo'));
 });
 
 test('adapter#removeClass removes a class from the root', () => {
   const {root, component} = setupTest();
   root.classList.add('foo');
   component.getDefaultFoundation().adapter_.removeClass('foo');
-  assert.isNotOk(root.classList.contains('foo'));
+  assert.isFalse(root.classList.contains('foo'));
 });
 
 test('adapter#containsEventTarget returns true if the passed element is a descendant of the root element', () => {


### PR DESCRIPTION
Refs #4225

This PR improves consistency across TS files:

* Replaces `Object.assign()` with `{...spread}` operator
* Changes foundation constructor arg types to `Partial<MDCFooAdapter>`
* Uses `ponyfill.matches()` from `mdc-dom` instead of `getMatchesProperty()` from `mdc-ripple`
    - `getMatchesProperty()` still exists to avoid breaking backward compatibility, but it is no longer used in TS
* Standardizes naming: `evt`, `evtType`, and `<K extends EventType>`
* Always import `/index` (e.g., `@material/foo/index` instead of `@material/foo`)