### PR TITLE
fix(slider): use secondary custom property color for slider container

### DIFF
--- a/packages/mdc-slider/_mixins.scss
+++ b/packages/mdc-slider/_mixins.scss
@@ -435,8 +435,16 @@
   $feat-color: feature-targeting-functions.create-target($query, color);
 
   .mdc-slider__track-container {
-    @include feature-targeting-mixins.targets($feat-color) {
-      @include theme-mixins.prop(background-color, rgba(theme-variables.prop-value($color), $opacity));
+    &::after {
+      display: block;
+      width: 100%;
+      height: 100%;
+      opacity: $opacity;
+      content: "";
+
+	  @include feature-targeting-mixins.targets($feat-color) {
+        @include theme-mixins.prop(background-color, rgba(theme-variables.prop-value($color), $opacity));
+      }
     }
   }
 }

--- a/packages/mdc-slider/_mixins.scss
+++ b/packages/mdc-slider/_mixins.scss
@@ -435,9 +435,9 @@
   $feat-color: feature-targeting-functions.create-target($query, color);
 
   .mdc-slider__track-container {
-	@include feature-targeting-mixins.targets($feat-color) {
+	  @include feature-targeting-mixins.targets($feat-color) {
       &::after {
-        @include theme-mixins.prop(background-color, rgba(theme-variables.prop-value($color), $opacity));
+        @include theme-mixins.prop(background-color, $color);
 
         display: block;
         width: 100%;

--- a/packages/mdc-slider/_mixins.scss
+++ b/packages/mdc-slider/_mixins.scss
@@ -435,15 +435,15 @@
   $feat-color: feature-targeting-functions.create-target($query, color);
 
   .mdc-slider__track-container {
-    &::after {
-      display: block;
-      width: 100%;
-      height: 100%;
-      opacity: $opacity;
-      content: "";
-
-	  @include feature-targeting-mixins.targets($feat-color) {
+	@include feature-targeting-mixins.targets($feat-color) {
+      &::after {
         @include theme-mixins.prop(background-color, rgba(theme-variables.prop-value($color), $opacity));
+
+        display: block;
+        width: 100%;
+        height: 100%;
+        opacity: $opacity;
+        content: "";
       }
     }
   }


### PR DESCRIPTION
Overcomes css limitation of not being able to use a hex value inside of an rgba value by using the after pseudo class and applying opacity on it instead.  In this way, the container and track are left alone and only the track container has the opacity applied to it.