### PR TITLE
docs: Make framework wrappers page discoverable to site generator

### DIFF
--- a/docs/framework-wrappers.md
+++ b/docs/framework-wrappers.md
@@ -1,3 +1,11 @@
+<!--docs:
+title: "MDC Web on other frameworks"
+navTitle: "Framework Wrappers"
+layout: landing
+section: docs
+path: /docs/framework-wrappers/
+-->
+
 ## MDC Web on other frameworks
 
 Material Components for the web are architected to be adaptable to various major web frameworks. The following wrapper libraries are available:


### PR DESCRIPTION
Adds front-matter to the framework-wrappers.md page, because one of our designers on the site team pointed out it would be a really helpful page to have showing up on material.io.