### PR TITLE
fix(menu): Incorrect menu positioning when first click

### DIFF
--- a/packages/mdc-menu-surface/_mixins.scss
+++ b/packages/mdc-menu-surface/_mixins.scss
@@ -95,6 +95,8 @@
   @include mdc-feature-targets($feat-structure) {
     display: none;
     position: absolute;
+    top: 0;
+    left: 0;
     box-sizing: border-box;
     max-width: calc(100vw - #{$mdc-menu-surface-min-distance-from-edge});
     max-height: calc(100vh - #{$mdc-menu-surface-min-distance-from-edge});

--- a/packages/mdc-menu-surface/_mixins.scss
+++ b/packages/mdc-menu-surface/_mixins.scss
@@ -95,8 +95,6 @@
   @include mdc-feature-targets($feat-structure) {
     display: none;
     position: absolute;
-    top: 0;
-    left: 0;
     box-sizing: border-box;
     max-width: calc(100vw - #{$mdc-menu-surface-min-distance-from-edge});
     max-height: calc(100vh - #{$mdc-menu-surface-min-distance-from-edge});

--- a/packages/mdc-menu-surface/foundation.ts
+++ b/packages/mdc-menu-surface/foundation.ts
@@ -174,14 +174,14 @@ export class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapte
    */
   open() {
     this.adapter_.saveFocus();
-
+    this.autoPosition_();
+    
     if (!this.isQuickOpen_) {
       this.adapter_.addClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_OPEN);
     }
 
     this.animationRequestId_ = requestAnimationFrame(() => {
       this.adapter_.addClass(MDCMenuSurfaceFoundation.cssClasses.OPEN);
-      this.dimensions_ = this.adapter_.getInnerDimensions();
       this.autoPosition_();
       if (this.isQuickOpen_) {
         this.adapter_.notifyOpen();
@@ -252,6 +252,7 @@ export class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapte
   }
 
   private autoPosition_() {
+    this.dimensions_ = this.adapter_.getInnerDimensions();
     // Compute measurements for autoposition methods reuse.
     this.measurements_ = this.getAutoLayoutMeasurements_();
 

--- a/packages/mdc-menu-surface/foundation.ts
+++ b/packages/mdc-menu-surface/foundation.ts
@@ -175,7 +175,7 @@ export class MDCMenuSurfaceFoundation extends MDCFoundation<MDCMenuSurfaceAdapte
   open() {
     this.adapter_.saveFocus();
     this.autoPosition_();
-    
+
     if (!this.isQuickOpen_) {
       this.adapter_.addClass(MDCMenuSurfaceFoundation.cssClasses.ANIMATING_OPEN);
     }

--- a/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
+++ b/test/unit/mdc-menu-surface/menu-surface.foundation.test.js
@@ -825,6 +825,6 @@ testFoundation('should cancel animation after destroy', ({foundation, mockAdapte
 
   td.verify(
     mockAdapter.setPosition(td.matchers.anything()),
-    {times: 0}
+    {times: 1}
   );
 });


### PR DESCRIPTION
![스크린샷 2019-04-09 오후 12 20 34](https://user-images.githubusercontent.com/20078201/55776863-0d5b4880-5ad9-11e9-8286-742afc16a5fa.png)
> When you first click on the menu, dropdown is positioning incorrect.

![스크린샷 2019-04-09 오후 12 20 47](https://user-images.githubusercontent.com/20078201/55776973-61fec380-5ad9-11e9-8e89-36010bb47552.png)
> But it works find after second click.

![스크린샷 2019-04-09 오후 12 27 32](https://user-images.githubusercontent.com/20078201/55777112-e0f3fc00-5ad9-11e9-8c05-fd03dd3e7108.png)
The position of the dropdown goes inline style.
But when first click, there is no top/left value.
In this case dropdown make inner scroll and position calculated incorrect.
So how about give initial position?