### PR TITLE
refactor(select): Move disabled logic into foundation

### DIFF
--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -352,8 +352,8 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 | `notifyChange(value: string) => void` | Emits the `MDCSelect:change` event when an element is selected. |
 | `checkValidity() => boolean` | Returns whether the component is currently valid, using the select's `checkValidity`. |
 | `setValid(isValid: boolean) => void` | Adds or removes invalid styles. |
-| `setSelectedText(text: string): void` | Sets the text content of the selectedText element to the given string. |
-| `setSelectedTextAttr(attr: string, value: string): void` | Sets the given attribute on the selected text element. |
+| `setSelectedText(text: string) => void` | Sets the text content of the selectedText element to the given string. |
+| `setSelectedTextAttr(attr: string, value: string) => void` | Sets the given attribute on the selected text element. |
 | `openMenu() => void` | Causes the menu element in the enhanced select to open. |
 | `closeMenu() => void` | Causes the menu element in the enhanced select to close. |
 | `isMenuOpen() => boolean` | Returns true if the menu is currently opened in the enhanced select. |

--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -353,6 +353,7 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 | `checkValidity() => boolean` | Returns whether the component is currently valid, using the select's `checkValidity`. |
 | `setValid(isValid: boolean) => void` | Adds or removes invalid styles. |
 | `setSelectedText(text: string): void` | Sets the text content of the selectedText element to the given string. |
+| `setSelectedTextAttr(attr: string, value: string): void` | Sets the given attribute on the selected text element. |
 | `openMenu() => void` | Causes the menu element in the enhanced select to open. |
 | `closeMenu() => void` | Causes the menu element in the enhanced select to close. |
 | `isMenuOpen() => boolean` | Returns true if the menu is currently opened in the enhanced select. |
@@ -367,7 +368,8 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 | Method Signature | Description |
 | --- | --- |
 | `notchOutline(openNotch: boolean) => void` | Opens/closes the notched outline. |
-| `setDisabled(isDisabled: boolean) => void` | Updates appearance based on disabled state. This must be called whenever the `disabled` state changes. |
+| `getDisabled() => boolean` | Gets the disabled state. |
+| `setDisabled(isDisabled: boolean) => void` | Updates the disabled state. |
 | `handleFocus() => void` | Handles a focus event on the `select` element. |
 | `handleBlur() => void` | Handles a blur event on the `select` element. |
 | `handleClick(normalizedX: number) => void` | Sets the line ripple center to the normalizedX for the line ripple. |

--- a/packages/mdc-select/adapter.ts
+++ b/packages/mdc-select/adapter.ts
@@ -85,11 +85,6 @@ export interface MDCSelectAdapter {
   closeOutline(): void;
 
   /**
-   * Sets the select to disabled.
-   */
-  setDisabled(isDisabled: boolean): void;
-
-  /**
    * Sets the line ripple transform origin center.
    */
   setRippleCenter(normalizedX: number): void;

--- a/packages/mdc-select/adapter.ts
+++ b/packages/mdc-select/adapter.ts
@@ -114,6 +114,11 @@ export interface MDCSelectAdapter {
    */
   setSelectedText(text: string): void;
 
+  /**
+   * Sets the given attribute on the selected text element.
+   */
+  setSelectedTextAttr(attr: string, value: string): void;
+
   // Menu-related methods ======================================================
   /**
    * Opens the menu.

--- a/packages/mdc-select/component.ts
+++ b/packages/mdc-select/component.ts
@@ -186,6 +186,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
     // Initially sync floating label
     this.foundation_.handleChange(/* didChange */ false);
 
+    // Sets disabled state in foundation
     this.disabled = this.selectAnchor_.classList.contains(cssClasses.DISABLED);
   }
 

--- a/packages/mdc-select/component.ts
+++ b/packages/mdc-select/component.ts
@@ -349,10 +349,6 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
         }
         return '';
       },
-      setDisabled: (isDisabled: boolean) => {
-        this.selectedText_.setAttribute('tabindex', isDisabled ? '-1' : '0');
-        this.selectedText_.setAttribute('aria-disabled', isDisabled.toString());
-      },
       checkValidity: () => {
         const classList = this.selectAnchor_.classList;
         if (classList.contains(cssClasses.REQUIRED) && !classList.contains(cssClasses.DISABLED)) {

--- a/packages/mdc-select/component.ts
+++ b/packages/mdc-select/component.ts
@@ -186,9 +186,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
     // Initially sync floating label
     this.foundation_.handleChange(/* didChange */ false);
 
-    if (this.selectAnchor_.classList.contains(cssClasses.DISABLED)) {
-      this.disabled = true;
-    }
+    this.disabled = this.selectAnchor_.classList.contains(cssClasses.DISABLED);
   }
 
   destroy() {

--- a/packages/mdc-select/component.ts
+++ b/packages/mdc-select/component.ts
@@ -52,13 +52,13 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
 
   private ripple_!: MDCRipple | null;
 
-  private menu_!: MDCMenu; // assigned in selectSetup_()
+  private menu_!: MDCMenu; // assigned in menuSetup_()
   private isMenuOpen_!: boolean; // assigned in initialize()
 
   private selectAnchor_!: HTMLElement; // assigned in initialize()
   private selectedText_!: HTMLElement; // assigned in initialize()
 
-  private menuElement_!: Element; // assigned in selectSetup_()
+  private menuElement_!: Element; // assigned in menuSetup_()
   private leadingIcon_?: MDCSelectIcon; // assigned in initialize()
   private helperText_!: MDCSelectHelperText | null; // assigned in initialize()
   private lineRipple_!: MDCLineRipple | null; // assigned in initialize()
@@ -100,7 +100,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
       }
     }
 
-    this.selectSetup_(menuFactory);
+    this.menuSetup_(menuFactory);
 
     const labelElement = this.root_.querySelector(strings.LABEL_SELECTOR);
     this.label_ = labelElement ? labelFactory(labelElement) : null;
@@ -318,9 +318,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
   /**
    * Handles setup for the menu.
    */
-  private selectSetup_(menuFactory: MDCMenuFactory) {
-    const isDisabled = this.selectAnchor_.classList.contains(cssClasses.DISABLED);
-    this.selectedText_.setAttribute('tabindex', isDisabled ? '-1' : '0');
+  private menuSetup_(menuFactory: MDCMenuFactory) {
     this.menuElement_ = this.root_.querySelector(strings.MENU_SELECTOR)!;
     this.menu_ = menuFactory(this.menuElement_);
     this.menu_.setAnchorElement(this.root_.querySelector(strings.SELECT_ANCHOR_SELECTOR)!);
@@ -428,6 +426,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
       addClass: (className: string) => this.selectAnchor_.classList.add(className),
       removeClass: (className: string) => this.selectAnchor_.classList.remove(className),
       hasClass: (className: string) => this.selectAnchor_.classList.contains(className),
+      setSelectedTextAttr: (attr: string, value: string) => this.selectedText_.setAttribute(attr, value),
       setRippleCenter: (normalizedX: number) => this.lineRipple_ && this.lineRipple_.setRippleCenter(normalizedX),
       activateBottomLine: () => this.lineRipple_ && this.lineRipple_.activate(),
       deactivateBottomLine: () => this.lineRipple_ && this.lineRipple_.deactivate(),

--- a/packages/mdc-select/component.ts
+++ b/packages/mdc-select/component.ts
@@ -238,7 +238,7 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
   }
 
   get disabled(): boolean {
-    return this.selectAnchor_.classList.contains(cssClasses.DISABLED);
+    return this.foundation_.getDisabled();
   }
 
   set disabled(disabled: boolean) {

--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -64,6 +64,7 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
       checkValidity: () => false,
       setValid: () => undefined,
       setSelectedText: () => undefined,
+      setSelectedTextAttr: () => undefined,
       openMenu: () => undefined,
       closeMenu: () => undefined,
       isMenuOpen: () => false,
@@ -96,6 +97,7 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     this.helperText_ = foundationMap.helperText;
 
     this.menuItemValues_ = this.adapter_.getMenuItemValues();
+    this.selectSetup_();
   }
 
   /** Returns the index of the currently selected menu item, or -1 if none. */
@@ -303,6 +305,14 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
 
   isValid() {
     return this.adapter_.checkValidity();
+  }
+
+  /**
+   * Handles setup for the select.
+   */
+  private selectSetup_() {
+    const isDisabled = this.adapter_.hasClass(cssClasses.DISABLED);
+    this.adapter_.setSelectedTextAttr('tabindex', isDisabled ? '-1' : '0');
   }
 }
 

--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -84,7 +84,7 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
   // VALUE_ATTR values of the menu items.
   private readonly menuItemValues_: string[];
   // Disabled state
-  private disabled_: boolean;
+  private disabled_ = false;
 
   /* istanbul ignore next: optional argument is not a branch statement */
   /**
@@ -98,7 +98,6 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     this.helperText_ = foundationMap.helperText;
 
     this.menuItemValues_ = this.adapter_.getMenuItemValues();
-    this.disabled_ = false;
   }
 
   /** Returns the index of the currently selected menu item, or -1 if none. */

--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -58,7 +58,6 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
       hasOutline: () => false,
       notchOutline: () => undefined,
       closeOutline: () => undefined,
-      setDisabled: () => undefined,
       setRippleCenter: () => undefined,
       notifyChange: () => undefined,
       checkValidity: () => false,
@@ -97,7 +96,6 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     this.helperText_ = foundationMap.helperText;
 
     this.menuItemValues_ = this.adapter_.getMenuItemValues();
-    this.selectSetup_();
   }
 
   /** Returns the index of the currently selected menu item, or -1 if none. */
@@ -148,12 +146,14 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     } else {
       this.adapter_.removeClass(cssClasses.DISABLED);
     }
-    this.adapter_.setDisabled(isDisabled);
     this.adapter_.closeMenu();
 
     if (this.leadingIcon_) {
       this.leadingIcon_.setDisabled(isDisabled);
     }
+
+    this.adapter_.setSelectedTextAttr('tabindex', isDisabled ? '-1' : '0');
+    this.adapter_.setSelectedTextAttr('aria-disabled', isDisabled.toString());
   }
 
   /**
@@ -305,14 +305,6 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
 
   isValid() {
     return this.adapter_.checkValidity();
-  }
-
-  /**
-   * Handles setup for the select.
-   */
-  private selectSetup_() {
-    const isDisabled = this.adapter_.hasClass(cssClasses.DISABLED);
-    this.adapter_.setSelectedTextAttr('tabindex', isDisabled ? '-1' : '0');
   }
 }
 

--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -83,6 +83,8 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
   private selectedIndex_: number = numbers.UNSET_INDEX;
   // VALUE_ATTR values of the menu items.
   private readonly menuItemValues_: string[];
+  // Disabled state
+  private disabled_: boolean;
 
   /* istanbul ignore next: optional argument is not a branch statement */
   /**
@@ -96,6 +98,7 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     this.helperText_ = foundationMap.helperText;
 
     this.menuItemValues_ = this.adapter_.getMenuItemValues();
+    this.disabled_ = false;
   }
 
   /** Returns the index of the currently selected menu item, or -1 if none. */
@@ -140,8 +143,13 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     return this.adapter_.getValue();
   }
 
+  getDisabled() {
+    return this.disabled_;
+  }
+
   setDisabled(isDisabled: boolean) {
-    if (isDisabled) {
+    this.disabled_ = isDisabled;
+    if (this.disabled_) {
       this.adapter_.addClass(cssClasses.DISABLED);
       this.adapter_.closeMenu();
     } else {
@@ -149,11 +157,11 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     }
 
     if (this.leadingIcon_) {
-      this.leadingIcon_.setDisabled(isDisabled);
+      this.leadingIcon_.setDisabled(this.disabled_);
     }
 
-    this.adapter_.setSelectedTextAttr('tabindex', isDisabled ? '-1' : '0');
-    this.adapter_.setSelectedTextAttr('aria-disabled', isDisabled.toString());
+    this.adapter_.setSelectedTextAttr('tabindex', this.disabled_ ? '-1' : '0');
+    this.adapter_.setSelectedTextAttr('aria-disabled', this.disabled_.toString());
   }
 
   /**

--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -143,10 +143,10 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
   setDisabled(isDisabled: boolean) {
     if (isDisabled) {
       this.adapter_.addClass(cssClasses.DISABLED);
+      this.adapter_.closeMenu();
     } else {
       this.adapter_.removeClass(cssClasses.DISABLED);
     }
-    this.adapter_.closeMenu();
 
     if (this.leadingIcon_) {
       this.leadingIcon_.setDisabled(isDisabled);

--- a/test/unit/mdc-select/foundation.test.js
+++ b/test/unit/mdc-select/foundation.test.js
@@ -49,7 +49,7 @@ test('default adapter returns a complete adapter implementation', () => {
     'addClass', 'removeClass', 'hasClass',
     'floatLabel', 'activateBottomLine', 'deactivateBottomLine', 'getValue',
     'getLabelWidth', 'hasOutline', 'notchOutline', 'closeOutline', 'isMenuOpen', 'openMenu',
-    'closeMenu', 'setDisabled', 'setSelectedText',
+    'closeMenu', 'setDisabled', 'setSelectedText', 'setSelectedTextAttr',
     'setAttributeAtIndex', 'removeAttributeAtIndex', 'getMenuItemValues', 'getMenuItemTextAtIndex',
     'toggleClassAtIndex', 'setRippleCenter', 'notifyChange',
     'checkValidity', 'setValid',

--- a/test/unit/mdc-select/foundation.test.js
+++ b/test/unit/mdc-select/foundation.test.js
@@ -84,6 +84,18 @@ function setupTest(hasLeadingIcon = true, hasHelperText = false) {
   return {foundation, mockAdapter, leadingIcon, helperText};
 }
 
+test('#getDisabled() returns true if disabled', () => {
+  const {foundation} = setupTest();
+  foundation.setDisabled(true);
+  assert.equal(foundation.getDisabled(), true);
+});
+
+test('#getDisabled() returns false if not disabled', () => {
+  const {foundation} = setupTest();
+  foundation.setDisabled(false);
+  assert.equal(foundation.getDisabled(), false);
+});
+
 test('#setDisabled(true) calls adapter.addClass', () => {
   const {mockAdapter, foundation} = setupTest();
   foundation.setDisabled(true);

--- a/test/unit/mdc-select/foundation.test.js
+++ b/test/unit/mdc-select/foundation.test.js
@@ -49,7 +49,7 @@ test('default adapter returns a complete adapter implementation', () => {
     'addClass', 'removeClass', 'hasClass',
     'floatLabel', 'activateBottomLine', 'deactivateBottomLine', 'getValue',
     'getLabelWidth', 'hasOutline', 'notchOutline', 'closeOutline', 'isMenuOpen', 'openMenu',
-    'closeMenu', 'setDisabled', 'setSelectedText', 'setSelectedTextAttr',
+    'closeMenu', 'setSelectedText', 'setSelectedTextAttr',
     'setAttributeAtIndex', 'removeAttributeAtIndex', 'getMenuItemValues', 'getMenuItemTextAtIndex',
     'toggleClassAtIndex', 'setRippleCenter', 'notifyChange',
     'checkValidity', 'setValid',
@@ -87,14 +87,12 @@ function setupTest(hasLeadingIcon = true, hasHelperText = false) {
 test('#setDisabled(true) calls adapter.addClass', () => {
   const {mockAdapter, foundation} = setupTest();
   foundation.setDisabled(true);
-  td.verify(mockAdapter.setDisabled(true));
   td.verify(mockAdapter.addClass(cssClasses.DISABLED));
 });
 
 test('#setDisabled(false) calls adapter.removeClass', () => {
   const {mockAdapter, foundation} = setupTest();
   foundation.setDisabled(false);
-  td.verify(mockAdapter.setDisabled(false));
   td.verify(mockAdapter.removeClass(cssClasses.DISABLED));
 });
 

--- a/test/unit/mdc-select/mdc-select.test.js
+++ b/test/unit/mdc-select/mdc-select.test.js
@@ -203,7 +203,7 @@ function setupWithMockFoundation() {
   return setupTest(false, true, true);
 }
 
-suite('MDCSelect-Enhanced');
+suite('MDCSelect');
 
 test('attachTo returns a component instance', () => {
   assert.isOk(MDCSelect.attachTo(getFixture()) instanceof MDCSelect);
@@ -244,7 +244,7 @@ test('#get/set disabled', () => {
   component.disabled = true;
   td.verify(mockFoundation.setDisabled(true), {times: 1});
   component.disabled = false;
-  td.verify(mockFoundation.setDisabled(false), {times: 1});
+  td.verify(mockFoundation.setDisabled(false), {times: 2}); // called once at initialization, once when setting to false
 });
 
 test('#get/set required', () => {
@@ -735,6 +735,21 @@ test('adapter#setSelectedText sets the select text content correctly', () => {
   document.body.removeChild(fixture);
 });
 
+test('adapter#setSelectedTextAttr sets the select text content correctly', () => {
+  const hasMockFoundation = true;
+  const hasMockMenu = true;
+  const hasOutline = false;
+  const hasLabel = true;
+  const {fixture, component, selectedText} = setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
+  document.body.appendChild(fixture);
+  const adapter = component.getDefaultFoundation().adapter_;
+
+  assert.isFalse(selectedText.hasAttribute('foo'));
+  adapter.setSelectedTextAttr('foo', '1');
+  assert.equal(selectedText.getAttribute('foo'), '1');
+  document.body.removeChild(fixture);
+});
+
 test('adapter#openMenu causes the menu to open', () => {
   const hasMockFoundation = true;
   const hasMockMenu = true;
@@ -810,29 +825,6 @@ test('adapter#toggleClassAtIndex toggles class correctly', () => {
   assert.isTrue(menuItem.classList.contains(cssClasses.SELECTED_ITEM_CLASS));
   adapter.toggleClassAtIndex(index, cssClasses.SELECTED_ITEM_CLASS, false);
   assert.isFalse(menuItem.classList.contains(cssClasses.SELECTED_ITEM_CLASS));
-
-  document.body.removeChild(fixture);
-});
-
-test('adapter#setDisabled adds the --disabled class to the root element', () => {
-  const hasMockFoundation = true;
-  const hasMockMenu = true;
-  const hasOutline = false;
-  const hasLabel = true;
-  const {fixture, component, selectedText} =
-      setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
-  document.body.appendChild(fixture);
-  const adapter = component.getDefaultFoundation().adapter_;
-
-  assert.equal(selectedText.tabIndex, 0);
-
-  adapter.setDisabled(true);
-  assert.equal(selectedText.getAttribute('aria-disabled'), 'true');
-  assert.equal(selectedText.tabIndex, -1);
-
-  adapter.setDisabled(false);
-  expect(selectedText.getAttribute('aria-disabled')).to.equal('false');
-  expect(selectedText.tabIndex).to.equal(0);
 
   document.body.removeChild(fixture);
 });
@@ -1083,6 +1075,7 @@ test('menu surface closed event does not call foundation.handleBlur if selected-
   const {fixture, menuSurface, mockFoundation, selectedText} = setupTest(hasOutline, hasLabel,
     hasMockFoundation, hasMockMenu);
   document.body.appendChild(fixture);
+  fixture.querySelector('.mdc-select__selected-text').tabIndex = 0;
   fixture.querySelector('.mdc-select__selected-text').focus();
   const event = document.createEvent('Event');
   event.initEvent(MDCMenuSurfaceFoundation.strings.CLOSED_EVENT, false, true);
@@ -1102,21 +1095,6 @@ test('menu surface closed event calls foundation.handleBlur if selected-text is 
   const {fixture, menuSurface, mockFoundation} = setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
   document.body.appendChild(fixture);
   document.body.focus();
-  const event = document.createEvent('Event');
-  event.initEvent(MDCMenuSurfaceFoundation.strings.CLOSED_EVENT, false, true);
-  menuSurface.dispatchEvent(event);
-
-  td.verify(mockFoundation.handleBlur(), {times: 1});
-  document.body.removeChild(fixture);
-});
-
-test('menu surface closed event does not call foundation blur if selected-text is not focused', () => {
-  const hasMockFoundation = true;
-  const hasMockMenu = false;
-  const hasOutline = false;
-  const hasLabel = true;
-  const {fixture, menuSurface, mockFoundation} = setupTest(hasOutline, hasLabel, hasMockFoundation, hasMockMenu);
-  document.body.appendChild(fixture);
   const event = document.createEvent('Event');
   event.initEvent(MDCMenuSurfaceFoundation.strings.CLOSED_EVENT, false, true);
   menuSurface.dispatchEvent(event);


### PR DESCRIPTION
Simplify adapter and component by moving `setDisabled` logic into foundation.

BREAKING CHANGE: `MDCSelectAdapter#setDisabled` is removed, and `MDCSelectAdapter#setSelectedTextAttr` is added.