### PR TITLE
fix(select): make select focus themeable

### DIFF
--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -191,6 +191,7 @@
 
 @mixin mdc-select-dd-arrow-bg_($color, $opacity: 1) {
   @include mdc-theme-prop(border-top-color, $color);
+
   opacity: $opacity;
 }
 

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -47,7 +47,7 @@
 @mixin mdc-select-focused-label-color($color) {
   &:not(.mdc-select--disabled) {
     &.mdc-select--focused .mdc-floating-label {
-      @include mdc-floating-label-ink-color(mdc-theme-prop-value($color));
+      @include mdc-floating-label-ink-color($color);
     }
   }
 }
@@ -189,15 +189,9 @@
   }
 }
 
-@mixin mdc-select-dd-arrow-svg-bg_($fill-hex-number, $opacity) {
-  // Lookup color and remove leading #.
-  $fill-hex-number: mdc-theme-prop-value($fill-hex-number);
-  $fill-hex-number: str-slice(unquote("#{$fill-hex-number}"), 2);
-
-  background:
-    url("data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%23#{$fill-hex-number}%22%20fill-rule%3D%22evenodd%22%20opacity%3D%22#{$opacity}%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E")
-    no-repeat
-    center;
+@mixin mdc-select-dd-arrow-bg_($color, $opacity: 1) {
+  @include mdc-theme-prop(border-top-color, $color);
+  opacity: $opacity;
 }
 
 @mixin mdc-select-outline-color_($color) {
@@ -316,7 +310,7 @@
   }
 
   .mdc-select__dropdown-icon {
-    @include mdc-select-dd-arrow-svg-bg_($mdc-select-dropdown-color, $mdc-select-disabled-dropdown-opacity);
+    @include mdc-select-dd-arrow-bg_($mdc-select-dropdown-color, $mdc-select-disabled-dropdown-opacity);
   }
 
   .mdc-line-ripple {

--- a/packages/mdc-select/_variables.scss
+++ b/packages/mdc-select/_variables.scss
@@ -32,7 +32,7 @@ $mdc-select-ink-color: rgba(mdc-theme-prop-value(on-surface), .87) !default;
 $mdc-select-dropdown-color: mdc-theme-prop-value(on-surface) !default;
 $mdc-select-icon-color: rgba(mdc-theme-prop-value(on-surface), .54) !default;
 $mdc-select-label-color: rgba(mdc-theme-prop-value(on-surface), .6) !default;
-$mdc-select-focused-label-color: rgba(mdc-theme-prop-value(primary), .87) !default;
+$mdc-select-focused-label-color: primary !default;
 $mdc-select-bottom-line-idle-color: rgba(mdc-theme-prop-value(on-surface), .42) !default;
 $mdc-select-bottom-line-hover-color: rgba(mdc-theme-prop-value(on-surface), .87) !default;
 $mdc-select-helper-text-color: rgba(mdc-theme-prop-value(on-surface), .6) !default;

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -57,22 +57,25 @@
   position: relative; // Menu is absolutely positioned relative to this.
 
   &__dropdown-icon {
-    @include mdc-select-dd-arrow-svg-bg_($mdc-select-dropdown-color, $mdc-select-dropdown-opacity);
+    @include mdc-select-dd-arrow-bg_($mdc-select-dropdown-color, $mdc-select-dropdown-opacity);
     @include mdc-rtl-reflexive(left, auto, right, 8px);
 
     position: absolute;
-    bottom: 16px;
-    width: 24px;
-    height: 24px;
+    bottom: 26px;
+    width: 0;
+    height: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-top: 6px solid;
     transition: transform $mdc-select-dropdown-transition-duration $mdc-animation-standard-curve-timing-function;
     pointer-events: none;
 
     .mdc-select--focused & {
-      @include mdc-select-dd-arrow-svg-bg_(mdc-theme-prop-value(primary), 1);
+      @include mdc-select-dd-arrow-bg_(primary);
     }
 
     .mdc-select--activated & {
-      transform: rotate(180deg) translateY(-5px);
+      transform: rotate(180deg);
       transition: transform $mdc-select-dropdown-transition-duration $mdc-animation-standard-curve-timing-function;
     }
   }
@@ -127,7 +130,7 @@
   }
 
   .mdc-select__dropdown-icon {
-    @include mdc-select-dd-arrow-svg-bg_($mdc-select-error-color, 1);
+    @include mdc-select-dd-arrow-bg_($mdc-select-error-color);
   }
 
   // stylelint-disable-next-line plugin/selector-bem-pattern

--- a/packages/mdc-select/mdc-select.scss
+++ b/packages/mdc-select/mdc-select.scss
@@ -64,10 +64,10 @@
     bottom: 26px;
     width: 0;
     height: 0;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-    border-top: 6px solid;
     transition: transform $mdc-select-dropdown-transition-duration $mdc-animation-standard-curve-timing-function;
+    border-top: 6px solid;
+    border-right: 6px solid transparent;
+    border-left: 6px solid transparent;
     pointer-events: none;
 
     .mdc-select--focused & {

--- a/test/screenshot/spec/mdc-select/classes/themeable-baseline.html
+++ b/test/screenshot/spec/mdc-select/classes/themeable-baseline.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2019 Google Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Themeable Baseline Select - MDC Web Screenshot Test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../../out/mdc.list.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu-surface.css">
+    <link rel="stylesheet" href="../../../out/mdc.menu.css">
+    <link rel="stylesheet" href="../../../out/mdc.select.css">
+    <link rel="stylesheet" href="../../../out/spec/fixture.css">
+    <link rel="stylesheet" href="../../../out/spec/mdc-select/fixture.css">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118996389-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-118996389-2');
+    </script>
+    <style>
+      :root {
+        --mdc-theme-primary: #03A9F4;
+        --mdc-theme-on-primary: #03A9F4;
+        --mdc-theme-primary-light: #90CAF9;
+        --mdc-theme-primary-dark: #1976D2;
+        --mdc-theme-secondary: #5C6BC0;
+        --mdc-theme-secondary-light: #9FA8DA;
+        --mdc-theme-secondary-dark: #1A237E;
+      }
+    </style>
+  </head>
+
+  <body class="test-container">
+    <main class="test-viewport test-viewport--mobile">
+      <div class="test-layout">
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label screenshot-selected-text"></div>
+              <span id="screenshot-select-label" class="mdc-floating-label">Pick a Food Group</span>
+              <div class="mdc-line-ripple"></div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value=""></li>
+                <li class="mdc-list-item" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text2" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label2 screenshot-selected-text2"></div>
+              <div class="mdc-notched-outline">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__notch">
+                  <span id="screenshot-select-label2" class="mdc-floating-label">Pick a Food Group</span>
+                </div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value=""></li>
+                <li class="mdc-list-item" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text3" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label3 screenshot-selected-text3">Bread, Cereal, Rice, and Pasta</div>
+              <span id="screenshot-select-label3" class="mdc-floating-label mdc-floating-label--float-above">Pick a Food Group</span>
+              <div class="mdc-line-ripple"></div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="test-cell test-cell--select">
+          <div class="mdc-select mdc-select--outlined">
+            <div class="mdc-select__anchor custom-enhanced-select-width">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div id="screenshot-selected-text4" class="mdc-select__selected-text" role="button" aria-haspopup="listbox"
+                  aria-labelledby="screenshot-select-label4 screenshot-selected-text4">Bread, Cereal, Rice, and Pasta</div>
+              <div class="mdc-notched-outline mdc-notched-outline--notched">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__notch">
+                  <span id="screenshot-select-label4" class="mdc-floating-label mdc-floating-label--float-above">Pick a Food Group</span>
+                </div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+
+            <div class="mdc-select__menu mdc-menu mdc-menu-surface custom-enhanced-select-width" role="listbox">
+              <ul class="mdc-list">
+                <li class="mdc-list-item mdc-list-item--selected" aria-selected="true" role="option" data-value="grains">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdc-list-item" role="option" data-value="vegetables">
+                  Vegetables
+                </li>
+                <li class="mdc-list-item" role="option" data-value="fruit">
+                  Fruit
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+
+    <!-- Automatically provides/replaces `Promise` if missing or broken. -->
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fontfaceobserver/2.0.13/fontfaceobserver.standalone.js"></script>
+    <script src="../../../out/material-components-web.js"></script>
+    <script src="../../../out/spec/fixture.js"></script>
+    <script src="../../../out/spec/mdc-select/fixture.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #2360
- [x] bug
- [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
use `$mdc-select-focused-label-color: primary !default;` instead of `$mdc-select-focused-label-color: rgba(mdc-theme-prop-value(primary), .87) !default;`

##### Is there anything you'd like reviewers to focus on?
Replaced dropdown `svg` image with `css` to draw a triangle as its color need to match with custom primary color