### PR TITLE
feat(text-field): define icon's cssClasses

### DIFF
--- a/packages/mdc-textfield/icon/constants.ts
+++ b/packages/mdc-textfield/icon/constants.ts
@@ -26,4 +26,8 @@ const strings = {
   ICON_ROLE: 'button',
 };
 
-export {strings};
+const cssClasses = {
+  ROOT: 'mdc-text-field__icon',
+};
+
+export {strings, cssClasses};

--- a/packages/mdc-textfield/icon/foundation.ts
+++ b/packages/mdc-textfield/icon/foundation.ts
@@ -24,7 +24,7 @@
 import {MDCFoundation} from '@material/base/foundation';
 import {SpecificEventListener} from '@material/base/types';
 import {MDCTextFieldIconAdapter} from './adapter';
-import {strings} from './constants';
+import {cssClasses, strings} from './constants';
 
 type InteractionEventType = 'click' | 'keydown';
 
@@ -33,6 +33,10 @@ const INTERACTION_EVENTS: InteractionEventType[] = ['click', 'keydown'];
 export class MDCTextFieldIconFoundation extends MDCFoundation<MDCTextFieldIconAdapter> {
   static get strings() {
     return strings;
+  }
+
+  static get cssClasses() {
+    return cssClasses;
   }
 
   /**


### PR DESCRIPTION
There is one question!
"mdc-text-field__icon" or "mdc-text-field-icon", which one is correct?
Almost code is written "mdc-text-field__icon".

![스크린샷 2019-04-17 오후 5 20 19](https://user-images.githubusercontent.com/20078201/56272165-1c737380-6135-11e9-9095-8707e6afe976.png)
But definition of cssClasses is written "mdc-text-field-icon" in README.
And other module(helper-text/counter) follows this convention.