### PR TITLE
fix(checkbox): Remove RTL styles from checkbox ripple

### DIFF
--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -25,7 +25,6 @@
 @import "@material/feature-targeting/functions";
 @import "@material/feature-targeting/mixins";
 @import "@material/ripple/mixins";
-@import "@material/rtl/mixins";
 @import "@material/touch-target/mixins";
 @import "./functions";
 @import "./keyframes";
@@ -61,7 +60,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
     }
 
     @include mdc-checkbox-focus-indicator-color($mdc-checkbox-baseline-theme-color, $query: $query);
-    @include mdc-checkbox-density($mdc-checkbox-density-default-scale, $query: $query);
+    @include mdc-checkbox-density($mdc-checkbox-density-scale, $query: $query);
   }
 
   @include mdc-checkbox-container-colors($query: $query);
@@ -217,7 +216,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 /// Sets density scale for checkbox.
 ///
 /// @param {Number | String} $density-scale - Density scale value for component. Supported density scale values
-///     `-3`, `-2`, `-1`, `0`.
+///     `-4`, `-3`, `-2`, `-1`, `0`.
 ///
 @mixin mdc-checkbox-density($density-scale, $query: mdc-feature-all()) {
   $size: mdc-density-prop-value(
@@ -239,9 +238,8 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
   .mdc-checkbox__background {
     @include mdc-feature-targets($feat-structure) {
-      @include mdc-rtl-reflexive-position(left, $checkbox-padding, ".mdc-checkbox");
-
       top: $checkbox-padding;
+      left: $checkbox-padding;
     }
   }
 

--- a/packages/mdc-checkbox/_variables.scss
+++ b/packages/mdc-checkbox/_variables.scss
@@ -39,7 +39,7 @@ $mdc-checkbox-focus-indicator-opacity: map-get($mdc-ripple-dark-ink-opacities, f
 
 $mdc-checkbox-minimum-size: 28px !default;
 $mdc-checkbox-maximum-size: $mdc-checkbox-ripple-size !default;
-$mdc-checkbox-density-default-scale: $mdc-density-default-scale !default;
+$mdc-checkbox-density-scale: $mdc-density-default-scale !default;
 $mdc-checkbox-density-config: (
   size: (
     minimum: $mdc-checkbox-minimum-size,

--- a/packages/mdc-checkbox/package.json
+++ b/packages/mdc-checkbox/package.json
@@ -24,7 +24,6 @@
     "@material/dom": "^3.1.0",
     "@material/feature-targeting": "^3.1.0",
     "@material/ripple": "^3.2.0",
-    "@material/rtl": "^3.2.0",
     "@material/theme": "^3.1.0",
     "@material/touch-target": "^0.0.0",
     "tslib": "^1.9.3"


### PR DESCRIPTION
It was original introduced in #381 but no longer required.
