### PR TITLE
fix: add missing import to mdc-floating-label/mixins

### DIFF
--- a/packages/mdc-floating-label/_mixins.scss
+++ b/packages/mdc-floating-label/_mixins.scss
@@ -21,6 +21,7 @@
 //
 
 @import "@material/rtl/mixins";
+@import "@material/theme/mixins";
 @import "./variables";
 
 @mixin mdc-floating-label-ink-color($color) {


### PR DESCRIPTION
add missing @material/theme/mixins.scss `@import` to @material/floating-label/mixins.scss