### PR TITLE
chore: Fix checkout in release action

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -17,11 +17,14 @@ jobs:
   release-canary:
     runs-on: ubuntu-latest
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v1.0.0
       - name: Checkout master branch
-        uses: actions/checkout@v1
-        with:
-          ref: master
-          fetch-depth: 1
+        # GITHUB_REF:11 gets `refs/heads/master` => `master`.
+        # See https://github.com/actions/checkout/issues/6
+        run: |
+          git checkout "${GITHUB_REF:11}"
+          git pull
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -18,11 +18,14 @@ jobs:
   release-pull-request:
     runs-on: ubuntu-latest
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v1.0.0
       - name: Checkout master branch
-        uses: actions/checkout@v1
-        with:
-          ref: master
-          fetch-depth: 1
+        # GITHUB_REF:11 gets `refs/heads/master` => `master`.
+        # See https://github.com/actions/checkout/issues/6
+        run: |
+          git checkout "${GITHUB_REF:11}"
+          git pull
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v1.0.0
       - name: Checkout master branch
-        uses: actions/checkout@v1
-        with:
-          ref: master
+        # GITHUB_REF:11 gets `refs/heads/master` => `master`.
+        # See https://github.com/actions/checkout/issues/6
+        run: |
+          git checkout "${GITHUB_REF:11}"
+          git pull
       - name: Setup node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
actions/checkout does not seem to give access to latest copy of `master` 🤦🏻‍♂️, explicitly checkout master branch and pull changes.