### PR TITLE
fix(text-field): Fix TextField padding with leading icon

### DIFF
--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -381,7 +381,7 @@
 @mixin mdc-text-field-dense-with-leading-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
     left,
-    $mdc-text-field-dense-icon-position,
+    $mdc-text-field-icon-position,
     $mdc-text-field-dense-icon-padding,
     $mdc-text-field-input-padding
   );
@@ -430,7 +430,7 @@
 @mixin mdc-text-field-with-trailing-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
     right,
-    $mdc-text-field-trailing-icon-position,
+    $mdc-text-field-icon-position,
     $mdc-text-field-icon-padding,
     $mdc-text-field-input-padding
   );
@@ -449,7 +449,7 @@
 @mixin mdc-text-field-dense-with-trailing-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
     right,
-    $mdc-text-field-dense-icon-position,
+    $mdc-text-field-icon-position,
     $mdc-text-field-dense-icon-padding,
     $mdc-text-field-input-padding
   );
@@ -459,16 +459,16 @@
   @include mdc-text-field-icon-horizontal-position-two-icons_(
     $mdc-text-field-icon-position,
     $mdc-text-field-icon-padding,
-    $mdc-text-field-trailing-icon-position,
+    $mdc-text-field-icon-position,
     $mdc-text-field-icon-padding
   );
 }
 
 @mixin mdc-text-field-dense-with-both-icons_ {
   @include mdc-text-field-icon-horizontal-position-two-icons_(
-    $mdc-text-field-dense-icon-position,
+    $mdc-text-field-icon-position,
     $mdc-text-field-dense-icon-padding,
-    $mdc-text-field-dense-icon-position,
+    $mdc-text-field-icon-position,
     $mdc-text-field-dense-icon-padding
   );
 }

--- a/packages/mdc-textfield/icon/_variables.scss
+++ b/packages/mdc-textfield/icon/_variables.scss
@@ -22,4 +22,5 @@
 
 $mdc-text-field-icon-position: 12px !default;
 $mdc-text-field-icon-padding: 48px !default;
+$mdc-text-field-dense-icon-padding: 44px !default;
 $mdc-text-field-dense-icon-padding: 38px !default;

--- a/packages/mdc-textfield/icon/_variables.scss
+++ b/packages/mdc-textfield/icon/_variables.scss
@@ -22,5 +22,4 @@
 
 $mdc-text-field-icon-position: 12px !default;
 $mdc-text-field-icon-padding: 48px !default;
-$mdc-text-field-dense-icon-padding: 44px !default;
 $mdc-text-field-dense-icon-padding: 38px !default;

--- a/packages/mdc-textfield/icon/_variables.scss
+++ b/packages/mdc-textfield/icon/_variables.scss
@@ -23,4 +23,3 @@
 $mdc-text-field-icon-position: 12px !default;
 $mdc-text-field-icon-padding: 48px !default;
 $mdc-text-field-dense-icon-padding: 44px !default;
-$mdc-text-field-dense-icon-padding: 38px !default;

--- a/packages/mdc-textfield/icon/_variables.scss
+++ b/packages/mdc-textfield/icon/_variables.scss
@@ -20,9 +20,7 @@
 // THE SOFTWARE.
 //
 
-$mdc-text-field-icon-position: 16px !default;
-$mdc-text-field-trailing-icon-position: 12px !default;
+$mdc-text-field-icon-position: 12px !default;
 $mdc-text-field-icon-padding: 48px !default;
 $mdc-text-field-dense-icon-padding: 44px !default;
-$mdc-text-field-dense-icon-position: 12px !default;
 $mdc-text-field-dense-icon-padding: 38px !default;


### PR DESCRIPTION
Refs #4294 

Padding is now constant across text field variants and icon position at 12px.
I have a question about a variable initialized 2 times with different values, please see comment.