### PR TITLE
chore: change checkout branch master => chore/actions_fix_checkout

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -33,7 +33,7 @@ jobs:
           npm install
       - name: Bump version
         run: |
-          git checkout -B release/lerna master
+          git checkout -B release/lerna refs/remotes/origin/master
           npx lerna version --conventional-commits --no-git-tag-version --no-push --yes
       - name: Create PR
         uses: peter-evans/create-pull-request@v1.5.2


### PR DESCRIPTION
actions/checkout seem to have a [bug](https://github.com/actions/checkout/issues/6) where it checkout detached to HEAD.  Changed base branch from `master` to `refs/remotes/origin/master`. 

Excerpts from previous action:

```
$ git checkout --progress --force refs/remotes/origin/master
Note: switching to 'refs/remotes/origin/master'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.
```

```
$ git checkout -B release/lerna master

fatal: 'master' is not a commit and a branch 'release/lerna' cannot be created from it.
```