### PR TITLE
fix(select): Fix notch outline width when floating

### DIFF
--- a/packages/mdc-select/foundation.ts
+++ b/packages/mdc-select/foundation.ts
@@ -251,8 +251,8 @@ export class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
     this.adapter_.addClass(cssClasses.FOCUSED);
 
     if (this.adapter_.hasLabel()) {
-      this.adapter_.floatLabel(true);
       this.notchOutline(true);
+      this.adapter_.floatLabel(true);
     }
 
     this.adapter_.activateBottomLine();


### PR DESCRIPTION
Need to call notch first to get width of label before it floats (and is consequentially shrunk). Same behavior as outlined textfield