### PR TITLE
fix(chips): Add `pointer-events: none` to chip ripple element.

### DIFF
--- a/packages/mdc-chips/_mixins.scss
+++ b/packages/mdc-chips/_mixins.scss
@@ -264,6 +264,8 @@ $mdc-chip-ripple-target: ".mdc-chip__ripple";
         left: 0;
         width: 100%;
         height: 100%;
+        // Necessary for clicks on e.g. the close icon to go through.
+        pointer-events: none;
         overflow: hidden;
       }
     }


### PR DESCRIPTION
Ripple element is stacked below other chip inner elements that are not positioned, thereby blocking clicks on chip close icon.