### PR TITLE
chore: GitHub Actions to automate minor / major releases

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,9 +1,12 @@
-name: NPM Publish
+name: MDC Release (Canary)
+
+# This workflow creates a pre-release and publishes packages to NPM with canary
+# tag on every commit to master.
 
 on:
   push:
     branches:
-      - develop
+      - master
     paths:
       - 'packages/**/*.ts'
       - 'packages/**/*.scss'
@@ -11,13 +14,13 @@ on:
       - '**/.npmignore'
 
 jobs:
-  publish-npm:
+  release-canary:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout develop branch
+      - name: Checkout master branch
         uses: actions/checkout@v1
         with:
-          ref: develop
+          ref: master
           fetch-depth: 1
       - name: Setup node
         uses: actions/setup-node@v1
@@ -32,13 +35,13 @@ jobs:
           npm run dist
           node scripts/cp-pkgs.js
           node scripts/verify-pkg-main.js
-      - name: Create release
+      - name: Create canary release
         run: |
           npx lerna version premajor --no-git-tag-version --no-push --preid canary.$(git rev-parse --short HEAD) --yes --exact
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -am "chore: Publish"
-      - name: Publish to NPM registry
+      - name: Publish to NPM registry with canary tag
         run: npx lerna publish from-package --yes --dist-tag canary
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -1,0 +1,54 @@
+name: MDC Release (Pull Request)
+
+# This workflow creates or updates (if already exists) a pull request with new
+# version bump on every commit to master.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/**/*.ts'
+      - 'packages/**/*.scss'
+      - '**/package*.json'
+      - '**/.npmignore'
+      - '**/*.md'
+
+jobs:
+  release-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v1
+        with:
+          ref: master
+          fetch-depth: 1
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: |
+          npm install
+      - name: Bump version
+        run: |
+          npx lerna version --conventional-commits --no-git-tag-version --no-push --yes
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v1.5.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_MESSAGE: "chore: Release"
+          COMMIT_AUTHOR_EMAIL: action@@users.noreply.github.com
+          COMMIT_AUTHOR_NAME: GitHub Action
+          PULL_REQUEST_TITLE: "chore: Release"
+          PULL_REQUEST_BODY: |
+            This PR was opened by [release][1] GitHub action.
+            When you're ready to do a release, you can merge this and release
+            action will automatically publishes to npm registry.
+            If you're not ready to do a release yet, that's fine, whenever you
+            add more commits to master, this PR will be updated.
+
+            [1]: http://github.com/material-components/material-components-web/tree/master/.github/workflows/release-pull-request.yml
+          PULL_REQUEST_BRANCH: chore/release
+          BRANCH_SUFFIX: none

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: MDC Release
+
+# This workflow does the following if repo does not have git tag that was updated in lerna.json
+#  - creates release git tag
+#  - publishes packages to NPM with latest tag
+#
+# This workflow is expected to run after merge of release pull requested created by release-pull-request workflow.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'lerna.json'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v1
+        with:
+          ref: master
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: |
+          npm install
+      - name: Check if release tag is already created
+        id: vars
+        # Sets action's output parameter using `set-output`.
+        # See https://help.github.com/en/github/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-output-parameter-set-output
+        run: |
+          MDC_CURRENT_VERSION="v$(npm run version --silent)"
+          # If empty then set `mdc_version_changed` variable to `true`
+          [[ -z $(git tag -l "$MDC_CURRENT_VERSION") ]] && echo "::set-output name=mdc_version_changed::true
+      - name: Build packages
+        if: steps.vars.outputs.mdc_version_changed == true
+        run: |
+          npm run dist
+          node scripts/cp-pkgs.js
+          node scripts/verify-pkg-main.js
+      - name: Create release tag
+        if: steps.vars.outputs.mdc_version_changed == true
+        run: |
+          MDC_CURRENT_VERSION="v$(npm run version --silent)"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag "$MDC_CURRENT_VERSION"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git push origin "$MDC_CURRENT_VERSION"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to NPM registry
+        if: steps.vars.outputs.mdc_version_changed == true
+        run: npx lerna publish from-package --yes
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
### Description

* Updated canary release action to create canary tag based on `master` branch (Previously on `develop` branch).
* New GitHub action to create release pull request that bumps MDC Web & automatically creates changelog.
* New GitHub action that is triggered when release pull request is merged, creates a new git tag & publishes to npm registry.