### PR TITLE
style: Add explanations to `tslint:disable` comments

### DIFF
--- a/packages/mdc-checkbox/component.ts
+++ b/packages/mdc-checkbox/component.ts
@@ -33,8 +33,6 @@ import {MDCCheckboxFoundation} from './foundation';
  */
 type PropertyDescriptorGetter = (() => any) | undefined; // tslint:disable-line:no-any
 
-const {NATIVE_CONTROL_SELECTOR} = MDCCheckboxFoundation.strings;
-
 const CB_PROTO_PROPS = ['checked', 'indeterminate'];
 
 export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements MDCRippleCapableSurface {
@@ -42,15 +40,49 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
     return new MDCCheckbox(root);
   }
 
-  /**
-   * Returns the state of the native control element, or null if the native control element is not present.
-   */
-  get nativeCb_(): HTMLInputElement {
-    const cbEl = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
-    if (!cbEl) {
-      throw new Error(`Checkbox requires a ${NATIVE_CONTROL_SELECTOR} element`);
+  get ripple(): MDCRipple {
+    return this.ripple_;
+  }
+
+  get checked(): boolean {
+    return this.nativeControl_.checked;
+  }
+
+  set checked(checked: boolean) {
+    this.nativeControl_.checked = checked;
+  }
+
+  get indeterminate(): boolean {
+    return this.nativeControl_.indeterminate;
+  }
+
+  set indeterminate(indeterminate: boolean) {
+    this.nativeControl_.indeterminate = indeterminate;
+  }
+
+  get disabled(): boolean {
+    return this.nativeControl_.disabled;
+  }
+
+  set disabled(disabled: boolean) {
+    this.foundation_.setDisabled(disabled);
+  }
+
+  get value(): string {
+    return this.nativeControl_.value;
+  }
+
+  set value(value: string) {
+    this.nativeControl_.value = value;
+  }
+
+  private get nativeControl_(): HTMLInputElement {
+    const {NATIVE_CONTROL_SELECTOR} = MDCCheckboxFoundation.strings;
+    const el = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
+    if (!el) {
+      throw new Error(`Checkbox component requires a ${NATIVE_CONTROL_SELECTOR} element`);
     }
-    return cbEl;
+    return el;
   }
 
   // Public visibility for this property is required by MDCRippleCapableSurface.
@@ -63,14 +95,14 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
   initialSyncWithDOM() {
     this.handleChange_ = () => this.foundation_.handleChange();
     this.handleAnimationEnd_ = () => this.foundation_.handleAnimationEnd();
-    this.nativeCb_.addEventListener('change', this.handleChange_);
+    this.nativeControl_.addEventListener('change', this.handleChange_);
     this.listen(getCorrectEventName(window, 'animationend'), this.handleAnimationEnd_);
     this.installPropertyChangeHooks_();
   }
 
   destroy() {
     this.ripple_.destroy();
-    this.nativeCb_.removeEventListener('change', this.handleChange_);
+    this.nativeControl_.removeEventListener('change', this.handleChange_);
     this.unlisten(getCorrectEventName(window, 'animationend'), this.handleAnimationEnd_);
     this.uninstallPropertyChangeHooks_();
     super.destroy();
@@ -82,14 +114,14 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
     const adapter: MDCCheckboxAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       forceLayout: () => (this.root_ as HTMLElement).offsetWidth,
-      hasNativeControl: () => !!this.nativeCb_,
+      hasNativeControl: () => !!this.nativeControl_,
       isAttachedToDOM: () => Boolean(this.root_.parentNode),
       isChecked: () => this.checked,
       isIndeterminate: () => this.indeterminate,
       removeClass: (className) => this.root_.classList.remove(className),
-      removeNativeControlAttr: (attr) => this.nativeCb_.removeAttribute(attr),
-      setNativeControlAttr: (attr, value) => this.nativeCb_.setAttribute(attr, value),
-      setNativeControlDisabled: (disabled) => this.nativeCb_.disabled = disabled,
+      removeNativeControlAttr: (attr) => this.nativeControl_.removeAttribute(attr),
+      setNativeControlAttr: (attr, value) => this.nativeControl_.setAttribute(attr, value),
+      setNativeControlDisabled: (disabled) => this.nativeControl_.disabled = disabled,
     };
     return new MDCCheckboxFoundation(adapter);
   }
@@ -99,16 +131,16 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
     const adapter: MDCRippleAdapter = {
       ...MDCRipple.createAdapter(this),
-      deregisterInteractionHandler: (evtType, handler) => this.nativeCb_.removeEventListener(evtType, handler),
-      isSurfaceActive: () => ponyfill.matches(this.nativeCb_, ':active'),
+      deregisterInteractionHandler: (evtType, handler) => this.nativeControl_.removeEventListener(evtType, handler),
+      isSurfaceActive: () => ponyfill.matches(this.nativeControl_, ':active'),
       isUnbounded: () => true,
-      registerInteractionHandler: (evtType, handler) => this.nativeCb_.addEventListener(evtType, handler),
+      registerInteractionHandler: (evtType, handler) => this.nativeControl_.addEventListener(evtType, handler),
     };
     return new MDCRipple(this.root_, new MDCRippleFoundation(adapter));
   }
 
   private installPropertyChangeHooks_() {
-    const nativeCb = this.nativeCb_;
+    const nativeCb = this.nativeControl_;
     const cbProto = Object.getPrototypeOf(nativeCb);
 
     CB_PROTO_PROPS.forEach((controlState) => {
@@ -136,7 +168,7 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
   }
 
   private uninstallPropertyChangeHooks_() {
-    const nativeCb = this.nativeCb_;
+    const nativeCb = this.nativeControl_;
     const cbProto = Object.getPrototypeOf(nativeCb);
 
     CB_PROTO_PROPS.forEach((controlState) => {
@@ -146,42 +178,6 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
       }
       Object.defineProperty(nativeCb, controlState, desc);
     });
-  }
-
-  get ripple(): MDCRipple {
-    return this.ripple_;
-  }
-
-  get checked(): boolean {
-    return this.nativeCb_.checked;
-  }
-
-  set checked(checked: boolean) {
-    this.nativeCb_.checked = checked;
-  }
-
-  get indeterminate(): boolean {
-    return this.nativeCb_.indeterminate;
-  }
-
-  set indeterminate(indeterminate: boolean) {
-    this.nativeCb_.indeterminate = indeterminate;
-  }
-
-  get disabled(): boolean {
-    return this.nativeCb_.disabled;
-  }
-
-  set disabled(disabled: boolean) {
-    this.foundation_.setDisabled(disabled);
-  }
-
-  get value(): string {
-    return this.nativeCb_.value;
-  }
-
-  set value(value: string) {
-    this.nativeCb_.value = value;
   }
 }
 

--- a/packages/mdc-checkbox/component.ts
+++ b/packages/mdc-checkbox/component.ts
@@ -76,15 +76,6 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
     this.nativeControl_.value = value;
   }
 
-  private get nativeControl_(): HTMLInputElement {
-    const {NATIVE_CONTROL_SELECTOR} = MDCCheckboxFoundation.strings;
-    const el = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
-    if (!el) {
-      throw new Error(`Checkbox component requires a ${NATIVE_CONTROL_SELECTOR} element`);
-    }
-    return el;
-  }
-
   // Public visibility for this property is required by MDCRippleCapableSurface.
   root_!: Element; // assigned in MDCComponent constructor
 
@@ -178,6 +169,15 @@ export class MDCCheckbox extends MDCComponent<MDCCheckboxFoundation> implements 
       }
       Object.defineProperty(nativeCb, controlState, desc);
     });
+  }
+
+  private get nativeControl_(): HTMLInputElement {
+    const {NATIVE_CONTROL_SELECTOR} = MDCCheckboxFoundation.strings;
+    const el = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
+    if (!el) {
+      throw new Error(`Checkbox component requires a ${NATIVE_CONTROL_SELECTOR} element`);
+    }
+    return el;
   }
 }
 

--- a/packages/mdc-drawer/component.ts
+++ b/packages/mdc-drawer/component.ts
@@ -118,7 +118,7 @@ export class MDCDrawer extends MDCComponent<MDCDismissibleDrawerFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCDrawerAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-drawer/dismissible/foundation.ts
+++ b/packages/mdc-drawer/dismissible/foundation.ts
@@ -35,7 +35,7 @@ export class MDCDismissibleDrawerFoundation extends MDCFoundation<MDCDrawerAdapt
   }
 
   static get defaultAdapter(): MDCDrawerAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-floating-label/component.ts
+++ b/packages/mdc-floating-label/component.ts
@@ -55,7 +55,7 @@ export class MDCFloatingLabel extends MDCComponent<MDCFloatingLabelFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCFloatingLabelAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-floating-label/foundation.ts
+++ b/packages/mdc-floating-label/foundation.ts
@@ -35,7 +35,7 @@ export class MDCFloatingLabelFoundation extends MDCFoundation<MDCFloatingLabelAd
    * See {@link MDCFloatingLabelAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCFloatingLabelAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-line-ripple/component.ts
+++ b/packages/mdc-line-ripple/component.ts
@@ -57,7 +57,7 @@ export class MDCLineRipple extends MDCComponent<MDCLineRippleFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCLineRippleAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-line-ripple/foundation.ts
+++ b/packages/mdc-line-ripple/foundation.ts
@@ -35,7 +35,7 @@ export class MDCLineRippleFoundation extends MDCFoundation<MDCLineRippleAdapter>
    * See {@link MDCLineRippleAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCLineRippleAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-menu-surface/component.ts
+++ b/packages/mdc-menu-surface/component.ts
@@ -149,7 +149,7 @@ export class MDCMenuSurface extends MDCComponent<MDCMenuSurfaceFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCMenuSurfaceAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-menu-surface/foundation.ts
+++ b/packages/mdc-menu-surface/foundation.ts
@@ -56,7 +56,7 @@ export class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapte
    * @see {@link MDCMenuSurfaceAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCMenuSurfaceAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,
@@ -292,9 +292,8 @@ export class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapte
     const viewportSize = this.adapter_.getWindowDimensions();
     const windowScroll = this.adapter_.getWindowScroll();
 
-    // tslint:disable:object-literal-sort-keys
-
     if (!anchorRect) {
+      // tslint:disable:object-literal-sort-keys Positional properties are more readable when they're grouped together
       anchorRect = {
         top: this.position_.y,
         right: this.position_.x,
@@ -303,6 +302,7 @@ export class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapte
         width: 0,
         height: 0,
       };
+      // tslint:enable:object-literal-sort-keys
     }
 
     return {
@@ -310,16 +310,16 @@ export class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapte
       bodySize,
       surfaceSize: this.dimensions_,
       viewportDistance: {
+        // tslint:disable:object-literal-sort-keys Positional properties are more readable when they're grouped together
         top: anchorRect.top,
         right: viewportSize.width - anchorRect.right,
         bottom: viewportSize.height - anchorRect.bottom,
         left: anchorRect.left,
+        // tslint:enable:object-literal-sort-keys
       },
       viewportSize,
       windowScroll,
     };
-
-    // tslint:enable:object-literal-sort-keys
   }
 
   /**

--- a/packages/mdc-menu/component.ts
+++ b/packages/mdc-menu/component.ts
@@ -176,7 +176,7 @@ export class MDCMenu extends MDCComponent<MDCMenuFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCMenuAdapter = {
       addClassToElementAtIndex: (index, className) => {
         const list = this.items;

--- a/packages/mdc-menu/foundation.ts
+++ b/packages/mdc-menu/foundation.ts
@@ -42,7 +42,7 @@ export class MDCMenuFoundation extends MDCFoundation<MDCMenuAdapter> {
    * @see {@link MDCMenuAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCMenuAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClassToElementAtIndex: () => undefined,
       removeClassFromElementAtIndex: () => undefined,

--- a/packages/mdc-notched-outline/component.ts
+++ b/packages/mdc-notched-outline/component.ts
@@ -69,7 +69,7 @@ export class MDCNotchedOutline extends MDCComponent<MDCNotchedOutlineFoundation>
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCNotchedOutlineAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-notched-outline/foundation.ts
+++ b/packages/mdc-notched-outline/foundation.ts
@@ -42,7 +42,7 @@ export class MDCNotchedOutlineFoundation extends MDCFoundation<MDCNotchedOutline
    * See {@link MDCNotchedOutlineAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCNotchedOutlineAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-radio/component.ts
+++ b/packages/mdc-radio/component.ts
@@ -59,15 +59,6 @@ export class MDCRadio extends MDCComponent<MDCRadioFoundation> implements MDCRip
     return this.ripple_;
   }
 
-  private get nativeControl_(): HTMLInputElement {
-    const {NATIVE_CONTROL_SELECTOR} = MDCRadioFoundation.strings;
-    const el = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
-    if (!el) {
-      throw new Error(`Radio component requires a ${NATIVE_CONTROL_SELECTOR} element`);
-    }
-    return el;
-  }
-
   // Public visibility for this property is required by MDCRippleCapableSurface.
   root_!: Element; // assigned in MDCComponent constructor
 
@@ -104,5 +95,14 @@ export class MDCRadio extends MDCComponent<MDCRadioFoundation> implements MDCRip
     };
     // tslint:enable:object-literal-sort-keys
     return new MDCRipple(this.root_, new MDCRippleFoundation(adapter));
+  }
+
+  private get nativeControl_(): HTMLInputElement {
+    const {NATIVE_CONTROL_SELECTOR} = MDCRadioFoundation.strings;
+    const el = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
+    if (!el) {
+      throw new Error(`Radio component requires a ${NATIVE_CONTROL_SELECTOR} element`);
+    }
+    return el;
   }
 }

--- a/packages/mdc-radio/component.ts
+++ b/packages/mdc-radio/component.ts
@@ -31,11 +31,6 @@ export class MDCRadio extends MDCComponent<MDCRadioFoundation> implements MDCRip
     return new MDCRadio(root);
   }
 
-  // Public visibility for this property is required by MDCRippleCapableSurface.
-  root_!: Element; // assigned in MDCComponent constructor
-
-  private readonly ripple_: MDCRipple = this.createRipple_();
-
   get checked(): boolean {
     return this.nativeControl_.checked;
   }
@@ -64,6 +59,20 @@ export class MDCRadio extends MDCComponent<MDCRadioFoundation> implements MDCRip
     return this.ripple_;
   }
 
+  private get nativeControl_(): HTMLInputElement {
+    const {NATIVE_CONTROL_SELECTOR} = MDCRadioFoundation.strings;
+    const el = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
+    if (!el) {
+      throw new Error(`Radio component requires a ${NATIVE_CONTROL_SELECTOR} element`);
+    }
+    return el;
+  }
+
+  // Public visibility for this property is required by MDCRippleCapableSurface.
+  root_!: Element; // assigned in MDCComponent constructor
+
+  private readonly ripple_: MDCRipple = this.createRipple_();
+
   destroy() {
     this.ripple_.destroy();
     super.destroy();
@@ -83,7 +92,7 @@ export class MDCRadio extends MDCComponent<MDCRadioFoundation> implements MDCRip
   private createRipple_(): MDCRipple {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCRippleAdapter = {
       ...MDCRipple.createAdapter(this),
       registerInteractionHandler: (evtType, handler) => this.nativeControl_.addEventListener(evtType, handler),
@@ -95,17 +104,5 @@ export class MDCRadio extends MDCComponent<MDCRadioFoundation> implements MDCRip
     };
     // tslint:enable:object-literal-sort-keys
     return new MDCRipple(this.root_, new MDCRippleFoundation(adapter));
-  }
-
-  /**
-   * Returns the state of the native control element, or null if the native control element is not present.
-   */
-  private get nativeControl_(): HTMLInputElement {
-    const {NATIVE_CONTROL_SELECTOR} = MDCRadioFoundation.strings;
-    const el = this.root_.querySelector<HTMLInputElement>(NATIVE_CONTROL_SELECTOR);
-    if (!el) {
-      throw new Error(`Radio component requires a ${NATIVE_CONTROL_SELECTOR} element`);
-    }
-    return el;
   }
 }

--- a/packages/mdc-select/component.ts
+++ b/packages/mdc-select/component.ts
@@ -367,7 +367,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> implements MDCR
   private createRipple_(): MDCRipple {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCRippleAdapter = {
       ...MDCRipple.createAdapter(this),
       registerInteractionHandler: (evtType, handler) => this.targetElement_.addEventListener(evtType, handler),
@@ -378,7 +378,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> implements MDCR
   }
 
   private getNativeSelectAdapterMethods_() {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       getValue: () => this.nativeControl_!.value,
       setValue: (value: string) => {
@@ -406,7 +406,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> implements MDCR
   }
 
   private getEnhancedSelectAdapterMethods_() {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       getValue: () => {
         const listItem = this.menuElement_!.querySelector(strings.SELECTED_ITEM_SELECTOR);
@@ -463,7 +463,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> implements MDCR
   }
 
   private getCommonAdapterMethods_() {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: (className: string) => this.root_.classList.add(className),
       removeClass: (className: string) => this.root_.classList.remove(className),
@@ -480,7 +480,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> implements MDCR
   }
 
   private getOutlineAdapterMethods_() {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       hasOutline: () => Boolean(this.outline_),
       notchOutline: (labelWidth: number) => this.outline_ && this.outline_.notch(labelWidth),

--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -45,7 +45,7 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
    * See {@link MDCSelectAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCSelectAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-select/helper-text/component.ts
+++ b/packages/mdc-select/helper-text/component.ts
@@ -40,7 +40,7 @@ export class MDCSelectHelperText extends MDCComponent<MDCSelectHelperTextFoundat
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCSelectHelperTextAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-select/helper-text/foundation.ts
+++ b/packages/mdc-select/helper-text/foundation.ts
@@ -38,7 +38,7 @@ export class MDCSelectHelperTextFoundation extends MDCFoundation<MDCSelectHelper
    * See {@link MDCSelectHelperTextAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCSelectHelperTextAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-select/icon/component.ts
+++ b/packages/mdc-select/icon/component.ts
@@ -39,7 +39,7 @@ export class MDCSelectIcon extends MDCComponent<MDCSelectIconFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCSelectIconAdapter = {
       getAttr: (attr) => this.root_.getAttribute(attr),
       setAttr: (attr, value) => this.root_.setAttribute(attr, value),

--- a/packages/mdc-select/icon/foundation.ts
+++ b/packages/mdc-select/icon/foundation.ts
@@ -39,7 +39,7 @@ export class MDCSelectIconFoundation extends MDCFoundation<MDCSelectIconAdapter>
    * See {@link MDCSelectIconAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCSelectIconAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       getAttr: () => null,
       setAttr: () => undefined,

--- a/packages/mdc-slider/component.ts
+++ b/packages/mdc-slider/component.ts
@@ -88,7 +88,7 @@ export class MDCSlider extends MDCComponent<MDCSliderFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCSliderAdapter = {
       hasClass: (className) => this.root_.classList.contains(className),
       addClass: (className) => this.root_.classList.add(className),
@@ -138,7 +138,7 @@ export class MDCSlider extends MDCComponent<MDCSliderFoundation> {
       },
       isRTL: () => getComputedStyle(this.root_).direction === 'rtl',
     };
-    // tslint:disable:object-literal-sort-keys
+    // tslint:enable:object-literal-sort-keys
     return new MDCSliderFoundation(adapter);
   }
 

--- a/packages/mdc-slider/foundation.ts
+++ b/packages/mdc-slider/foundation.ts
@@ -70,7 +70,7 @@ export class MDCSliderFoundation extends MDCFoundation<MDCSliderAdapter> {
   }
 
   static get defaultAdapter(): MDCSliderAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       hasClass: () => false,
       addClass: () => undefined,

--- a/packages/mdc-tab-bar/component.ts
+++ b/packages/mdc-tab-bar/component.ts
@@ -88,7 +88,7 @@ export class MDCTabBar extends MDCComponent<MDCTabBarFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTabBarAdapter = {
       scrollTo: (scrollX) => this.tabScroller_!.scrollTo(scrollX),
       incrementScroll: (scrollXIncrement) => this.tabScroller_!.incrementScroll(scrollXIncrement),

--- a/packages/mdc-tab-bar/foundation.ts
+++ b/packages/mdc-tab-bar/foundation.ts
@@ -54,7 +54,7 @@ export class MDCTabBarFoundation extends MDCFoundation<MDCTabBarAdapter> {
   }
 
   static get defaultAdapter(): MDCTabBarAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       scrollTo: () => undefined,
       incrementScroll: () => undefined,

--- a/packages/mdc-tab-indicator/component.ts
+++ b/packages/mdc-tab-indicator/component.ts
@@ -48,7 +48,7 @@ export class MDCTabIndicator extends MDCComponent<MDCTabIndicatorFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTabIndicatorAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-tab-indicator/foundation.ts
+++ b/packages/mdc-tab-indicator/foundation.ts
@@ -35,7 +35,7 @@ export abstract class MDCTabIndicatorFoundation extends MDCFoundation<MDCTabIndi
   }
 
   static get defaultAdapter(): MDCTabIndicatorAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-tab-scroller/component.ts
+++ b/packages/mdc-tab-scroller/component.ts
@@ -73,7 +73,7 @@ export class MDCTabScroller extends MDCComponent<MDCTabScrollerFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTabScrollerAdapter = {
       eventTargetMatchesSelector: (evtTarget, selector) => ponyfill.matches(evtTarget as Element, selector),
       addClass: (className) => this.root_.classList.add(className),

--- a/packages/mdc-tab-scroller/foundation.ts
+++ b/packages/mdc-tab-scroller/foundation.ts
@@ -40,7 +40,7 @@ export class MDCTabScrollerFoundation extends MDCFoundation<MDCTabScrollerAdapte
   }
 
   static get defaultAdapter(): MDCTabScrollerAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       eventTargetMatchesSelector: () => false,
       addClass: () => undefined,

--- a/packages/mdc-tab/component.ts
+++ b/packages/mdc-tab/component.ts
@@ -80,7 +80,7 @@ export class MDCTab extends MDCComponent<MDCTabFoundation> implements MDCRippleC
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTabAdapter = {
       setAttr: (attr, value) => this.root_.setAttribute(attr, value),
       addClass: (className) => this.root_.classList.add(className),

--- a/packages/mdc-tab/foundation.ts
+++ b/packages/mdc-tab/foundation.ts
@@ -36,7 +36,7 @@ export class MDCTabFoundation extends MDCFoundation<MDCTabAdapter> {
   }
 
   static get defaultAdapter(): MDCTabAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-tabs/tab-bar-scroller/component.ts
+++ b/packages/mdc-tabs/tab-bar-scroller/component.ts
@@ -60,7 +60,7 @@ export class MDCTabBarScroller extends MDCComponent<MDCTabBarScrollerFoundation>
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTabBarScrollerAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-tabs/tab-bar-scroller/foundation.ts
+++ b/packages/mdc-tabs/tab-bar-scroller/foundation.ts
@@ -40,7 +40,7 @@ export class MDCTabBarScrollerFoundation extends MDCFoundation<MDCTabBarScroller
   }
 
   static get defaultAdapter(): MDCTabBarScrollerAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-tabs/tab-bar/component.ts
+++ b/packages/mdc-tabs/tab-bar/component.ts
@@ -75,7 +75,7 @@ export class MDCTabBar extends MDCComponent<MDCTabBarFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTabBarAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-tabs/tab-bar/foundation.ts
+++ b/packages/mdc-tabs/tab-bar/foundation.ts
@@ -37,7 +37,7 @@ export class MDCTabBarFoundation extends MDCFoundation<MDCTabBarAdapter> {
   }
 
   static get defaultAdapter(): MDCTabBarAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-tabs/tab/component.ts
+++ b/packages/mdc-tabs/tab/component.ts
@@ -80,7 +80,7 @@ export class MDCTab extends MDCComponent<MDCTabFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTabAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-tabs/tab/foundation.ts
+++ b/packages/mdc-tabs/tab/foundation.ts
@@ -36,7 +36,7 @@ export class MDCTabFoundation extends MDCFoundation<MDCTabAdapter> {
   }
 
   static get defaultAdapter(): MDCTabAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-textfield/component.ts
+++ b/packages/mdc-textfield/component.ts
@@ -342,7 +342,7 @@ export class MDCTextField extends MDCComponent<MDCTextFieldFoundation> implement
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTextFieldAdapter = {
       ...this.getRootAdapterMethods_(),
       ...this.getInputAdapterMethods_(),
@@ -355,7 +355,7 @@ export class MDCTextField extends MDCComponent<MDCTextFieldFoundation> implement
   }
 
   private getRootAdapterMethods_(): MDCTextFieldRootAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),
@@ -379,7 +379,7 @@ export class MDCTextField extends MDCComponent<MDCTextFieldFoundation> implement
   }
 
   private getInputAdapterMethods_(): MDCTextFieldInputAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       getNativeInput: () => this.input_,
       isFocused: () => document.activeElement === this.input_,
@@ -448,7 +448,7 @@ export class MDCTextField extends MDCComponent<MDCTextFieldFoundation> implement
 
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCRippleAdapter = {
       ...MDCRipple.createAdapter(this),
       isSurfaceActive: () => ponyfill.matches(this.input_, ':active'),

--- a/packages/mdc-textfield/foundation.ts
+++ b/packages/mdc-textfield/foundation.ts
@@ -66,7 +66,7 @@ export class MDCTextFieldFoundation extends MDCFoundation<MDCTextFieldAdapter> {
    * See {@link MDCTextFieldAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCTextFieldAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-textfield/helper-text/component.ts
+++ b/packages/mdc-textfield/helper-text/component.ts
@@ -40,7 +40,7 @@ export class MDCTextFieldHelperText extends MDCComponent<MDCTextFieldHelperTextF
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTextFieldHelperTextAdapter = {
       addClass: (className) => this.root_.classList.add(className),
       removeClass: (className) => this.root_.classList.remove(className),

--- a/packages/mdc-textfield/helper-text/foundation.ts
+++ b/packages/mdc-textfield/helper-text/foundation.ts
@@ -38,7 +38,7 @@ export class MDCTextFieldHelperTextFoundation extends MDCFoundation<MDCTextField
    * See {@link MDCTextFieldHelperTextAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCTextFieldHelperTextAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,

--- a/packages/mdc-textfield/icon/component.ts
+++ b/packages/mdc-textfield/icon/component.ts
@@ -39,7 +39,7 @@ export class MDCTextFieldIcon extends MDCComponent<MDCTextFieldIconFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTextFieldIconAdapter = {
       getAttr: (attr) => this.root_.getAttribute(attr),
       setAttr: (attr, value) => this.root_.setAttribute(attr, value),

--- a/packages/mdc-textfield/icon/foundation.ts
+++ b/packages/mdc-textfield/icon/foundation.ts
@@ -39,7 +39,7 @@ export class MDCTextFieldIconFoundation extends MDCFoundation<MDCTextFieldIconAd
    * See {@link MDCTextFieldIconAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCTextFieldIconAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       getAttr: () => null,
       setAttr: () => undefined,

--- a/packages/mdc-toolbar/component.ts
+++ b/packages/mdc-toolbar/component.ts
@@ -77,7 +77,7 @@ export class MDCToolbar extends MDCComponent<MDCToolbarFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCToolbarAdapter = {
       hasClass: (className) => this.root_.classList.contains(className),
       addClass: (className) => this.root_.classList.add(className),

--- a/packages/mdc-toolbar/foundation.ts
+++ b/packages/mdc-toolbar/foundation.ts
@@ -74,7 +74,7 @@ export class MDCToolbarFoundation extends MDCFoundation<MDCToolbarAdapter> {
   }
 
   static get defaultAdapter(): MDCToolbarAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       hasClass: () => false,
       addClass: () => undefined,

--- a/packages/mdc-top-app-bar/component.ts
+++ b/packages/mdc-top-app-bar/component.ts
@@ -75,7 +75,7 @@ export class MDCTopAppBar extends MDCComponent<MDCTopAppBarBaseFoundation> {
   getDefaultFoundation() {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     const adapter: MDCTopAppBarAdapter = {
       hasClass: (className) => this.root_.classList.contains(className),
       addClass: (className) => this.root_.classList.add(className),

--- a/packages/mdc-top-app-bar/foundation.ts
+++ b/packages/mdc-top-app-bar/foundation.ts
@@ -43,7 +43,7 @@ export class MDCTopAppBarBaseFoundation extends MDCFoundation<MDCTopAppBarAdapte
    * See {@link MDCTopAppBarAdapter} for typing information on parameters and return types.
    */
   static get defaultAdapter(): MDCTopAppBarAdapter {
-    // tslint:disable:object-literal-sort-keys
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
       addClass: () => undefined,
       removeClass: () => undefined,


### PR DESCRIPTION
All `tslint:disable:object-literal-sort-keys` comments now include a description that explains why the linter rule needs to be disabled. For the most part, it's to ensure consistent ordering of methods between adapter interfaces and their implementations in the foundation and component.

This PR also reorders a few properties in `MDCCheckbox` and `MDCRadio` for consistency.

Refs #4225