### PR TITLE
fix(chips): Reference ripple/index in types for consistency

### DIFF
--- a/packages/mdc-chips/chip/types.ts
+++ b/packages/mdc-chips/chip/types.ts
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-import {MDCRipple, MDCRippleFoundation} from '@material/ripple';
+import {MDCRipple, MDCRippleFoundation} from '@material/ripple/index';
 
 export interface MDCChipInteractionEventDetail {
   chipId: string;


### PR DESCRIPTION
This fixes the build, which previously was complaining about two references to MDCRipple not matching due to inconsistent imports.