### PR TITLE
chore: Add a script to automate creating pre-release (canary)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,9 +2,6 @@
   "version": "3.2.0",
   "command": {
     "version": {
-      "allowBranch": [
-        "master"
-      ],
       "conventionalCommits": true
     },
     "publish": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:unit": "karma start --single-run",
     "test:dependency": "./scripts/dependency-test.sh",
     "test:feature-targeting": "node test/scss/verify-feature-targeting.js",
-    "test:site": "npm run clean:site && ./scripts/site-generator-test.sh"
+    "test:site": "npm run clean:site && ./scripts/site-generator-test.sh",
+    "version": "cat lerna.json | grep -e '^  \"version\": ' | awk '{print $2}' | sed 's/[\",]//g'"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/scripts/canary-release.sh
+++ b/scripts/canary-release.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+function log() {
+  echo '\033[36m[canary-release]\033[0m' "$@"
+}
+
+function fail() {
+  echo '\033[31mFAILURE:\033[0m' "$@"
+}
+
+log "Preparing for canary release..."
+
+log "Installing dependencies..."
+if ! npm i; then
+  fail "npm install failed."
+  exit 1
+fi
+echo ""
+
+log "Running pre-release script..."
+if ! ./scripts/pre-release.sh; then
+  fail "Pre-release script failed"
+  exit 1
+fi
+
+log "Bumping up MDC Web version to canary..."
+if ! npx lerna version premajor --no-git-tag-version --no-push --preid canary.$(git rev-parse --short HEAD) --yes; then
+  fail "lerna version command failed"
+  exit 1
+fi
+echo ""
+
+PREVIOUS_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CANARY_RELEASE_VERSION=$(npm run version --silent)
+CANARY_RELEASE_BRANCH=release/v$CANARY_RELEASE_VERSION
+
+log "Creating temporary release branch..."
+  git checkout -B $CANARY_RELEASE_BRANCH
+  git commit -am "chore: Publish"
+echo ""
+
+log "Publishing packages to NPM..."
+if ! npx lerna publish from-package --dist-tag canary; then
+  fail "NPM Publish was not successful"
+  exit 1
+fi
+echo ""
+
+log "Creating release..."
+  git tag v$CANARY_RELEASE_VERSION
+echo "Created git tag v$CANARY_RELEASE_VERSION."
+echo ""
+
+log "Cleaning up..."
+  git checkout $PREVIOUS_GIT_BRANCH
+  git branch -D $CANARY_RELEASE_BRANCH
+echo ""
+
+log "MDC Web v$CANARY_RELEASE_VERSION is successfully published!"
+echo ""
+echo "  Run git push origin v$CANARY_RELEASE_VERSION"
+echo ""

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -76,6 +76,5 @@ log "Verifying that all packages are correctly pointing main to dist..."
 node scripts/verify-pkg-main.js
 echo ""
 
-log "Pre-release steps done! Next, continue with the Release step in the Release Process documentation:"
-echo "https://github.com/material-components/material-components-web/blob/master/docs/open_source/release-process.md#release"
+log "Pre-release steps done! Next, continue with the Release process."
 echo ""


### PR DESCRIPTION
### Description

* This script fully automates publishing current commit to NPM and also creating a release on git.
* Releases are tagged to `@canary` so MDC Web frameworks can always point to `material-components-web@canary` or `@material/button@canary` which'll be always synced to `develop` branch (Latest updates to MDC Web including breaking changes).

### Todo

* Create a GitHub Action to automatically run this script on every merge to `develop` branch.