### PR TITLE
refactor(menu): Remove #hoistMenuToBody from menu and menu-surface

### DIFF
--- a/packages/mdc-menu-surface/component.ts
+++ b/packages/mdc-menu-surface/component.ts
@@ -92,15 +92,6 @@ export class MDCMenuSurface extends MDCComponent<MDCMenuSurfaceFoundation> {
     this.foundation_.setQuickOpen(quickOpen);
   }
 
-  /**
-   * Removes the menu-surface from its current location and appends it to the
-   * body to overcome any overflow:hidden issues.
-   */
-  hoistMenuToBody() {
-    document.body.appendChild(this.root_);
-    this.setIsHoisted(true);
-  }
-
   /** Sets the foundation to use page offsets for an positioning when the menu is hoisted to the body. */
   setIsHoisted(isHoisted: boolean) {
     this.foundation_.setIsHoisted(isHoisted);

--- a/packages/mdc-menu/component.ts
+++ b/packages/mdc-menu/component.ts
@@ -173,10 +173,6 @@ export class MDCMenu extends MDCComponent<MDCMenuFoundation> {
     this.menuSurface_.setFixedPosition(isFixed);
   }
 
-  hoistMenuToBody() {
-    this.menuSurface_.hoistMenuToBody();
-  }
-
   setIsHoisted(isHoisted: boolean) {
     this.menuSurface_.setIsHoisted(isHoisted);
   }

--- a/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
+++ b/test/unit/mdc-menu-surface/mdc-menu-surface.test.js
@@ -144,20 +144,6 @@ test('anchorElement is properly initialized when the DOM contains an anchor', ()
   assert.equal(component.anchorElement, anchor);
 });
 
-test('hoistMenuToBody', () => {
-  const {root, component, mockFoundation} = setupTest();
-  const div = document.createElement('div');
-  div.appendChild(root);
-  document.body.appendChild(div);
-  component.hoistMenuToBody();
-
-  td.verify(mockFoundation.setIsHoisted(true));
-  assert.equal(root.parentElement, document.body);
-
-  document.body.removeChild(root);
-  document.body.removeChild(div);
-});
-
 test('setIsHoisted', () => {
   const {component, mockFoundation} = setupTest();
   component.setIsHoisted(true);

--- a/test/unit/mdc-menu/mdc-menu.test.js
+++ b/test/unit/mdc-menu/mdc-menu.test.js
@@ -99,7 +99,6 @@ class FakeMenuSurface {
     this.quickOpen = false;
     this.setFixedPosition = td.func('.setFixedPosition');
     this.setAbsolutePosition = td.func('.setAbsolutePosition');
-    this.hoistMenuToBody = td.func('.hoistMenuToBody');
     this.setIsHoisted = td.func('.setIsHoisted');
     this.anchorElement = null;
   }
@@ -285,12 +284,6 @@ test('setFixedPosition', () => {
 
   component.setFixedPosition(false);
   td.verify(menuSurface.setFixedPosition(false));
-});
-
-test('hoistMenuToBody', () => {
-  const {component, menuSurface} = setupTestWithFakes();
-  component.hoistMenuToBody();
-  td.verify(menuSurface.hoistMenuToBody());
 });
 
 test('setIsHoisted', () => {

--- a/test/unit/mdc-select/mdc-select.test.js
+++ b/test/unit/mdc-select/mdc-select.test.js
@@ -92,7 +92,7 @@ function getFixture() {
   return bel`
     <div class="mdc-select">
       <div class="mdc-select__anchor">
-        <input type="hidden" name="enhanced-select">
+        <input type="hidden" name="select">
         <i class="mdc-select__icon material-icons">code</i>
         <div class="mdc-select__selected-text"></div>
         <i class="mdc-select__dropdown-icon"></i>
@@ -119,7 +119,7 @@ function getOutlineFixture() {
   return bel`
     <div class="mdc-select">
       <div class="mdc-select__anchor mdc-select--outlined">
-        <input type="hidden" name="enhanced-select">
+        <input type="hidden" name="select">
         <i class="mdc-select__icon material-icons">code</i>
         <div class="mdc-select__selected-text"></div>
         <i class="mdc-select__dropdown-icon"></i>
@@ -203,7 +203,7 @@ function setupWithMockFoundation() {
   return setupTest(false, true, true);
 }
 
-suite('MDCSelect-Enhanced');
+suite('MDCSelect');
 
 test('attachTo returns a component instance', () => {
   assert.isOk(MDCSelect.attachTo(getFixture()) instanceof MDCSelect);


### PR DESCRIPTION
BREAKING CHANGE: #hoistMenuToBody is removed from `MDCMenu` and `MDCMenuSurface`.
Ref #4935 