### PR TITLE
feat(menu): Added new API to manually set focus when menu is opened

### DIFF
--- a/packages/mdc-menu/adapter.ts
+++ b/packages/mdc-menu/adapter.ts
@@ -79,4 +79,16 @@ export interface MDCMenuAdapter {
    * Emit an event when a menu item is selected.
    */
   notifySelected(evtData: MDCMenuItemEventDetail): void;
+
+  /** Returns the menu item count. */
+  getMenuItemCount(): number;
+
+  /** Focuses the menu item at given index. */
+  focusItemAtIndex(index: number): void;
+
+  /** Returns true if menu root element is on focus. */
+  isFocused(): boolean;
+
+  /** Focuses the menu root element. */
+  focus(): void;
 }

--- a/packages/mdc-menu/foundation.ts
+++ b/packages/mdc-menu/foundation.ts
@@ -37,6 +37,7 @@ export class MDCMenuFoundation extends MDCFoundation<MDCMenuAdapter> {
   }
 
   private closeAnimationEndTimerId_ = 0;
+  private focusItemIndex_ = -1;
 
   /**
    * @see {@link MDCMenuAdapter} for typing information on parameters and return types.
@@ -54,6 +55,10 @@ export class MDCMenuFoundation extends MDCFoundation<MDCMenuAdapter> {
       getParentElement: () => null,
       getSelectedElementIndex: () => -1,
       notifySelected: () => undefined,
+      getMenuItemCount: () => 0,
+      focusItemAtIndex: () => undefined,
+      isFocused: () => false,
+      focus: () => undefined,
     };
     // tslint:enable:object-literal-sort-keys
   }
@@ -77,6 +82,17 @@ export class MDCMenuFoundation extends MDCFoundation<MDCMenuAdapter> {
     if (isTab) {
       this.adapter_.closeSurface();
     }
+
+    const arrowUp = evt.key === 'ArrowUp' || evt.keyCode === 38;
+    const arrowDown = evt.key === 'ArrowDown' || evt.keyCode === 40;
+
+    if (!this.adapter_.isFocused()) return;
+
+    if (arrowUp || arrowDown) {
+      evt.preventDefault();
+      const focusItemIndex = arrowUp ? this.adapter_.getMenuItemCount() - 1 : 0;
+      this.focusItemAtIndex_(focusItemIndex);
+    }
   }
 
   handleItemAction(listItem: Element) {
@@ -95,6 +111,27 @@ export class MDCMenuFoundation extends MDCFoundation<MDCMenuAdapter> {
         this.handleSelectionGroup_(selectionGroup, index);
       }
     }, MDCMenuSurfaceFoundation.numbers.TRANSITION_CLOSE_DURATION);
+  }
+
+  handleMenuSurfaceOpened() {
+    this.focusItemAtIndex_(this.focusItemIndex_);
+  }
+
+  /**
+   * Sets the focus item index where the menu should focus on open. Focuses
+   * the menu root element by default.
+   */
+  setFocusItemIndex(index: number) {
+    const lastItemIndex = this.adapter_.getMenuItemCount() - 1;
+    this.focusItemIndex_ = Math.min(lastItemIndex, index);
+  }
+
+  private focusItemAtIndex_(index: number) {
+    if (index < 0) {
+      this.adapter_.focus();
+    } else {
+      this.adapter_.focusItemAtIndex(index);
+    }
   }
 
   /**

--- a/test/screenshot/spec/mdc-menu/fixture.js
+++ b/test/screenshot/spec/mdc-menu/fixture.js
@@ -30,7 +30,26 @@ window.mdc.testFixture.fontsLoaded.then(() => {
   menu.open = true;
 
   buttonEl.addEventListener('click', () => {
+    menu.setFocusItemIndex(-1);
     menu.open = !menu.open;
+  });
+
+  buttonEl.addEventListener('keydown', (evt) => {
+    const arrowUp = evt.key === 'ArrowUp' || evt.keyCode === 38;
+    const arrowDown = evt.key === 'ArrowDown' || evt.keyCode === 40;
+    const isEnter = evt.key === 'Enter' || evt.keyCode === 13;
+
+    if (arrowUp || arrowDown || isEnter) {
+      evt.preventDefault();
+      let focusItemIndex = 0;
+
+      if (arrowUp) {
+        focusItemIndex = menu.items.length - 1;
+      }
+      menu.setFocusItemIndex(focusItemIndex);
+
+      menu.open = true;
+    }
   });
 
   window.mdc.testFixture.notifyDomReady();


### PR DESCRIPTION
BREAKING CHANGE: Focus is no more set to first menu item when clicked on menu button. Introduced new APIs to manually set the focus on specific menu item on open. Also introduced new foundation & adapter methods to incorporate this change.

TODO: Update tests & docs.