### PR TITLE
fix(tab): Explicitly set margin to 0 on tabs for Safari

### DIFF
--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -42,6 +42,7 @@
   box-sizing: border-box;
   height: $mdc-tab-height;
   padding: 0 24px;
+  margin: 0;
   border: none;
   outline: none;
   background: none;

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -41,6 +41,7 @@
   justify-content: center;
   box-sizing: border-box;
   height: $mdc-tab-height;
+  // Explicitly setting margin to 0 is to override safari default margin for button elements.
   margin: 0;
   padding: 0 24px;
   border: none;

--- a/packages/mdc-tab/mdc-tab.scss
+++ b/packages/mdc-tab/mdc-tab.scss
@@ -41,8 +41,8 @@
   justify-content: center;
   box-sizing: border-box;
   height: $mdc-tab-height;
-  padding: 0 24px;
   margin: 0;
+  padding: 0 24px;
   border: none;
   outline: none;
   background: none;


### PR DESCRIPTION
fixes #4653 