### PR TITLE
fix(tab): Stop changing tabindex on activation and deactivation

### DIFF
--- a/demos/tab-bar.html
+++ b/demos/tab-bar.html
@@ -51,7 +51,7 @@
           <div class="mdc-tab-scroller">
             <div class="mdc-tab-scroller__scroll-area">
               <div class="mdc-tab-scroller__scroll-content">
-                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                   <span class="mdc-tab__content">
                     <span class="mdc-tab__text-label">Banana</span>
                   </span>
@@ -69,7 +69,7 @@
                   </span>
                   <span class="mdc-tab__ripple"></span>
                 </button>
-                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                   <span class="mdc-tab__content">
                     <span class="mdc-tab__text-label">Mangosteen</span>
                   </span>
@@ -78,7 +78,7 @@
                   </span>
                   <span class="mdc-tab__ripple"></span>
                 </button>
-                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                   <span class="mdc-tab__content">
                     <span class="mdc-tab__text-label">Pitaya</span>
                   </span>
@@ -87,7 +87,7 @@
                   </span>
                   <span class="mdc-tab__ripple"></span>
                 </button>
-                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                   <span class="mdc-tab__content">
                     <span class="mdc-tab__text-label">Lychee</span>
                   </span>
@@ -96,7 +96,7 @@
                   </span>
                   <span class="mdc-tab__ripple"></span>
                 </button>
-                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                   <span class="mdc-tab__content">
                     <span class="mdc-tab__text-label">Passionfruit</span>
                   </span>
@@ -105,7 +105,7 @@
                   </span>
                   <span class="mdc-tab__ripple"></span>
                 </button>
-                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                   <span class="mdc-tab__content">
                     <span class="mdc-tab__text-label">Kiwi</span>
                   </span>
@@ -114,7 +114,7 @@
                   </span>
                   <span class="mdc-tab__ripple"></span>
                 </button>
-                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                   <span class="mdc-tab__content">
                     <span class="mdc-tab__text-label">Mango</span>
                   </span>
@@ -146,7 +146,7 @@
             <div class="mdc-tab-scroller mdc-tab-scroller--align-start">
               <div class="mdc-tab-scroller__scroll-area">
                 <div class="mdc-tab-scroller__scroll-content">
-                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__text-label">Potato</span>
                     </span>
@@ -164,7 +164,7 @@
                     </span>
                     <span class="mdc-tab__ripple"></span>
                   </button>
-                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__text-label">Parsnip</span>
                     </span>
@@ -185,7 +185,7 @@
             <div class="mdc-tab-scroller mdc-tab-scroller--align-center">
               <div class="mdc-tab-scroller__scroll-area">
                 <div class="mdc-tab-scroller__scroll-content">
-                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__text-label">Potato</span>
                     </span>
@@ -203,7 +203,7 @@
                     </span>
                     <span class="mdc-tab__ripple"></span>
                   </button>
-                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__text-label">Parsnip</span>
                     </span>
@@ -224,7 +224,7 @@
             <div class="mdc-tab-scroller mdc-tab-scroller--align-end">
               <div class="mdc-tab-scroller__scroll-area">
                 <div class="mdc-tab-scroller__scroll-content">
-                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__text-label">Potato</span>
                     </span>
@@ -242,7 +242,7 @@
                     </span>
                     <span class="mdc-tab__ripple"></span>
                   </button>
-                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab mdc-tab--min-width" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__text-label">Parsnip</span>
                     </span>
@@ -266,7 +266,7 @@
             <div class="mdc-tab-scroller">
               <div class="mdc-tab-scroller__scroll-area">
                 <div class="mdc-tab-scroller__scroll-content">
-                  <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__icon material-icons" aria-hidden="true">access_time</span>
                       <span class="mdc-tab__text-label">Recents</span>
@@ -286,7 +286,7 @@
                     </span>
                     <span class="mdc-tab__ripple"></span>
                   </button>
-                  <button class="mdc-tab" role="tab" aria-selected="false" tabindex="-1">
+                  <button class="mdc-tab" role="tab" aria-selected="false" tabindex="0">
                     <span class="mdc-tab__content">
                       <span class="mdc-tab__icon material-icons" aria-hidden="true">favorite</span>
                       <span class="mdc-tab__text-label">Favorites</span>

--- a/packages/mdc-tab/constants.js
+++ b/packages/mdc-tab/constants.js
@@ -32,7 +32,6 @@ const strings = {
   RIPPLE_SELECTOR: '.mdc-tab__ripple',
   CONTENT_SELECTOR: '.mdc-tab__content',
   TAB_INDICATOR_SELECTOR: '.mdc-tab-indicator',
-  TABINDEX: 'tabIndex',
   INTERACTED_EVENT: 'MDCTab:interacted',
 };
 

--- a/packages/mdc-tab/foundation.js
+++ b/packages/mdc-tab/foundation.js
@@ -108,7 +108,6 @@ class MDCTabFoundation extends MDCFoundation {
   activate(previousIndicatorClientRect) {
     this.adapter_.addClass(cssClasses.ACTIVE);
     this.adapter_.setAttr(strings.ARIA_SELECTED, 'true');
-    this.adapter_.setAttr(strings.TABINDEX, '0');
     this.adapter_.activateIndicator(previousIndicatorClientRect);
     if (this.focusOnActivate_) {
       this.adapter_.focus();
@@ -126,7 +125,6 @@ class MDCTabFoundation extends MDCFoundation {
 
     this.adapter_.removeClass(cssClasses.ACTIVE);
     this.adapter_.setAttr(strings.ARIA_SELECTED, 'false');
-    this.adapter_.setAttr(strings.TABINDEX, '-1');
     this.adapter_.deactivateIndicator();
   }
 

--- a/test/unit/mdc-tab/foundation.test.js
+++ b/test/unit/mdc-tab/foundation.test.js
@@ -63,12 +63,6 @@ test('#activate sets the root element aria-selected attribute to true', () => {
   td.verify(mockAdapter.setAttr(MDCTabFoundation.strings.ARIA_SELECTED, 'true'));
 });
 
-test('#activate sets the root element tabindex to 0', () => {
-  const {foundation, mockAdapter} = setupTest();
-  foundation.activate();
-  td.verify(mockAdapter.setAttr(MDCTabFoundation.strings.TABINDEX, '0'));
-});
-
 test('#activate activates the indicator', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.activate({width: 100, left: 200});
@@ -120,13 +114,6 @@ test('#deactivate deactivates the indicator', () => {
   td.when(mockAdapter.hasClass(MDCTabFoundation.cssClasses.ACTIVE)).thenReturn(true);
   foundation.deactivate();
   td.verify(mockAdapter.deactivateIndicator());
-});
-
-test('#deactivate sets the root element tabindex to -1', () => {
-  const {foundation, mockAdapter} = setupTest();
-  td.when(mockAdapter.hasClass(MDCTabFoundation.cssClasses.ACTIVE)).thenReturn(true);
-  foundation.deactivate();
-  td.verify(mockAdapter.setAttr(MDCTabFoundation.strings.TABINDEX, '-1'));
 });
 
 test(`#handleClick emits the ${MDCTabFoundation.strings.INTERACTED_EVENT} event`, () => {


### PR DESCRIPTION
Fix #4429.

Blame indicates that this `tabindex` code has been there since the very first code drop of `mdc-tab`, and I can't for the life of me figure out what it's for. Deactivated tabs should be keyboard accessible, and so should activated tabs. It seems like some effort went into making this bug!