### PR TITLE
fix(ripple): Use standard element removal method

### DIFF
--- a/packages/mdc-ripple/util.ts
+++ b/packages/mdc-ripple/util.ts
@@ -48,7 +48,10 @@ function detectEdgePseudoVarBug(windowObj: Window): boolean {
   // See: https://bugzilla.mozilla.org/show_bug.cgi?id=548397
   const computedStyle = windowObj.getComputedStyle(node);
   const hasPseudoVarBug = computedStyle !== null && computedStyle.borderTopStyle === 'solid';
-  document.body.removeChild(node);
+  const el = document.documentElement.querySelector('.mdc-ripple-surface--test-edge-var-bug');
+  if (el) {
+    document.documentElement.removeChild(el);
+  }
   return hasPseudoVarBug;
 }
 

--- a/packages/mdc-ripple/util.ts
+++ b/packages/mdc-ripple/util.ts
@@ -48,7 +48,7 @@ function detectEdgePseudoVarBug(windowObj: Window): boolean {
   // See: https://bugzilla.mozilla.org/show_bug.cgi?id=548397
   const computedStyle = windowObj.getComputedStyle(node);
   const hasPseudoVarBug = computedStyle !== null && computedStyle.borderTopStyle === 'solid';
-  node.remove();
+  document.body.removeChild(node);
   return hasPseudoVarBug;
 }
 

--- a/packages/mdc-ripple/util.ts
+++ b/packages/mdc-ripple/util.ts
@@ -48,9 +48,8 @@ function detectEdgePseudoVarBug(windowObj: Window): boolean {
   // See: https://bugzilla.mozilla.org/show_bug.cgi?id=548397
   const computedStyle = windowObj.getComputedStyle(node);
   const hasPseudoVarBug = computedStyle !== null && computedStyle.borderTopStyle === 'solid';
-  const el = document.documentElement.querySelector('.mdc-ripple-surface--test-edge-var-bug');
-  if (el) {
-    document.documentElement.removeChild(el);
+  if (node.parentNode) {
+    node.parentNode.removeChild(node);
   }
   return hasPseudoVarBug;
 }

--- a/test/unit/mdc-ripple/helpers.js
+++ b/test/unit/mdc-ripple/helpers.js
@@ -66,6 +66,9 @@ export function createMockWindowForCssVariables() {
 
   td.when(mockDoc.createElement('div')).thenReturn({
     remove: remove,
+    parentNode: {
+      removeChild: () => mockWindow.appendedNodes--,
+    },
   });
 
   const mockWindow = {


### PR DESCRIPTION
No functional change but helps with linters.