### PR TITLE
docs: Removed icon toggle unbounded = true in docs 

### DIFF
--- a/packages/mdc-icon-button/README.md
+++ b/packages/mdc-icon-button/README.md
@@ -89,7 +89,6 @@ Then instantiate an `MDCIconButtonToggle` on the root element.
 ```js
 import {MDCIconButtonToggle} from '@material/icon-button';
 const iconToggle = new MDCIconButtonToggle(document.querySelector('.mdc-icon-button'));
-iconToggle.unbounded = true;
 ```
 
 #### Icon Button Toggle with SVG


### PR DESCRIPTION
As it already happens by default.

Fixes #5192 
