### PR TITLE
feat(checkbox): Add disabled state color mixins

### DIFF
--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -152,7 +152,8 @@ Mixin | Description
 --- | ---
 `mdc-checkbox-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color, $generate-keyframes)` | Generates CSS classes to set and animate the stroke color and/or container fill color of an enabled checkbox
 `mdc-checkbox-disabled-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color)` | Generates CSS classes to set the stroke color and/or container fill color of a disabled checkbox
-`mdc-checkbox-ink-color($color)` | Sets the ink color of the checked and indeterminate icons
+`mdc-checkbox-ink-color($color)` | Sets the ink color of the checked and indeterminate icons for an enabled checkbox
+`mdc-checkbox-disabled-ink-color($color)` | Sets the ink color of the checked and indeterminate icons for a disabled checkbox
 `mdc-checkbox-focus-indicator-color($color)` | Sets the color of the focus indicator (ripple) when checkbox is selected or is in indeterminate state.
 `mdc-checkbox-ripple-size($ripple-size)` | Sets the ripple size of the checkbox.
 `mdc-checkbox-density($density-scale)` | Sets density scale for checkbox, Supported density scales are `-3`, `-2`, `-1`, and `0` (default).

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -150,7 +150,8 @@ The following mixins apply only to _enabled_ checkboxes. It is not currently pos
 
 Mixin | Description
 --- | ---
-`mdc-checkbox-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color, $generate-keyframes)` | Generates CSS classes to set and animate the stroke color and/or container fill color of a checkbox
+`mdc-checkbox-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color, $generate-keyframes)` | Generates CSS classes to set and animate the stroke color and/or container fill color of an enabled checkbox
+`mdc-checkbox-disabled-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color)` | Generates CSS classes to set the stroke color and/or container fill color of a disabled checkbox
 `mdc-checkbox-ink-color($color)` | Sets the ink color of the checked and indeterminate icons
 `mdc-checkbox-focus-indicator-color($color)` | Sets the color of the focus indicator (ripple) when checkbox is selected or is in indeterminate state.
 `mdc-checkbox-ripple-size($ripple-size)` | Sets the ripple size of the checkbox.
@@ -165,6 +166,10 @@ Stroke and fill color may be customized independently in both the marked and unm
 All parameters are optional, and if left unspecified will use their default values.
 
 If you plan to use CSS-only checkboxes, set `$generate-keyframes` to `false` to prevent the mixin from generating `@keyframes` and CSS classes used by the JavaScript component.
+
+#### `mdc-checkbox-disabled-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color)`
+
+Usage for `mdc-checkbox-disabled-container-colors` is generally the same as `mdc-checkbox-container-colors`, but without animation keyframes.
 
 #### Caveat: Edge and CSS Variables
 

--- a/packages/mdc-checkbox/README.md
+++ b/packages/mdc-checkbox/README.md
@@ -146,12 +146,10 @@ MDC Checkbox uses [MDC Theme](../mdc-theme)'s `secondary` color by default for "
 
 ### Sass Mixins
 
-The following mixins apply only to _enabled_ checkboxes. It is not currently possible to customize the color of a _disabled_ checkbox.
-
 Mixin | Description
 --- | ---
-`mdc-checkbox-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color, $generate-keyframes)` | Generates CSS classes to set and animate the stroke color and/or container fill color of an enabled checkbox
-`mdc-checkbox-disabled-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color)` | Generates CSS classes to set the stroke color and/or container fill color of a disabled checkbox
+`mdc-checkbox-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color, $generate-keyframes)` | Sets stroke & fill colors for both marked and unmarked state of enabled checkbox. Set $generate-keyframes to false to prevent the mixin from generating @keyframes.
+`mdc-checkbox-disabled-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color)` | Sets stroke & fill colors for both marked and unmarked state of disabled checkbox.
 `mdc-checkbox-ink-color($color)` | Sets the ink color of the checked and indeterminate icons for an enabled checkbox
 `mdc-checkbox-disabled-ink-color($color)` | Sets the ink color of the checked and indeterminate icons for a disabled checkbox
 `mdc-checkbox-focus-indicator-color($color)` | Sets the color of the focus indicator (ripple) when checkbox is selected or is in indeterminate state.
@@ -159,18 +157,6 @@ Mixin | Description
 `mdc-checkbox-density($density-scale)` | Sets density scale for checkbox, Supported density scales are `-3`, `-2`, `-1`, and `0` (default).
 
 The ripple effect for the Checkbox component is styled using [MDC Ripple](../mdc-ripple) mixins.
-
-#### `mdc-checkbox-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color, $generate-keyframes)`
-
-Stroke and fill color may be customized independently in both the marked and unmarked state.
-
-All parameters are optional, and if left unspecified will use their default values.
-
-If you plan to use CSS-only checkboxes, set `$generate-keyframes` to `false` to prevent the mixin from generating `@keyframes` and CSS classes used by the JavaScript component.
-
-#### `mdc-checkbox-disabled-container-colors($unmarked-stroke-color, $unmarked-fill-color, $marked-stroke-color, $marked-fill-color)`
-
-Usage for `mdc-checkbox-disabled-container-colors` is generally the same as `mdc-checkbox-container-colors`, but without animation keyframes.
 
 #### Caveat: Edge and CSS Variables
 

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -557,7 +557,6 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 }
 
 @mixin mdc-checkbox-background-selector-disabled_ {
-  // stylelint-disable-next-line selector-max-specificity
   .mdc-checkbox__native-control:disabled ~ .mdc-checkbox__background {
     @content;
   }

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -65,7 +65,8 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
   @include mdc-checkbox-container-colors($query: $query);
   @include mdc-checkbox-disabled-container-colors($query: $query);
-  @include mdc-checkbox-ink-color($mdc-checkbox-mark-color, $query);
+  @include mdc-checkbox-ink-color($query: $query);
+  @include mdc-checkbox-disabled-ink-color($query: $query);
 
   @media screen and (-ms-high-contrast: active) {
     .mdc-checkbox__mixedmark {
@@ -321,11 +322,13 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
+///
 /// Customizes disabled state stroke and fill colors
 /// @param {Color} $unmarked-stroke-color - The desired stroke color for the unmarked state
 /// @param {Color} $unmarked-fill-color - The desired fill color for the unmarked state
 /// @param {Color} $marked-stroke-color - The desired stroke color for the marked state
 /// @param {Color} $marked-fill-color - The desired fill color for the marked state
+///
 @mixin mdc-checkbox-disabled-container-colors(
   $unmarked-stroke-color: $mdc-checkbox-disabled-color,
   $unmarked-fill-color: transparent,
@@ -350,18 +353,46 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox-ink-color($color, $query: mdc-feature-all()) {
+///
+/// Customizes ink color for an enabled checkbox
+/// @param {Color} $color - The desired ink color in enabled state
+///
+@mixin mdc-checkbox-ink-color($color: $mdc-checkbox-mark-color, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
 
-  .mdc-checkbox__checkmark {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(color, $color);
+  @include mdc-checkbox-background-selector-enabled_ {
+    .mdc-checkbox__checkmark {
+      @include mdc-feature-targets($feat-color) {
+        @include mdc-theme-prop(color, $color);
+      }
+    }
+
+    .mdc-checkbox__mixedmark {
+      @include mdc-feature-targets($feat-color) {
+        @include mdc-theme-prop(border-color, $color);
+      }
     }
   }
+}
 
-  .mdc-checkbox__mixedmark {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(border-color, $color);
+///
+/// Customizes ink color for a disabled checkbox
+/// @param {Color} $color - The desired ink color in disabled state
+///
+@mixin mdc-checkbox-disabled-ink-color($color: $mdc-checkbox-mark-color, $query: mdc-feature-all()) {
+  $feat-color: mdc-feature-create-target($query, color);
+
+  @include mdc-checkbox-background-selector-disabled_ {
+    .mdc-checkbox__checkmark {
+      @include mdc-feature-targets($feat-color) {
+        @include mdc-theme-prop(color, $color);
+      }
+    }
+
+    .mdc-checkbox__mixedmark {
+      @include mdc-feature-targets($feat-color) {
+        @include mdc-theme-prop(border-color, $color);
+      }
     }
   }
 }
@@ -518,6 +549,19 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 }
 
 // Background
+
+@mixin mdc-checkbox-background-selector-enabled_ {
+  .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
+    @content;
+  }
+}
+
+@mixin mdc-checkbox-background-selector-disabled_ {
+  // stylelint-disable-next-line selector-max-specificity
+  .mdc-checkbox__native-control:disabled ~ .mdc-checkbox__background {
+    @content;
+  }
+}
 
 @mixin mdc-checkbox-unmarked-background-selector-enabled_ {
   // stylelint-disable-next-line selector-max-specificity

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -64,11 +64,8 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 
   @include mdc-checkbox-container-colors($query: $query);
+  @include mdc-checkbox-disabled-container-colors($query: $query);
   @include mdc-checkbox-ink-color($mdc-checkbox-mark-color, $query);
-
-  @include mdc-feature-targets($feat-color) {
-    @include mdc-checkbox-disabled-container-color_;
-  }
 
   @media screen and (-ms-high-contrast: active) {
     .mdc-checkbox__mixedmark {
@@ -324,6 +321,35 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
+/// Customizes disabled state stroke and fill colors
+/// @param {Color} $unmarked-stroke-color - The desired stroke color for the unmarked state
+/// @param {Color} $unmarked-fill-color - The desired fill color for the unmarked state
+/// @param {Color} $marked-stroke-color - The desired stroke color for the marked state
+/// @param {Color} $marked-fill-color - The desired fill color for the marked state
+@mixin mdc-checkbox-disabled-container-colors(
+  $unmarked-stroke-color: $mdc-checkbox-disabled-color,
+  $unmarked-fill-color: transparent,
+  $marked-stroke-color: transparent,
+  $marked-fill-color: $mdc-checkbox-disabled-color,
+  $query: mdc-feature-all()
+) {
+  $feat-color: mdc-feature-create-target($query, color);
+
+  @include mdc-checkbox-unmarked-background-selector-disabled_ {
+    @include mdc-feature-targets($feat-color) {
+      @include mdc-theme-prop(border-color, $unmarked-stroke-color);
+      @include mdc-theme-prop(background-color, $unmarked-fill-color);
+    }
+  }
+
+  @include mdc-checkbox-marked-background-selector-disabled_ {
+    @include mdc-feature-targets($feat-color) {
+      @include mdc-theme-prop(border-color, $marked-stroke-color);
+      @include mdc-theme-prop(background-color, $marked-fill-color);
+    }
+  }
+}
+
 @mixin mdc-checkbox-ink-color($color, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
 
@@ -399,17 +425,6 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   white-space: nowrap;
   cursor: pointer;
   vertical-align: bottom;
-}
-
-@mixin mdc-checkbox-disabled-container-color_ {
-  @include mdc-checkbox-unmarked-background-selector-disabled_ {
-    @include mdc-theme-prop(border-color, $mdc-checkbox-disabled-color);
-  }
-
-  @include mdc-checkbox-marked-background-selector-disabled_ {
-    @include mdc-theme-prop(border-color, transparent);
-    @include mdc-theme-prop(background-color, $mdc-checkbox-disabled-color);
-  }
 }
 
 @mixin mdc-checkbox--disabled_ {

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -264,7 +264,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 /// @param {Color} $unmarked-fill-color - The desired fill color for the unmarked state
 /// @param {Color} $marked-stroke-color - The desired stroke color for the marked state
 /// @param {Color} $marked-fill-color - The desired fill color for the marked state
-/// @param {bool} $generate-keyframes [true] - Whether animation keyframes should be generated
+/// @param {Boolean} $generate-keyframes [true] - Whether animation keyframes should be generated
 ///
 @mixin mdc-checkbox-container-colors(
   $unmarked-stroke-color: $mdc-checkbox-border-color,

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -65,8 +65,8 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
   @include mdc-checkbox-container-colors($query: $query);
   @include mdc-checkbox-disabled-container-colors($query: $query);
-  @include mdc-checkbox-ink-color($query: $query);
-  @include mdc-checkbox-disabled-ink-color($query: $query);
+  @include mdc-checkbox-ink-color($mdc-checkbox-mark-color, $query: $query);
+  @include mdc-checkbox-disabled-ink-color($mdc-checkbox-mark-color, $query: $query);
 
   @media screen and (-ms-high-contrast: active) {
     .mdc-checkbox__mixedmark {
@@ -257,6 +257,15 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   @include mdc-checkbox-touch-target($ripple-size, $ripple-size: $ripple-size, $query: $query);
 }
 
+///
+/// Sets stroke & fill colors for both marked and unmarked state of enabled checkbox.
+/// Set $generate-keyframes to false to prevent the mixin from generating @keyframes
+/// @param {Color} $unmarked-stroke-color - The desired stroke color for the unmarked state
+/// @param {Color} $unmarked-fill-color - The desired fill color for the unmarked state
+/// @param {Color} $marked-stroke-color - The desired stroke color for the marked state
+/// @param {Color} $marked-fill-color - The desired fill color for the marked state
+/// @param {bool} $generate-keyframes [true] - Whether animation keyframes should be generated
+///
 @mixin mdc-checkbox-container-colors(
   $unmarked-stroke-color: $mdc-checkbox-border-color,
   $unmarked-fill-color: transparent,
@@ -268,11 +277,11 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-color: mdc-feature-create-target($query, color);
 
-  @include mdc-checkbox-unmarked-background-selector-enabled_ {
+  @include mdc-checkbox-if-unmarked-enabled_ {
     @include mdc-checkbox-container-colors_($unmarked-stroke-color, $unmarked-fill-color, $query: $query);
   }
 
-  @include mdc-checkbox-marked-background-selector-enabled_ {
+  @include mdc-checkbox-if-marked-enabled_ {
     @include mdc-checkbox-container-colors_($marked-stroke-color, $marked-fill-color, $query: $query);
   }
 
@@ -317,7 +326,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 }
 
 ///
-/// Customizes disabled state stroke and fill colors
+/// Sets stroke & fill colors for both marked and unmarked state of disabled checkbox.
 /// @param {Color} $unmarked-stroke-color - The desired stroke color for the unmarked state
 /// @param {Color} $unmarked-fill-color - The desired fill color for the unmarked state
 /// @param {Color} $marked-stroke-color - The desired stroke color for the marked state
@@ -330,33 +339,33 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   $marked-fill-color: $mdc-checkbox-disabled-color,
   $query: mdc-feature-all()
 ) {
-  @include mdc-checkbox-unmarked-background-selector-disabled_ {
+  @include mdc-checkbox-if-unmarked-disabled_ {
     @include mdc-checkbox-container-colors_($unmarked-stroke-color, $unmarked-fill-color, $query: $query);
   }
 
-  @include mdc-checkbox-marked-background-selector-disabled_ {
+  @include mdc-checkbox-if-marked-disabled_ {
     @include mdc-checkbox-container-colors_($marked-stroke-color, $marked-fill-color, $query: $query);
   }
 }
 
 ///
-/// Customizes ink color for an enabled checkbox
+/// Sets the ink color of the checked and indeterminate icons for an enabled checkbox
 /// @param {Color} $color - The desired ink color in enabled state
 ///
-@mixin mdc-checkbox-ink-color($color: $mdc-checkbox-mark-color, $query: mdc-feature-all()) {
-  @include mdc-checkbox-background-selector-enabled_ {
+@mixin mdc-checkbox-ink-color($color, $query: mdc-feature-all()) {
+  @include mdc-checkbox-if-enabled_ {
     @include mdc-checkbox-ink-color_($color, $query: $query);
   }
 }
 
 ///
-/// Customizes ink color for a disabled checkbox
+/// Sets the ink color of the checked and indeterminate icons for a disabled checkbox
 /// @param {Color} $color - The desired ink color in disabled state
 ///
-@mixin mdc-checkbox-disabled-ink-color($color: $mdc-checkbox-mark-color, $query: mdc-feature-all()) {
+@mixin mdc-checkbox-disabled-ink-color($color, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
 
-  @include mdc-checkbox-background-selector-disabled_ {
+  @include mdc-checkbox-if-disabled_ {
     @include mdc-checkbox-ink-color_($color, $query: $query);
   }
 }
@@ -514,49 +523,81 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
 // Background
 
-@mixin mdc-checkbox-background-selector-enabled_ {
-  .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
+///
+/// Helps select the checkbox background only when its native control is in
+/// enabled state.
+/// @access private
+///
+@mixin mdc-checkbox-if-enabled_ {
+  .mdc-checkbox__native-control:enabled ~ {
     @content;
   }
 }
 
-@mixin mdc-checkbox-background-selector-disabled_ {
-  .mdc-checkbox__native-control:disabled ~ .mdc-checkbox__background {
+///
+/// Helps select the checkbox background only when its native control is in
+/// disabled state.
+/// @access private
+///
+@mixin mdc-checkbox-if-disabled_ {
+  .mdc-checkbox__native-control:disabled ~ {
     @content;
   }
 }
 
-@mixin mdc-checkbox-unmarked-background-selector-enabled_ {
-  // stylelint-disable-next-line selector-max-specificity
-  .mdc-checkbox__native-control:enabled:not(:checked):not(:indeterminate) ~ .mdc-checkbox__background {
+///
+/// Helps select the checkbox background only when its native control is in
+/// unmarked & enabled state.
+/// @access private
+///
+@mixin mdc-checkbox-if-unmarked-enabled_ {
+  .mdc-checkbox__native-control:enabled:not(:checked):not(:indeterminate) ~ {
     @content;
   }
 }
 
-@mixin mdc-checkbox-unmarked-background-selector-disabled_ {
+///
+/// Helps select the checkbox background only when its native control is in
+/// unmarked & disabled state.
+/// @access private
+///
+@mixin mdc-checkbox-if-unmarked-disabled_ {
   // Note: we must use `[disabled]` instead of `:disabled` below because Edge does not always recalculate the style
   // property when the `:disabled` pseudo-class is followed by a sibling combinator. See:
   // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11295231/
-  // stylelint-disable-next-line selector-max-specificity
-  .mdc-checkbox__native-control[disabled]:not(:checked):not(:indeterminate) ~ .mdc-checkbox__background {
+  .mdc-checkbox__native-control[disabled]:not(:checked):not(:indeterminate) ~ {
     @content;
   }
 }
 
-@mixin mdc-checkbox-marked-background-selector-enabled_ {
-  .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
-  .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background {
-    @content;
+///
+/// Helps select the checkbox background only when its native control is in
+/// marked & enabled state.
+/// @access private
+///
+@mixin mdc-checkbox-if-marked-enabled_ {
+  .mdc-checkbox__native-control:enabled:checked,
+  .mdc-checkbox__native-control:enabled:indeterminate {
+    ~ {
+      @content;
+    }
   }
 }
 
-@mixin mdc-checkbox-marked-background-selector-disabled_ {
+///
+/// Helps select the checkbox background only when its native control is in
+/// marked & disabled state.
+/// @access private
+///
+@mixin mdc-checkbox-if-marked-disabled_ {
   // Note: we must use `[disabled]` instead of `:disabled` below because Edge does not always recalculate the style
   // property when the `:disabled` pseudo-class is followed by a sibling combinator. See:
   // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11295231/
-  .mdc-checkbox__native-control[disabled]:checked ~ .mdc-checkbox__background,
-  .mdc-checkbox__native-control[disabled]:indeterminate ~ .mdc-checkbox__background {
-    @content;
+  .mdc-checkbox__native-control[disabled]:checked,
+  .mdc-checkbox__native-control[disabled]:indeterminate {
+    ~ {
+      @content;
+    }
   }
 }
 
@@ -600,12 +641,20 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
     mdc-checkbox-transition-enter(background-color);
 }
 
+///
+/// Sets the stroke & fill colors for the checkbox.
+/// This mixin should be wrapped in a mixin that qualifies state such as
+/// `mdc-checkbox-if-unmarked-enabled_`.
+/// @access private
+///
 @mixin mdc-checkbox-container-colors_($stroke-color, $fill-color, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
 
-  @include mdc-feature-targets($feat-color) {
-    @include mdc-theme-prop(border-color, $stroke-color);
-    @include mdc-theme-prop(background-color, $fill-color);
+  .mdc-checkbox__background {
+    @include mdc-feature-targets($feat-color) {
+      @include mdc-theme-prop(border-color, $stroke-color);
+      @include mdc-theme-prop(background-color, $fill-color);
+    }
   }
 }
 
@@ -716,18 +765,26 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
+///
+/// Sets the ink color of the checked and indeterminate icons for a checkbox.
+/// This mixin should be wrapped in a mixin that qualifies state such as
+/// `mdc-checkbox-if-unmarked_`.
+/// @access private
+///
 @mixin mdc-checkbox-ink-color_($color, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
 
-  .mdc-checkbox__checkmark {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(color, $color);
+  .mdc-checkbox__background {
+    .mdc-checkbox__checkmark {
+      @include mdc-feature-targets($feat-color) {
+        @include mdc-theme-prop(color, $color);
+      }
     }
-  }
 
-  .mdc-checkbox__mixedmark {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(border-color, $color);
+    .mdc-checkbox__mixedmark {
+      @include mdc-feature-targets($feat-color) {
+        @include mdc-theme-prop(border-color, $color);
+      }
     }
   }
 }

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -269,17 +269,11 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   $feat-color: mdc-feature-create-target($query, color);
 
   @include mdc-checkbox-unmarked-background-selector-enabled_ {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(border-color, $unmarked-stroke-color);
-      @include mdc-theme-prop(background-color, $unmarked-fill-color);
-    }
+    @include mdc-checkbox-container-colors_($unmarked-stroke-color, $unmarked-fill-color, $query: $query);
   }
 
   @include mdc-checkbox-marked-background-selector-enabled_ {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(border-color, $marked-stroke-color);
-      @include mdc-theme-prop(background-color, $marked-fill-color);
-    }
+    @include mdc-checkbox-container-colors_($marked-stroke-color, $marked-fill-color, $query: $query);
   }
 
   @if $generate-keyframes {
@@ -336,20 +330,12 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   $marked-fill-color: $mdc-checkbox-disabled-color,
   $query: mdc-feature-all()
 ) {
-  $feat-color: mdc-feature-create-target($query, color);
-
   @include mdc-checkbox-unmarked-background-selector-disabled_ {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(border-color, $unmarked-stroke-color);
-      @include mdc-theme-prop(background-color, $unmarked-fill-color);
-    }
+    @include mdc-checkbox-container-colors_($unmarked-stroke-color, $unmarked-fill-color, $query: $query);
   }
 
   @include mdc-checkbox-marked-background-selector-disabled_ {
-    @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(border-color, $marked-stroke-color);
-      @include mdc-theme-prop(background-color, $marked-fill-color);
-    }
+    @include mdc-checkbox-container-colors_($marked-stroke-color, $marked-fill-color, $query: $query);
   }
 }
 
@@ -358,20 +344,8 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 /// @param {Color} $color - The desired ink color in enabled state
 ///
 @mixin mdc-checkbox-ink-color($color: $mdc-checkbox-mark-color, $query: mdc-feature-all()) {
-  $feat-color: mdc-feature-create-target($query, color);
-
   @include mdc-checkbox-background-selector-enabled_ {
-    .mdc-checkbox__checkmark {
-      @include mdc-feature-targets($feat-color) {
-        @include mdc-theme-prop(color, $color);
-      }
-    }
-
-    .mdc-checkbox__mixedmark {
-      @include mdc-feature-targets($feat-color) {
-        @include mdc-theme-prop(border-color, $color);
-      }
-    }
+    @include mdc-checkbox-ink-color_($color, $query: $query);
   }
 }
 
@@ -383,17 +357,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   $feat-color: mdc-feature-create-target($query, color);
 
   @include mdc-checkbox-background-selector-disabled_ {
-    .mdc-checkbox__checkmark {
-      @include mdc-feature-targets($feat-color) {
-        @include mdc-theme-prop(color, $color);
-      }
-    }
-
-    .mdc-checkbox__mixedmark {
-      @include mdc-feature-targets($feat-color) {
-        @include mdc-theme-prop(border-color, $color);
-      }
-    }
+    @include mdc-checkbox-ink-color_($color, $query: $query);
   }
 }
 
@@ -636,6 +600,15 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
     mdc-checkbox-transition-enter(background-color);
 }
 
+@mixin mdc-checkbox-container-colors_($stroke-color, $fill-color, $query: mdc-feature-all()) {
+  $feat-color: mdc-feature-create-target($query, color);
+
+  @include mdc-feature-targets($feat-color) {
+    @include mdc-theme-prop(border-color, $stroke-color);
+    @include mdc-theme-prop(background-color, $fill-color);
+  }
+}
+
 // Focus indicator
 
 @mixin mdc-checkbox__focus-indicator_($query: mdc-feature-all()) {
@@ -740,6 +713,22 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
     transition:
       mdc-checkbox-transition-exit(opacity, 0ms, $mdc-checkbox-transition-duration),
       mdc-checkbox-transition-exit(transform, 0ms, $mdc-checkbox-transition-duration);
+  }
+}
+
+@mixin mdc-checkbox-ink-color_($color, $query: mdc-feature-all()) {
+  $feat-color: mdc-feature-create-target($query, color);
+
+  .mdc-checkbox__checkmark {
+    @include mdc-feature-targets($feat-color) {
+      @include mdc-theme-prop(color, $color);
+    }
+  }
+
+  .mdc-checkbox__mixedmark {
+    @include mdc-feature-targets($feat-color) {
+      @include mdc-theme-prop(border-color, $color);
+    }
   }
 }
 

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -152,11 +152,11 @@
     }
   },
   "spec/mdc-checkbox/mixins/container-colors.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/07/08/19_30_20_273/spec/mdc-checkbox/mixins/container-colors.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/07/08/19_30_20_273/spec/mdc-checkbox/mixins/container-colors.html.windows_chrome_75.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/07/08/19_30_20_273/spec/mdc-checkbox/mixins/container-colors.html.windows_firefox_67.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/travis/2019/07/08/19_30_20_273/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html.windows_chrome_77.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11.png"
     }
   },
   "spec/mdc-checkbox/mixins/density.html": {

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -152,11 +152,11 @@
     }
   },
   "spec/mdc-checkbox/mixins/container-colors.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/container-colors.html?utm_source=golden_json",
     "screenshots": {
-      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html.windows_chrome_77.png",
-      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html.windows_firefox_69.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/19_41_46_972/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11.png"
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/container-colors.html.windows_chrome_77.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/container-colors.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/container-colors.html.windows_ie_11.png"
     }
   },
   "spec/mdc-checkbox/mixins/density.html": {
@@ -165,6 +165,14 @@
       "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/08/21/18_28_05_666/spec/mdc-checkbox/mixins/density.html.windows_chrome_76.png",
       "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/08/21/18_28_05_666/spec/mdc-checkbox/mixins/density.html.windows_firefox_67.png",
       "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/08/21/18_28_05_666/spec/mdc-checkbox/mixins/density.html.windows_ie_11.png"
+    }
+  },
+  "spec/mdc-checkbox/mixins/ink-color.html": {
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/ink-color.html?utm_source=golden_json",
+    "screenshots": {
+      "desktop_windows_chrome@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/ink-color.html.windows_chrome_77.png",
+      "desktop_windows_firefox@latest": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/ink-color.html.windows_firefox_69.png",
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/allanchen/2019/10/10/21_48_57_933/spec/mdc-checkbox/mixins/ink-color.html.windows_ie_11.png"
     }
   },
   "spec/mdc-checkbox/mixins/ripple-size.html": {

--- a/test/screenshot/spec/mdc-checkbox/fixture.scss
+++ b/test/screenshot/spec/mdc-checkbox/fixture.scss
@@ -24,8 +24,7 @@
 @import "../mixins";
 
 $custom-checkbox-color: crimson;
-$custom-disabled-checkbox-unmarked-color: rgba(black, .3);
-$custom-disabled-checkbox-marked-color: rgba(burlywood, .5);
+$custom-disabled-checkbox-color: rgba(purple, .3);
 
 .test-cell--checkbox {
   @include test-cell-size(91);
@@ -38,13 +37,13 @@ $custom-disabled-checkbox-marked-color: rgba(burlywood, .5);
     $marked-fill-color: $custom-checkbox-color
   );
   @include mdc-checkbox-disabled-container-colors(
-    $unmarked-stroke-color: $custom-disabled-checkbox-unmarked-color,
-    $marked-fill-color: $custom-disabled-checkbox-marked-color
+    $marked-fill-color: $custom-disabled-checkbox-color
   );
 }
 
 .custom-checkbox--ink-color {
   @include mdc-checkbox-ink-color($custom-checkbox-color);
+  @include mdc-checkbox-disabled-ink-color($custom-disabled-checkbox-color);
 }
 
 .test-checkbox-ripple-size {

--- a/test/screenshot/spec/mdc-checkbox/fixture.scss
+++ b/test/screenshot/spec/mdc-checkbox/fixture.scss
@@ -24,6 +24,8 @@
 @import "../mixins";
 
 $custom-checkbox-color: crimson;
+$custom-disabled-checkbox-unmarked-color: rgba(black, .3);
+$custom-disabled-checkbox-marked-color: rgba(burlywood, .5);
 
 .test-cell--checkbox {
   @include test-cell-size(91);
@@ -34,6 +36,10 @@ $custom-checkbox-color: crimson;
   @include mdc-checkbox-container-colors(
     $marked-stroke-color: $custom-checkbox-color,
     $marked-fill-color: $custom-checkbox-color
+  );
+  @include mdc-checkbox-disabled-container-colors(
+    $unmarked-stroke-color: $custom-disabled-checkbox-unmarked-color,
+    $marked-fill-color: $custom-disabled-checkbox-marked-color
   );
 }
 

--- a/test/screenshot/spec/mdc-checkbox/mixins/ink-color.html
+++ b/test/screenshot/spec/mdc-checkbox/mixins/ink-color.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2018 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>ink-color Checkbox Mixin - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.checkbox.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-checkbox/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox custom-checkbox--ink-color">
+            <input type="checkbox"
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-unchecked"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+            <div class="mdc-checkbox__ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--selected custom-checkbox--ink-color">
+            <input type="checkbox"
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-checked"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+            <div class="mdc-checkbox__ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--selected custom-checkbox--ink-color">
+            <input type="checkbox"
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-indeterminate"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+            <div class="mdc-checkbox__ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--disabled custom-checkbox--ink-color">
+            <input type="checkbox"
+                   disabled
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-unchecked-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+            <div class="mdc-checkbox__ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--selected mdc-checkbox--disabled custom-checkbox--ink-color">
+            <input type="checkbox"
+                   disabled
+                   checked
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-checked-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+            <div class="mdc-checkbox__ripple"></div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--checkbox">
+          <div class="mdc-checkbox mdc-checkbox--selected mdc-checkbox--disabled custom-checkbox--ink-color">
+            <input type="checkbox"
+                   disabled
+                   class="mdc-checkbox__native-control"
+                   id="checkbox-indeterminate-disabled"/>
+            <div class="mdc-checkbox__background">
+              <svg class="mdc-checkbox__checkmark"
+                   viewBox="0 0 24 24">
+                <path class="mdc-checkbox__checkmark-path"
+                      fill="none"
+                      d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+              </svg>
+              <div class="mdc-checkbox__mixedmark"></div>
+            </div>
+            <div class="mdc-checkbox__ripple"></div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-checkbox/fixture.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds the `mdc-checkbox-disabled-container-colors` and `mdc-checkbox-disabled-ink-color` mixins to allow customizing disabled state colors. 

Screenshot test for ink colors that was previously removed has been re-added. (fixes #4774)

BREAKING CHANGE: `mdc-checkbox-ink-color` mixin now only applies to enabled checkboxes