### PR TITLE
fix(tabs): Fix tab indicator underline not being centered in compact tabs.

### DIFF
--- a/packages/mdc-tab-indicator/_mixins.scss
+++ b/packages/mdc-tab-indicator/_mixins.scss
@@ -171,6 +171,7 @@
     position: absolute;
     top: 0;
     left: 0;
+    justify-content: center;
     width: 100%;
     height: 100%;
     pointer-events: none;


### PR DESCRIPTION
Accidentally removed in
https://github.com/material-components/material-components-web/commit/c7efc10afea37f724c7c258e80dfd95a455f31d8#diff-d1669061bc1d2998fb197e25382d0f6c