### PR TITLE
fix(infrastructure): support ssr by removing the reference from window

### DIFF
--- a/scripts/webpack/js-bundle-factory.js
+++ b/scripts/webpack/js-bundle-factory.js
@@ -64,6 +64,7 @@ class JsBundleFactory {
         httpDirAbsolutePath = undefined, // Required for running the demo server
         filenamePattern = this.env_.isProd() ? '[name].min.js' : '[name].js',
         library,
+        globalObject = 'this',
       },
       plugins = [],
       tsConfigFilePath = path.resolve(__dirname, '../../tsconfig.json'),
@@ -97,6 +98,7 @@ class JsBundleFactory {
         filename: filenamePattern,
         libraryTarget: 'umd',
         library,
+        globalObject,
       },
       resolve: {extensions},
       devtool: 'source-map',


### PR DESCRIPTION
related https://github.com/material-components/material-components-web-react/issues/954

Confirmed that in [v2.3.0 of drawer](https://unpkg.com/@material/drawer@2.3.0/dist/mdc.drawer.js), the output.globalObject referenced `this`. In the [webpack 4 update](https://github.com/material-components/material-components-web/pull/4847), this was changed to `window`. To support SSR and ensure that no breaking changes occur during the webpack 4 upgrade, I suggest this change. 