### PR TITLE
fix(select): Use correct shape category consistently with text-field

### DIFF
--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -363,7 +363,7 @@
   @include mdc-select-hover-outline-color($mdc-select-outlined-hover-border);
   @include mdc-select-focused-outline-color(primary);
   @include mdc-floating-label-shake-animation(text-field-outlined);
-  @include mdc-select-outline-shape-radius(medium);
+  @include mdc-select-outline-shape-radius(small);
   @include mdc-states-base-color(transparent);
   @include mdc-select-container-fill-color(transparent);
   @include mdc-notched-outline-floating-label-float-position($mdc-select-outlined-label-position-y, 0);

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -48,7 +48,7 @@
   @include mdc-select-label-color($mdc-select-label-color);
   @include mdc-select-bottom-line-color($mdc-select-bottom-line-idle-color);
   @include mdc-select-helper-text-color($mdc-select-helper-text-color);
-  @include mdc-select-shape-radius(medium);
+  @include mdc-select-shape-radius(small);
 
   // Focused state colors
   @include mdc-select-focused-bottom-line-color(primary);


### PR DESCRIPTION
I realized while digging into #4547 that our select and text field were using inconsistent shape categories. I checked with design and our text field is correctly using `small`, so select needs to be updated.

This causes no diffs in CSS because small and medium both default to `4px` (which is also how this went unnoticed for so long).