### PR TITLE
chore: Bump up idle_timeout to fix webdriver timeout issues

### DIFF
--- a/test/screenshot/infra/lib/cbt-api.js
+++ b/test/screenshot/infra/lib/cbt-api.js
@@ -204,6 +204,7 @@ https://crossbrowsertesting.com/account
       record_video: true,
       record_network: true,
       max_duration: 3600, // in seconds
+      idle_timeout: 600, // in seconds
     };
 
     /** @type {!selenium.proto.RawCapabilities} */


### PR DESCRIPTION
Possible fix for WebDriver timeout issue:

```
ERROR: WebDriverError: FORWARDING_ERROR: timeout from remote selenium
```