### PR TITLE
feat(density): Added density utility component.

### DIFF
--- a/packages/material-components-web/package.json
+++ b/packages/material-components-web/package.json
@@ -25,6 +25,7 @@
     "@material/checkbox": "^3.1.0",
     "@material/chips": "^3.1.0",
     "@material/data-table": "^3.1.0",
+    "@material/density": "^0.0.0",
     "@material/dialog": "^3.1.0",
     "@material/dom": "^3.1.0",
     "@material/drawer": "^3.1.0",

--- a/packages/mdc-density/README.md
+++ b/packages/mdc-density/README.md
@@ -1,0 +1,56 @@
+<!--docs:
+title: "Density"
+layout: detail
+section: components
+excerpt: "Density subsystem provides adaptive layout to components."
+path: /catalog/density/
+-->
+
+# Density
+
+Density subsystem provides adaptive layout to components.
+
+## Installation
+
+```
+npm install @material/density
+```
+
+## Basic Usage
+
+### Styles
+
+This package is used as utility for other components' density mixins. Mixin provided by this package is not intended to
+be consumed directly by developers, use component's density mixin instead.
+
+The styles for applying density to button component instance looks like this:
+
+```scss
+@import "@material/button/mixins";
+
+.my-custom-button {
+  @include mdc-button-density(compact);
+}
+```
+
+This would apply `compact` (highest density) to button component instance.
+
+> You would indirectly use the Density API through respective component's mixin which takes care of setting appropriate
+> component height.
+
+## Style Customization
+
+### Sass Variables
+
+Variable | Description
+--- | ---
+`$mdc-density-interval` | Density interval between each dense scale. This interval is used for numbered density scale to calculate dense height based on baseline component height.
+`$mdc-density-minimum-scale` | Minimum scale supported by density subsystem. This scale always maps to highest dense scale.
+`$mdc-density-maximum-scale` | Maximum scale supported by density subsystem. This scale always maps to lowest dense scale.
+`$mdc-density-supported-scales` | Supported density scale when density token or literal is used (For example, `compact`).
+
+### Sass Functions
+
+Function | Description
+--- | ---
+`mdc-density-prop-value($density-config, $density-scale, $property-name)` | Returns component property value based on given density config and density scale.

--- a/packages/mdc-density/_functions.scss
+++ b/packages/mdc-density/_functions.scss
@@ -1,0 +1,108 @@
+//
+// Copyright 2019 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+@import "./variables";
+
+///
+/// Returns component property value based on given density config and density scale.
+///
+/// @param {Map} $density-config - Density configuration for component.
+/// @param {Number | String} $density-scale - Density scale value for component. Examples: `-3`, `0` or `compact`.
+/// @param {Map} $property-name - Density scale map for the target component.
+///
+/// @example
+///   mdc-density-prop-value(
+///     $density-config: (
+///       height: (
+///         default: 36px,
+///         comfortable: 32px,
+///         compact: 24px,
+///       ),
+///     ),
+///     $density-scale: compact,
+///     $property-name: height,
+///   )
+///   // 24px
+///
+/// @example
+///   mdc-density-prop-value(
+///     $density-config: (
+///       height: (
+///         default: 36px,
+///         comfortable: 32px,
+///         compact: 24px,
+///       ),
+///     ),
+///     $density-scale: -2,
+///     $property-name: height,
+///   )
+///   // 28px
+///
+/// @example
+///   mdc-density-prop-value(
+///     $density-config: (
+///       height: (
+///         default: 36px,
+///         comfortable: 32px,
+///         compact: 24px,
+///       ),
+///       width: (
+///         default: 64px,
+///         comfortable: 56px,
+///         compact: 48px,
+///       ),
+///     ),
+///     $density-scale: compact,
+///     $property-name: width,
+///   )
+///   // 48px
+///
+@function mdc-density-prop-value($density-config, $density-scale, $property-name) {
+  @if (type-of($density-scale) == "string" and
+  index($list: $mdc-density-supported-scales, $value: $density-scale) == null) {
+    @error "mdc-density: Supported density scales #{$mdc-density-supported-scales}, but received #{$density-scale}.";
+  }
+
+  @if (index($list: $mdc-density-supported-properties, $value: $property-name) == null) {
+    @error "mdc-density: Supported density properties #{$mdc-density-supported-properties}," +
+      "but received #{$property-name}.";
+  }
+
+  $value: null;
+  $property-scale-map: map-get($density-config, $property-name);
+
+  @if map-has-key($property-scale-map, $density-scale) {
+    $value: map-get($property-scale-map, $density-scale);
+  } @else {
+    $value: map-get($property-scale-map, default) + $density-scale * $mdc-density-interval;
+  }
+
+  $min-value: map-get($property-scale-map, $mdc-density-minimum-scale);
+  $max-value: map-get($property-scale-map, $mdc-density-maximum-scale);
+
+  @if ($value < $min-value or $value > $max-value) {
+    @error "mdc-density: Height must be between #{$min-height} and " +
+      "#{$max-height}, but received #{$height}.";
+  }
+
+  @return $value;
+}

--- a/packages/mdc-density/_variables.scss
+++ b/packages/mdc-density/_variables.scss
@@ -1,0 +1,28 @@
+//
+// Copyright 2019 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+$mdc-density-interval: 4px !default;
+$mdc-density-minimum-scale: compact !default;
+$mdc-density-maximum-scale: default !default;
+$mdc-density-supported-scales: (default, comfortable, compact) !default;
+$mdc-density-supported-properties: (height) !default;
+$mdc-density-default-scale: default !default;

--- a/packages/mdc-density/package.json
+++ b/packages/mdc-density/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@material/density",
+  "description": "Density utilities for Material Components for the web",
+  "version": "0.0.0",
+  "license": "MIT",
+  "keywords": [
+    "material components",
+    "material design",
+    "density",
+    "adaptive layout"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web.git",
+    "directory": "packages/mdc-density"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
### Description

* Added `mdc-density-prop-value` function to return appropriate component height / size based on given density scale and component's density scale map. The `*-prop-value` name is given to be consistent with other utility functions used within MDC. For example, `mdc-theme-prop-value`.
* Component scale maps (e.g., `$mdc-button-density-scale-map`) use literals (e.g., `compact`) as keys to easily refer baseline / default component (max) height and compact (min) height to easily validate and throw error for unsupported component height. Scale map variable can be overridden by developers.

@jelbourn For review.