### PR TITLE
fix(tab): Update moz-focusring to moz-focus-inner to match button

### DIFF
--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -52,7 +52,7 @@
   z-index: 1;
 
   // Firefox still draws a dotted border around focused buttons unless specifically overridden.
-  ::-moz-focus-inner {
+  &::-moz-focus-inner {
     padding: 0;
     border: 0;
   }

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -52,8 +52,9 @@
   z-index: 1;
 
   // Firefox still draws a dotted border around focused buttons unless specifically overridden.
-  :-moz-focusring {
-    border: none;
+  ::-moz-focus-inner {
+    padding: 0;
+    border: 0;
   }
 }
 


### PR DESCRIPTION
The previous style does not work as expected on all versions of firefox, so this change copies the selector used by the button element to disable the dotted line outline.