### PR TITLE
fix(ripple): Remove unnecessary overflow: hidden.

### DIFF
--- a/packages/mdc-ripple/_mixins.scss
+++ b/packages/mdc-ripple/_mixins.scss
@@ -412,7 +412,6 @@
       left: calc(50% - #{$radius});
       width: $radius * 2;
       height: $radius * 2;
-      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
Added accidentally in #5173 