### PR TITLE
feat(button): support disabled design in <a> element

### DIFF
--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -276,7 +276,8 @@
     }
   }
 
-  &:disabled {
+  &:disabled,
+  &[disabled][href=""] {
     @include mdc-feature-targets($feat-color) {
       @include mdc-theme-prop(background-color, transparent);
 
@@ -324,7 +325,8 @@
     border-style: solid;
   }
 
-  &:disabled {
+  &:disabled,
+  &[disabled][href=""] {
     @include mdc-feature-targets($feat-color) {
       border-color: $mdc-button-disabled-ink-color;
     }
@@ -337,7 +339,8 @@
 
   @include mdc-button-horizontal-padding($mdc-button-contained-horizontal-padding, $query);
 
-  &:disabled {
+  &:disabled,
+  &[disabled][href=""] {
     @include mdc-feature-targets($feat-color) {
       background-color: rgba(mdc-theme-prop-value(on-surface), .12);
       color: $mdc-button-disabled-ink-color;
@@ -360,7 +363,8 @@
     @include mdc-elevation(8, $query: $query);
   }
 
-  &:disabled {
+  &:disabled,
+  &[disabled][href=""] {
     @include mdc-elevation(0, $query: $query);
   }
 

--- a/test/screenshot/spec/mdc-button/classes/baseline-button-without-icons.html
+++ b/test/screenshot/spec/mdc-button/classes/baseline-button-without-icons.html
@@ -82,6 +82,9 @@
         <div class="test-cell test-cell--button">
           <button class="mdc-button mdc-button--outlined" disabled>Button</button>
         </div>
+        <div class="test-cell test-cell--button">
+          <a class="mdc-button mdc-button--outlined" href disabled>Button</a>
+        </div>
       </div>
     </main>
 


### PR DESCRIPTION
closes #5012

I want to write just `[disabled]` or `[href=""]`.
But [&:not(:disabled)](https://github.com/material-components/material-components-web/blob/master/packages/mdc-button/_mixins.scss#L156) rule has higher priority, so I write like this...
If you have some great idea, please tell me :)