### PR TITLE
fix(shape): Allow percentage based global overrides

### DIFF
--- a/packages/mdc-shape/_functions.scss
+++ b/packages/mdc-shape/_functions.scss
@@ -71,13 +71,15 @@
 }
 
 @function mdc-shape-resolve-percentage-for-corner_($component-height, $radius) {
-  @if type-of($radius) == "number" and unit($radius) == "%" {
+  $radius-value: mdc-shape-prop-corner-value_($radius);
+
+  @if type-of($radius-value) == "number" and unit($radius-value) == "%" {
     // Converts the percentage to number without unit. Example: 50% => 50.
-    $percentage: $radius / ($radius * 0 + 1);
+    $percentage: $radius-value / ($radius-value * 0 + 1);
 
     @return $component-height * ($percentage / 100);
   } @else {
-    @return $radius;
+    @return $radius-value;
   }
 }
 

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -1079,6 +1079,14 @@
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/21/19_18_38_795/spec/mdc-select/mixins/shape-radius.html.windows_ie_11.png"
     }
   },
+  "spec/mdc-shape/variables/override.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/28/02_09_33_134/spec/mdc-shape/variables/override.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/28/02_09_33_134/spec/mdc-shape/variables/override.html.windows_chrome_73.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/28/02_09_33_134/spec/mdc-shape/variables/override.html.windows_firefox_65.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/28/02_09_33_134/spec/mdc-shape/variables/override.html.windows_ie_11.png"
+    }
+  },
   "spec/mdc-snackbar/classes/baseline-with-action.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2019/02/11/21_55_33_374/spec/mdc-snackbar/classes/baseline-with-action.html?utm_source=golden_json",
     "screenshots": {

--- a/test/screenshot/spec/mdc-shape/fixture.js
+++ b/test/screenshot/spec/mdc-shape/fixture.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+window.mdc.testFixture.fontsLoaded.then(() => {
+  window.mdc.testFixture.notifyDomReady();
+});

--- a/test/screenshot/spec/mdc-shape/fixture.js
+++ b/test/screenshot/spec/mdc-shape/fixture.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc.
+ * Copyright 2019 Google Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/screenshot/spec/mdc-shape/fixture.scss
+++ b/test/screenshot/spec/mdc-shape/fixture.scss
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Google Inc.
+// Copyright 2019 Google Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,14 +30,10 @@ $mdc-shape-large-component-radius: 50%;
 @import "../../../../packages/mdc-fab/mdc-fab";
 @import "../../../../packages/mdc-textfield/mdc-text-field";
 @import "../../../../packages/mdc-select/mdc-select";
-@import "../../../../packages/mdc-fab/mixins";
 @import "../mixins";
 
 .test-cell--fab,
-.test-cell--button {
-  @include test-cell-size(301, 81);
-}
-
+.test-cell--button,
 .test-cell--textfield,
 .test-cell--select {
   @include test-cell-size(301, 81);

--- a/test/screenshot/spec/mdc-shape/fixture.scss
+++ b/test/screenshot/spec/mdc-shape/fixture.scss
@@ -20,9 +20,11 @@
 // THE SOFTWARE.
 //
 
+// stylelint-disable scss/dollar-variable-pattern
 $mdc-shape-small-component-radius: 50%;
 $mdc-shape-medium-component-radius: 50%;
 $mdc-shape-large-component-radius: 50%;
+// stylelint-enable scss/dollar-variable-pattern
 
 @import "../../../../packages/mdc-button/mdc-button";
 @import "../../../../packages/mdc-fab/mdc-fab";

--- a/test/screenshot/spec/mdc-shape/fixture.scss
+++ b/test/screenshot/spec/mdc-shape/fixture.scss
@@ -1,0 +1,42 @@
+//
+// Copyright 2018 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+$mdc-shape-small-component-radius: 50%;
+$mdc-shape-medium-component-radius: 50%;
+$mdc-shape-large-component-radius: 50%;
+
+@import "../../../../packages/mdc-button/mdc-button";
+@import "../../../../packages/mdc-fab/mdc-fab";
+@import "../../../../packages/mdc-textfield/mdc-text-field";
+@import "../../../../packages/mdc-select/mdc-select";
+@import "../../../../packages/mdc-fab/mixins";
+@import "../mixins";
+
+.test-cell--fab,
+.test-cell--button {
+  @include test-cell-size(301, 81);
+}
+
+.test-cell--textfield,
+.test-cell--select {
+  @include test-cell-size(301, 81);
+}

--- a/test/screenshot/spec/mdc-shape/variables/override.html
+++ b/test/screenshot/spec/mdc-shape/variables/override.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  Copyright 2018 Google Inc.
+  Copyright 2019 Google Inc.
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/test/screenshot/spec/mdc-shape/variables/override.html
+++ b/test/screenshot/spec/mdc-shape/variables/override.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Shape Global Overrides - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-shape/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--fab">
+          <button class="mdc-fab" aria-label="Favorite">
+            <span class="mdc-fab__icon material-icons">favorite_border</span>
+          </button>
+        </div>
+        <div class="test-cell test-cell--fab">
+          <button class="mdc-fab mdc-fab--extended" aria-label="Create">
+            <span class="material-icons mdc-fab__icon">add</span>
+            <span class="mdc-fab__label">Create</span>
+          </button>
+        </div>
+        <div class="test-cell test-cell--button">
+          <button class="mdc-button mdc-button--raised">
+            <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
+            <span class="mdc-button__label">Font Icon</span>
+          </button>
+        </div>
+
+        <div class="test-cell test-cell--textfield">
+            <div class="mdc-text-field">
+              <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
+              <label class="mdc-floating-label" for="filled-text-field">Label</label>
+              <div class="mdc-line-ripple"></div>
+            </div>
+          </div>
+
+          <div class="test-cell test-cell--textfield">
+            <div class="mdc-text-field mdc-text-field--outlined">
+              <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
+              <div class="mdc-notched-outline">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__notch">
+                  <label for="outlined-text-field" class="mdc-floating-label">Label</label>
+                </div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="test-cell test-cell--select">
+              <div class="mdc-select">
+                <select class="mdc-select__native-control" id="my-select">
+                  <option selected></option>
+                  <option value="grains">
+                    Bread, Cereal, Rice, and Pasta
+                  </option>
+                  <option value="vegetables">
+                    Vegetables
+                  </option>
+                  <option value="fruit">
+                    Fruit
+                  </option>
+                </select>
+                <label class="mdc-floating-label" for="my-select">Pick a Food Group</label>
+                <i class="mdc-select__dropdown-icon"></i>
+                <div class="mdc-line-ripple"></div>
+              </div>
+            </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-shape/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-shape/variables/override.html
+++ b/test/screenshot/spec/mdc-shape/variables/override.html
@@ -46,6 +46,7 @@
             <span class="mdc-fab__icon material-icons">favorite_border</span>
           </button>
         </div>
+
         <div class="test-cell test-cell--fab">
           <button class="mdc-fab mdc-fab--extended" aria-label="Create">
             <span class="material-icons mdc-fab__icon">add</span>
@@ -60,46 +61,70 @@
         </div>
 
         <div class="test-cell test-cell--textfield">
-            <div class="mdc-text-field">
-              <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
-              <label class="mdc-floating-label" for="filled-text-field">Label</label>
-              <div class="mdc-line-ripple"></div>
+          <div class="mdc-text-field">
+            <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
+            <label class="mdc-floating-label" for="filled-text-field">Label</label>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--textfield">
+          <div class="mdc-text-field mdc-text-field--outlined">
+            <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
+            <div class="mdc-notched-outline">
+              <div class="mdc-notched-outline__leading"></div>
+              <div class="mdc-notched-outline__notch">
+                <label for="outlined-text-field" class="mdc-floating-label">Label</label>
+              </div>
+              <div class="mdc-notched-outline__trailing"></div>
             </div>
           </div>
+        </div>
 
-          <div class="test-cell test-cell--textfield">
-            <div class="mdc-text-field mdc-text-field--outlined">
-              <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
-              <div class="mdc-notched-outline">
-                <div class="mdc-notched-outline__leading"></div>
-                <div class="mdc-notched-outline__notch">
-                  <label for="outlined-text-field" class="mdc-floating-label">Label</label>
-                </div>
-                <div class="mdc-notched-outline__trailing"></div>
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select">
+            <select class="mdc-select__native-control" id="my-select">
+              <option selected></option>
+              <option value="grains">
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <label class="mdc-floating-label" for="my-select">Pick a Food Group</label>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-line-ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined">
+            <select class="mdc-select__native-control" id="my-select2">
+              <option selected></option>
+              <option value="grains">
+                Bread, Cereal, Rice, and Pasta
+              </option>
+              <option value="vegetables">
+                Vegetables
+              </option>
+              <option value="fruit">
+                Fruit
+              </option>
+            </select>
+            <i class="mdc-select__dropdown-icon"></i>
+            <div class="mdc-notched-outline">
+              <div class="mdc-notched-outline__leading"></div>
+              <div class="mdc-notched-outline__notch">
+                <label class="mdc-floating-label" for="my-select2">Pick a Food Group</label>
               </div>
+              <div class="mdc-notched-outline__trailing"></div>
             </div>
           </div>
-
-          <div class="test-cell test-cell--select">
-              <div class="mdc-select">
-                <select class="mdc-select__native-control" id="my-select">
-                  <option selected></option>
-                  <option value="grains">
-                    Bread, Cereal, Rice, and Pasta
-                  </option>
-                  <option value="vegetables">
-                    Vegetables
-                  </option>
-                  <option value="fruit">
-                    Fruit
-                  </option>
-                </select>
-                <label class="mdc-floating-label" for="my-select">Pick a Food Group</label>
-                <i class="mdc-select__dropdown-icon"></i>
-                <div class="mdc-line-ripple"></div>
-              </div>
-            </div>
-
+        </div>
       </div>
     </main>
 


### PR DESCRIPTION
This PR fixes issue with overriding global shape variables with percentage values.

For example, overriding small component shape global variable would apply given radius (i.e., `50%`) to all small components (button, textfield, etc.).

```
$mdc-shape-small-component-radius: 50%;
```

Whereas, default shape radius value of small component is `4px`. Before this change, overriding shape global variables with percentages resulted in compilation error or wouldn't resolve the percentage value from shape literals.

This change fixes it by resolving shape literals (e.g., `small`) before resolving percentage values.

Refs #4140 