### PR TITLE
fix(checkbox): Disabled state colors in IE11 high contrast mode

### DIFF
--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -71,6 +71,15 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   @include mdc-checkbox-disabled-ink-color($mdc-checkbox-mark-color, $query: $query);
 
   @media screen and (-ms-high-contrast: active) {
+    @include mdc-checkbox-disabled-container-colors(
+      $unmarked-stroke-color: GrayText,
+      $unmarked-fill-color: transparent,
+      $marked-stroke-color: GrayText,
+      $marked-fill-color: transparent,
+      $query: $query
+    );
+    @include mdc-checkbox-disabled-ink-color(GrayText, $query: $query);
+
     .mdc-checkbox__mixedmark {
       @include mdc-feature-targets($feat-structure) {
         margin: 0 1px; // Extra horizontal space around mixedmark symbol.

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -158,13 +158,13 @@ $mdc-theme-property-values: (
 
 // NOTE: This function is depended upon by mdc-theme-prop-value (above) and thus must be defined in this file.
 @function mdc-theme-is-valid-theme-prop-value_($style) {
-  // NOTE: `GrayText` is deprecated, but is the only feasible way to convey the
-  // correct high-contrast mode colors in alignment with Windows system colors.
   @return type-of($style) == "color" or
     $style == "currentColor" or
     str_slice($style, 1, 4) == "var(" or
     $style == "inherit" or
     $style == "transparent" or
+    // NOTE: `GrayText` is deprecated, but is the only feasible way to convey the
+    // correct high-contrast mode colors in alignment with Windows system colors.
     $style == "GrayText";
 }
 

--- a/packages/mdc-theme/_variables.scss
+++ b/packages/mdc-theme/_variables.scss
@@ -158,11 +158,14 @@ $mdc-theme-property-values: (
 
 // NOTE: This function is depended upon by mdc-theme-prop-value (above) and thus must be defined in this file.
 @function mdc-theme-is-valid-theme-prop-value_($style) {
+  // NOTE: `GrayText` is deprecated, but is the only feasible way to convey the
+  // correct high-contrast mode colors in alignment with Windows system colors.
   @return type-of($style) == "color" or
     $style == "currentColor" or
     str_slice($style, 1, 4) == "var(" or
     $style == "inherit" or
-    $style == "transparent";
+    $style == "transparent" or
+    $style == "GrayText";
 }
 
 @function mdc-theme-text-emphasis($emphasis) {


### PR DESCRIPTION
Preview:

HC theme 1:
![image](https://user-images.githubusercontent.com/7828061/69192977-9a886600-0ada-11ea-803c-28f40c639a56.png)


HC theme 2:
![image](https://user-images.githubusercontent.com/7828061/69192912-72006c00-0ada-11ea-99ec-6a975d9ccb40.png)
