### PR TITLE
feat(radio): Add density mixin to radio

### DIFF
--- a/packages/mdc-density/_variables.scss
+++ b/packages/mdc-density/_variables.scss
@@ -25,4 +25,4 @@ $mdc-density-minimum-scale: minimum !default;
 $mdc-density-maximum-scale: maximum !default;
 $mdc-density-supported-scales: (default, minimum, maximum) !default;
 $mdc-density-supported-properties: (height, size) !default;
-$mdc-density-default-scale: default !default;
+$mdc-density-default-scale: 0 !default;

--- a/packages/mdc-radio/README.md
+++ b/packages/mdc-radio/README.md
@@ -131,6 +131,9 @@ Mixin | Description
 `mdc-radio-checked-stroke-color($color)` | Sets the stroke color of a checked radio button
 `mdc-radio-ink-color($color)` | Sets the ink color of a radio button
 `mdc-radio-focus-indicator-color($color)` | Sets the color of the focus indicator
+`mdc-radio-touch-target($size, $ripple-size)` | Sets radio touch target size which can be more than the ripple size. Param `$ripple-size` is required for custom ripple size, defaults to `$mdc-radio-ripple-size`.
+`mdc-radio-ripple-size($size)` | Sets custom ripple size of radio.
+`mdc-radio-density($density-scale)` | Sets density scale for radio. Supported density scale values are `-3`, `-2`, `-1` and `0` (default).
 
 #### Caveat: Edge and CSS Custom Properties
 

--- a/packages/mdc-radio/_mixins.scss
+++ b/packages/mdc-radio/_mixins.scss
@@ -21,6 +21,7 @@
 //
 
 @import "@material/animation/functions";
+@import "@material/density/functions";
 @import "@material/feature-targeting/functions";
 @import "@material/feature-targeting/mixins";
 @import "@material/ripple/mixins";
@@ -48,22 +49,20 @@ $mdc-radio-ripple-target: ".mdc-radio__ripple";
   $feat-color: mdc-feature-create-target($query, color);
   $feat-structure: mdc-feature-create-target($query, structure);
 
-  @include mdc-radio-touch-target($size: $mdc-radio-touch-area, $query: $query);
-
   .mdc-radio {
     @include mdc-radio-unchecked-stroke-color($mdc-radio-unchecked-color, $query);
     @include mdc-radio-checked-stroke-color($mdc-radio-baseline-theme-color, $query);
     @include mdc-radio-ink-color($mdc-radio-baseline-theme-color, $query);
     @include mdc-radio-focus-indicator-color($mdc-radio-baseline-theme-color, $query);
+    @include mdc-radio-density($mdc-radio-density-scale, $query);
 
     @include mdc-feature-targets($feat-structure) {
       display: inline-block;
       position: relative;
       flex: 0 0 auto;
-      box-sizing: border-box;
-      width: $mdc-radio-touch-area;
-      height: $mdc-radio-touch-area;
-      padding: ($mdc-radio-touch-area - $mdc-radio-ui-size) / 2;
+      box-sizing: content-box;
+      width: $mdc-radio-icon-size;
+      height: $mdc-radio-icon-size;
       cursor: pointer;
       /* @alternate */
       will-change: opacity, transform, border-color, color;
@@ -73,20 +72,15 @@ $mdc-radio-ripple-target: ".mdc-radio__ripple";
     &__background {
       @include mdc-feature-targets($feat-structure) {
         display: inline-block;
-        position: absolute;
-        left: ($mdc-radio-touch-area - $mdc-radio-ui-size) / 2;
+        position: relative;
         box-sizing: border-box;
-        width: $mdc-radio-ui-pct;
-        height: $mdc-radio-ui-pct;
+        width: $mdc-radio-icon-size;
+        height: $mdc-radio-icon-size;
       }
 
       &::before {
         @include mdc-feature-targets($feat-structure) {
           position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
           transform: scale(0, 0);
           border-radius: 50%;
           opacity: 0;
@@ -142,8 +136,6 @@ $mdc-radio-ripple-target: ".mdc-radio__ripple";
     &__native-control {
       @include mdc-feature-targets($feat-structure) {
         position: absolute;
-        width: 100%;
-        height: 100%;
         margin: 0;
         padding: 0;
         opacity: 0;
@@ -154,8 +146,8 @@ $mdc-radio-ripple-target: ".mdc-radio__ripple";
 
     &--touch {
       @include mdc-touch-target-component(
-        $component-height: $mdc-radio-touch-area,
-        $component-width: $mdc-radio-touch-area,
+        $component-height: $mdc-radio-ripple-size,
+        $component-width: $mdc-radio-ripple-size,
         $query: $query);
       @include mdc-radio-touch-target($size: $mdc-touch-target-height, $query: $query);
     }
@@ -233,7 +225,7 @@ $mdc-radio-ripple-target: ".mdc-radio__ripple";
   .mdc-radio__native-control:focus {
     + .mdc-radio__background::before {
       @include mdc-feature-targets($feat-structure) {
-        transform: scale(2, 2);
+        transform: scale(1);
         opacity: map-get($mdc-ripple-dark-ink-opacities, focus);
       }
 
@@ -318,9 +310,19 @@ $mdc-radio-ripple-target: ".mdc-radio__ripple";
   }
 }
 
-@mixin mdc-radio-touch-target($size: $mdc-radio-touch-area, $query: mdc-feature-all()) {
+///
+/// Sets radio touch target size which can be more than the ripple size. Param `$ripple-size` is required for custom
+/// ripple size.
+///
+/// @param {Number} $size Size of touch target (Native input) in `px`.
+/// @param {Number} $ripple-size Size of ripple in `px`. Required only for custom ripple size.
+///
+@mixin mdc-radio-touch-target(
+  $size: $mdc-radio-ripple-size,
+  $ripple-size: $mdc-radio-ripple-size,
+  $query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
-  $offset: ($mdc-radio-touch-area - $size) / 2;
+  $offset: ($ripple-size - $size) / 2;
 
   .mdc-radio__native-control {
     @include mdc-feature-targets($feat-structure) {
@@ -330,5 +332,64 @@ $mdc-radio-ripple-target: ".mdc-radio__ripple";
       width: $size;
       height: $size;
     }
+  }
+}
+
+///
+/// Sets density scale for radio.
+///
+/// @param {Number | String} $density-scale - Density scale value for component. Supported density scale values
+///     `-3`, `-2`, `-1`, `0`.
+///
+@mixin mdc-radio-density($density-scale, $query: mdc-feature-all()) {
+  $size: mdc-density-prop-value(
+    $density-config: $mdc-radio-density-config,
+    $density-scale: $density-scale,
+    $property-name: size,
+  );
+
+  @include mdc-radio-ripple-size($size, $query: $query);
+  // Sets touch target size same as ripple size.
+  @include mdc-radio-touch-target($size: $size, $ripple-size: $size, $query: $query);
+
+  @if $density-scale != 0 {
+    @include mdc-radio-touch-target-reset_($query: $query);
+  }
+}
+
+///
+/// Sets radio ripple size.
+///
+/// @param {Number} $size - Ripple size in `px`.
+///
+@mixin mdc-radio-ripple-size($size, $query: mdc-feature-all()) {
+  $feat-structure: mdc-feature-create-target($query, structure);
+  $padding: ($size - $mdc-radio-icon-size) / 2;
+
+  @include mdc-feature-targets($feat-structure) {
+    padding: $padding;
+  }
+
+  .mdc-radio__background::before {
+    @include mdc-feature-targets($feat-structure) {
+      top: -$padding;
+      left: -$padding;
+      width: $size;
+      height: $size;
+    }
+  }
+}
+
+///
+/// Resets touch target-related styles. This is called from the density mixin to
+/// automatically remove the increased touch target, since dense components
+/// don't have the same default a11y requirements.
+/// @access private
+///
+@mixin mdc-radio-touch-target-reset_($query: mdc-feature-all()) {
+  $feat-structure: mdc-feature-create-target($query, structure);
+
+  @include mdc-feature-targets($feat-structure) {
+    margin: 0;
   }
 }

--- a/packages/mdc-radio/_variables.scss
+++ b/packages/mdc-radio/_variables.scss
@@ -20,13 +20,24 @@
 // THE SOFTWARE.
 //
 
+@import "@material/density/variables";
 @import "@material/theme/variables";
 
-$mdc-radio-touch-area: 40px !default;
-$mdc-radio-ui-size: 20px !default;
-$mdc-radio-ui-pct: percentage($mdc-radio-ui-size / $mdc-radio-touch-area) !default;
+$mdc-radio-ripple-size: 40px !default;
+$mdc-radio-icon-size: 20px !default;
 $mdc-radio-transition-duration: 120ms !default;
 $mdc-radio-ripple-opacity: .14 !default;
 $mdc-radio-baseline-theme-color: secondary !default;
 $mdc-radio-unchecked-color: rgba(mdc-theme-prop-value(on-surface), .54) !default;
 $mdc-radio-circle-color: rgba(mdc-theme-prop-value(on-surface), .26) !default;
+
+$mdc-radio-minimum-size: 28px !default;
+$mdc-radio-maximum-size: $mdc-radio-ripple-size !default;
+$mdc-radio-density-scale: $mdc-density-default-scale !default;
+$mdc-radio-density-config: (
+  size: (
+    minimum: $mdc-radio-minimum-size,
+    default: $mdc-radio-ripple-size,
+    maximum: $mdc-radio-maximum-size,
+  ),
+) !default;

--- a/packages/mdc-radio/package.json
+++ b/packages/mdc-radio/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@material/animation": "^3.1.0",
     "@material/base": "^3.1.0",
+    "@material/density": "^0.0.0",
     "@material/dom": "^3.1.0",
     "@material/feature-targeting": "^3.1.0",
     "@material/ripple": "^3.2.0",

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -903,20 +903,36 @@
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/01/18/07_50_32_667/spec/mdc-menu/issues/4025.html.windows_ie_11.png"
     }
   },
-  "spec/mdc-radio/classes/baseline.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/03/18_19_22_511/spec/mdc-radio/classes/baseline.html?utm_source=golden_json",
+  "spec/mdc-radio/classes/baseline-touch-target.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/classes/baseline-touch-target.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/03/18_19_22_511/spec/mdc-radio/classes/baseline.html.windows_chrome_74.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-radio/classes/baseline.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/classes/baseline.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/classes/baseline-touch-target.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/classes/baseline-touch-target.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/classes/baseline-touch-target.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-radio/classes/baseline.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/classes/baseline.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/classes/baseline.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/classes/baseline.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/classes/baseline.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-radio/mixins/density.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/mixins/density.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/mixins/density.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/mixins/density.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/27/01_14_23_992/spec/mdc-radio/mixins/density.html.windows_ie_11.png"
     }
   },
   "spec/mdc-radio/mixins/mixins.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/03/18_19_22_511/spec/mdc-radio/mixins/mixins.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/mixins/mixins.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/05/03/18_19_22_511/spec/mdc-radio/mixins/mixins.html.windows_chrome_74.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2018/09/10/17_42_51_602/spec/mdc-radio/mixins/mixins.html.windows_firefox_62.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/advorak/2018/09/03/23_44_52_047/spec/mdc-radio/mixins/mixins.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/mixins/mixins.html.windows_chrome_76.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/mixins/mixins.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/20/22_06_30_583/spec/mdc-radio/mixins/mixins.html.windows_ie_11.png"
     }
   },
   "spec/mdc-rtl/variables/include.html": {

--- a/test/screenshot/spec/mdc-radio/classes/baseline-touch-target.html
+++ b/test/screenshot/spec/mdc-radio/classes/baseline-touch-target.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2019 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Radio With Touch Target - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.radio.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-radio/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio mdc-radio--touch">
+            <input class="mdc-radio__native-control" type="radio" name="enabled-radio-group"
+                   id="test-radio-1" data-autofocus>
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-1">1</label>
+        </div>
+
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio mdc-radio--touch">
+            <input class="mdc-radio__native-control" type="radio" name="enabled-radio-group" checked
+                   id="test-radio-2">
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-2">2</label>
+        </div>
+
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio mdc-radio--touch mdc-radio--disabled">
+            <input class="mdc-radio__native-control" type="radio" name="disabled-radio-group" disabled
+                   id="test-radio-3">
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-3">3</label>
+        </div>
+
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio mdc-radio--touch mdc-radio--disabled">
+            <input class="mdc-radio__native-control" type="radio" name="disabled-radio-group" disabled checked
+                   id="test-radio-4">
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-4">4</label>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-radio/fixture.js"></script>
+  </body>
+</html>

--- a/test/screenshot/spec/mdc-radio/fixture.js
+++ b/test/screenshot/spec/mdc-radio/fixture.js
@@ -22,5 +22,13 @@
  */
 
 window.mdc.testFixture.fontsLoaded.then(() => {
+  [].slice.call(document.querySelectorAll('.mdc-radio')).forEach((el) => {
+    mdc.radio.MDCRadio.attachTo(el);
+    const autoFocusEl = el.querySelector('input[data-autofocus]');
+    if (autoFocusEl) {
+      autoFocusEl.focus();
+    }
+  });
+
   window.mdc.testFixture.notifyDomReady();
 });

--- a/test/screenshot/spec/mdc-radio/fixture.scss
+++ b/test/screenshot/spec/mdc-radio/fixture.scss
@@ -29,16 +29,17 @@ $custom-radio-color: $material-color-red-300;
 .test-cell--radio {
   @include test-cell-size(71, 91);
 
+  display: flex;
   position: relative;
+  flex-direction: column;
+  align-items: center;
 }
 
 .test-radio-label {
   display: block;
-  position: absolute;
-  bottom: 11px;
-  left: 11px;
   width: 39px;
   height: 19px;
+  margin-top: 6px;
   background: rgba($custom-radio-color, .4);
   text-align: center;
   cursor: pointer;
@@ -60,4 +61,8 @@ $custom-radio-color: $material-color-red-300;
 
 .custom-radio--ink-color {
   @include mdc-radio-ink-color($custom-radio-color);
+}
+
+.custom-radio-density {
+  @include mdc-radio-density(-3);
 }

--- a/test/screenshot/spec/mdc-radio/mixins/density.html
+++ b/test/screenshot/spec/mdc-radio/mixins/density.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2019 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Radio Density Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.radio.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-radio/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio custom-radio-density mdc-radio--touch">
+            <input class="mdc-radio__native-control" type="radio" name="enabled-radio-group"
+                   id="test-radio-1" data-autofocus>
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-1">1</label>
+        </div>
+
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio custom-radio-density mdc-radio--touch">
+            <input class="mdc-radio__native-control" type="radio" name="enabled-radio-group" checked
+                   id="test-radio-2">
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-2">2</label>
+        </div>
+
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio custom-radio-density mdc-radio--touch mdc-radio--disabled">
+            <input class="mdc-radio__native-control" type="radio" name="disabled-radio-group" disabled
+                   id="test-radio-3">
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-3">3</label>
+        </div>
+
+        <div class="test-cell test-cell--light test-cell--radio">
+          <div class="mdc-radio custom-radio-density mdc-radio--touch mdc-radio--disabled">
+            <input class="mdc-radio__native-control" type="radio" name="disabled-radio-group" disabled checked
+                   id="test-radio-4">
+            <div class="mdc-radio__background">
+              <div class="mdc-radio__outer-circle"></div>
+              <div class="mdc-radio__inner-circle"></div>
+            </div>
+            <div class="mdc-radio__ripple"></div>
+          </div>
+          <label class="test-radio-label" for="test-radio-4">4</label>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-radio/fixture.js"></script>
+  </body>
+</html>

--- a/test/scss/_feature-targeting-test.scss
+++ b/test/scss/_feature-targeting-test.scss
@@ -225,6 +225,8 @@
     @include mdc-radio-ripple($query: $query);
     @include mdc-radio-without-ripple($query: $query);
     @include mdc-radio-touch-target(900px, $query: $query);
+    @include mdc-radio-density(-1, $query: $query);
+    @include mdc-radio-ripple-size(0, $query: $query);
 
     // Ripple
     @include mdc-ripple-core-styles($query: $query);


### PR DESCRIPTION
### Description

* Added `mdc-radio-ripple-size($size)` & `mdc-radio-density($density-scale)` mixins to adjust component dimension.
* Renamed `$mdc-radio-touch-area` => `$mdc-radio-ripple-size` to be consistent with checkbox.
* Renamed `$mdc-radio-ui-size` => `$mdc-radio-icon-size` to be consistent with checkbox.
* Removed `$mdc-radio-ui-pct` sass variable.

BREAKING CHANGE: In Checkbox, Renamed sass variables `$mdc-radio-touch-area` => `$mdc-radio-ripple-size` & `$mdc-radio-ui-size` => `$mdc-radio-icon-size` to be consistent with checkbox. Also, removed `$mdc-radio-ui-pct` sass variable.

Fixes #5102 #5101 