### PR TITLE
refactor: Swap MDCTopAppBar Sass Variable Word Order

### DIFF
--- a/packages/mdc-top-app-bar/README.md
+++ b/packages/mdc-top-app-bar/README.md
@@ -176,7 +176,7 @@ Class | Description
 `mdc-top-app-bar--prominent-fixed-adjust` | Class used to style the content below the prominent top app bar to prevent the top app bar from covering it.
 `mdc-top-app-bar--dense` | Class used to style the top app bar as a dense top app bar.
 `mdc-top-app-bar--dense-fixed-adjust` | Class used to style the content below the dense top app bar to prevent the top app bar from covering it.
-`mdc-top-app-bar--dense-prominent-fixed-adjust` | Class used to style the content below the top app bar when styled as both prominent and dense, to prevent the top app bar from covering it.
+`mdc-top-app-bar--dense-prominent-fixed-adjust` | Class used to style the content below the top app bar when styled as both dense and prominent, to prevent the top app bar from covering it.
 `mdc-top-app-bar--short` | Class used to style the top app bar as a short top app bar.
 `mdc-top-app-bar--short-collapsed` | Class used to indicate the short top app bar is collapsed.
 `mdc-top-app-bar--short-fixed-adjust` | Class used to style the content below the short top app bar to prevent the top app bar from covering it.

--- a/packages/mdc-top-app-bar/_variables.scss
+++ b/packages/mdc-top-app-bar/_variables.scss
@@ -53,4 +53,4 @@ $mdc-top-app-bar-dense-section-horizontal-padding: 4px !default;
 $mdc-top-app-bar-dense-title-left-padding: 12px !default;
 
 // Dense & Prominent styles
-$mdc-top-app-bar-prominent-dense-title-bottom-padding: 9px !default;
+$mdc-top-app-bar-dense-prominent-title-bottom-padding: 9px !default;

--- a/packages/mdc-top-app-bar/mdc-top-app-bar.scss
+++ b/packages/mdc-top-app-bar/mdc-top-app-bar.scss
@@ -182,7 +182,7 @@
   transition: box-shadow 200ms linear;
 }
 
-// Specific styles for prominent and dense styled top app bar
+// Specific styles for dense and prominent styled top app bar
 // stylelint-disable plugin/selector-bem-pattern
 .mdc-top-app-bar--dense.mdc-top-app-bar--prominent {
   .mdc-top-app-bar__row {
@@ -196,7 +196,7 @@
   .mdc-top-app-bar__title {
     @include mdc-rtl-reflexive-box(padding, left, $mdc-top-app-bar-title-left-padding);
 
-    padding-bottom: $mdc-top-app-bar-prominent-dense-title-bottom-padding;
+    padding-bottom: $mdc-top-app-bar-dense-prominent-title-bottom-padding;
   }
 }
 // stylelint-enable plugin/selector-bem-pattern


### PR DESCRIPTION
Swap the order of prominent and dense within the variables file to match other sections of the package.

Issue: #4497