### PR TITLE
fix(tab): Disable firefox focus ring

### DIFF
--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -50,6 +50,11 @@
   cursor: pointer;
   -webkit-appearance: none;
   z-index: 1;
+
+  // Firefox still draws a dotted border around focused buttons unless specifically overridden.
+  :-moz-focusring {
+    border: none;
+  }
 }
 
 .mdc-tab--min-width {


### PR DESCRIPTION
Disables the dotted line focus ring, added on firefox, from the button used by `mdc-tab`.

![image](https://user-images.githubusercontent.com/34519388/55361933-6bf74580-548d-11e9-9335-b03ab463af64.png)
