### PR TITLE
fix(checkbox): Fixed checkbox container fill color when animating

### DIFF
--- a/packages/mdc-checkbox/_functions.scss
+++ b/packages/mdc-checkbox/_functions.scss
@@ -22,18 +22,10 @@
 
 @import "@material/theme/functions";
 
-$mdc-checkbox-container-keyframes-uid_: -1;
-
 @function mdc-checkbox-transition-enter($property, $delay: 0ms, $duration: $mdc-checkbox-transition-duration) {
   @return mdc-animation-enter($property, $duration, $delay);
 }
 
 @function mdc-checkbox-transition-exit($property, $delay: 0ms, $duration: $mdc-checkbox-transition-duration) {
   @return mdc-animation-exit-temporary($property, $duration, $delay);
-}
-
-@function mdc-checkbox-container-keyframes-uid_() {
-  $mdc-checkbox-container-keyframes-uid_: $mdc-checkbox-container-keyframes-uid_ + 1 !global;
-
-  @return $mdc-checkbox-container-keyframes-uid_;
 }

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -248,7 +248,7 @@
   }
 
   @if $generate-keyframes {
-    $uid: mdc-checkbox-container-keyframes-uid_();
+    $uid: unique-id();
     $anim-selector: if(&, "&.mdc-checkbox--anim", ".mdc-checkbox--anim");
 
     @include mdc-feature-targets($feat-animation, $feat-color) {


### PR DESCRIPTION
### Description

Used Sass's `unique-id()` unique id generator function instead of using number incriminator which might not work if override Sass mixin is compiled in another session.

Fixes #4710

