### PR TITLE
fix(core): Fix canary release by excluding test files from default tsconfig

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -142,6 +142,9 @@ const jasmineConfig = {
         },
       },
     },
+    exclude: [
+      'scripts/**/*.ts',
+    ],
     reports: {
       html: 'coverage',
       lcovonly: 'coverage',
@@ -150,7 +153,7 @@ const jasmineConfig = {
         filename: 'coverage.json',
       },
     },
-    tsconfig: './tsconfig.json',
+    tsconfig: './tsconfig-base.json',
   },
   preprocessors: FILES_TO_USE.reduce((obj, file) => {
     obj[file] = 'karma-typescript';

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "downlevelIteration": true,
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "lib": ["es5", "es6", "dom"],
+    "moduleResolution": "node",
+    "newLine": "lf",
+    "noEmitOnError": false,
+    "noErrorTruncation": true,
+    "noFallthroughCasesInSwitch": true,
+    "noStrictGenericChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "preserveConstEnums": true,
+    "pretty": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "stripInternal": true,
+    "target": "es5",
+    "types": []
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,8 @@
 {
-  "compilerOptions": {
-    "declaration": true,
-    "downlevelIteration": true,
-    "emitDecoratorMetadata": true,
-    "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "lib": ["es5", "es6", "dom"],
-    "moduleResolution": "node",
-    "newLine": "lf",
-    "noEmitOnError": false,
-    "noErrorTruncation": true,
-    "noFallthroughCasesInSwitch": true,
-    "noStrictGenericChecks": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "preserveConstEnums": true,
-    "pretty": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "stripInternal": true,
-    "target": "es5",
-    "types": []
-  },
   "exclude": [
-    "scripts/**/*.ts"
-  ]
+    "packages/**/test/*.ts",
+    "scripts/**/*.ts",
+    "testing/**/*.ts"
+  ],
+  "extends": "./tsconfig-base.json"
 }


### PR DESCRIPTION
For some reason, test files in the tsconfig are causing `package/<component>/index.js` not to be generated when running `npm run build:esmodules`, leading to a failure in the canary release: https://github.com/material-components/material-components-web/runs/340549500