### PR TITLE
fix(text-field): Padding between Textfield and Icon

### DIFF
--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -398,7 +398,10 @@
     $mdc-text-field-icon-padding,
     $mdc-text-field-input-padding
   );
-  @include mdc-notched-outline-floating-label-float-position($mdc-text-field-outlined-label-position-y, 32px);
+  @include mdc-notched-outline-floating-label-float-position(
+    $mdc-text-field-outlined-label-position-y,
+    $mdc-text-field-outlined-with-leading-icon-label-position-x
+  );
   @include mdc-floating-label-shake-animation(text-field-outlined-leading-icon);
 
   @include mdc-rtl {

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -59,7 +59,7 @@ $mdc-text-field-dense-label-position-y: 70% !default;
 $mdc-text-field-dense-label-scale: .8 !default;
 $mdc-text-field-outlined-label-position-y: 130% !default;
 $mdc-text-field-outlined-dense-label-position-y: 120% !default;
-$mdc-text-field-outlined-with-leading-icon-label-position-x: 0 !default;
+$mdc-text-field-outlined-with-leading-icon-label-position-x: 36px !default;
 $mdc-text-field-outlined-dense-with-leading-icon-label-position-x: 21px !default;
 $mdc-text-field-textarea-label-position-y: 130% !default;
 $mdc-text-field-helper-line-padding: 16px !default;

--- a/packages/mdc-textfield/icon/_variables.scss
+++ b/packages/mdc-textfield/icon/_variables.scss
@@ -22,7 +22,7 @@
 
 $mdc-text-field-icon-position: 16px !default;
 $mdc-text-field-trailing-icon-position: 12px !default;
-$mdc-text-field-icon-padding: 48px !default;
+$mdc-text-field-icon-padding: 52px !default;
 $mdc-text-field-dense-icon-padding: 44px !default;
 $mdc-text-field-dense-icon-position: 12px !default;
 $mdc-text-field-dense-icon-padding: 38px !default;


### PR DESCRIPTION
Together with my PR #4595, this should fix #4296 
`$mdc-text-field-icon-padding` was set to `48px`.
But when an icon is present, the input padding should be the sum of:
- the icon padding: `12px`,
- the icon width: `24px`,
- the input padding: `16px`
Therefore `52px`.
