### PR TITLE
docs: Update status of react material web components

### DIFF
--- a/docs/framework-wrappers.md
+++ b/docs/framework-wrappers.md
@@ -10,7 +10,7 @@ path: /docs/framework-wrappers/
 
 Material Components for the web are architected to be adaptable to various major web frameworks. The following wrapper libraries are available:
 
-  - [Material Components for React](https://github.com/material-components/material-components-web-react): MDC Web integration for React (using [foundations/adapters](./integrating-into-frameworks.md#the-advanced-approach-using-foundations-and-adapters))
+  - [Material Components for React](https://github.com/material-components/material-components-web-react): MDC Web integration for React (using [foundations/adapters](./integrating-into-frameworks.md#the-advanced-approach-using-foundations-and-adapters)). *Please note that this project is no longer under active development.*
   - [Material Web Components](https://github.com/material-components/material-components-web-components): MDC Web integration for Web Components (using [vanilla components](./integrating-into-frameworks.md#the-simple-approach-wrapping-mdc-web-vanilla-components))
   - Additional third-party integrations
     - [Preact Material Components](https://github.com/prateekbh/preact-material-components)

--- a/docs/framework-wrappers.md
+++ b/docs/framework-wrappers.md
@@ -10,8 +10,8 @@ path: /docs/framework-wrappers/
 
 Material Components for the web are architected to be adaptable to various major web frameworks. The following wrapper libraries are available:
 
-  - [Material Components for React](https://github.com/material-components/material-components-web-react): MDC Web integration for React (using [foundations/adapters](./integrating-into-frameworks.md#the-advanced-approach-using-foundations-and-adapters)). *Please note that this project is no longer under active development.*
   - [Material Web Components](https://github.com/material-components/material-components-web-components): MDC Web integration for Web Components (using [vanilla components](./integrating-into-frameworks.md#the-simple-approach-wrapping-mdc-web-vanilla-components))
+  - [Material Components for React](https://github.com/material-components/material-components-web-react): MDC Web integration for React (using [foundations/adapters](./integrating-into-frameworks.md#the-advanced-approach-using-foundations-and-adapters)). *Please note that this project is no longer under active development.*
   - Additional third-party integrations
     - [Preact Material Components](https://github.com/prateekbh/preact-material-components)
     - [RMWC: React Material Web Components](https://github.com/jamesmfriedman/rmwc) (using [foundations/adapters](./integrating-into-frameworks.md#the-advanced-approach-using-foundations-and-adapters).)


### PR DESCRIPTION
The purpose of this change is to let the reader know that react material web components is no longer under active development.