### PR TITLE
fix(dialog): Use 100vw for dialog max-width calculation.

### DIFF
--- a/packages/mdc-dialog/_mixins.scss
+++ b/packages/mdc-dialog/_mixins.scss
@@ -392,7 +392,7 @@
 
 @mixin mdc-dialog-max-width($max-width, $margin, $query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
-  $max-size-calc-expr: calc(100% - #{$margin * 2});
+  $max-size-calc-expr: calc(100vw - #{$margin * 2});
 
   .mdc-dialog__surface {
     @include mdc-feature-targets($feat-structure) {


### PR DESCRIPTION
Use 100vw as it doesn't have the same browser incompatibilities that 100vh does (see PR #4746 for context). 100% width on the other hand breaks on mobile/Safari.