### PR TITLE
fix(tab-bar): fix the activation of tab without previous active tab

### DIFF
--- a/packages/mdc-tab-bar/adapter.ts
+++ b/packages/mdc-tab-bar/adapter.ts
@@ -74,7 +74,7 @@ export interface MDCTabBarAdapter {
    * @param index The index of the tab to activate
    * @param clientRect The client rect of the previously active Tab Indicator
    */
-  activateTabAtIndex(index: number, clientRect: ClientRect): void;
+  activateTabAtIndex(index: number, clientRect?: ClientRect): void;
 
   /**
    * Deactivates the tab at the given index

--- a/packages/mdc-tab-bar/foundation.ts
+++ b/packages/mdc-tab-bar/foundation.ts
@@ -97,8 +97,13 @@ export class MDCTabBarFoundation extends MDCFoundation<MDCTabBarAdapter> {
       return;
     }
 
-    this.adapter_.deactivateTabAtIndex(previousActiveIndex);
-    this.adapter_.activateTabAtIndex(index, this.adapter_.getTabIndicatorClientRectAtIndex(previousActiveIndex));
+    let previousClientRect;
+    if (previousActiveIndex !== -1) {
+      this.adapter_.deactivateTabAtIndex(previousActiveIndex);
+      previousClientRect = this.adapter_.getTabIndicatorClientRectAtIndex(previousActiveIndex);
+    }
+
+    this.adapter_.activateTabAtIndex(index, previousClientRect);
     this.scrollIntoView(index);
 
     this.adapter_.notifyTabActivated(index);

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -376,7 +376,7 @@ test('#activateTab() deactivates the previously active tab', () => {
   td.verify(mockAdapter.deactivateTabAtIndex(6), {times: 1});
 });
 
-test('#activateTab() does not try deactivate the previously active tab if there is none', () => {
+test('#activateTab() does not deactivate the previously active tab if there is none', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);
   td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(-1);

--- a/test/unit/mdc-tab-bar/foundation.test.js
+++ b/test/unit/mdc-tab-bar/foundation.test.js
@@ -376,6 +376,14 @@ test('#activateTab() deactivates the previously active tab', () => {
   td.verify(mockAdapter.deactivateTabAtIndex(6), {times: 1});
 });
 
+test('#activateTab() does not try deactivate the previously active tab if there is none', () => {
+  const {foundation, mockAdapter} = setupActivateTabTest();
+  td.when(mockAdapter.getTabListLength()).thenReturn(13);
+  td.when(mockAdapter.getPreviousActiveTabIndex()).thenReturn(-1);
+  foundation.activateTab(1);
+  td.verify(mockAdapter.deactivateTabAtIndex(td.matchers.anything()), {times: 0});
+});
+
 test('#activateTab() activates the newly active tab with the previously active tab\'s indicatorClientRect', () => {
   const {foundation, mockAdapter} = setupActivateTabTest();
   td.when(mockAdapter.getTabListLength()).thenReturn(13);


### PR DESCRIPTION
If there is no previous active tab, the index will be `-1`, which will be trigger errors in the adapter of the component when trying to call methods on `this.tabList_[index]`. This is now handled gracefully for the case when there is no previously active tab.

Fixes #4226 