### PR TITLE
fix(snackbar): close snackbar when keydown esc

### DIFF
--- a/packages/mdc-snackbar/component.ts
+++ b/packages/mdc-snackbar/component.ts
@@ -150,7 +150,6 @@ export class MDCSnackbar extends MDCComponent<MDCSnackbarFoundation> {
 
   private deregisterWindowKeyDownHandler_(handler: SpecificEventListener<'keydown'>) {
     window.removeEventListener('keydown', handler);
-    this.unlisten('keydown', handler);
   }
 
   private registerSurfaceClickHandler_(handler: SpecificEventListener<'click'>) {

--- a/packages/mdc-snackbar/component.ts
+++ b/packages/mdc-snackbar/component.ts
@@ -68,13 +68,13 @@ export class MDCSnackbar extends MDCComponent<MDCSnackbarFoundation> {
       }
     };
 
-    this.registerKeyDownHandler_(this.handleKeyDown_);
+    this.registerWindowKeyDownHandler_(this.handleKeyDown_);
     this.registerSurfaceClickHandler_(this.handleSurfaceClick_);
   }
 
   destroy() {
     super.destroy();
-    this.deregisterKeyDownHandler_(this.handleKeyDown_);
+    this.deregisterWindowKeyDownHandler_(this.handleKeyDown_);
     this.deregisterSurfaceClickHandler_(this.handleSurfaceClick_);
   }
 
@@ -144,11 +144,12 @@ export class MDCSnackbar extends MDCComponent<MDCSnackbarFoundation> {
     this.actionEl_.textContent = actionButtonText;
   }
 
-  private registerKeyDownHandler_(handler: SpecificEventListener<'keydown'>) {
-    this.listen('keydown', handler);
+  private registerWindowKeyDownHandler_(handler: SpecificEventListener<'keydown'>) {
+    window.addEventListener('keydown', handler);
   }
 
-  private deregisterKeyDownHandler_(handler: SpecificEventListener<'keydown'>) {
+  private deregisterWindowKeyDownHandler_(handler: SpecificEventListener<'keydown'>) {
+    window.removeEventListener('keydown', handler);
     this.unlisten('keydown', handler);
   }
 

--- a/test/unit/mdc-snackbar/mdc-snackbar.test.js
+++ b/test/unit/mdc-snackbar/mdc-snackbar.test.js
@@ -116,10 +116,10 @@ test('#initialSyncWithDOM registers click handlers for action button and action 
   component.destroy();
 });
 
-test('#initialSyncWithDOM registers keydown handler on the root element', () => {
-  const {component, mockFoundation, root} = setupTestWithMocks();
+test('#initialSyncWithDOM registers keydown handler on the window', () => {
+  const {component, mockFoundation} = setupTestWithMocks();
   component.open();
-  domEvents.emit(root, 'keydown');
+  domEvents.emit(window, 'keydown');
   td.verify(mockFoundation.handleKeyDown(td.matchers.isA(Event)), {times: 1});
   component.destroy();
 });


### PR DESCRIPTION
Now `closeOnEscape_` property isn't working.
Because event target is the root element of snackbar.
I think we need to add listener to window in this case :)
