### PR TITLE
fix(button): Set ripple target box-sizing to content-box

### DIFF
--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -147,6 +147,9 @@ $mdc-button-ripple-target: ".mdc-button__ripple";
     #{$mdc-button-ripple-target} {
       @include mdc-feature-targets($feat-structure) {
         position: absolute;
+        // Ripple needs content-box as the box sizing and box-sizing: border-box
+        // is often set as a default, so we override that here. 
+        box-sizing: content-box;
         width: 100%;
         height: 100%;
         overflow: hidden;


### PR DESCRIPTION
Often users of the web apply box-sizing: border-box; to all of their components.
If this is done with a page that has a mdc-button, the ripple hover state will be off by a few pixels.
Since this practice is so common and it is a very difficult bug to track down and fix, we can take a preventitve measure and enforce the default style on the ripple target.
This prevents the problem from happening and has no effect on users who do not use the universal border-box rule.