### PR TITLE
fix(linear-progress): Fix indeterminate animation bug

### DIFF
--- a/packages/mdc-linear-progress/README.md
+++ b/packages/mdc-linear-progress/README.md
@@ -95,6 +95,7 @@ The adapter for linear progress must provide the following functions, with corre
 | `addClass(className: string) => void` | Adds a class to the root element. |
 | `removeClass(className: string) => void` | Removes a class from the root element. |
 | `hasClass(className: string) => boolean` | Returns boolean indicating whether the root element has a given class. |
+| `forceLayout() => void` | Force-trigger a layout on the root element. This is needed to restart animations correctly. |
 | `getPrimaryBar() => Element` | Returns the primary bar element. |
 | `getBuffer() => Element` | Returns the buffer element. |
 | `setStyle(el: Element, styleProperty: string, value: string) => void` | Sets the inline style on the given element. |

--- a/packages/mdc-linear-progress/adapter.ts
+++ b/packages/mdc-linear-progress/adapter.ts
@@ -30,6 +30,7 @@
  */
 export interface MDCLinearProgressAdapter {
   addClass(className: string): void;
+  forceLayout(): void;
   getBuffer(): HTMLElement | null;
   getPrimaryBar(): HTMLElement | null;
   hasClass(className: string): boolean;

--- a/packages/mdc-linear-progress/component.ts
+++ b/packages/mdc-linear-progress/component.ts
@@ -59,6 +59,7 @@ export class MDCLinearProgress extends MDCComponent<MDCLinearProgressFoundation>
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
     const adapter: MDCLinearProgressAdapter = {
       addClass: (className: string) => this.root_.classList.add(className),
+      forceLayout: () => (this.root_ as HTMLElement).offsetWidth,
       getBuffer: () => this.root_.querySelector(MDCLinearProgressFoundation.strings.BUFFER_SELECTOR),
       getPrimaryBar: () => this.root_.querySelector(MDCLinearProgressFoundation.strings.PRIMARY_BAR_SELECTOR),
       hasClass: (className: string) => this.root_.classList.contains(className),

--- a/packages/mdc-linear-progress/foundation.ts
+++ b/packages/mdc-linear-progress/foundation.ts
@@ -72,9 +72,11 @@ export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgress
       this.setScale_(this.adapter_.getBuffer(), this.buffer_);
     } else {
       if (this.isReversed_) {
-        // reset translation animation timer that was started when reverse
-        // class was introduced, as to keep it in sync with the new scaling
-        // animation timer that's about to start from adding indeterminate class
+        // Adding/removing REVERSED_CLASS starts a translate animation, while
+        // adding INDETERMINATE_CLASS starts a scale animation. Here, we reset
+        // the translate animation in order to keep it in sync with the new
+        // scale animation that will start from adding INDETERMINATE_CLASS
+        // below.
         this.adapter_.removeClass(cssClasses.REVERSED_CLASS);
         this.adapter_.forceLayout();
         this.adapter_.addClass(cssClasses.REVERSED_CLASS);
@@ -104,10 +106,11 @@ export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgress
     this.isReversed_ = isReversed;
 
     if (!this.isDeterminate_) {
-      // reset scaling animation timer that was started when indeterminate
-      // class was introduced, as to keep it in sync with the reversed
-      // translation timer that's about to start from adding/removing reversed
-      // class
+      // Adding INDETERMINATE_CLASS starts a scale animation, while
+      // adding/removing REVERSED_CLASS starts a translate animation. Here, we
+      // reset the scale animation in order to keep it in sync with the new
+      // translate animation that will start from adding/removing REVERSED_CLASS
+      // below.
       this.adapter_.removeClass(cssClasses.INDETERMINATE_CLASS);
       this.adapter_.forceLayout();
       this.adapter_.addClass(cssClasses.INDETERMINATE_CLASS);

--- a/packages/mdc-linear-progress/foundation.ts
+++ b/packages/mdc-linear-progress/foundation.ts
@@ -66,20 +66,20 @@ export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgress
   setDeterminate(isDeterminate: boolean) {
     this.isDeterminate_ = isDeterminate;
 
-    if (this.isReversed_) {
-      // reset translation animation timer that was started when reverse
-      // class was introduced, as to keep it in sync with the new scaling
-      // animation timer that's about to start from adding indeterminate class
-      this.adapter_.removeClass(cssClasses.REVERSED_CLASS);
-      this.adapter_.forceLayout();
-      this.adapter_.addClass(cssClasses.REVERSED_CLASS);
-    }
-
     if (this.isDeterminate_) {
       this.adapter_.removeClass(cssClasses.INDETERMINATE_CLASS);
       this.setScale_(this.adapter_.getPrimaryBar(), this.progress_);
       this.setScale_(this.adapter_.getBuffer(), this.buffer_);
     } else {
+      if (this.isReversed_) {
+        // reset translation animation timer that was started when reverse
+        // class was introduced, as to keep it in sync with the new scaling
+        // animation timer that's about to start from adding indeterminate class
+        this.adapter_.removeClass(cssClasses.REVERSED_CLASS);
+        this.adapter_.forceLayout();
+        this.adapter_.addClass(cssClasses.REVERSED_CLASS);
+      }
+
       this.adapter_.addClass(cssClasses.INDETERMINATE_CLASS);
       this.setScale_(this.adapter_.getPrimaryBar(), 1);
       this.setScale_(this.adapter_.getBuffer(), 1);
@@ -106,7 +106,8 @@ export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgress
     if (!this.isDeterminate_) {
       // reset scaling animation timer that was started when indeterminate
       // class was introduced, as to keep it in sync with the reversed
-      // translation timer that's about to start from adding reversed class
+      // translation timer that's about to start from adding/removing reversed
+      // class
       this.adapter_.removeClass(cssClasses.INDETERMINATE_CLASS);
       this.adapter_.forceLayout();
       this.adapter_.addClass(cssClasses.INDETERMINATE_CLASS);

--- a/packages/mdc-linear-progress/foundation.ts
+++ b/packages/mdc-linear-progress/foundation.ts
@@ -38,6 +38,7 @@ export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgress
   static get defaultAdapter(): MDCLinearProgressAdapter {
     return {
       addClass: () => undefined,
+      forceLayout: () => undefined,
       getBuffer: () => null,
       getPrimaryBar: () => null,
       hasClass: () => false,
@@ -64,6 +65,16 @@ export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgress
 
   setDeterminate(isDeterminate: boolean) {
     this.isDeterminate_ = isDeterminate;
+
+    if (this.isReversed_) {
+      // reset translation animation timer that was started when reverse
+      // class was introduced, as to keep it in sync with the new scaling
+      // animation timer that's about to start from adding indeterminate class
+      this.adapter_.removeClass(cssClasses.REVERSED_CLASS);
+      this.adapter_.forceLayout();
+      this.adapter_.addClass(cssClasses.REVERSED_CLASS);
+    }
+
     if (this.isDeterminate_) {
       this.adapter_.removeClass(cssClasses.INDETERMINATE_CLASS);
       this.setScale_(this.adapter_.getPrimaryBar(), this.progress_);
@@ -91,6 +102,16 @@ export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgress
 
   setReverse(isReversed: boolean) {
     this.isReversed_ = isReversed;
+
+    if (!this.isDeterminate_) {
+      // reset scaling animation timer that was started when indeterminate
+      // class was introduced, as to keep it in sync with the reversed
+      // translation timer that's about to start from adding reversed class
+      this.adapter_.removeClass(cssClasses.INDETERMINATE_CLASS);
+      this.adapter_.forceLayout();
+      this.adapter_.addClass(cssClasses.INDETERMINATE_CLASS);
+    }
+
     if (this.isReversed_) {
       this.adapter_.addClass(cssClasses.REVERSED_CLASS);
     } else {

--- a/test/unit/mdc-linear-progress/foundation.test.js
+++ b/test/unit/mdc-linear-progress/foundation.test.js
@@ -70,11 +70,11 @@ test('#setDeterminate removes class', () => {
   td.verify(mockAdapter.removeClass(cssClasses.INDETERMINATE_CLASS));
 });
 
-test('#setDeterminate calls forceLayout to correctly reset animation timers', () => {
+test('#setDeterminate false calls forceLayout to correctly reset animation timers when reversed', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.REVERSED_CLASS)).thenReturn(true);
   foundation.init();
-  foundation.setDeterminate(true);
+  foundation.setDeterminate(false);
   td.verify(mockAdapter.forceLayout());
 });
 
@@ -167,11 +167,19 @@ test('#setReverse removes class', () => {
   td.verify(mockAdapter.removeClass(cssClasses.REVERSED_CLASS));
 });
 
-test('#setReverse calls forceLayout to correctly reset animation timers', () => {
+test('#setReverse true calls forceLayout to correctly reset animation timers when indeterminate', () => {
   const {foundation, mockAdapter} = setupTest();
   td.when(mockAdapter.hasClass(cssClasses.INDETERMINATE_CLASS)).thenReturn(true);
   foundation.init();
   foundation.setReverse(true);
+  td.verify(mockAdapter.forceLayout());
+});
+
+test('#setReverse false calls forceLayout to correctly reset animation timers when indeterminate', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasClass(cssClasses.INDETERMINATE_CLASS)).thenReturn(true);
+  foundation.init();
+  foundation.setReverse(false);
   td.verify(mockAdapter.forceLayout());
 });
 

--- a/test/unit/mdc-linear-progress/foundation.test.js
+++ b/test/unit/mdc-linear-progress/foundation.test.js
@@ -42,7 +42,7 @@ test('exports cssClasses', () => {
 
 test('defaultAdapter returns a complete adapter implementation', () => {
   verifyDefaultAdapter(MDCLinearProgressFoundation, [
-    'addClass', 'getPrimaryBar', 'getBuffer', 'hasClass', 'removeClass', 'setStyle',
+    'addClass', 'getPrimaryBar', 'forceLayout', 'getBuffer', 'hasClass', 'removeClass', 'setStyle',
   ]);
 });
 
@@ -68,6 +68,14 @@ test('#setDeterminate removes class', () => {
   foundation.init();
   foundation.setDeterminate(true);
   td.verify(mockAdapter.removeClass(cssClasses.INDETERMINATE_CLASS));
+});
+
+test('#setDeterminate calls forceLayout to correctly reset animation timers', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasClass(cssClasses.REVERSED_CLASS)).thenReturn(true);
+  foundation.init();
+  foundation.setDeterminate(true);
+  td.verify(mockAdapter.forceLayout());
 });
 
 test('#setDeterminate restores previous progress value after toggled from false to true', () => {
@@ -157,6 +165,14 @@ test('#setReverse removes class', () => {
   foundation.init();
   foundation.setReverse(false);
   td.verify(mockAdapter.removeClass(cssClasses.REVERSED_CLASS));
+});
+
+test('#setReverse calls forceLayout to correctly reset animation timers', () => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.hasClass(cssClasses.INDETERMINATE_CLASS)).thenReturn(true);
+  foundation.init();
+  foundation.setReverse(true);
+  td.verify(mockAdapter.forceLayout());
 });
 
 test('#open removes class', () => {


### PR DESCRIPTION
This fixes the bug where if the bar is in indeterminate state,
setting it to reverse after the page has loaded will cause the animation timers to go out of
sync and make the bar look funny.

BREAKING CHANGE: adapter has new forceLayout() method