### PR TITLE
chore: add `repository.directory` in `package.json` for all packages

### DIFF
--- a/packages/material-components-web/package.json
+++ b/packages/material-components-web/package.json
@@ -13,7 +13,8 @@
   "types": "dist/material-components-web.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/material-components-web"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-animation/package.json
+++ b/packages/mdc-animation/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.animation.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-animation"
   },
   "dependencies": {
     "tslib": "^1.9.3"

--- a/packages/mdc-auto-init/package.json
+++ b/packages/mdc-auto-init/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-auto-init"
   },
   "dependencies": {
     "@material/base": "^3.0.0",

--- a/packages/mdc-base/package.json
+++ b/packages/mdc-base/package.json
@@ -9,7 +9,8 @@
   "types": "dist/mdc.base.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-base"
   },
   "dependencies": {
     "tslib": "^1.9.3"

--- a/packages/mdc-button/package.json
+++ b/packages/mdc-button/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-button"
   },
   "dependencies": {
     "@material/elevation": "^3.0.0",

--- a/packages/mdc-card/package.json
+++ b/packages/mdc-card/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-card"
   },
   "dependencies": {
     "@material/elevation": "^3.0.0",

--- a/packages/mdc-checkbox/package.json
+++ b/packages/mdc-checkbox/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.checkbox.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-checkbox"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-chips/package.json
+++ b/packages/mdc-chips/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-chips"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-dialog/package.json
+++ b/packages/mdc-dialog/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.dialog.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-dialog"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-dom/package.json
+++ b/packages/mdc-dom/package.json
@@ -9,7 +9,8 @@
   "types": "dist/mdc.dom.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-dom"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-drawer/package.json
+++ b/packages/mdc-drawer/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.drawer.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-drawer"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-elevation/package.json
+++ b/packages/mdc-elevation/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-elevation"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-fab/package.json
+++ b/packages/mdc-fab/package.json
@@ -11,7 +11,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-fab"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-feature-targeting/package.json
+++ b/packages/mdc-feature-targeting/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-feature-targeting"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-floating-label/package.json
+++ b/packages/mdc-floating-label/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.floatingLabel.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/material-components/material-components-web.git"
+    "url": "git+https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-floating-label"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-form-field/package.json
+++ b/packages/mdc-form-field/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.formField.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-form-field"
   },
   "dependencies": {
     "@material/base": "^3.0.0",

--- a/packages/mdc-grid-list/package.json
+++ b/packages/mdc-grid-list/package.json
@@ -9,7 +9,8 @@
   "types": "dist/mdc.gridList.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-grid-list"
   },
   "keywords": [
     "material components",

--- a/packages/mdc-icon-button/package.json
+++ b/packages/mdc-icon-button/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-icon-button"
   },
   "dependencies": {
     "@material/base": "^3.0.0",

--- a/packages/mdc-image-list/package.json
+++ b/packages/mdc-image-list/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-image-list"
   },
   "keywords": [
     "material components",

--- a/packages/mdc-layout-grid/package.json
+++ b/packages/mdc-layout-grid/package.json
@@ -11,7 +11,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-layout-grid"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-line-ripple/package.json
+++ b/packages/mdc-line-ripple/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.lineRipple.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/material-components/material-components-web.git"
+    "url": "git+https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-line-ripple"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-linear-progress/package.json
+++ b/packages/mdc-linear-progress/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-linear-progress"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-list/package.json
+++ b/packages/mdc-list/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-list"
   },
   "dependencies": {
     "@material/base": "^3.0.0",

--- a/packages/mdc-menu-surface/package.json
+++ b/packages/mdc-menu-surface/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.menuSurface.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-menu-surface"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-menu/package.json
+++ b/packages/mdc-menu/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.menu.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-menu"
   },
   "dependencies": {
     "@material/base": "^3.0.0",

--- a/packages/mdc-notched-outline/package.json
+++ b/packages/mdc-notched-outline/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.notchedOutline.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/material-components/material-components-web.git"
+    "url": "git+https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-notched-outline"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-radio/package.json
+++ b/packages/mdc-radio/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.radio.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-radio"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-ripple/package.json
+++ b/packages/mdc-ripple/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.ripple.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-ripple"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-rtl/package.json
+++ b/packages/mdc-rtl/package.json
@@ -11,6 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-rtl"
   }
 }

--- a/packages/mdc-select/package.json
+++ b/packages/mdc-select/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.select.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-select"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-shape/package.json
+++ b/packages/mdc-shape/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-shape"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mdc-slider/package.json
+++ b/packages/mdc-slider/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-slider"
   },
   "keywords": [
     "material components",

--- a/packages/mdc-snackbar/package.json
+++ b/packages/mdc-snackbar/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.snackbar.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-snackbar"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-switch/package.json
+++ b/packages/mdc-switch/package.json
@@ -14,7 +14,8 @@
   "types": "dist/mdc.switch.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-switch"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-tab-bar/package.json
+++ b/packages/mdc-tab-bar/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.tabBar.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-tab-bar"
   },
   "dependencies": {
     "@material/base": "^3.0.0",

--- a/packages/mdc-tab-indicator/package.json
+++ b/packages/mdc-tab-indicator/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.tabIndicator.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-tab-indicator"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-tab-scroller/package.json
+++ b/packages/mdc-tab-scroller/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.tabScroller.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-tab-scroller"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-tab/package.json
+++ b/packages/mdc-tab/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-tab"
   },
   "main": "dist/mdc.tab.js",
   "module": "index.js",

--- a/packages/mdc-textfield/package.json
+++ b/packages/mdc-textfield/package.json
@@ -15,7 +15,8 @@
   "types": "dist/mdc.textfield.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-textfield"
   },
   "dependencies": {
     "@material/animation": "^3.0.0",

--- a/packages/mdc-theme/package.json
+++ b/packages/mdc-theme/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-theme"
   },
   "dependencies": {
     "@material/feature-targeting": "^3.0.0"

--- a/packages/mdc-top-app-bar/package.json
+++ b/packages/mdc-top-app-bar/package.json
@@ -9,7 +9,8 @@
   "types": "dist/mdc.topAppBar.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-top-app-bar"
   },
   "keywords": [
     "material components",

--- a/packages/mdc-typography/package.json
+++ b/packages/mdc-typography/package.json
@@ -11,7 +11,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/material-components/material-components-web.git"
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-typography"
   },
   "dependencies": {
     "@material/feature-targeting": "^3.0.0"


### PR DESCRIPTION
This is the new way to mark a package in a monorepo.
See [repository.directory](https://docs.npmjs.com/files/package.json#repository) property in `package.json`.
In a future release of `npmjs.com` this will allow to link directly to a package in a monorepo.

https://docs.npmjs.com/files/package.json#repository
https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md

Related https://github.com/material-components/material-components-web-react/pull/975
Related https://github.com/material-components/material-components-web-components/pull/302