### PR TITLE
feat(switch): add ripple opacity customization mixins

### DIFF
--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -275,27 +275,19 @@
   }
 }
 
-// Simple mixin for base states; custom opacity values can be provided; for those
-// not provided, opacity values are automatically selected based on whether the ink color is
+// Simple mixin for base states which automatically selects opacity values based on whether the ink color is
 // light or dark.
 @mixin mdc-states(
   $color: mdc-theme-prop-value(on-surface),
   $has-nested-focusable-element: false,
-  $custom-opacity-map: (),
   $query: mdc-feature-all()
 ) {
-  @include mdc-states-interactions_($color, $has-nested-focusable-element, $custom-opacity-map, 0, $query);
+  @include mdc-states-interactions_($color, $has-nested-focusable-element, 0, $query);
 }
 
-// Simple mixin for activated states; custom opacity values can be provided; for those
-// not provided, opacity values are automatically selected based on whether the ink color is
+// Simple mixin for activated states which automatically selects opacity values based on whether the ink color is
 // light or dark.
-@mixin mdc-states-activated(
-  $color,
-  $has-nested-focusable-element: false,
-  $custom-opacity-map: (),
-  $query: mdc-feature-all()
-) {
+@mixin mdc-states-activated($color, $has-nested-focusable-element: false, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
   $activated-opacity: mdc-states-opacity($color, activated);
 
@@ -309,20 +301,13 @@
       }
     }
 
-    @include mdc-states-interactions_(
-      $color, $has-nested-focusable-element, $custom-opacity-map, $activated-opacity, $query);
+    @include mdc-states-interactions_($color, $has-nested-focusable-element, $activated-opacity, $query);
   }
 }
 
-// Simple mixin for selected states; custom opacity values can be provided; for those
-// not provided, opacity values are automatically selected based on whether the ink color is
+// Simple mixin for selected states which automatically selects opacity values based on whether the ink color is
 // light or dark.
-@mixin mdc-states-selected(
-  $color,
-  $has-nested-focusable-element: false,
-  $custom-opacity-map: (),
-  $query: mdc-feature-all()
-) {
+@mixin mdc-states-selected($color, $has-nested-focusable-element: false, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
   $selected-opacity: mdc-states-opacity($color, selected);
 
@@ -335,8 +320,7 @@
       }
     }
 
-    @include mdc-states-interactions_(
-      $color, $has-nested-focusable-element, $custom-opacity-map, $selected-opacity, $query);
+    @include mdc-states-interactions_($color, $has-nested-focusable-element, $selected-opacity, $query);
   }
 }
 
@@ -398,23 +382,15 @@
 @mixin mdc-states-interactions_(
   $color,
   $has-nested-focusable-element,
-  $custom-opacity-map: (),
   $opacity-modifier: 0,
   $query: mdc-feature-all()
 ) {
-  $default-opacity-map: (
-    hover: mdc-states-opacity($color, hover),
-    focus: mdc-states-opacity($color, focus),
-    press: mdc-states-opacity($color, press)
-  );
-  $applied-opacity-map: map-merge($default-opacity-map, $custom-opacity-map);
-
   @include mdc-states-base-color($color, $query);
-  @include mdc-states-hover-opacity(map-get($applied-opacity-map, hover) + $opacity-modifier, $query);
+  @include mdc-states-hover-opacity(mdc-states-opacity($color, hover) + $opacity-modifier, $query);
   @include mdc-states-focus-opacity(
-    map-get($applied-opacity-map, focus) + $opacity-modifier,
+    mdc-states-opacity($color, focus) + $opacity-modifier,
     $has-nested-focusable-element,
     $query
   );
-  @include mdc-states-press-opacity(map-get($applied-opacity-map, press) + $opacity-modifier, $query);
+  @include mdc-states-press-opacity(mdc-states-opacity($color, press) + $opacity-modifier, $query);
 }

--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -275,19 +275,27 @@
   }
 }
 
-// Simple mixin for base states which automatically selects opacity values based on whether the ink color is
+// Simple mixin for base states; custom opacity values can be provided; for those
+// not provided, opacity values are automatically selected based on whether the ink color is
 // light or dark.
 @mixin mdc-states(
   $color: mdc-theme-prop-value(on-surface),
   $has-nested-focusable-element: false,
+  $custom-opacity-map: (),
   $query: mdc-feature-all()
 ) {
-  @include mdc-states-interactions_($color, $has-nested-focusable-element, 0, $query);
+  @include mdc-states-interactions_($color, $has-nested-focusable-element, $custom-opacity-map, 0, $query);
 }
 
-// Simple mixin for activated states which automatically selects opacity values based on whether the ink color is
+// Simple mixin for activated states; custom opacity values can be provided; for those
+// not provided, opacity values are automatically selected based on whether the ink color is
 // light or dark.
-@mixin mdc-states-activated($color, $has-nested-focusable-element: false, $query: mdc-feature-all()) {
+@mixin mdc-states-activated(
+  $color,
+  $has-nested-focusable-element: false,
+  $custom-opacity-map: (),
+  $query: mdc-feature-all()
+) {
   $feat-color: mdc-feature-create-target($query, color);
   $activated-opacity: mdc-states-opacity($color, activated);
 
@@ -301,13 +309,20 @@
       }
     }
 
-    @include mdc-states-interactions_($color, $has-nested-focusable-element, $activated-opacity, $query);
+    @include mdc-states-interactions_(
+      $color, $has-nested-focusable-element, $custom-opacity-map, $activated-opacity, $query);
   }
 }
 
-// Simple mixin for selected states which automatically selects opacity values based on whether the ink color is
+// Simple mixin for selected states; custom opacity values can be provided; for those
+// not provided, opacity values are automatically selected based on whether the ink color is
 // light or dark.
-@mixin mdc-states-selected($color, $has-nested-focusable-element: false, $query: mdc-feature-all()) {
+@mixin mdc-states-selected(
+  $color,
+  $has-nested-focusable-element: false,
+  $custom-opacity-map: (),
+  $query: mdc-feature-all()
+) {
   $feat-color: mdc-feature-create-target($query, color);
   $selected-opacity: mdc-states-opacity($color, selected);
 
@@ -320,7 +335,8 @@
       }
     }
 
-    @include mdc-states-interactions_($color, $has-nested-focusable-element, $selected-opacity, $query);
+    @include mdc-states-interactions_(
+      $color, $has-nested-focusable-element, $custom-opacity-map, $selected-opacity, $query);
   }
 }
 
@@ -382,15 +398,23 @@
 @mixin mdc-states-interactions_(
   $color,
   $has-nested-focusable-element,
+  $custom-opacity-map: (),
   $opacity-modifier: 0,
   $query: mdc-feature-all()
 ) {
+  $default-opacity-map: (
+    hover: mdc-states-opacity($color, hover),
+    focus: mdc-states-opacity($color, focus),
+    press: mdc-states-opacity($color, press)
+  );
+  $applied-opacity-map: map-merge($default-opacity-map, $custom-opacity-map);
+
   @include mdc-states-base-color($color, $query);
-  @include mdc-states-hover-opacity(mdc-states-opacity($color, hover) + $opacity-modifier, $query);
+  @include mdc-states-hover-opacity(map-get($applied-opacity-map, hover) + $opacity-modifier, $query);
   @include mdc-states-focus-opacity(
-    mdc-states-opacity($color, focus) + $opacity-modifier,
+    map-get($applied-opacity-map, focus) + $opacity-modifier,
     $has-nested-focusable-element,
     $query
   );
-  @include mdc-states-press-opacity(mdc-states-opacity($color, press) + $opacity-modifier, $query);
+  @include mdc-states-press-opacity(map-get($applied-opacity-map, press) + $opacity-modifier, $query);
 }

--- a/packages/mdc-switch/README.md
+++ b/packages/mdc-switch/README.md
@@ -132,6 +132,9 @@ Mixin | Description
 `mdc-switch-toggled-off-thumb-color($color)` | Sets color of the thumb when the switch is toggled off.
 `mdc-switch-toggled-on-ripple-color($color)` | Sets the color of the ripple surrounding the thumb when the switch is toggled on.
 `mdc-switch-toggled-off-ripple-color($color)` | Sets the color of the ripple surrounding the thumb when the switch is toggled off.
+`mdc-switch-ripple-hover-opacity($opacity)` | Sets the opacity of the ripple surrounding the thumb when hovered.
+`mdc-switch-ripple-focus-opacity($opacity)` | Sets the opacity of the ripple surrounding the thumb when focused.
+`mdc-switch-ripple-press-opacity($opacity)` | Sets the opacity of the ripple surrounding the thumb when pressed.
 
 ## `MDCSwitch` Properties and Methods
 

--- a/packages/mdc-switch/README.md
+++ b/packages/mdc-switch/README.md
@@ -132,9 +132,7 @@ Mixin | Description
 `mdc-switch-toggled-off-thumb-color($color)` | Sets color of the thumb when the switch is toggled off.
 `mdc-switch-toggled-on-ripple-color($color)` | Sets the color of the ripple surrounding the thumb when the switch is toggled on.
 `mdc-switch-toggled-off-ripple-color($color)` | Sets the color of the ripple surrounding the thumb when the switch is toggled off.
-`mdc-switch-ripple-hover-opacity($opacity)` | Sets the opacity of the ripple surrounding the thumb when hovered.
-`mdc-switch-ripple-focus-opacity($opacity)` | Sets the opacity of the ripple surrounding the thumb when focused.
-`mdc-switch-ripple-press-opacity($opacity)` | Sets the opacity of the ripple surrounding the thumb when pressed.
+`mdc-switch-ripple-states-opacity($opacity-map)` | Sets the opacity of the ripple surrounding the thumb in any of the `hover`, `focus`, or `press` states. The `opacity-map` can specify any of these states as keys. States not specified in the map resort to default opacity values.
 
 ## `MDCSwitch` Properties and Methods
 

--- a/packages/mdc-switch/_mixins.scss
+++ b/packages/mdc-switch/_mixins.scss
@@ -158,9 +158,9 @@
   }
 }
 
-@mixin mdc-switch-toggled-on-ripple-color($color, $opacity-map: (), $query: mdc-feature-all()) {
+@mixin mdc-switch-toggled-on-ripple-color($color, $query: mdc-feature-all()) {
   &.mdc-switch--checked .mdc-switch__thumb-underlay {
-    @include mdc-states($color, false, $opacity-map, $query);
+    @include mdc-states($color, false, $query);
   }
 }
 
@@ -186,9 +186,29 @@
   }
 }
 
-@mixin mdc-switch-toggled-off-ripple-color($color, $opacity-map: (), $query: mdc-feature-all()) {
+@mixin mdc-switch-toggled-off-ripple-color($color, $query: mdc-feature-all()) {
   &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay {
-    @include mdc-states($color, false, $opacity-map, $query);
+    @include mdc-states($color, false, $query);
+  }
+}
+
+// Opacity customizations apply to both on and off states to ensure symmetry.
+@mixin mdc-switch-ripple-hover-opacity($opacity, $query: mdc-feature-all()) {
+  // Ensure sufficient specificity to override base state opacities
+  &.mdc-switch .mdc-switch__thumb-underlay {
+    @include mdc-states-hover-opacity($opacity, $query);
+  }
+}
+
+@mixin mdc-switch-ripple-focus-opacity($opacity, $query: mdc-feature-all()) {
+  &.mdc-switch .mdc-switch__thumb-underlay {
+    @include mdc-states-focus-opacity($opacity, $query);
+  }
+}
+
+@mixin mdc-switch-ripple-press-opacity($opacity, $query: mdc-feature-all()) {
+  &.mdc-switch .mdc-switch__thumb-underlay {
+    @include mdc-states-press-opacity($opacity, $query);
   }
 }
 

--- a/packages/mdc-switch/_mixins.scss
+++ b/packages/mdc-switch/_mixins.scss
@@ -192,8 +192,10 @@
   }
 }
 
-// Opacity customizations apply to both on and off states to ensure symmetry.
-@mixin mdc-switch-ripple-states-opacity($opacity-map, $query: mdc-feature-all()) {
+/// Customizes ripple opacities surrounding the thumb in `hover`, `focus`, or `press` states
+/// The customizations apply to both on and off switches to ensure symmetry
+/// @param {map} $opacity-map - map specifying custom opacity of zero or more states
+@mixin mdc-switch-ripple-states-opacity($opacity-map: (), $query: mdc-feature-all()) {
   // Ensure sufficient specificity to override base state opacities
   &.mdc-switch .mdc-switch__thumb-underlay {
     @if map-has-key($opacity-map, "hover") {

--- a/packages/mdc-switch/_mixins.scss
+++ b/packages/mdc-switch/_mixins.scss
@@ -193,22 +193,20 @@
 }
 
 // Opacity customizations apply to both on and off states to ensure symmetry.
-@mixin mdc-switch-ripple-hover-opacity($opacity, $query: mdc-feature-all()) {
+@mixin mdc-switch-ripple-states-opacity($opacity-map, $query: mdc-feature-all()) {
   // Ensure sufficient specificity to override base state opacities
   &.mdc-switch .mdc-switch__thumb-underlay {
-    @include mdc-states-hover-opacity($opacity, $query);
-  }
-}
+    @if map-has-key($opacity-map, "hover") {
+      @include mdc-states-hover-opacity(map-get($opacity-map, "hover"), $query);
+    }
 
-@mixin mdc-switch-ripple-focus-opacity($opacity, $query: mdc-feature-all()) {
-  &.mdc-switch .mdc-switch__thumb-underlay {
-    @include mdc-states-focus-opacity($opacity, $query);
-  }
-}
+    @if map-has-key($opacity-map, "focus") {
+      @include mdc-states-focus-opacity(map-get($opacity-map, "focus"), $query);
+    }
 
-@mixin mdc-switch-ripple-press-opacity($opacity, $query: mdc-feature-all()) {
-  &.mdc-switch .mdc-switch__thumb-underlay {
-    @include mdc-states-press-opacity($opacity, $query);
+    @if map-has-key($opacity-map, "press") {
+      @include mdc-states-press-opacity(map-get($opacity-map, "press"), $query);
+    }
   }
 }
 

--- a/packages/mdc-switch/_mixins.scss
+++ b/packages/mdc-switch/_mixins.scss
@@ -158,9 +158,9 @@
   }
 }
 
-@mixin mdc-switch-toggled-on-ripple-color($color, $query: mdc-feature-all()) {
+@mixin mdc-switch-toggled-on-ripple-color($color, $opacity-map: (), $query: mdc-feature-all()) {
   &.mdc-switch--checked .mdc-switch__thumb-underlay {
-    @include mdc-states($color, false, $query);
+    @include mdc-states($color, false, $opacity-map, $query);
   }
 }
 
@@ -186,29 +186,9 @@
   }
 }
 
-@mixin mdc-switch-toggled-off-ripple-color($color, $query: mdc-feature-all()) {
+@mixin mdc-switch-toggled-off-ripple-color($color, $opacity-map: (), $query: mdc-feature-all()) {
   &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay {
-    @include mdc-states($color, false, $query);
-  }
-}
-
-// Opacity customizations apply to both on and off states to ensure symmetry.
-@mixin mdc-switch-ripple-hover-opacity($opacity, $query: mdc-feature-all()) {
-  // Ensure sufficient specificity to override base state opacities
-  &.mdc-switch .mdc-switch__thumb-underlay {
-    @include mdc-states-hover-opacity($opacity, $query);
-  }
-}
-
-@mixin mdc-switch-ripple-focus-opacity($opacity, $query: mdc-feature-all()) {
-  &.mdc-switch .mdc-switch__thumb-underlay {
-    @include mdc-states-focus-opacity($opacity, $query);
-  }
-}
-
-@mixin mdc-switch-ripple-press-opacity($opacity, $query: mdc-feature-all()) {
-  &.mdc-switch .mdc-switch__thumb-underlay {
-    @include mdc-states-press-opacity($opacity, $query);
+    @include mdc-states($color, false, $opacity-map, $query);
   }
 }
 

--- a/packages/mdc-switch/_mixins.scss
+++ b/packages/mdc-switch/_mixins.scss
@@ -193,24 +193,21 @@
 }
 
 // Opacity customizations apply to both on and off states to ensure symmetry.
-// Both checked and unchecked selectors are included to preserve specificity.
 @mixin mdc-switch-ripple-hover-opacity($opacity, $query: mdc-feature-all()) {
-  &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay,
-  &.mdc-switch--checked .mdc-switch__thumb-underlay {
+  // Ensure sufficient specificity to override base state opacities
+  &.mdc-switch .mdc-switch__thumb-underlay {
     @include mdc-states-hover-opacity($opacity, $query);
   }
 }
 
 @mixin mdc-switch-ripple-focus-opacity($opacity, $query: mdc-feature-all()) {
-  &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay,
-  &.mdc-switch--checked .mdc-switch__thumb-underlay {
+  &.mdc-switch .mdc-switch__thumb-underlay {
     @include mdc-states-focus-opacity($opacity, $query);
   }
 }
 
 @mixin mdc-switch-ripple-press-opacity($opacity, $query: mdc-feature-all()) {
-  &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay,
-  &.mdc-switch--checked .mdc-switch__thumb-underlay {
+  &.mdc-switch .mdc-switch__thumb-underlay {
     @include mdc-states-press-opacity($opacity, $query);
   }
 }

--- a/packages/mdc-switch/_mixins.scss
+++ b/packages/mdc-switch/_mixins.scss
@@ -192,6 +192,29 @@
   }
 }
 
+// Opacity customizations apply to both on and off states to ensure symmetry.
+// Both checked and unchecked selectors are included to preserve specificity.
+@mixin mdc-switch-ripple-hover-opacity($opacity, $query: mdc-feature-all()) {
+  &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay,
+  &.mdc-switch--checked .mdc-switch__thumb-underlay {
+    @include mdc-states-hover-opacity($opacity, $query);
+  }
+}
+
+@mixin mdc-switch-ripple-focus-opacity($opacity, $query: mdc-feature-all()) {
+  &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay,
+  &.mdc-switch--checked .mdc-switch__thumb-underlay {
+    @include mdc-states-focus-opacity($opacity, $query);
+  }
+}
+
+@mixin mdc-switch-ripple-press-opacity($opacity, $query: mdc-feature-all()) {
+  &:not(.mdc-switch--checked) .mdc-switch__thumb-underlay,
+  &.mdc-switch--checked .mdc-switch__thumb-underlay {
+    @include mdc-states-press-opacity($opacity, $query);
+  }
+}
+
 //
 // Private
 //


### PR DESCRIPTION
Allow customization of ripple opacity in MDC switch. 