### PR TITLE
feat(list): Add density mixin to list

### DIFF
--- a/packages/mdc-drawer/_mixins.scss
+++ b/packages/mdc-drawer/_mixins.scss
@@ -277,7 +277,7 @@
 }
 
 @mixin mdc-drawer-item-shape-radius($radius, $rtl-reflexive: true, $query: mdc-feature-all()) {
-  @include mdc-list-item-shape-radius($radius, $rtl-reflexive, $query: $query);
+  @include mdc-list-single-line-shape-radius($radius, $rtl-reflexive, $query: $query);
 }
 
 @mixin mdc-drawer-shape-radius($radius, $query: mdc-feature-all()) {

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -91,20 +91,20 @@ in the double line list style as defined by
 <ul class="mdc-list mdc-list--two-line">
   <li class="mdc-list-item" tabindex="0">
     <span class="mdc-list-item__text">
-      <span class="mdc-list-item__primary-text">First-line text</span>
-      <span class="mdc-list-item__secondary-text">Second-line text</span>
+      <span class="mdc-list-item__primary-text">Two-line item</span>
+      <span class="mdc-list-item__secondary-text">Secondary text</span>
     </span>
   </li>
   <li class="mdc-list-item">
     <span class="mdc-list-item__text">
-      <span class="mdc-list-item__primary-text">First-line text</span>
-      <span class="mdc-list-item__secondary-text">Second-line text</span>
+      <span class="mdc-list-item__primary-text">Two-line item</span>
+      <span class="mdc-list-item__secondary-text">Secondary text</span>
     </span>
   </li>
   <li class="mdc-list-item">
     <span class="mdc-list-item__text">
-      <span class="mdc-list-item__primary-text">First-line text</span>
-      <span class="mdc-list-item__secondary-text">Second-line text</span>
+      <span class="mdc-list-item__primary-text">Two-line item</span>
+      <span class="mdc-list-item__secondary-text">Secondary text</span>
     </span>
   </li>
 </ul>
@@ -408,11 +408,13 @@ Mixin | Description
 `mdc-list-item-graphic-fill-color($color)` | Sets background ink color of the graphic element within list item.
 `mdc-list-item-graphic-ink-color($color)` | Sets ink color of the graphic element within list item.
 `mdc-list-item-meta-ink-color($color)` | Sets ink color of the meta element within list item.
-`mdc-list-item-shape-radius($radius, $rtl-reflexive)` | Sets the rounded shape to list item with given radius size. Set `$rtl-reflexive` to true to flip radius values in RTL context, defaults to false.
+`mdc-list-single-line-shape-radius($radius, $rtl-reflexive, $density-scale)` | Sets the rounded shape to list item with given radius size. Set `$rtl-reflexive` to true to flip radius values in RTL context, defaults to false. Set `$density-scale` only when custom density is applied, defaults to `$mdc-list-single-line-density-scale`.
 `mdc-list-divider-color($color)` | Sets divider ink color.
 `mdc-list-group-subheader-ink-color($color)` | Sets ink color of subheader text within list group.
 `mdc-list-item-disabled-text-color($color`) | Sets the color of the text when the list item is disabled.
 `mdc-list-item-disabled-text-opacity($opacity`) | Sets the opacity of the text when the list item is disabled.
+`mdc-list-single-line-density($density-scale)` | Sets density scale to single line list variant. Supported density scales are `-4`, `-3`, `-2`, `-1` and  `0`.
+`mdc-list-single-line-height($height)` | Sets height to single line list variant.
 
 ### Accessibility
 

--- a/packages/mdc-list/_mixins.scss
+++ b/packages/mdc-list/_mixins.scss
@@ -18,8 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+@import "@material/density/functions";
 @import "@material/rtl/mixins";
 @import "@material/theme/mixins";
+@import "@material/shape/functions";
 @import "@material/shape/mixins";
 @import "@material/ripple/mixins";
 @import "@material/theme/functions";
@@ -58,6 +60,7 @@
     @include mdc-list-base_($query);
   }
 
+  @include mdc-list-single-line-density($mdc-list-single-line-density-scale, $query: $query);
   @include mdc-list-item-secondary-text-ink-color(text-secondary-on-background, $query);
   @include mdc-list-item-graphic-fill-color(transparent, $query);
   @include mdc-list-item-graphic-ink-color(text-icon-on-background, $query);
@@ -365,9 +368,33 @@
   }
 }
 
-@mixin mdc-list-item-shape-radius($radius, $rtl-reflexive: false, $query: mdc-feature-all()) {
+///
+/// Sets shape radius (rounded) to single line list variant.
+///
+/// @param {Number | List<Number>} $radius Radius size in `px` or percentage. It can be 4 value corner or single radius.
+///     Set to `50%` for rounded shape.
+/// @param {Boolean} $rtl-reflexive Set to true to flip border radius in RTL context. Defaults to `false`.
+/// @param {Number} $density-scale Density scale of single line list. Set this only when custom density is applied.
+///     Defaults to `$mdc-list-single-line-density-scale`.
+///
+/// @access public
+///
+@mixin mdc-list-single-line-shape-radius(
+  $radius,
+  $rtl-reflexive: false,
+  $density-scale: $mdc-list-single-line-density-scale,
+  $query: mdc-feature-all()) {
+
+  $height: mdc-density-prop-value(
+    $density-config: $mdc-list-single-line-density-config,
+    $density-scale: $density-scale,
+    $property-name: height,
+  );
+
+  $resolved-radius: mdc-shape-resolve-percentage-radius($height, $radius);
+
   .mdc-list-item {
-    @include mdc-shape-radius($radius, $rtl-reflexive, $query: $query);
+    @include mdc-shape-radius($resolved-radius, $rtl-reflexive, $query: $query);
   }
 }
 
@@ -411,6 +438,40 @@
   }
 }
 
+///
+/// Sets density scale to single line list variant.
+///
+/// @param {Number} $density-scale Density scale for list. Supported density scales are `-4`, `-3`, `-2`, `-1` and  `0`.
+///
+/// @access public
+///
+@mixin mdc-list-single-line-density($density-scale, $query: mdc-feature-all()) {
+  $height: mdc-density-prop-value(
+    $density-config: $mdc-list-single-line-density-config,
+    $density-scale: $density-scale,
+    $property-name: height,
+  );
+
+  .mdc-list-item {
+    @include mdc-list-single-line-height($height, $query: $query);
+  }
+}
+
+///
+/// Sets height to single line list variant.
+///
+/// @param {Number} $height Height value in `px`.
+///
+/// @access public
+///
+@mixin mdc-list-single-line-height($height, $query: mdc-feature-all()) {
+  $feat-structure: mdc-feature-create-target($query, structure);
+
+  @include mdc-feature-targets($feat-structure) {
+    height: $height;
+  }
+}
+
 //
 // Private
 //
@@ -447,7 +508,6 @@
   position: relative;
   align-items: center;
   justify-content: flex-start;
-  height: 48px;
   padding: 0 $mdc-list-side-padding;
   overflow: hidden;
 

--- a/packages/mdc-list/_variables.scss
+++ b/packages/mdc-list/_variables.scss
@@ -18,9 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+@import "@material/density/variables";
+
 $mdc-list-divider-color-on-light-bg: rgba(0, 0, 0, .12) !default;
 $mdc-list-divider-color-on-dark-bg: rgba(255, 255, 255, .2) !default;
 $mdc-list-side-padding: 16px !default;
 $mdc-list-text-offset: 72px !default;
 $mdc-list-text-disabled-opacity: mdc-theme-text-emphasis(disabled) !default;
 $mdc-list-text-disabled-color: on-surface !default;
+
+$mdc-list-single-line-height: 48px !default;
+$mdc-list-single-line-minimum-height: 24px !default;
+$mdc-list-single-line-maximum-height: $mdc-list-single-line-height !default;
+$mdc-list-single-line-density-scale: $mdc-density-default-scale !default;
+$mdc-list-single-line-density-config: (
+  height: (
+    default: $mdc-list-single-line-height,
+    maximum: $mdc-list-single-line-maximum-height,
+    minimum: $mdc-list-single-line-minimum-height,
+  ),
+) !default;

--- a/packages/mdc-list/package.json
+++ b/packages/mdc-list/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@material/base": "^3.1.0",
+    "@material/density": "^0.0.0",
     "@material/dom": "^3.1.0",
     "@material/feature-targeting": "^3.1.0",
     "@material/ripple": "^3.1.0",

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -767,6 +767,14 @@
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/04/08/21_52_36_805/spec/mdc-list/classes/disabled-items.html.windows_ie_11.png"
     }
   },
+  "spec/mdc-list/classes/list-group.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/list-group.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/list-group.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/list-group.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/list-group.html.windows_ie_11.png"
+    }
+  },
   "spec/mdc-list/classes/meta-text.html": {
     "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/10/14_25_41_111/spec/mdc-list/classes/meta-text.html?utm_source=golden_json",
     "screenshots": {
@@ -789,6 +797,38 @@
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/10/14_25_41_111/spec/mdc-list/classes/selected.html.windows_chrome_74.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/28/20_57_26_802/spec/mdc-list/classes/selected.html.windows_firefox_63.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/11/28/20_57_26_802/spec/mdc-list/classes/selected.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-list/classes/two-line.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/two-line.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/two-line.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/two-line.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/classes/two-line.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-list/mixins/density-checkbox.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density-checkbox.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density-checkbox.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density-checkbox.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density-checkbox.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-list/mixins/density.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/density.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-list/mixins/shape-single-line.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/shape-single-line.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/shape-single-line.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/shape-single-line.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/11/16_03_07_425/spec/mdc-list/mixins/shape-single-line.html.windows_ie_11.png"
     }
   },
   "spec/mdc-menu/classes/baseline.html": {

--- a/test/screenshot/spec/mdc-list/classes/list-group.html
+++ b/test/screenshot/spec/mdc-list/classes/list-group.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>List Groups - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-list/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--light test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--light test-cell--list">
+          <div class="mdc-list-group">
+            <h3 class="mdc-list-group__subheader">List 1</h3>
+            <ul class="mdc-list">
+              <li class="mdc-list-item" tabindex="0">
+                <span class="mdc-list-item__text">line item</span>
+              </li>
+              <li class="mdc-list-item">
+                <span class="mdc-list-item__text">line item</span>
+              </li>
+              <li class="mdc-list-item">
+                <span class="mdc-list-item__text">line item</span>
+              </li>
+            </ul>
+            <h3 class="mdc-list-group__subheader">List 2</h3>
+            <ul class="mdc-list">
+              <li class="mdc-list-item">
+                <span class="mdc-list-item__text">line item</span>
+              </li>
+              <li class="mdc-list-item">
+                <span class="mdc-list-item__text">line item</span>
+              </li>
+              <li class="mdc-list-item">
+                <span class="mdc-list-item__text">line item</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-list/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-list/classes/two-line.html
+++ b/test/screenshot/spec/mdc-list/classes/two-line.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Two-line List - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-list/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--light test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--light test-cell--list">
+          <ul class="mdc-list mdc-list--two-line">
+            <li class="mdc-list-item" tabindex="0">
+              <span class="mdc-list-item__text">
+                <span class="mdc-list-item__primary-text">Two-line item</span>
+                <span class="mdc-list-item__secondary-text">Secondary text</span>
+              </span>
+            </li>
+            <li class="mdc-list-item">
+              <span class="mdc-list-item__text">
+                <span class="mdc-list-item__primary-text">Two-line item</span>
+                <span class="mdc-list-item__secondary-text">Secondary text</span>
+              </span>
+            </li>
+            <li class="mdc-list-item">
+              <span class="mdc-list-item__text">
+                <span class="mdc-list-item__primary-text">Two-line item</span>
+                <span class="mdc-list-item__secondary-text">Secondary text</span>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-list/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-list/fixture.scss
+++ b/test/screenshot/spec/mdc-list/fixture.scss
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 //
 
+@import "../../../../packages/mdc-checkbox/mixins";
 @import "../../../../packages/mdc-list/mixins";
 @import "../../../../packages/mdc-theme/color-palette";
 @import "../../../../packages/mdc-theme/variables";
@@ -33,4 +34,22 @@
 .test-radio-list,
 .test-checkbox-list {
   width: 100%;
+}
+
+.custom-list-single-line-density {
+  @include mdc-list-single-line-density(-4);
+}
+
+.custom-list-single-line-checkbox-density {
+  @include mdc-list-single-line-density(-4);
+
+  max-width: 180px;
+}
+
+.custom-checkbox-single-line-list-density {
+  @include mdc-checkbox-density(-3);
+}
+
+.custom-shape-list-single-line {
+  @include mdc-list-single-line-shape-radius(50%);
 }

--- a/test/screenshot/spec/mdc-list/mixins/density-checkbox.html
+++ b/test/screenshot/spec/mdc-list/mixins/density-checkbox.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Checkbox List - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/mdc.checkbox.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-list/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--light test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--light test-cell--list">
+          <ul class="mdc-list custom-list-single-line-checkbox-density" style="list-style-type: none;" role="group" aria-label="Checkbox options">
+            <li class="mdc-list-item" role="checkbox" aria-checked="false" tabindex="0">
+              <label class="mdc-list-item__text test-list-item__label" for="test-list-checkbox-item-1">Option 1</label>
+              <div class="mdc-list-item__meta">
+                <div class="mdc-checkbox custom-checkbox-single-line-list-density">
+                  <input type="checkbox"
+                          class="mdc-checkbox__native-control"
+                          id="test-list-checkbox-item-1" />
+                  <div class="mdc-checkbox__background">
+                    <svg class="mdc-checkbox__checkmark"
+                          viewBox="0 0 24 24">
+                      <path class="mdc-checkbox__checkmark-path"
+                            fill="none"
+                            d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                    </svg>
+                    <div class="mdc-checkbox__mixedmark"></div>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li class="mdc-list-item" role="checkbox" aria-checked="false">
+              <label class="mdc-list-item__text test-list-item__label" for="test-list-checkbox-item-2">Option 2</label>
+              <div class="mdc-list-item__meta">
+                <div class="mdc-checkbox custom-checkbox-single-line-list-density">
+                  <input type="checkbox"
+                          class="mdc-checkbox__native-control"
+                          id="test-list-checkbox-item-2" />
+                  <div class="mdc-checkbox__background">
+                    <svg class="mdc-checkbox__checkmark"
+                          viewBox="0 0 24 24">
+                      <path class="mdc-checkbox__checkmark-path"
+                            fill="none"
+                            d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                    </svg>
+                    <div class="mdc-checkbox__mixedmark"></div>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li class="mdc-list-item" role="checkbox" aria-checked="false">
+              <label class="mdc-list-item__text test-list-item__label" for="test-list-checkbox-item-3">Option 3</label>
+              <div class="mdc-list-item__meta">
+                <div class="mdc-checkbox custom-checkbox-single-line-list-density">
+                  <input type="checkbox"
+                          class="mdc-checkbox__native-control"
+                          id="test-list-checkbox-item-3" />
+                  <div class="mdc-checkbox__background">
+                    <svg class="mdc-checkbox__checkmark"
+                          viewBox="0 0 24 24">
+                      <path class="mdc-checkbox__checkmark-path"
+                            fill="none"
+                            d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                    </svg>
+                    <div class="mdc-checkbox__mixedmark"></div>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li class="mdc-list-item" role="checkbox" aria-checked="false">
+              <label class="mdc-list-item__text test-list-item__label" for="test-list-checkbox-item-4">Option 4</label>
+              <div class="mdc-list-item__meta">
+                <div class="mdc-checkbox custom-checkbox-single-line-list-density">
+                  <input type="checkbox"
+                          class="mdc-checkbox__native-control"
+                          id="test-list-checkbox-item-4" />
+                  <div class="mdc-checkbox__background">
+                    <svg class="mdc-checkbox__checkmark"
+                          viewBox="0 0 24 24">
+                      <path class="mdc-checkbox__checkmark-path"
+                            fill="none"
+                            d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                    </svg>
+                    <div class="mdc-checkbox__mixedmark"></div>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li class="mdc-list-item" role="checkbox" aria-checked="false">
+              <label class="mdc-list-item__text test-list-item__label" for="test-list-checkbox-item-5">Option 5</label>
+              <div class="mdc-list-item__meta">
+                <div class="mdc-checkbox custom-checkbox-single-line-list-density">
+                  <input type="checkbox"
+                          class="mdc-checkbox__native-control"
+                          id="test-list-checkbox-item-5" />
+                  <div class="mdc-checkbox__background">
+                    <svg class="mdc-checkbox__checkmark"
+                          viewBox="0 0 24 24">
+                      <path class="mdc-checkbox__checkmark-path"
+                            fill="none"
+                            d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                    </svg>
+                    <div class="mdc-checkbox__mixedmark"></div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-list/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-list/mixins/density.html
+++ b/test/screenshot/spec/mdc-list/mixins/density.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>List Density Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-list/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--light test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--light test-cell--list">
+          <ul class="mdc-list test-list-baseline custom-list-single-line-density">
+            <li class="mdc-list-item" tabindex="0">
+              <span class="mdc-list-item__text">Single-line item</span>
+            </li>
+            <li class="mdc-list-item">
+              <span class="mdc-list-item__text">Single-line item</span>
+            </li>
+            <li class="mdc-list-item">
+              <span class="mdc-list-item__text">Single-line item</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-list/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-list/mixins/shape-single-line.html
+++ b/test/screenshot/spec/mdc-list/mixins/shape-single-line.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Shape Mixin for Single Line - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-list/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--light test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--light test-cell--list">
+          <ul id="my-list" class="mdc-list custom-shape-list-single-line" role="listbox" aria-orientation="vertical">
+            <li class="mdc-list-item" role="option" aria-selected="false">
+              <span class="mdc-list-item__text">Single-line item 1</span>
+            </li>
+            <li class="mdc-list-item mdc-list-item--selected" role="option" aria-selected="true" tabindex="0">
+              <span class="mdc-list-item__text">Single-line item 2</span>
+            </li>
+            <li class="mdc-list-item" role="option" aria-selected="false">
+              <span class="mdc-list-item__text">Single-line item 3</span>
+            </li>
+            <li class="mdc-list-item" role="option" aria-selected="false">
+              <span class="mdc-list-item__text">Single-line item 4</span>
+            </li>
+            <li class="mdc-list-item" role="option" aria-selected="false">
+              <span class="mdc-list-item__text">Single-line item 5</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-list/fixture.js"></script>
+  </body>
+</html>

--- a/test/scss/_feature-targeting-test.scss
+++ b/test/scss/_feature-targeting-test.scss
@@ -197,7 +197,9 @@
     @include mdc-list-item-graphic-fill-color(red, $query: $query);
     @include mdc-list-item-graphic-ink-color(red, $query: $query);
     @include mdc-list-item-meta-ink-color(red, $query: $query);
-    @include mdc-list-item-shape-radius(42, $rtl-reflexive: false, $query: $query);
+    @include mdc-list-single-line-shape-radius(42, $rtl-reflexive: false, $density-scale: 0, $query: $query);
+    @include mdc-list-single-line-height(0, $query: $query);
+    @include mdc-list-single-line-density(0, $query: $query);
     @include mdc-list-divider-color(red, $query: $query);
     @include mdc-list-group-subheader-ink-color(red, $query: $query);
     @include mdc-list-ripple($query: $query);


### PR DESCRIPTION
### Description

* Added `mdc-list-single-line-density()` mixin to customize density of single line list variant.
* Fixed shape mixin to accept percentage radius value.
* Added additional screenshot tests (Two-line, shape etc).

BREAKING CHANGE: Renamed mixin `mdc-list-item-shape-radius()` => `mdc-list-single-line-shape-radius()`

Fixes #5046 