### PR TITLE
chore: fix and run feature tageting checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "npm-run-all --parallel lint:*",
     "postinstall": "lerna bootstrap",
     "pretest": "npm run lint",
-    "test": "npm run test:unit && npm run test:dependency && npm run build && npm run clean",
+    "test": "npm run test:unit && npm run test:feature-targeting && npm run test:dependency && npm run build && npm run clean",
     "screenshot:approve": "node test/screenshot/run.js approve",
     "screenshot:build": "node test/screenshot/run.js build",
     "screenshot:clean": "node test/screenshot/run.js clean",

--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -113,7 +113,9 @@ $mdc-fab-ripple-target: ".mdc-fab__ripple";
     #{$mdc-fab-ripple-target} {
       @include mdc-ripple-target-common($query: $query);
 
-      overflow: hidden;
+      @include mdc-feature-targets($feat-structure) {
+        overflow: hidden;
+      }
     }
   }
 

--- a/test/scss/_feature-targeting-test.scss
+++ b/test/scss/_feature-targeting-test.scss
@@ -154,8 +154,8 @@
     @include mdc-elevation-overlay-common($query: $query);
     @include mdc-elevation(0, $query: $query);
     @include mdc-elevation-shadow(none, $query: $query);
-    @include mdc-elevation-overlay-parent($query: $query);
     @include mdc-elevation-overlay-dimensions(100%, $query: $query);
+    @include mdc-elevation-overlay-surface-position($query: $query);
     @include mdc-elevation-overlay-fill-color(red, $query: $query);
     @include mdc-elevation-overlay-opacity(99%, $query: $query);
 


### PR DESCRIPTION
The `test:feature-targeting` check wasn't running on the CI and was failing as a result. Furthermore, since the check wasn't running, there were some `mdc-fab` styles that weren't under a feature target which will cause them to always be emitted.