### PR TITLE
fix(tab): Fix tab color variables to use color literals

### DIFF
--- a/packages/mdc-tab/_variables.scss
+++ b/packages/mdc-tab/_variables.scss
@@ -28,5 +28,5 @@ $mdc-tab-text-label-opacity: .6 !default;
 $mdc-tab-icon-opacity: .54 !default;
 $mdc-tab-text-label-color-default: rgba(mdc-theme-prop-value(on-surface), $mdc-tab-text-label-opacity) !default;
 $mdc-tab-icon-color-default: rgba(mdc-theme-prop-value(on-surface), $mdc-tab-icon-opacity) !default;
-$mdc-tab-text-label-color-active: mdc-theme-prop-value(primary);
-$mdc-tab-icon-color-active: mdc-theme-prop-value(primary);
+$mdc-tab-text-label-color-active: primary !default;
+$mdc-tab-icon-color-active: primary !default;


### PR DESCRIPTION
This should fix #4686 to some extent.

- Used theme literal (`primary`) when defining override variables, where as, `mdc-theme-prop-value` is a function that returns a color value of `primary`.
- Set `!default` to all sass variables defined in `_variable.scss` for full customization.