### PR TITLE
fix(top-app-bar): "always collapsed" variant semantics in Short TopAppBar Foundation

### DIFF
--- a/packages/mdc-top-app-bar/README.md
+++ b/packages/mdc-top-app-bar/README.md
@@ -237,7 +237,12 @@ Method Signature | Description
 
 #### `MDCShortTopAppBarFoundation`
 
-In addition to the methods above, the short variant provides the following public properties:
+In addition to the methods above, the short variant provides the following public methods and properties:
+
+Method Signature | Description
+--- | ---
+`setAlwaysCollapsed(value: boolean) => void` | When `value` is `true`, sets the short top app bar to always be collapsed.
+`getAlwaysCollapsed() => boolean` | Gets if the short top app bar is in the "always collapsed" state.
 
 Property | Value Type | Description
 --- | --- | ---

--- a/packages/mdc-top-app-bar/short/foundation.ts
+++ b/packages/mdc-top-app-bar/short/foundation.ts
@@ -55,8 +55,7 @@ export class MDCShortTopAppBarFoundation extends MDCTopAppBarBaseFoundation {
   /**
    * Set if the short top app bar should always be collapsed.
    *
-   * When set to `true`, the bar collapses.
-   * When set to `false`, the bar will determine if it should collapse based on scroll position.
+   * @param value When `true`, bar will always be collapsed. When `false`, bar may collapse or expand based on scroll.
    */
   setAlwaysCollapsed(value: boolean) {
     this.isAlwaysCollapsed_ = !!value;

--- a/packages/mdc-top-app-bar/short/foundation.ts
+++ b/packages/mdc-top-app-bar/short/foundation.ts
@@ -33,6 +33,8 @@ export class MDCShortTopAppBarFoundation extends MDCTopAppBarBaseFoundation {
 
   private isCollapsed_ = false;
 
+  private isAlwaysCollapsed_ = false;
+
   /* istanbul ignore next: optional argument is not a branch statement */
   constructor(adapter?: Partial<MDCTopAppBarAdapter>) {
     super(adapter);
@@ -45,9 +47,29 @@ export class MDCShortTopAppBarFoundation extends MDCTopAppBarBaseFoundation {
       this.adapter_.addClass(cssClasses.SHORT_HAS_ACTION_ITEM_CLASS);
     }
 
-    // this is intended as the short variant must calculate if the
-    // page starts off from the top of the page.
-    this.handleTargetScroll();
+    // If initialized with SHORT_COLLAPSED_CLASS, the bar should always be collapsed
+    this.setAlwaysCollapsed(
+      this.adapter_.hasClass(cssClasses.SHORT_COLLAPSED_CLASS));
+  }
+
+  /**
+   * Set if the short top app bar should always be collapsed.
+   *
+   * When set to `true`, the bar collapses.
+   * When set to `false`, the bar will determine if it should collapse based on scroll position.
+   */
+  setAlwaysCollapsed(value: boolean) {
+    this.isAlwaysCollapsed_ = !!value;
+    if (this.isAlwaysCollapsed_) {
+      this.collapse_();
+    } else {
+      // let handleTargetScroll determine if the bar should be collapsed
+      this.handleTargetScroll();
+    }
+  }
+
+  getAlwaysCollapsed() {
+    return this.isAlwaysCollapsed_;
   }
 
   /**
@@ -55,22 +77,30 @@ export class MDCShortTopAppBarFoundation extends MDCTopAppBarBaseFoundation {
    * @override
    */
   handleTargetScroll() {
-    if (this.adapter_.hasClass(cssClasses.SHORT_COLLAPSED_CLASS)) {
+    if (this.isAlwaysCollapsed_) {
       return;
     }
     const currentScroll = this.adapter_.getViewportScrollY();
 
     if (currentScroll <= 0) {
       if (this.isCollapsed_) {
-        this.adapter_.removeClass(cssClasses.SHORT_COLLAPSED_CLASS);
-        this.isCollapsed_ = false;
+        this.uncollapse_();
       }
     } else {
       if (!this.isCollapsed_) {
-        this.adapter_.addClass(cssClasses.SHORT_COLLAPSED_CLASS);
-        this.isCollapsed_ = true;
+        this.collapse_();
       }
     }
+  }
+
+  private uncollapse_() {
+    this.adapter_.removeClass(cssClasses.SHORT_COLLAPSED_CLASS);
+    this.isCollapsed_ = false;
+  }
+
+  private collapse_() {
+    this.adapter_.addClass(cssClasses.SHORT_COLLAPSED_CLASS);
+    this.isCollapsed_ = true;
   }
 }
 

--- a/packages/mdc-top-app-bar/short/foundation.ts
+++ b/packages/mdc-top-app-bar/short/foundation.ts
@@ -63,8 +63,8 @@ export class MDCShortTopAppBarFoundation extends MDCTopAppBarBaseFoundation {
     if (this.isAlwaysCollapsed_) {
       this.collapse_();
     } else {
-      // let handleTargetScroll determine if the bar should be collapsed
-      this.handleTargetScroll();
+      // let maybeCollapseBar_ determine if the bar should be collapsed
+      this.maybeCollapseBar_();
     }
   }
 
@@ -77,6 +77,10 @@ export class MDCShortTopAppBarFoundation extends MDCTopAppBarBaseFoundation {
    * @override
    */
   handleTargetScroll() {
+    this.maybeCollapseBar_();
+  }
+
+  private maybeCollapseBar_() {
     if (this.isAlwaysCollapsed_) {
       return;
     }

--- a/test/unit/mdc-top-app-bar/short.foundation.test.js
+++ b/test/unit/mdc-top-app-bar/short.foundation.test.js
@@ -110,3 +110,69 @@ test('isCollapsed returns true if top-app-bar is collapsed', () => {
   foundation.handleTargetScroll();
   assert.isTrue(foundation.isCollapsed);
 });
+
+test('isCollapsed returns false when page is scrolled to the top', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(0);
+  foundation.init();
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(1);
+  foundation.handleTargetScroll();
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(0);
+  foundation.handleTargetScroll();
+  assert.isFalse(foundation.isCollapsed);
+});
+
+test('setAlwaysCollapsed(true) sets bar to be collapsed', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasClass(MDCTopAppBarFoundation.cssClasses.SHORT_CLASS)).thenReturn(false);
+  foundation.init();
+  foundation.setAlwaysCollapsed(true);
+  assert.isTrue(foundation.isCollapsed);
+});
+
+test('setAlwaysCollapsed(true) will keep bar collapsed', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasClass(MDCTopAppBarFoundation.cssClasses.SHORT_CLASS)).thenReturn(false);
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(0);
+  foundation.init();
+  foundation.setAlwaysCollapsed(true);
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(1);
+  foundation.handleTargetScroll();
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(0);
+  foundation.handleTargetScroll();
+  td.verify(mockAdapter.removeClass(MDCTopAppBarFoundation.cssClasses.SHORT_CLASS), {times: 0});
+});
+
+test('setAlwaysCollapsed(false) will keep bar collapsed when scrolled', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasClass(MDCTopAppBarFoundation.cssClasses.SHORT_CLASS)).thenReturn(false);
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(0);
+  foundation.init();
+  foundation.setAlwaysCollapsed(true);
+  td.when(mockAdapter.getViewportScrollY()).thenReturn(1);
+  foundation.handleTargetScroll();
+  assert.isTrue(foundation.isCollapsed);
+  foundation.setAlwaysCollapsed(false);
+  assert.isTrue(foundation.isCollapsed);
+  foundation.handleTargetScroll();
+  assert.isTrue(foundation.isCollapsed);
+});
+
+test('setAlwaysCollapsed is called on init', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.init();
+  td.verify(mockAdapter.getViewportScrollY(), {times: 1});
+});
+
+test('getAlwaysCollapsed returns false by default', () => {
+  const {foundation} = setupTest();
+  assert.isFalse(foundation.getAlwaysCollapsed());
+});
+
+test('getAlwaysCollapsed matches value of setAlwaysCollapsed', () => {
+  const {foundation} = setupTest();
+  foundation.setAlwaysCollapsed(false);
+  assert.isFalse(foundation.getAlwaysCollapsed());
+  foundation.setAlwaysCollapsed(true);
+  assert.isTrue(foundation.getAlwaysCollapsed());
+});


### PR DESCRIPTION
- Add `setAlwaysCollapsed(value: boolean)` and `getAlwaysCollapsed()`
  methods
- Keep behavior of initializing with `SHORT_COLLAPSED_CLASS` to mean
  that the component should always be collapsed.

Fixes #4928