### PR TITLE
chore: Add ability to cherry-pick commits for minor releases

### DIFF
--- a/docs/open_source/release-process.md
+++ b/docs/open_source/release-process.md
@@ -34,7 +34,7 @@ This will pull the latest tags and `master` commits into your local repository.
 Run the following script to automatically cherry-pick new bugfixes on top of the last release:
 
 ```
-node scripts/cherry-pick-patch-commits
+node scripts/cherry-pick-commits --patch
 ```
 
 > Note: After running the script, you are in a detached HEAD state. You can create a temporary local branch if desired,

--- a/scripts/cherry-pick-commits.js
+++ b/scripts/cherry-pick-commits.js
@@ -54,8 +54,10 @@ const logFormat = {
 // Use a splitter that is very unlikely to be included in commit descriptions, to be used with the above format
 const logSplitter = ';;;';
 
-// Resolves to the most recent non-pre-release git tag.
-async function getMostRecentTag(mode) {
+// Resolves to the appropriate git tag to serve as the base for a minor or patch release.
+// The base for minor releases is the latest minor release (*.0).
+// The base for patch releases is the latest patch release.
+async function getBaseTag(mode) {
   const tags = await simpleGit.tags();
   // Filter old independent-versioned tags and pre-releases.
   // If cherry-picking for a minor release, ignore patch releases to work from the latest major or minor release.
@@ -176,7 +178,7 @@ async function run() {
   }
   const mode = modeArg.slice(2);
 
-  const tag = args.find((arg) => arg[0] === 'v') || await getMostRecentTag(mode);
+  const tag = args.find((arg) => arg[0] === 'v') || await getBaseTag(mode);
   const isInHistory = await isCommitInHistory(tag);
   const commit = isInHistory ? tag : await resolveCherryPick(tag);
   const list = await getCommitsAfter(commit);

--- a/scripts/cherry-pick-commits.js
+++ b/scripts/cherry-pick-commits.js
@@ -187,13 +187,22 @@ async function run() {
   // non-patch commits from master between the last .0 release and the previous patch release.
   const results = await attemptCherryPicks(tag, list, mode);
 
-  console.log('');
-  console.log('Test-running build...');
-  const buildSucceeded = checkSpawnSuccess('npm run build');
+  let buildSucceeded;
+  let testsSucceeded;
+  const skipTests = args.includes('--skip-tests');
 
-  console.log('');
-  console.log('Running unit tests...');
-  const testsSucceeded = checkSpawnSuccess('npm run test:unit');
+  if (skipTests) {
+    console.log('Skipping npm run build and npm run test:unit.');
+    console.log('You should _really_ run these unless you\'re just testing this script.');
+  } else {
+    console.log('');
+    console.log('Test-running build...');
+    buildSucceeded = checkSpawnSuccess('npm run build');
+
+    console.log('');
+    console.log('Running unit tests...');
+    testsSucceeded = checkSpawnSuccess('npm run test:unit');
+  }
 
   console.log('');
   console.log('Finished!');
@@ -215,9 +224,11 @@ async function run() {
     console.log('(git cherry-pick -x <hash>, then resolve conflicts, then git cherry-pick --continue)');
   }
 
-  console.log('');
-  console.log(`Build status: ${buildSucceeded ? 'Success!' : 'FAIL (see above for errors)'}`);
-  console.log(`Unit tests status: ${testsSucceeded ? 'Success!' : 'FAIL (see above for failures)'}`);
+  if (!skipTests) {
+    console.log('');
+    console.log(`Build status: ${buildSucceeded ? 'Success!' : 'FAIL (see above for errors)'}`);
+    console.log(`Unit tests status: ${testsSucceeded ? 'Success!' : 'FAIL (see above for failures)'}`);
+  }
 
   console.log('');
   console.log('Please review `git log` to make sure there are no commits dependent on omitted feature commits.');


### PR DESCRIPTION
This renames `cherry-pick-patch-commits.js` to just `cherry-pick-commits.js`, and it now expects to see either a `--patch` or `--minor` argument.

`--patch` continues to behave as this script behaved before.

`--minor` seeks to the latest major/minor (not patch) tag, then cherry-picks all non-breaking-change commits.

The end result is similar in both cases - you end up detached from any branch in your local clone and can follow the rest of the release process from there.

(I'll send a separate PR to update the rest of our release process doc.)

This also adds a `--skip-tests` flag to the script, which really shouldn't be used for actual releases, but can be useful when testing updates to this script since it takes a while to build our assets and run our tests, and the final results don't get output until after they run.