### PR TITLE
fix(ripple): eliminate double ripple effect on iOS

### DIFF
--- a/packages/mdc-ripple/foundation.ts
+++ b/packages/mdc-ripple/foundation.ts
@@ -46,17 +46,17 @@ interface Coordinates {
   top: number;
 }
 
-type ActivationEventType = 'touchstart' | 'pointerdown' | 'mousedown' | 'keydown';
-type DeactivationEventType = 'touchend' | 'pointerup' | 'mouseup' | 'contextmenu';
+type ActivationEventType = 'touchstart' | 'pointerdown' | 'keydown';
+type DeactivationEventType = 'touchend' | 'pointerup' | 'contextmenu';
 
 // Activation events registered on the root element of each instance for activation
 const ACTIVATION_EVENT_TYPES: ActivationEventType[] = [
-  'touchstart', 'pointerdown', 'mousedown', 'keydown',
+  'touchstart', 'pointerdown', 'keydown',
 ];
 
 // Deactivation events registered on documentElement when a pointer-related down event occurs
 const POINTER_DEACTIVATION_EVENT_TYPES: DeactivationEventType[] = [
-  'touchend', 'pointerup', 'mouseup', 'contextmenu',
+  'touchend', 'pointerup', 'contextmenu',
 ];
 
 // simultaneous nested activations
@@ -314,7 +314,7 @@ export class MDCRippleFoundation extends MDCFoundation<MDCRippleAdapter> {
     activationState.isProgrammatic = evt === undefined;
     activationState.activationEvent = evt;
     activationState.wasActivatedByPointer = activationState.isProgrammatic ? false : evt !== undefined && (
-        evt.type === 'mousedown' || evt.type === 'touchstart' || evt.type === 'pointerdown'
+        evt.type === 'touchstart' || evt.type === 'pointerdown'
     );
 
     const hasActivatedChild = evt !== undefined && activatedTargets.length > 0 && activatedTargets.some(

--- a/test/unit/mdc-ripple/foundation-activation.test.js
+++ b/test/unit/mdc-ripple/foundation-activation.test.js
@@ -37,56 +37,9 @@ testFoundation('does nothing if component if isSurfaceDisabled is true',
 
     td.when(adapter.isSurfaceDisabled()).thenReturn(true);
 
-    handlers.mousedown();
+    handlers.pointerdown();
 
     td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 0});
-  });
-
-testFoundation('adds activation classes on mousedown', ({foundation, adapter, clock}) => {
-  const handlers = captureHandlers(adapter, 'registerInteractionHandler');
-  foundation.init();
-  clock.runToFrame();
-
-  handlers.mousedown();
-  clock.runToFrame();
-  td.verify(adapter.addClass(cssClasses.FG_ACTIVATION));
-});
-
-testFoundation('sets FG position from the coords to the center within surface on mousedown',
-  ({foundation, adapter, clock}) => {
-    const handlers = captureHandlers(adapter, 'registerInteractionHandler');
-    const left = 50;
-    const top = 50;
-    const width = 200;
-    const height = 100;
-    const maxSize = Math.max(width, height);
-    const initialSize = maxSize * numbers.INITIAL_ORIGIN_SCALE;
-    const pageX = 100;
-    const pageY = 75;
-
-    td.when(adapter.computeBoundingRect()).thenReturn({width, height, left, top});
-    foundation.init();
-    clock.runToFrame();
-
-    handlers.mousedown({pageX, pageY});
-    clock.runToFrame();
-
-    const startPosition = {
-      x: pageX - left - (initialSize / 2),
-      y: pageY - top - (initialSize / 2),
-    };
-
-    const endPosition = {
-      x: (width / 2) - (initialSize / 2),
-      y: (height / 2) - (initialSize / 2),
-    };
-
-    td.verify(adapter.updateCssVariable(
-      strings.VAR_FG_TRANSLATE_START, `${startPosition.x}px, ${startPosition.y}px`
-    ));
-    td.verify(adapter.updateCssVariable(
-      strings.VAR_FG_TRANSLATE_END, `${endPosition.x}px, ${endPosition.y}px`
-    ));
   });
 
 testFoundation('adds activation classes on touchstart', ({foundation, adapter, clock}) => {
@@ -307,19 +260,6 @@ testFoundation('sets FG position to center on non-pointer activation', ({foundat
     `${position.x}px, ${position.y}px`));
 });
 
-testFoundation('does not redundantly add classes on touchstart followed by mousedown',
-  ({foundation, adapter, clock}) => {
-    const handlers = captureHandlers(adapter, 'registerInteractionHandler');
-    foundation.init();
-    clock.runToFrame();
-
-    handlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
-    clock.runToFrame();
-    handlers.mousedown();
-    clock.runToFrame();
-    td.verify(adapter.addClass(cssClasses.FG_ACTIVATION), {times: 1});
-  });
-
 testFoundation('does not redundantly add classes on touchstart followed by pointerstart',
   ({foundation, adapter, clock}) => {
     const handlers = captureHandlers(adapter, 'registerInteractionHandler');
@@ -340,11 +280,11 @@ testFoundation('removes deactivation classes on activate to ensure ripples can b
     foundation.init();
     clock.runToFrame();
 
-    handlers.mousedown();
+    handlers.pointerdown();
     clock.runToFrame();
-    documentHandlers.mouseup();
+    documentHandlers.pointerup();
     clock.runToFrame();
-    handlers.mousedown();
+    handlers.pointerdown();
     clock.runToFrame();
 
     td.verify(adapter.removeClass(cssClasses.FG_DEACTIVATION));
@@ -360,8 +300,8 @@ testFoundation('will not activate multiple ripples on same frame if one surface 
     secondRipple.foundation.init();
     clock.runToFrame();
 
-    firstHandlers.mousedown();
-    secondHandlers.mousedown();
+    firstHandlers.pointerdown();
+    secondHandlers.pointerdown();
     clock.runToFrame();
 
     td.verify(adapter.addClass(cssClasses.FG_ACTIVATION));
@@ -380,10 +320,10 @@ testFoundation('will not activate multiple ripples on same frame for parent surf
 
     firstHandlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
     secondHandlers.touchstart({changedTouches: [{pageX: 0, pageY: 0}]});
-    // Simulated mouse events on touch devices always happen after a delay, not on the same frame
+    // Simulated pointer events on touch devices always happen after a delay, not on the same frame
     clock.runToFrame();
-    firstHandlers.mousedown();
-    secondHandlers.mousedown();
+    firstHandlers.pointerdown();
+    secondHandlers.pointerdown();
     clock.runToFrame();
 
     td.verify(adapter.addClass(cssClasses.FG_ACTIVATION));
@@ -400,8 +340,8 @@ testFoundation('will activate multiple ripples on same frame for surfaces withou
     secondRipple.foundation.init();
     clock.runToFrame();
 
-    firstHandlers.mousedown();
-    secondHandlers.mousedown();
+    firstHandlers.pointerdown();
+    secondHandlers.pointerdown();
     clock.runToFrame();
 
     td.verify(adapter.addClass(cssClasses.FG_ACTIVATION));
@@ -415,7 +355,7 @@ testFoundation('displays the foreground ripple on activation when unbounded', ({
   foundation.init();
   clock.runToFrame();
 
-  handlers.mousedown({pageX: 0, pageY: 0});
+  handlers.pointerdown({pageX: 0, pageY: 0});
   clock.runToFrame();
 
   td.verify(adapter.addClass(cssClasses.FG_ACTIVATION));

--- a/test/unit/mdc-ripple/util.test.js
+++ b/test/unit/mdc-ripple/util.test.js
@@ -86,7 +86,7 @@ test('#supportsCssVariables returns false when CSS is not an object', () => {
 });
 
 test('#getNormalizedEventCoords maps event coords into the relative coordinates of the given rect', () => {
-  const ev = {type: 'mousedown', pageX: 70, pageY: 70};
+  const ev = {type: 'pointerdown', pageX: 70, pageY: 70};
   const pageOffset = {x: 10, y: 10};
   const clientRect = {left: 50, top: 50};
 


### PR DESCRIPTION
This PR fix the issue that ripple effect is activated twice on iOS when zoom in page.
see issue details: #4293

When tap a ripple surface on iOS Safari/Chrome below events are fired sequentially:
* pointerdown (activate ripple)
* touchstart (skipped)
* pointerup (deactivate ripple)
* mousedown (activate ripple again)

To solve this issue, we could find a solution to prevent mousedown after pointerup, but I had a doubt that why we had to handle mousedown event. There might be some sort of history, such as pointerdown was not supported on major browsers, but I couldn't figure out the actual reason (since this project was migrated from [material-design-lite](https://github.com/google/material-design-lite) and there are no history remains about this) and, at this time, it looks like mousedown can be replaced with pointerdown.

Therefore, I removed mousedown/mouseup from ACTIVATION/DEACTIVATION event types and it worked well on various devices, including:
* Safari / Chrome on iOS (13.1.3)
* Safari / Chrome on macOS (10.15.1)
* Chrome on Android (9)
* Edge / Chrome on Windows 10