### PR TITLE
chore: Fix regression in `MDCChipFoundation.getDimensions()`

### DIFF
--- a/packages/mdc-checkbox/component.ts
+++ b/packages/mdc-checkbox/component.ts
@@ -28,12 +28,16 @@ import {MDCRipple, MDCRippleAdapter, MDCRippleCapableSurface, MDCRippleFoundatio
 import {MDCCheckboxAdapter} from './adapter';
 import {MDCCheckboxFoundation} from './foundation';
 
+/**
+ * This type is needed for compatibility with Closure Compiler.
+ */
+type PropertyDescriptorGetter = (() => any) | undefined; // tslint:disable-line:no-any
+
 const {NATIVE_CONTROL_SELECTOR} = MDCCheckboxFoundation.strings;
 
 const CB_PROTO_PROPS = ['checked', 'indeterminate'];
 
 export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements MDCRippleCapableSurface {
-
   static attachTo(root: Element) {
     return new MDCCheckbox(root);
   }
@@ -115,10 +119,13 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
         return;
       }
 
+      // Type cast is needed for compatibility with Closure Compiler.
+      const nativeGetter = (desc as {get: PropertyDescriptorGetter}).get;
+
       const nativeCbDesc = {
         configurable: desc.configurable,
         enumerable: desc.enumerable,
-        get: desc.get,
+        get: nativeGetter,
         set: (state: boolean) => {
           desc.set!.call(nativeCb, state);
           this.foundation_.handleChange();

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -94,19 +94,24 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
   }
 
   getDimensions(): ClientRect {
-    const rootRect = this.adapter_.getRootBoundingClientRect();
-    const checkmarkRect = this.adapter_.getCheckmarkBoundingClientRect();
+    const getRootRect = () => this.adapter_.getRootBoundingClientRect();
+    const getCheckmarkRect = () => this.adapter_.getCheckmarkBoundingClientRect();
 
     // When a chip has a checkmark and not a leading icon, the bounding rect changes in size depending on the current
     // size of the checkmark.
-    if (!this.adapter_.hasLeadingIcon() && checkmarkRect !== null) {
-      // The checkmark's width is initially set to 0, so use the checkmark's height as a proxy since the checkmark
-      // should always be square.
-      const width = rootRect.width + checkmarkRect.height;
-      return {...rootRect, width};
-    } else {
-      return rootRect;
+    if (!this.adapter_.hasLeadingIcon()) {
+      const checkmarkRect = getCheckmarkRect();
+      if (checkmarkRect) {
+        const rootRect = getRootRect();
+        const height = rootRect.height;
+        // The checkmark's width is initially set to 0, so use the checkmark's height as a proxy since the checkmark
+        // should always be square.
+        const width = rootRect.width + checkmarkRect.height;
+        return {...rootRect, width, height};
+      }
     }
+
+    return getRootRect();
   }
 
   /**

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -104,9 +104,12 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
       if (checkmarkRect) {
         const rootRect = getRootRect();
         const height = rootRect.height;
-        // The checkmark's width is initially set to 0, so use the checkmark's height as a proxy since the checkmark
-        // should always be square.
-        const width = rootRect.width + checkmarkRect.height;
+        // Checkmark is a square, meaning the client rect's width and height are identical once the animation completes.
+        // However, the checkbox is initially hidden by setting the width to 0.
+        // To account for an initial width of 0, we use the checkbox's height instead (which equals the end-state width)
+        // when adding it to the root client rect's width.
+        const checkmarkWidth = checkmarkRect.height;
+        const width = rootRect.width + checkmarkWidth;
         return {...rootRect, width, height};
       }
     }


### PR DESCRIPTION
PR #4332 inadvertently broke short-circuit logic and evaluation order.

The change caused incorrect ripple size calculations on filter chips without leading icons, which was caught by internal screenshot tests.