### PR TITLE
fix(text-field): fix overlapping icon and text field (#4617)

### DIFF
--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -127,7 +127,8 @@
 
   // Vertically center aligns the text input placeholder and value for only filled variant.
   .mdc-text-field--no-label:not(.mdc-text-field--outlined):not(.mdc-text-field--textarea) & {
-    padding: 16px;
+    padding-top: 16px;
+    padding-bottom: 16px;
   }
 }
 // stylelint-disable-next-line plugin/selector-bem-pattern


### PR DESCRIPTION
Set only top and bottom padding to vertically center without affecting
side padding that is set when an icon is present.

fixes #4617