### PR TITLE
refactor(animation): Remove `transformStyleProperties` export

### DIFF
--- a/packages/mdc-animation/index.js
+++ b/packages/mdc-animation/index.js
@@ -126,8 +126,6 @@ function getAnimationName(windowObj, eventType) {
 // Public functions to access getAnimationName() for JavaScript events or CSS
 // property names.
 
-const transformStyleProperties = ['transform', 'WebkitTransform', 'MozTransform', 'OTransform', 'MSTransform'];
-
 /**
  * @param {!Object} windowObj
  * @param {string} eventType
@@ -146,4 +144,4 @@ function getCorrectPropertyName(windowObj, eventType) {
   return getAnimationName(windowObj, eventType);
 }
 
-export {transformStyleProperties, getCorrectEventName, getCorrectPropertyName};
+export {getCorrectEventName, getCorrectPropertyName};

--- a/packages/mdc-linear-progress/foundation.js
+++ b/packages/mdc-linear-progress/foundation.js
@@ -22,7 +22,7 @@
  */
 
 import MDCFoundation from '@material/base/foundation';
-import {transformStyleProperties} from '@material/animation/index';
+import {getCorrectPropertyName} from '@material/animation/index';
 
 import {cssClasses, strings} from './constants';
 
@@ -100,8 +100,6 @@ export default class MDCLinearProgressFoundation extends MDCFoundation {
 
   setScale_(el, scaleValue) {
     const value = 'scaleX(' + scaleValue + ')';
-    transformStyleProperties.forEach((transformStyleProperty) => {
-      this.adapter_.setStyle(el, transformStyleProperty, value);
-    });
+    this.adapter_.setStyle(el, getCorrectPropertyName(window, 'transform'), value);
   }
 }


### PR DESCRIPTION
Mirrors https://github.com/material-components/material-components-web/pull/4407#discussion_r258668567 from the `feat/typescript` branch.

BREAKING CHANGE: The `transformStyleProperties` array export has been removed from `mdc-animation`. Please use `getCorrectPropertyName(window, 'transform')` instead.