### PR TITLE
chore: create local branch based on master before release

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -33,6 +33,7 @@ jobs:
           npm install
       - name: Bump version
         run: |
+          git checkout -B release/lerna master
           npx lerna version --conventional-commits --no-git-tag-version --no-push --yes
       - name: Create PR
         uses: peter-evans/create-pull-request@v1.5.2


### PR DESCRIPTION
Lerna.js does not allow creating release on `master`, had to create a new local branch based on master.

Here is a sample error from recent [GitHub Action](https://github.com/material-components/material-components-web/commit/a59617495c809d5d70ce7df0d127d996b69a51a0/checks?check_suite_id=299052838):

```sh
$ npx lerna version --conventional-commits --no-git-tag-version --no-push --yes
lerna notice cli v3.14.1
lerna info current version 4.0.0
lerna ERR! ENOGIT Detached git HEAD, please checkout a branch to choose versions.
##[error]Process completed with exit code 1.
```
