### PR TITLE
fix(slider): Applies secondary color to slider track container

### DIFF
--- a/packages/mdc-slider/_mixins.scss
+++ b/packages/mdc-slider/_mixins.scss
@@ -436,7 +436,14 @@
 
   .mdc-slider__track-container {
     @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(background-color, rgba(mdc-theme-prop-value($color), $opacity));
+      &::after {
+        content: '';
+        display: block;
+        height: 100%;
+        width: 100%;
+        opacity: $opacity;
+        @include mdc-theme-prop(background-color, $color);
+      }
     }
   }
 }


### PR DESCRIPTION
Overcomes css limitation of not being able to use a hex value inside of an rgba value by using the after pseudo class and applying opacity on it instead.  In this way, the container and track are left alone and only the track container has the opacity applied to it.