### PR TITLE
fix(menu): Vertically center the group icon

### DIFF
--- a/packages/mdc-menu/_mixins.scss
+++ b/packages/mdc-menu/_mixins.scss
@@ -107,6 +107,9 @@
 
         display: none;
         position: absolute;
+        // IE11 requires the icon to be vertically centered due to its absolute positioning
+        top: 50%;
+        transform: translateY(-50%);
       }
     }
   }

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -792,27 +792,27 @@
     }
   },
   "spec/mdc-menu/classes/menu-selection-group-only.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/10/14_25_41_111/spec/mdc-menu/classes/menu-selection-group-only.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/27/18_48_56_264/spec/mdc-menu/classes/menu-selection-group-only.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/10/14_25_41_111/spec/mdc-menu/classes/menu-selection-group-only.html.windows_chrome_74.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/19/17_12_22_925/spec/mdc-menu/classes/menu-selection-group-only.html.windows_firefox_65.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/19/17_12_22_925/spec/mdc-menu/classes/menu-selection-group-only.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/27/18_48_56_264/spec/mdc-menu/classes/menu-selection-group-only.html.windows_ie_11.png"
     }
   },
   "spec/mdc-menu/classes/menu-selection-group.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/10/14_25_41_111/spec/mdc-menu/classes/menu-selection-group.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/27/18_48_56_264/spec/mdc-menu/classes/menu-selection-group.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/10/14_25_41_111/spec/mdc-menu/classes/menu-selection-group.html.windows_chrome_74.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/15/18_35_08_782/spec/mdc-menu/classes/menu-selection-group.html.windows_firefox_65.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/03/15/18_35_08_782/spec/mdc-menu/classes/menu-selection-group.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/27/18_48_56_264/spec/mdc-menu/classes/menu-selection-group.html.windows_ie_11.png"
     }
   },
   "spec/mdc-menu/classes/multiple-menu-selection-group.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/12/17_35_21_026/spec/mdc-menu/classes/multiple-menu-selection-group.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/27/18_48_56_264/spec/mdc-menu/classes/multiple-menu-selection-group.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/12/17_35_21_026/spec/mdc-menu/classes/multiple-menu-selection-group.html.windows_chrome_75.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/12/17_35_21_026/spec/mdc-menu/classes/multiple-menu-selection-group.html.windows_firefox_67.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/12/17_35_21_026/spec/mdc-menu/classes/multiple-menu-selection-group.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/06/27/18_48_56_264/spec/mdc-menu/classes/multiple-menu-selection-group.html.windows_ie_11.png"
     }
   },
   "spec/mdc-menu/issues/4025.html": {


### PR DESCRIPTION
IE11 does not vertically position the group icon when it is followed by a text item. This fixes that behavior.
![UBXZKPFOvPi](https://user-images.githubusercontent.com/5939574/60291989-ff93b300-98d0-11e9-919a-bea1cf828cb7.png)
