### PR TITLE
fix(text-field): Do not trigger shake animation when text field is empty

### DIFF
--- a/packages/mdc-textfield/foundation.ts
+++ b/packages/mdc-textfield/foundation.ts
@@ -55,11 +55,11 @@ export class MDCTextFieldFoundation extends MDCFoundation<MDCTextFieldAdapter> {
   }
 
   get shouldFloat(): boolean {
-    return this.shouldAlwaysFloat_ || this.isFocused_ || Boolean(this.getValue()) || this.isBadInput_();
+    return this.shouldAlwaysFloat_ || this.isFocused_ || !!this.getValue() || this.isBadInput_();
   }
 
   get shouldShake(): boolean {
-    return !this.isFocused_ && !this.isValid() && Boolean(this.getValue());
+    return !this.isFocused_ && !this.isValid() && !!this.getValue();
   }
 
   /**
@@ -315,7 +315,7 @@ export class MDCTextFieldFoundation extends MDCFoundation<MDCTextFieldAdapter> {
     this.isValid_ = isValid;
     this.styleValidity_(isValid);
 
-    const shouldShake = !isValid && !this.isFocused_;
+    const shouldShake = !isValid && !this.isFocused_ && !!this.getValue();
     if (this.adapter_.hasLabel()) {
       this.adapter_.shakeLabel(shouldShake);
     }

--- a/test/screenshot/spec/mdc-textfield/fixture.js
+++ b/test/screenshot/spec/mdc-textfield/fixture.js
@@ -29,6 +29,11 @@ window.mdc.testFixture.fontsLoaded.then(() => {
       textField.useNativeValidation = false;
       textField.valid = false;
     }
+
+    el.querySelector('.mdc-text-field__input').addEventListener('blur', () => {
+      // Focusing out from empty text field input shouldn't trigger shake animation.
+      textField.valid = false;
+    });
   });
 
   // Fixes the wide notched outline issue.

--- a/test/unit/mdc-textfield/foundation.test.js
+++ b/test/unit/mdc-textfield/foundation.test.js
@@ -260,6 +260,9 @@ test('#setValid overrides native validation when useNativeValidation set to fals
 test('#setValid updates classes', () => {
   const {foundation, mockAdapter, helperText} = setupTest({useHelperText: true});
   td.when(mockAdapter.hasLabel()).thenReturn(true);
+  td.when(mockAdapter.getNativeInput()).thenReturn({
+    value: 'test',
+  });
 
   foundation.setValid(false);
   td.verify(mockAdapter.addClass(cssClasses.INVALID));
@@ -365,6 +368,16 @@ test('#setValid removes mdc-textfied--invalid when set to true', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.setValid(true);
   td.verify(mockAdapter.removeClass(cssClasses.INVALID));
+});
+
+test('#setValid should not trigger shake animation when text field is empty', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasLabel()).thenReturn(true);
+  td.when(mockAdapter.getNativeInput()).thenReturn({
+    value: '',
+  });
+  foundation.setValid(false);
+  td.verify(mockAdapter.shakeLabel(false));
 });
 
 test('#init focuses on input if adapter.isFocused is true', () => {


### PR DESCRIPTION
Fixes #4919