### PR TITLE
feat(data-table): Separated baseline theming from core styles

### DIFF
--- a/packages/mdc-data-table/README.md
+++ b/packages/mdc-data-table/README.md
@@ -9,7 +9,8 @@ path: /catalog/data-tables/
 
 # Data Table
 
-Data tables display sets of data.
+Data tables display information in a grid-like format of rows and columns. They organize information in a way that's
+easy to scan, so that users can look for patterns and insights.
 
 ## Design & API Documentation
 
@@ -111,7 +112,7 @@ MDC Data Table component auto instantiates `MDCCheckbox` for header row checkbox
       </tr>
     </thead>
     <tbody class="mdc-data-table__content">
-      <tr class="mdc-data-table__row">
+      <tr class="mdc-data-table__row" data-row-id="u0">
         <td class="mdc-data-table__cell mdc-data-table__cell--checkbox">
           <div class="mdc-checkbox mdc-data-table__row-checkbox">
             <input type="checkbox" class="mdc-checkbox__native-control" aria-labelledby="r0" />
@@ -124,10 +125,10 @@ MDC Data Table component auto instantiates `MDCCheckbox` for header row checkbox
           </div>
         </td>
         <td class="mdc-data-table__cell" id="r0">Frozen yogurt</td>
-        <td class="mdc-data-table__cell">24</td>
-        <td class="mdc-data-table__cell">4.0</td>
+        <td class="mdc-data-table__cell mdc-data-table__cell--numeric">24</td>
+        <td class="mdc-data-table__cell mdc-data-table__cell--numeric">4.0</td>
       </tr>
-      <tr class="mdc-data-table__row mdc-data-table__row--selected" aria-selected="true">
+      <tr class="mdc-data-table__row mdc-data-table__row--selected" aria-selected="true" data-row-id="u1">
         <td class="mdc-data-table__cell mdc-data-table__cell--checkbox">
           <div class="mdc-checkbox mdc-data-table__row-checkbox">
             <input type="checkbox" class="mdc-checkbox__native-control" checked aria-labelledby="r1" />
@@ -140,8 +141,8 @@ MDC Data Table component auto instantiates `MDCCheckbox` for header row checkbox
           </div>
         </td>
         <td class="mdc-data-table__cell" id="r1">Ice cream sandwich</td>
-        <td class="mdc-data-table__cell">37</td>
-        <td class="mdc-data-table__cell">4.3</td>
+        <td class="mdc-data-table__cell mdc-data-table__cell--numeric">37</td>
+        <td class="mdc-data-table__cell mdc-data-table__cell--numeric">4.3</td>
       </tr>
     </tbody>
   </table>

--- a/packages/mdc-data-table/_mixins.scss
+++ b/packages/mdc-data-table/_mixins.scss
@@ -52,7 +52,6 @@
       @include mdc-data-table-row-fill-color($mdc-data-table-row-fill-color, $query: $query);
       @include mdc-data-table-header-row-fill-color($mdc-data-table-header-row-fill-color, $query: $query);
       @include mdc-data-table-selected-row-fill-color($mdc-data-table-selected-row-fill-color, $query: $query);
-      @include mdc-data-table-checked-icon-color($mdc-data-table-checked-icon-color, $query: $query);
       @include mdc-data-table-divider-color($mdc-data-table-divider-color, $query: $query);
       @include mdc-data-table-divider-size($mdc-data-table-divider-size, $query: $query);
       @include mdc-data-table-row-hover-fill-color($mdc-data-table-row-hover-fill-color, $query: $query);
@@ -276,4 +275,8 @@
       }
     }
   }
+}
+
+@mixin mdc-data-table-theme-baseline($query: mdc-feature-all()) {
+  @include mdc-data-table-checked-icon-color($mdc-data-table-checked-icon-color, $query: $query);
 }

--- a/packages/mdc-data-table/mdc-data-table.scss
+++ b/packages/mdc-data-table/mdc-data-table.scss
@@ -22,3 +22,4 @@
 
 @import "./mixins";
 @include mdc-data-table-core-styles;
+@include mdc-data-table-theme-baseline;

--- a/test/scss/_feature-targeting-test.scss
+++ b/test/scss/_feature-targeting-test.scss
@@ -87,6 +87,7 @@
 
     // Data Table
     @include mdc-data-table-core-styles($query: $query);
+    @include mdc-data-table-theme-baseline($query: $query);
     @include mdc-data-table-fill-color(red, $query: $query);
     @include mdc-data-table-header-row-fill-color(red, $query: $query);
     @include mdc-data-table-row-fill-color(red, $query: $query);

--- a/test/unit/mdc-dialog/foundation.test.js
+++ b/test/unit/mdc-dialog/foundation.test.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google Inc.
+ * Copyright 2017 Google Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -440,7 +440,7 @@ test(`#handleClick: Click closes dialog when ${strings.SCRIM_SELECTOR} selector 
   td.verify(foundation.close(foundation.getScrimClickAction()));
 });
 
-test(`#handleClick: Click does nothing when ${strings.SCRIM_SELECTOR} class is present but scrimClickAction is
+test(`#handleClick: Click does nothing when ${strings.SCRIM_SELECTOR} class is present but scrimClickAction is 
     empty string`, () => {
   const {foundation, mockAdapter} = setupTest();
   const evt = {type: 'click', target: {}};


### PR DESCRIPTION
### Description

* Moved `mdc-data-table-checked-icon-color` mixin to separate baseline theme mixin that prevents duplicating checkbox styles when theming.
* Minor updates to README.
* Reverted dialog test changes.

Refs #4591 