### PR TITLE
feat(chips): Consolidate interaction event handlers

### DIFF
--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -445,10 +445,9 @@ Method Signature | Description
 `setShouldRemoveOnTrailingIconClick(shouldRemove: boolean) => void` | Sets whether a trailing icon click should trigger exit/removal of the chip
 `getDimensions() => ClientRect` | Returns the dimensions of the chip. This is used for applying ripple to the chip.
 `beginExit() => void` | Begins the exit animation which leads to removal of the chip
-`handleInteraction(evt: Event) => void` | Handles an interaction event on the root element
-`handleTransitionEnd(evt: Event) => void` | Handles a transition end event on the root element
-`handleTrailingIconInteraction(evt: Event) => void` | Handles an interaction event on the trailing icon element
+`handleClick(evt: Event) => void` | Handles a click event on the root element
 `handleKeydown(evt: Event) => void` | Handles a keydown event on the root element
+`handleTransitionEnd(evt: Event) => void` | Handles a transition end event on the root element
 `removeFocus() => void` | Removes focusability from the chip
 
 #### `MDCChipFoundation` Event Handlers
@@ -457,10 +456,9 @@ When wrapping the Chip foundation, the following events must be bound to the ind
 
 Events | Element Selector | Foundation Handler
 --- | --- | ---
-`click`, `keydown` | `.mdc-chip` (root) | `handleInteraction()`
-`click`, `keydown` | `.mdc-chip__icon--trailing` (if present) | `handleTrailingIconInteraction()`
-`transitionend` | `.mdc-chip` (root) | `handleTransitionEnd()`
+`click` | `.mdc-chip` (root) | `handleClick()`
 `keydown` | `.mdc-chip` (root) | `handleKeydown()`
+`transitionend` | `.mdc-chip` (root) | `handleTransitionEnd()`
 
 #### `MDCChipSetFoundation`
 

--- a/packages/mdc-chips/chip/component.ts
+++ b/packages/mdc-chips/chip/component.ts
@@ -33,10 +33,6 @@ import {MDCChipFoundation} from './foundation';
 import {MDCChipInteractionEventDetail, MDCChipNavigationEventDetail, MDCChipRemovalEventDetail,
     MDCChipSelectionEventDetail} from './types';
 
-type InteractionType = 'click' | 'keydown';
-
-const INTERACTION_EVENTS: InteractionType[] = ['click', 'keydown'];
-
 export type MDCChipFactory = (el: Element, foundation?: MDCChipFoundation) => MDCChip;
 
 export class MDCChip extends MDCComponent<MDCChipFoundation> implements MDCRippleCapableSurface {
@@ -84,20 +80,17 @@ export class MDCChip extends MDCComponent<MDCChipFoundation> implements MDCRippl
   root_!: HTMLElement; // assigned in MDCComponent constructor
 
   private leadingIcon_!: Element | null; // assigned in initialize()
-  private trailingIcon_!: Element | null; // assigned in initialize()
   private checkmark_!: Element | null; // assigned in initialize()
   private ripple_!: MDCRipple; // assigned in initialize()
   private primaryAction_!: Element | null; // assigned in initialize()
   private trailingAction_!: Element | null; // assigned in initialize()
 
-  private handleInteraction_!: SpecificEventListener<InteractionType>; // assigned in initialSyncWithDOM()
+  private handleClick_!: SpecificEventListener<'click'>; // assigned in initialSyncWithDOM()
   private handleTransitionEnd_!: SpecificEventListener<'transitionend'>; // assigned in initialSyncWithDOM()
-  private handleTrailingIconInteraction_!: SpecificEventListener<InteractionType>; // assigned in initialSyncWithDOM()
   private handleKeydown_!: SpecificEventListener<'keydown'>; // assigned in initialSyncWithDOM()
 
   initialize(rippleFactory: MDCRippleFactory = (el, foundation) => new MDCRipple(el, foundation)) {
     this.leadingIcon_ = this.root_.querySelector(strings.LEADING_ICON_SELECTOR);
-    this.trailingIcon_ = this.root_.querySelector(strings.TRAILING_ICON_SELECTOR);
     this.checkmark_ = this.root_.querySelector(strings.CHECKMARK_SELECTOR);
     this.primaryAction_ = this.root_.querySelector(strings.PRIMARY_ACTION_SELECTOR);
     this.trailingAction_ = this.root_.querySelector(strings.TRAILING_ACTION_SELECTOR);
@@ -112,39 +105,20 @@ export class MDCChip extends MDCComponent<MDCChipFoundation> implements MDCRippl
   }
 
   initialSyncWithDOM() {
-    this.handleInteraction_ = (evt: MouseEvent | KeyboardEvent) => this.foundation_.handleInteraction(evt);
+    this.handleClick_ = (evt: MouseEvent) => this.foundation_.handleClick(evt);
     this.handleTransitionEnd_ = (evt: TransitionEvent) => this.foundation_.handleTransitionEnd(evt);
-    this.handleTrailingIconInteraction_ = (evt: MouseEvent | KeyboardEvent) =>
-        this.foundation_.handleTrailingIconInteraction(evt);
     this.handleKeydown_ = (evt: KeyboardEvent) => this.foundation_.handleKeydown(evt);
 
-    INTERACTION_EVENTS.forEach((evtType) => {
-      this.listen(evtType, this.handleInteraction_);
-    });
+    this.listen('click', this.handleClick_);
     this.listen('transitionend', this.handleTransitionEnd_);
     this.listen('keydown', this.handleKeydown_);
-
-    if (this.trailingIcon_) {
-      INTERACTION_EVENTS.forEach((evtType) => {
-        this.trailingIcon_!.addEventListener(evtType, this.handleTrailingIconInteraction_ as EventListener);
-      });
-    }
   }
 
   destroy() {
     this.ripple_.destroy();
-
-    INTERACTION_EVENTS.forEach((evtType) => {
-      this.unlisten(evtType, this.handleInteraction_);
-    });
+    this.unlisten('click', this.handleClick_);
     this.unlisten('transitionend', this.handleTransitionEnd_);
     this.unlisten('keydown', this.handleKeydown_);
-
-    if (this.trailingIcon_) {
-      INTERACTION_EVENTS.forEach((evtType) => {
-        this.trailingIcon_!.removeEventListener(evtType, this.handleTrailingIconInteraction_ as EventListener);
-      });
-    }
 
     super.destroy();
   }

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -141,11 +141,13 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
   /**
    * Handles an interaction event on the root element.
    */
-  handleInteraction(evt: MouseEvent | KeyboardEvent) {
-    if (this.shouldHandleInteraction_(evt)) {
-      this.adapter_.notifyInteraction();
-      this.focusPrimaryAction_();
+  handleClick(evt: MouseEvent) {
+    const trailingIconIsSource = this.adapter_.eventTargetHasClass(evt.target, cssClasses.TRAILING_ICON);
+    if (trailingIconIsSource) {
+      return this.notifyTrailingIconInteractionAndRemove_(evt);
     }
+
+    this.notifyInteractionAndFocus_();
   }
 
   /**
@@ -203,27 +205,24 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
   }
 
   /**
-   * Handles an interaction event on the trailing icon element. This is used to
-   * prevent the ripple from activating on interaction with the trailing icon.
-   */
-  handleTrailingIconInteraction(evt: MouseEvent | KeyboardEvent) {
-    if (this.shouldHandleInteraction_(evt)) {
-      this.adapter_.notifyTrailingIconInteraction();
-      this.removeChip_(evt);
-    }
-  }
-
-  /**
    * Handles a keydown event from the root element.
    */
   handleKeydown(evt: KeyboardEvent) {
+    const trailingIconIsSource = this.adapter_.eventTargetHasClass(evt.target, cssClasses.TRAILING_ICON);
+    if (trailingIconIsSource && this.shouldProcessKeydownAsClick_(evt)) {
+      return this.notifyTrailingIconInteractionAndRemove_(evt);
+    }
+
+    if (this.shouldProcessKeydownAsClick_(evt)) {
+      return this.notifyInteractionAndFocus_();
+    }
+
     if (this.shouldRemoveChip_(evt)) {
       return this.removeChip_(evt);
     }
 
-    const key = evt.key;
     // Early exit if the key is not usable
-    if (!navigationKeys.has(key)) {
+    if (!navigationKeys.has(evt.key)) {
       return;
     }
 
@@ -308,20 +307,20 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
     this.adapter_.setPrimaryActionAttr(strings.TAB_INDEX, '-1');
   }
 
-  private removeChip_(evt: MouseEvent|KeyboardEvent) {
+  private removeChip_(evt: Event) {
     evt.stopPropagation();
     if (this.shouldRemoveOnTrailingIconClick_) {
       this.beginExit();
     }
   }
 
-  private shouldHandleInteraction_(evt: MouseEvent|KeyboardEvent): boolean {
-    if (evt.type === 'click') {
-      return true;
-    }
+  private notifyTrailingIconInteractionAndRemove_(evt: Event) {
+    this.adapter_.notifyTrailingIconInteraction();
+    this.removeChip_(evt);
+  }
 
-    const keyEvt = evt as KeyboardEvent;
-    return keyEvt.key === strings.ENTER_KEY || keyEvt.key === strings.SPACEBAR_KEY;
+  private shouldProcessKeydownAsClick_(evt: KeyboardEvent): boolean {
+    return evt.key === strings.ENTER_KEY || evt.key === strings.SPACEBAR_KEY;
   }
 
   private shouldRemoveChip_(evt: KeyboardEvent): boolean {
@@ -345,6 +344,11 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
 
   private notifyIgnoredSelection_(selected: boolean) {
     this.adapter_.notifySelection(selected, true);
+  }
+
+  private notifyInteractionAndFocus_() {
+    this.adapter_.notifyInteraction();
+    this.focusPrimaryAction_();
   }
 }
 

--- a/test/unit/mdc-chips/mdc-chip.test.js
+++ b/test/unit/mdc-chips/mdc-chip.test.js
@@ -113,7 +113,7 @@ test('#initialSyncWithDOM sets up event handlers', () => {
   const {root, mockFoundation} = setupMockFoundationTest();
 
   domEvents.emit(root, 'click');
-  td.verify(mockFoundation.handleInteraction(td.matchers.anything()), {times: 1});
+  td.verify(mockFoundation.handleClick(td.matchers.anything()), {times: 1});
 
   domEvents.emit(root, 'transitionend');
   td.verify(mockFoundation.handleTransitionEnd(td.matchers.anything()), {times: 1});
@@ -122,37 +122,18 @@ test('#initialSyncWithDOM sets up event handlers', () => {
   td.verify(mockFoundation.handleKeydown(td.matchers.anything()), {times: 1});
 });
 
-test('#initialSyncWithDOM sets up interaction event handler on trailing icon if present', () => {
-  const root = getFixture();
-  const icon = addTrailingIcon(root);
-  const {mockFoundation} = setupMockFoundationTest(root);
-
-  domEvents.emit(icon, 'click');
-  td.verify(mockFoundation.handleTrailingIconInteraction(td.matchers.anything()), {times: 1});
-});
-
 test('#destroy removes event handlers', () => {
   const {root, component, mockFoundation} = setupMockFoundationTest();
   component.destroy();
 
   domEvents.emit(root, 'click');
-  td.verify(mockFoundation.handleInteraction(td.matchers.anything()), {times: 0});
+  td.verify(mockFoundation.handleClick(td.matchers.anything()), {times: 0});
 
   domEvents.emit(root, 'transitionend');
   td.verify(mockFoundation.handleTransitionEnd(td.matchers.anything()), {times: 0});
 
   domEvents.emit(root, 'keydown');
   td.verify(mockFoundation.handleKeydown(td.matchers.anything()), {times: 0});
-});
-
-test('#destroy removes interaction event handler on trailing icon if present', () => {
-  const root = getFixture();
-  const icon = addTrailingIcon(root);
-  const {component, mockFoundation} = setupMockFoundationTest(root);
-
-  component.destroy();
-  domEvents.emit(icon, 'click');
-  td.verify(mockFoundation.handleTrailingIconInteraction(td.matchers.anything()), {times: 0});
 });
 
 test('#destroy destroys ripple', () => {


### PR DESCRIPTION
Consolidate interaction event handlers into discrete root-level handlers: `handleClick` and `handleKeydown`.

BREAKING CHANGE: the `handleInteraction` and `handleTrailingIconInteraction` handlers have been removed from the `MDCChipFoundation`. The `handleClick` handler has been added to the `MDCChipFoundation`