### PR TITLE
feat(select): add no-label variant of select

### DIFF
--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -286,6 +286,36 @@ See [here](helper-text/) for more information on using helper text.
 Leading icons can be added within the default or outlined variant of MDC Select as visual indicators as
 well as interaction targets. See [here](icon/) for more information on using icons.
 
+### Select with No Label
+
+A label is not required if a separate, adjacent label is provided elsewhere. To correctly style
+MDC Select without a label, add the class `mdc-select--no-label` and remove the label from the
+structure.
+
+```html
+<div class="mdc-select mdc-select--no-label">
+  <div class="mdc-select__anchor demo-width-class">
+    <i class="mdc-select__dropdown-icon"></i>
+    <div class="mdc-select__selected-text"></div>
+    <div class="mdc-line-ripple"></div>
+  </div>
+
+  <div class="mdc-select__menu mdc-menu mdc-menu-surface demo-width-class">
+    <ul class="mdc-list">
+      <li class="mdc-list-item mdc-list-item--selected" data-value="" aria-selected="true"></li>
+      <li class="mdc-list-item" data-value="grains">
+        Bread, Cereal, Rice, and Pasta
+      </li>
+      <li class="mdc-list-item" data-value="vegetables">
+        Vegetables
+      </li>
+      <li class="mdc-list-item" data-value="fruit">
+        Fruit
+      </li>
+    </ul>
+  </div>
+</div>
+```
 ## Style Customization
 
 #### CSS Classes
@@ -302,7 +332,7 @@ well as interaction targets. See [here](icon/) for more information on using ico
 | `mdc-select--disabled` | Optional. Styles the select as disabled. This class should be applied to the root element when the `disabled` attribute is applied to the `<select>` element. |
 | `mdc-select--outlined` | Optional. Styles the select as outlined select. |
 | `mdc-select--with-leading-icon` | Styles the select as a select with a leading icon. |
-
+| `mdc-select--no-label` | Styles the select as a select without a label. |
 > _NOTE_: To further customize the [MDCMenu](./../mdc-menu) or the [MDCList](./../mdc-list) component contained within the select, please refer to their respective documentation.
 
 ### Sass Mixins
@@ -362,6 +392,7 @@ If you are using a JavaScript framework, such as React or Angular, you can creat
 | `activateBottomLine() => void` | Activates the bottom line component. |
 | `deactivateBottomLine() => void` | Deactivates the bottom line component. |
 | `getSelectedMenuItem() => Element` | Returns the selected menu item element. |
+| `hasLabel() => boolean` | Returns true if the select contains a label. |
 | `floatLabel(value: boolean) => void` | Floats or defloats label. |
 | `getLabelWidth() => number` | Returns the offsetWidth of the label element. |
 | `hasOutline() => boolean` | Returns true if the `select` has the notched outline element. |

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -347,6 +347,14 @@
   pointer-events: none;
 }
 
+@mixin mdc-select-no-label_ {
+  &:not(.mdc-select--outlined) {
+    .mdc-select__anchor .mdc-select__selected-text {
+      padding-top: 14px;
+    }
+  }
+}
+
 @mixin mdc-select-outlined_ {
   @include mdc-select-container-fill-color(transparent);
   @include mdc-select-outline-color($mdc-select-outlined-idle-border);

--- a/packages/mdc-select/adapter.ts
+++ b/packages/mdc-select/adapter.ts
@@ -60,6 +60,11 @@ export interface MDCSelectAdapter {
   getSelectedMenuItem(): Element | null;
 
   /**
+   * Returns true if label exists, false if it doesn't.
+   */
+  hasLabel(): boolean;
+
+  /**
    * Floats label determined based off of the shouldFloat argument.
    */
   floatLabel(shouldFloat: boolean): void;

--- a/packages/mdc-select/component.ts
+++ b/packages/mdc-select/component.ts
@@ -387,10 +387,13 @@ export class MDCSelect extends MDCComponent<MDCSelectFoundation> {
   }
 
   private getLabelAdapterMethods_() {
+    // tslint:disable:object-literal-sort-keys Methods should be in the same order as the adapter interface.
     return {
+      hasLabel: () => Boolean(this.label_),
       floatLabel: (shouldFloat: boolean) => this.label_ && this.label_.float(shouldFloat),
       getLabelWidth: () => this.label_ ? this.label_.getWidth() : 0,
     };
+    // tslint:enable:object-literal-sort-keys
   }
 
   /**

--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -53,6 +53,7 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
       activateBottomLine: () => undefined,
       deactivateBottomLine: () => undefined,
       getSelectedMenuItem: () => null,
+      hasLabel: () => false,
       floatLabel: () => undefined,
       getLabelWidth: () => 0,
       hasOutline: () => false,
@@ -179,8 +180,10 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
   }
 
   layout() {
-    const openNotch = this.getValue().length > 0;
-    this.notchOutline(openNotch);
+    if (this.adapter_.hasLabel()) {
+      const openNotch = this.getValue().length > 0;
+      this.notchOutline(openNotch);
+    }
   }
 
   handleMenuOpened() {
@@ -199,10 +202,12 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     const optionHasValue = value.length > 0;
     const isRequired = this.adapter_.hasClass(cssClasses.REQUIRED);
 
-    this.notchOutline(optionHasValue);
+    if (this.adapter_.hasLabel()) {
+      this.notchOutline(optionHasValue);
 
-    if (!this.adapter_.hasClass(cssClasses.FOCUSED)) {
-      this.adapter_.floatLabel(optionHasValue);
+      if (!this.adapter_.hasClass(cssClasses.FOCUSED)) {
+        this.adapter_.floatLabel(optionHasValue);
+      }
     }
 
     if (didChange) {
@@ -222,8 +227,12 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
    */
   handleFocus() {
     this.adapter_.addClass(cssClasses.FOCUSED);
-    this.adapter_.floatLabel(true);
-    this.notchOutline(true);
+
+    if (this.adapter_.hasLabel()) {
+      this.adapter_.floatLabel(true);
+      this.notchOutline(true);
+    }
+
     this.adapter_.activateBottomLine();
     if (this.helperText_) {
       this.helperText_.showToScreenReader();

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -147,6 +147,10 @@
   @include mdc-select-disabled_;
 }
 
+.mdc-select--no-label {
+  @include mdc-select-no-label_;
+}
+
 .mdc-select--with-leading-icon {
   @include mdc-select-with-leading-icon_;
 }

--- a/test/screenshot/spec/mdc-select/classes/leading-icon-no-label.html
+++ b/test/screenshot/spec/mdc-select/classes/leading-icon-no-label.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Leading Icon No-Label Select - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu-surface.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu.css">
+    <link rel="stylesheet" href="../../../out/mdc.select.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-select/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--with-leading-icon mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="material-icons mdc-select__icon">code</i>
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label screenshot-selected-text"></div>
+              <div class="mdc-line-ripple"></div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value=""></li>
+                <li class="mdc-list-item" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--with-leading-icon mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="material-icons mdc-select__icon">code</i>
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text2" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label2 screenshot-selected-text2"></div>
+              <div class="mdc-notched-outline">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value=""></li>
+                <li class="mdc-list-item" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--with-leading-icon mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="material-icons mdc-select__icon">code</i>
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text3" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label3 screenshot-selected-text3">Bread, Cereal, Rice, and Pasta</div>
+              <div class="mdc-line-ripple"></div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--with-leading-icon mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="material-icons mdc-select__icon">code</i>
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text4" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label4 screenshot-selected-text4">Bread, Cereal, Rice, and Pasta</div>
+              <div class="mdc-notched-outline mdc-notched-outline--notched">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-select/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-select/classes/no-label.html
+++ b/test/screenshot/spec/mdc-select/classes/no-label.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>No-Label Select - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu-surface.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu.css">
+    <link rel="stylesheet" href="../../../out/mdc.select.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-select/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label screenshot-selected-text"></div>
+              <div class="mdc-line-ripple"></div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value=""></li>
+                <li class="mdc-list-item" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text2" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label2 screenshot-selected-text2"></div>
+              <div class="mdc-notched-outline">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value=""></li>
+                <li class="mdc-list-item" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text3" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label3 screenshot-selected-text3">Bread, Cereal, Rice, and Pasta</div>
+              <div class="mdc-line-ripple"></div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined mdc-select--no-label">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text4" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label4 screenshot-selected-text4">Bread, Cereal, Rice, and Pasta</div>
+              <div class="mdc-notched-outline mdc-notched-outline--notched">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-select/fixture.js"></script>
+  </body>
+</html>

--- a/test/unit/mdc-select/foundation.test.js
+++ b/test/unit/mdc-select/foundation.test.js
@@ -47,7 +47,7 @@ test('exports strings', () => {
 test('default adapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCSelectFoundation, [
     'addClass', 'removeClass', 'hasClass',
-    'activateBottomLine', 'deactivateBottomLine', 'getSelectedMenuItem', 'floatLabel',
+    'activateBottomLine', 'deactivateBottomLine', 'getSelectedMenuItem', 'hasLabel', 'floatLabel',
     'getLabelWidth', 'hasOutline', 'notchOutline', 'closeOutline', 'setRippleCenter', 'notifyChange',
     'setSelectedText', 'getSelectedTextAttr', 'setSelectedTextAttr',
     'isMenuOpen', 'openMenu', 'closeMenu', 'setMenuWrapFocus',
@@ -80,6 +80,7 @@ function setupTest(hasLeadingIcon = true, hasHelperText = false) {
   };
 
   td.when(mockAdapter.getSelectedMenuItem()).thenReturn(listItem);
+  td.when(mockAdapter.hasLabel()).thenReturn(true);
 
   const foundation = new MDCSelectFoundation(mockAdapter, foundationMap);
   return {foundation, mockAdapter, leadingIcon, helperText};
@@ -198,6 +199,14 @@ test('#handleChange does not call adapter.floatLabel(false) when there is no val
   td.verify(mockAdapter.floatLabel(false), {times: 0});
 });
 
+test('#handleChange does not call adapter.floatLabel() when no label is present', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasLabel()).thenReturn(false);
+
+  foundation.handleChange();
+  td.verify(mockAdapter.floatLabel(td.matchers.anything()), {times: 0});
+});
+
 test('#handleChange calls foundation.notchOutline(true) when there is a value', () => {
   const {foundation, mockAdapter} = setupTest();
   foundation.notchOutline = td.func();
@@ -216,6 +225,15 @@ test('#handleChange calls foundation.notchOutline(false) when there is no value'
   td.verify(foundation.notchOutline(false), {times: 1});
 });
 
+test('#handleChange does not call foundation.notchOutline() when there is no label', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.notchOutline = td.func();
+  td.when(mockAdapter.hasLabel()).thenReturn(false);
+
+  foundation.handleChange();
+  td.verify(foundation.notchOutline(td.matchers.anything()), {times: 0});
+});
+
 test('#handleChange calls adapter.notifyChange() if didChange is true', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.getMenuItemAttr(td.matchers.anything(), strings.VALUE_ATTR)).thenReturn('value');
@@ -231,11 +249,28 @@ test('#handleFocus calls adapter.floatLabel(true)', () => {
   td.verify(mockAdapter.floatLabel(true), {times: 1});
 });
 
+test('#handleFocus does not call adapter.floatLabel() if no label is present', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasLabel()).thenReturn(false);
+
+  foundation.handleFocus();
+  td.verify(mockAdapter.floatLabel(td.matchers.anything()), {times: 0});
+});
+
 test('#handleFocus calls foundation.notchOutline(true)', () => {
   const {foundation} = setupTest();
   foundation.notchOutline = td.func();
   foundation.handleFocus();
   td.verify(foundation.notchOutline(true), {times: 1});
+});
+
+test('#handleFocus does not call foundation.notchOutline() if no label is present', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.notchOutline = td.func();
+  td.when(mockAdapter.hasLabel()).thenReturn(false);
+
+  foundation.handleFocus();
+  td.verify(foundation.notchOutline(td.matchers.anything()), {times: 0});
 });
 
 test('#handleFocus calls adapter.activateBottomLine()', () => {
@@ -412,6 +447,14 @@ test('#layout calls notchOutline(false) if value is an empty string', () => {
   foundation.notchOutline = td.func();
   foundation.layout();
   td.verify(foundation.notchOutline(false), {times: 1});
+});
+
+test('#layout does not call notchOutline() if label does not exist', () => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.notchOutline = td.func();
+  td.when(mockAdapter.hasLabel()).thenReturn(false);
+  foundation.layout();
+  td.verify(foundation.notchOutline(td.matchers.anything()), {times: 0});
 });
 
 test('#setLeadingIconAriaLabel sets the aria-label of the leading icon element', () => {


### PR DESCRIPTION
- enables no-label variant of select without extra padding occupied by label
- added `hasLabel()` to adapter to guard against unnecessary label/notch manipulation

Resolves #4645 