### PR TITLE
Remove "demo-width-class"

### DIFF
--- a/packages/mdc-select/README.md
+++ b/packages/mdc-select/README.md
@@ -170,14 +170,14 @@ to set the selected item. The select also needs the text from the selected eleme
 
 ```html
 <div class="mdc-select">
-  <div class="mdc-select__anchor demo-width-class">
+  <div class="mdc-select__anchor">
     <i class="mdc-select__dropdown-icon"></i>
     <div class="mdc-select__selected-text">Vegetables</div>
     <span class="mdc-floating-label mdc-floating-label--float-above">Pick a Food Group</span>
     <div class="mdc-line-ripple"></div>
   </div>
 
-  <div class="mdc-select__menu demo-width-class mdc-menu mdc-menu-surface">
+  <div class="mdc-select__menu mdc-menu mdc-menu-surface">
     <ul class="mdc-list">
       <li class="mdc-list-item" data-value=""></li>
       <li class="mdc-list-item" data-value="grains">


### PR DESCRIPTION
Demo width class was causing issues with the dropdown:

![Kapture 2019-11-27 at 13 48 20](https://user-images.githubusercontent.com/1693164/69752163-a699a680-111e-11ea-8657-758f79685c9a.gif)
