### PR TITLE
fix(fab): clear text decoration

### DIFF
--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -204,6 +204,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
     padding: 0;
     border: none;
     fill: currentColor;
+    text-decoration: none;
     cursor: pointer;
     user-select: none;
     -moz-appearance: none;


### PR DESCRIPTION
Clears the `text-decoration` from the FAB, otherwise text-based icons might become underlined in some browsers.

Here's an example of Angular Material on Edge:
![Angular_Material_‎-_Microsoft_Edge_2019-06-30_12-18-24](https://user-images.githubusercontent.com/4450522/60395294-bc844a80-9b31-11e9-9efd-0fc22c95a959.png)
