### PR TITLE
docs: remove `mdc-select--with-trailing-icon`

### DIFF
--- a/packages/mdc-select/icon/README.md
+++ b/packages/mdc-select/icon/README.md
@@ -58,7 +58,7 @@ const icon = new MDCSelectIcon(document.querySelector('.mdc-select__icon'));
 
 ## Variants
 
-Leading icons can be applied to default or `mdc-select--outlined` Selects. To add an icon, add the relevant class (`mdc-select--with-leading-icon` and/or `mdc-select--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-select__icon`.
+Leading icons can be applied to default or `mdc-select--outlined` Selects. To add an icon, add the `mdc-select--with-leading-icon` class to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-select__icon`.
 
 > **NOTE:** if you would like to display un-clickable icons, simply omit `tabindex="0"` and `role="button"`, and the CSS will ensure the cursor is set to default, and that interacting with an icon doesn't do anything unexpected.
 


### PR DESCRIPTION
The select component currently does not support custom trailing icons, and the `mdc-select--with-trailing-icon` class has no effect. This update removes the text that mentions the `mdc-select--with-trailing-icon` class.