### PR TITLE
fix(text-field): Fixes input text alignment on IE11 for densed textfield 2

### DIFF
--- a/packages/mdc-notched-outline/_mixins.scss
+++ b/packages/mdc-notched-outline/_mixins.scss
@@ -49,7 +49,7 @@
 ///
 @mixin mdc-notched-outline-notch-offset($stroke-width) {
   .mdc-notched-outline--notched .mdc-notched-outline__notch {
-    padding-top: $stroke-width - $mdc-notched-outline-border-width;
+    padding-top: $stroke-width;
   }
 }
 

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -100,7 +100,6 @@
         // Set line-height to the height of input element excluding padding & border.
         line-height:
           $height
-          - $mdc-text-field-input-padding
           - $mdc-text-field-input-padding-top
           - $mdc-text-field-input-padding-bottom
           - $mdc-text-field-input-border-bottom;
@@ -304,12 +303,6 @@
   @include mdc-text-field-helper-text-validation-color($mdc-text-field-error);
   @include mdc-text-field-caret-color($mdc-text-field-error);
 
-  &:not(.mdc-text-field--disabled) {
-    @include mdc-required-text-field-label-asterisk_ {
-      @include mdc-theme-prop(color, $mdc-text-field-error);
-    }
-  }
-
   &.mdc-text-field--with-trailing-icon {
     &:not(.mdc-text-field--with-leading-icon) {
       @include mdc-text-field-icon-color($mdc-text-field-error);
@@ -327,10 +320,6 @@
 
 @mixin mdc-text-field-focused_ {
   @include mdc-text-field-label-color($mdc-text-field-focused-label-color);
-
-  @include mdc-required-text-field-label-asterisk_ {
-    @include mdc-theme-prop(color, $mdc-text-field-focused-label-color);
-  }
 
   + .mdc-text-field-helper-line .mdc-text-field-helper-text:not(.mdc-text-field-helper-text--validation-msg) {
     opacity: 1;

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -1840,35 +1840,35 @@
     }
   },
   "spec/mdc-textfield/mixins/density-invalid.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density-invalid.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density-invalid.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density-invalid.html.windows_chrome_76.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density-invalid.html.windows_firefox_69.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density-invalid.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density-invalid.html.windows_ie_11.png"
     }
   },
   "spec/mdc-textfield/mixins/density-leading-icon-invalid.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon-invalid.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density-leading-icon-invalid.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon-invalid.html.windows_chrome_76.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon-invalid.html.windows_firefox_69.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon-invalid.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density-leading-icon-invalid.html.windows_ie_11.png"
     }
   },
   "spec/mdc-textfield/mixins/density-leading-icon.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density-leading-icon.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon.html.windows_chrome_76.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon.html.windows_firefox_69.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/09/13/19_39_26_994/spec/mdc-textfield/mixins/density-leading-icon.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density-leading-icon.html.windows_ie_11.png"
     }
   },
   "spec/mdc-textfield/mixins/density.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density.html.windows_chrome_76.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density.html.windows_firefox_69.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/09/10/22_11_48_498/spec/mdc-textfield/mixins/density.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/10/02/19_16_46_900/spec/mdc-textfield/mixins/density.html.windows_ie_11.png"
     }
   },
   "spec/mdc-textfield/mixins/outline-shape-radius.html": {


### PR DESCRIPTION
Other changes:

- notched-outline: Remove padding calculation from notch offset
- Removed applying color to asterisk since it is inherited from parent (floating label).

This PR keeps text field in sync with internal version.