### PR TITLE
fix(linearprogress): Supports high contrast mode

### DIFF
--- a/packages/mdc-linear-progress/_mixins.scss
+++ b/packages/mdc-linear-progress/_mixins.scss
@@ -49,8 +49,10 @@
     @include mdc-feature-targets($feat-structure) {
       position: relative;
       width: 100%;
-      height: 4px;
+      height: $mdc-linear-progress-height;
       transform: translateZ(0);
+      // Create a border around the bar in Windows High Contrast Mode.
+      outline: 1px solid transparent;
       overflow: hidden;
     }
 
@@ -77,8 +79,10 @@
         display: inline-block;
         position: absolute;
         width: 100%;
-        height: 100%;
         animation: none;
+        // border-top is used rather than background-color to ensure that the
+        // bar is visible in Windows High Contrast Mode.
+        border-top: $mdc-linear-progress-height solid;
       }
     }
 
@@ -88,7 +92,7 @@
         width: 100%;
         height: 100%;
         background-repeat: repeat-x;
-        background-size: 10px 4px;
+        background-size: 10px $mdc-linear-progress-height;
       }
 
       @include mdc-feature-targets($feat-animation) {
@@ -162,7 +166,9 @@
 
   .mdc-linear-progress__bar-inner {
     @include mdc-feature-targets($feat-color) {
-      @include mdc-theme-prop(background-color, $color);
+      // Border is used rather than background-color to ensure that the
+      // bar is visible in Windows High Contrast Mode.
+      @include mdc-theme-prop(border-color, $color);
     }
   }
 }

--- a/packages/mdc-linear-progress/_variables.scss
+++ b/packages/mdc-linear-progress/_variables.scss
@@ -19,3 +19,4 @@
 // THE SOFTWARE.
 
 $mdc-linear-progress-baseline-buffer-color: #e6e6e6 !default;
+$mdc-linear-progress-height: 4px;


### PR DESCRIPTION
Adds styles to ensure that the progress bar is visible Windows high contrast mode.

Summary of issue:
- When in HCM on IE/Firefox, the browsers force all background-colors to the same color. This makes the progress bar invisible in those browsers.

Changes:
- Adds invisible outline around the entire component. The outline is rendered in a high contrast color when HCM is enabled.
- Updated inner bar colors using a border instead of background-color. This appears visually the same as the background-color in standard browser. In HCM, the browser recolors the bar to a high-contrast color which is easy to see.

Tested:
- Checked spec/mdc-linear-progress/classes/baseline.html to ensure no regressions in standard browser environment.
- Checked spec/mdc-linear-progress/classes/baseline.html in IE11/Firefox on windows with HCM enabled.