### PR TITLE
fix(menu-surface): remove duplicate export from menu-surface

### DIFF
--- a/packages/mdc-menu-surface/index.ts
+++ b/packages/mdc-menu-surface/index.ts
@@ -23,7 +23,6 @@
 
 import * as util from './util';
 
-export {Corner, CornerBit} from './constants';
 export {util};
 export * from './adapter';
 export * from './component';


### PR DESCRIPTION
This addresses issue: https://github.com/material-components/material-components-web/issues/5198

The removed variables are already exported below when all constants are exported.