### PR TITLE
fix(menu-surface): Fix anchorElement initialization

### DIFF
--- a/packages/mdc-menu-surface/component.ts
+++ b/packages/mdc-menu-surface/component.ts
@@ -38,7 +38,7 @@ export class MDCMenuSurface extends MDCComponent<MDCMenuSurfaceFoundation> {
     return new MDCMenuSurface(root);
   }
 
-  anchorElement: Element | null = null;
+  anchorElement!: Element | null; // assigned in initialSyncWithDOM()
 
   protected root_!: HTMLElement; // assigned in MDCComponent constructor
 
@@ -54,9 +54,7 @@ export class MDCMenuSurface extends MDCComponent<MDCMenuSurfaceFoundation> {
 
   initialSyncWithDOM() {
     const parentEl = this.root_.parentElement;
-    if (parentEl && parentEl.classList.contains(cssClasses.ANCHOR)) {
-      this.anchorElement = parentEl;
-    }
+    this.anchorElement = parentEl && parentEl.classList.contains(cssClasses.ANCHOR) ? parentEl : null;
 
     if (this.root_.classList.contains(cssClasses.FIXED)) {
       this.setFixedPosition(true);

--- a/test/screenshot/spec/mdc-menu/classes/baseline.html
+++ b/test/screenshot/spec/mdc-menu/classes/baseline.html
@@ -46,7 +46,7 @@
     <main class="test-viewport test-viewport--mobile">
       <div class="test-layout">
         <div class="test-cell test-cell--menu">
-          <div class="test-menu-button-container">
+          <div class="mdc-menu-surface--anchor test-menu-button-container">
             <button class="mdc-button test-menu-button">Open menu</button>
             <div class="mdc-menu mdc-menu-surface mdc-menu-surface--open test-menu--baseline" tabindex="-1" id="demo-menu">
               <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical">

--- a/test/screenshot/spec/mdc-menu/classes/bottom-anchored.html
+++ b/test/screenshot/spec/mdc-menu/classes/bottom-anchored.html
@@ -43,7 +43,7 @@
   </head>
 
   <body class="test-container">
-    <div class="test-menu-button-container test-menu-button-container--bottom-right">
+    <div class="mdc-menu-surface--anchor test-menu-button-container test-menu-button-container--bottom-right">
       <button class="mdc-button test-menu-button">Open menu</button>
       <div class="mdc-menu mdc-menu-surface mdc-menu-surface--open test-menu--bottom-right" tabindex="-1" id="demo-menu">
         <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical">

--- a/test/screenshot/spec/mdc-menu/classes/menu-selection-group.html
+++ b/test/screenshot/spec/mdc-menu/classes/menu-selection-group.html
@@ -46,77 +46,76 @@
     <main class="test-viewport test-viewport--mobile">
       <div class="test-layout">
         <div class="test-cell test-cell--menu">
-          <div class="test-menu-button-container">
+          <div class="mdc-menu-surface--anchor test-menu-button-container">
             <button class="mdc-button test-menu-button">Open menu</button>
-              <div class="mdc-menu mdc-menu-surface mdc-menu-surface--open" tabindex="-1" id="demo-menu" style="left: 0px; top: 36px;">
-                <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical">
-                  <li>
-                    <ul class="mdc-menu__selection-group">
-                      <li class="mdc-list-item" role="menuitem">
-                        <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
-                          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                            <path fill="none" d="M0 0h24v24H0z"/>
-                            <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
-                          </svg>
-                        </span>
-                        <span class="mdc-list-item__text">
-                          Single
-                        </span>
-                      </li>
-                      <li class="mdc-list-item mdc-list-item--disabled" role="menuitem">
-                        <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
-                          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                            <path fill="none" d="M0 0h24v24H0z"/>
-                            <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
-                          </svg>
-                        </span>
-                        <span class="mdc-list-item__text">
-                          1.15
-                        </span>
-                      </li>
-                      <li class="mdc-list-item" role="menuitem">
-                        <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
-                          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                            <path fill="none" d="M0 0h24v24H0z"/>
-                            <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
-                          </svg>
-                        </span>
-                        <span class="mdc-list-item__text">
-                          Double
-                        </span>
-                      </li>
-                      <li class="mdc-list-item mdc-menu-item--selected" role="menuitem">
-                        <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
-                          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                            <path fill="none" d="M0 0h24v24H0z"/>
-                            <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
-                          </svg>
-                        </span>
-                        <span class="mdc-list-item__text">
-                          Custom: 1.2
-                        </span>
-                      </li>
-                    </ul>
-                  </li>
-                  <li class="mdc-list-divider" role="separator"></li>
-                  <li class="mdc-list-item" role="menuitem">
-                    <span class="mdc-list-item__text test-font--redact-all">
-                      Add space before paragraph
-                    </span>
-                  </li>
-                  <li class="mdc-list-item" role="menuitem">
-                    <span class="mdc-list-item__text test-font--redact-all">
-                      Add space after paragraph
-                    </span>
-                  </li>
-                  <li class="mdc-list-divider" role="separator"></li>
-                  <li class="mdc-list-item" role="menuitem">
-                    <span class="mdc-list-item__text test-font--redact-all">
-                      Custom spacing...
-                    </span>
-                  </li>
-                </ul>
-              </div>
+            <div class="mdc-menu mdc-menu-surface mdc-menu-surface--open" tabindex="-1" id="demo-menu" style="left: 0px; top: 36px;">
+              <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical">
+                <li>
+                  <ul class="mdc-menu__selection-group">
+                    <li class="mdc-list-item" role="menuitem">
+                      <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                          <path fill="none" d="M0 0h24v24H0z"/>
+                          <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
+                        </svg>
+                      </span>
+                      <span class="mdc-list-item__text">
+                        Single
+                      </span>
+                    </li>
+                    <li class="mdc-list-item mdc-list-item--disabled" role="menuitem">
+                      <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                          <path fill="none" d="M0 0h24v24H0z"/>
+                          <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
+                        </svg>
+                      </span>
+                      <span class="mdc-list-item__text">
+                        1.15
+                      </span>
+                    </li>
+                    <li class="mdc-list-item" role="menuitem">
+                      <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                          <path fill="none" d="M0 0h24v24H0z"/>
+                          <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
+                        </svg>
+                      </span>
+                      <span class="mdc-list-item__text">
+                        Double
+                      </span>
+                    </li>
+                    <li class="mdc-list-item mdc-menu-item--selected" role="menuitem">
+                      <span class="mdc-list-item__graphic mdc-menu__selection-group-icon">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                          <path fill="none" d="M0 0h24v24H0z"/>
+                          <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
+                        </svg>
+                      </span>
+                      <span class="mdc-list-item__text">
+                        Custom: 1.2
+                      </span>
+                    </li>
+                  </ul>
+                </li>
+                <li class="mdc-list-divider" role="separator"></li>
+                <li class="mdc-list-item" role="menuitem">
+                  <span class="mdc-list-item__text test-font--redact-all">
+                    Add space before paragraph
+                  </span>
+                </li>
+                <li class="mdc-list-item" role="menuitem">
+                  <span class="mdc-list-item__text test-font--redact-all">
+                    Add space after paragraph
+                  </span>
+                </li>
+                <li class="mdc-list-divider" role="separator"></li>
+                <li class="mdc-list-item" role="menuitem">
+                  <span class="mdc-list-item__text test-font--redact-all">
+                    Custom spacing...
+                  </span>
+                </li>
+              </ul>
             </div>
           </div>
         </div>

--- a/test/screenshot/spec/mdc-menu/fixture.js
+++ b/test/screenshot/spec/mdc-menu/fixture.js
@@ -26,7 +26,6 @@ window.mdc.testFixture.fontsLoaded.then(() => {
   const menuEl = document.querySelector('.mdc-menu');
   const menu = mdc.menu.MDCMenu.attachTo(menuEl);
   menu.setAnchorCorner(mdc.menu.Corner.BOTTOM_LEFT);
-  menu.setAnchorElement(buttonEl);
   menu.open = true;
 
   buttonEl.addEventListener('click', () => {

--- a/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
+++ b/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
@@ -45,12 +45,28 @@ function getFixture(open, fixedPosition = false) {
   `;
 }
 
-function setupTest(open = false, fixedPosition = false) {
+function getAnchorFixture(menuFixture) {
+  const anchorEl = bel`
+    <div class="mdc-menu-surface--anchor">
+      <button class="mdc-button">Open</button>
+    </div>
+  `;
+  anchorEl.appendChild(menuFixture);
+  return anchorEl;
+}
+
+function setupTest(open = false, fixedPosition = false, withAnchor = false) {
   const root = getFixture(open, fixedPosition);
   const MockFoundationConstructor = td.constructor(MDCMenuSurfaceFoundation);
   const mockFoundation = new MockFoundationConstructor();
-  const component = new MDCMenuSurface(root, mockFoundation);
-  return {root, component, mockFoundation};
+
+  const fixtures = {root, mockFoundation};
+  if (withAnchor) {
+    fixtures.anchor = getAnchorFixture(root);
+  }
+
+  fixtures.component = new MDCMenuSurface(root, mockFoundation);
+  return fixtures;
 }
 
 suite('MDCMenuSurface');
@@ -128,6 +144,11 @@ test('setMenuSurfaceAnchorElement', () => {
   const myElement = {};
   component.setMenuSurfaceAnchorElement(myElement);
   assert.equal(component.anchorElement, myElement);
+});
+
+test('anchorElement is properly initialized when the DOM contains an anchor', () => {
+  const {component, anchor} = setupTest(false, false, true);
+  assert.equal(component.anchorElement, anchor);
 });
 
 test('hoistMenuToBody', () => {

--- a/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
+++ b/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
@@ -55,18 +55,13 @@ function getAnchorFixture(menuFixture) {
   return anchorEl;
 }
 
-function setupTest(open = false, fixedPosition = false, withAnchor = false) {
+function setupTest({open = false, fixedPosition = false, withAnchor = false} = {}) {
   const root = getFixture(open, fixedPosition);
   const MockFoundationConstructor = td.constructor(MDCMenuSurfaceFoundation);
   const mockFoundation = new MockFoundationConstructor();
-
-  const fixtures = {root, mockFoundation};
-  if (withAnchor) {
-    fixtures.anchor = getAnchorFixture(root);
-  }
-
-  fixtures.component = new MDCMenuSurface(root, mockFoundation);
-  return fixtures;
+  const anchor = withAnchor ? getAnchorFixture(root) : undefined;
+  const component = new MDCMenuSurface(root, mockFoundation);
+  return {root, mockFoundation, anchor, component};
 }
 
 suite('MDCMenuSurface');
@@ -147,7 +142,7 @@ test('setMenuSurfaceAnchorElement', () => {
 });
 
 test('anchorElement is properly initialized when the DOM contains an anchor', () => {
-  const {component, anchor} = setupTest(false, false, true);
+  const {component, anchor} = setupTest({withAnchor: true});
   assert.equal(component.anchorElement, anchor);
 });
 
@@ -172,7 +167,7 @@ test('setIsHoisted', () => {
 });
 
 test('setFixedPosition is called when CSS class is present', () => {
-  const {mockFoundation} = setupTest(false, true);
+  const {mockFoundation} = setupTest({fixedPosition: true});
   td.verify(mockFoundation.setFixedPosition(true));
 });
 
@@ -268,7 +263,7 @@ test(`adapter#notifyOpen fires an ${strings.OPENED_EVENT} custom event`, () => {
 });
 
 test('adapter#restoreFocus restores focus saved by adapter#saveFocus', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const button = bel`<button>Foo</button>`;
   document.body.appendChild(button);
   document.body.appendChild(root);
@@ -282,7 +277,7 @@ test('adapter#restoreFocus restores focus saved by adapter#saveFocus', () => {
 });
 
 test('adapter#restoreFocus does not restore focus if never called adapter#saveFocus', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const button = bel`<button>Foo</button>`;
   document.body.appendChild(button);
   document.body.appendChild(root);
@@ -295,7 +290,7 @@ test('adapter#restoreFocus does not restore focus if never called adapter#saveFo
 });
 
 test('adapter#restoreFocus does nothing if the active focused element is not in the menu-surface', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const button = bel`<button>Foo</button>`;
   document.body.appendChild(button);
   document.body.appendChild(root);
@@ -307,7 +302,7 @@ test('adapter#restoreFocus does nothing if the active focused element is not in 
 });
 
 test('adapter#isFocused returns whether the menu surface is focused', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   document.body.appendChild(root);
   root.focus();
   assert.isTrue(component.getDefaultFoundation().adapter_.isFocused());
@@ -315,7 +310,7 @@ test('adapter#isFocused returns whether the menu surface is focused', () => {
 });
 
 test('adapter#isFirstElementFocused returns true if the first element is focused', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const item = root.querySelectorAll(strings.FOCUSABLE_ELEMENTS)[0];
   document.body.appendChild(root);
   component.open = true;
@@ -329,7 +324,7 @@ test('adapter#isFirstElementFocused returns true if the first element is focused
 });
 
 test('adapter#isLastElementFocused returns true if the last element is focused', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const item = root.querySelectorAll(strings.FOCUSABLE_ELEMENTS)[1];
   document.body.appendChild(root);
   component.open = true;
@@ -343,7 +338,7 @@ test('adapter#isLastElementFocused returns true if the last element is focused',
 });
 
 test('adapter#focusFirstElement focuses the first menu surface element', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const item = root.querySelectorAll(strings.FOCUSABLE_ELEMENTS)[0];
   document.body.appendChild(root);
   component.open = true;
@@ -355,7 +350,7 @@ test('adapter#focusFirstElement focuses the first menu surface element', () => {
 });
 
 test('adapter#focusLastElement focuses the last menu surface element', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const item = root.querySelectorAll(strings.FOCUSABLE_ELEMENTS)[1];
   document.body.appendChild(root);
   component.open = true;
@@ -368,7 +363,7 @@ test('adapter#focusLastElement focuses the last menu surface element', () => {
 
 test('adapter#hasAnchor returns true if the menu surface has an anchor', () => {
   const anchor = bel`<div class="mdc-menu-surface--anchor"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   anchor.appendChild(root);
   component.initialSyncWithDOM();
   assert.isTrue(component.getDefaultFoundation().adapter_.hasAnchor());
@@ -376,7 +371,7 @@ test('adapter#hasAnchor returns true if the menu surface has an anchor', () => {
 
 test('adapter#hasAnchor returns false if it does not have an anchor', () => {
   const notAnAnchor = bel`<div></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   notAnAnchor.appendChild(root);
   component.initialSyncWithDOM();
   assert.isFalse(component.getDefaultFoundation().adapter_.hasAnchor());
@@ -384,7 +379,7 @@ test('adapter#hasAnchor returns false if it does not have an anchor', () => {
 
 test('adapter#getAnchorDimensions returns the dimensions of the anchor element', () => {
   const anchor = bel`<div class="mdc-menu-surface--anchor" style="height: 21px; width: 42px;"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   anchor.appendChild(root);
   document.body.appendChild(anchor);
   component.initialSyncWithDOM();
@@ -394,7 +389,7 @@ test('adapter#getAnchorDimensions returns the dimensions of the anchor element',
 });
 
 test('adapter#getAnchorDimensions returns undefined if there is no anchor element', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   document.body.appendChild(root);
   component.initialSyncWithDOM();
   assert.isNull(component.getDefaultFoundation().adapter_.getAnchorDimensions());
@@ -402,7 +397,7 @@ test('adapter#getAnchorDimensions returns undefined if there is no anchor elemen
 });
 
 test('adapter#getWindowDimensions returns the dimensions of the window', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   document.body.appendChild(root);
   assert.equal(component.getDefaultFoundation().adapter_.getWindowDimensions().height, window.innerHeight);
   assert.equal(component.getDefaultFoundation().adapter_.getWindowDimensions().width, window.innerWidth);
@@ -410,7 +405,7 @@ test('adapter#getWindowDimensions returns the dimensions of the window', () => {
 });
 
 test('adapter#getBodyDimensions returns the body dimensions', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   document.body.appendChild(root);
   assert.equal(component.getDefaultFoundation().adapter_.getBodyDimensions().height, document.body.clientHeight);
   assert.equal(component.getDefaultFoundation().adapter_.getBodyDimensions().width, document.body.clientWidth);
@@ -418,7 +413,7 @@ test('adapter#getBodyDimensions returns the body dimensions', () => {
 });
 
 test('adapter#getWindowScroll returns the scroll position of the window when not scrolled', () => {
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   document.body.appendChild(root);
   assert.equal(component.getDefaultFoundation().adapter_.getWindowScroll().x, window.pageXOffset);
   assert.equal(component.getDefaultFoundation().adapter_.getWindowScroll().y, window.pageYOffset);
@@ -427,7 +422,7 @@ test('adapter#getWindowScroll returns the scroll position of the window when not
 
 test('adapter#isRtl returns true for RTL documents', () => {
   const anchor = bel`<div dir="rtl" class="mdc-menu-surface--anchor"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   anchor.appendChild(root);
   document.body.appendChild(anchor);
   assert.isTrue(component.getDefaultFoundation().adapter_.isRtl());
@@ -436,7 +431,7 @@ test('adapter#isRtl returns true for RTL documents', () => {
 
 test('adapter#isRtl returns false for explicit LTR documents', () => {
   const anchor = bel`<div dir="ltr" class="mdc-menu-surface--anchor"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   anchor.appendChild(root);
   document.body.appendChild(anchor);
   assert.isFalse(component.getDefaultFoundation().adapter_.isRtl());
@@ -445,7 +440,7 @@ test('adapter#isRtl returns false for explicit LTR documents', () => {
 
 test('adapter#isRtl returns false for implicit LTR documents', () => {
   const anchor = bel`<div class="mdc-menu-surface--anchor"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   anchor.appendChild(root);
   document.body.appendChild(anchor);
   assert.isFalse(component.getDefaultFoundation().adapter_.isRtl());
@@ -454,7 +449,7 @@ test('adapter#isRtl returns false for implicit LTR documents', () => {
 
 test('adapter#isElementInContainer returns true if element is in the menu surface', () => {
   const anchor = bel`<div class="mdc-menu-surface--anchor"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const button = document.createElement('button');
   root.appendChild(button);
   anchor.appendChild(root);
@@ -466,7 +461,7 @@ test('adapter#isElementInContainer returns true if element is in the menu surfac
 
 test('adapter#isElementInContainer returns true if element is the menu surface', () => {
   const anchor = bel`<div class="mdc-menu-surface--anchor"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   anchor.appendChild(root);
   document.body.appendChild(anchor);
 
@@ -476,7 +471,7 @@ test('adapter#isElementInContainer returns true if element is the menu surface',
 
 test('adapter#isElementInContainer returns false if element is not in the menu surface', () => {
   const anchor = bel`<div class="mdc-menu-surface--anchor"></div>`;
-  const {root, component} = setupTest(true);
+  const {root, component} = setupTest({open: true});
   const button = document.createElement('button');
   anchor.appendChild(root);
   document.body.appendChild(anchor);


### PR DESCRIPTION
When Menu Surface was converted to TypeScript, its `anchorElement` field was initialized to `null`. This caused a regression, because any proper setup that occurred in `initialSyncWithDOM` was being steamrolled by this `null` initialization, because that occurs in `constructor` _after_ `super` is called.