### PR TITLE
test(infra): Fix `npm run test:unit` to exit with code 1 if Jasmine or Mocha tests fail.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:dependency": "./scripts/dependency-test.sh",
     "test:feature-targeting": "node test/scss/verify-feature-targeting.js",
     "test:site": "npm run clean:site && ./scripts/site-generator-test.sh",
-    "test:unit": "npm run test:jasmineunit; npm run test:mochaunit",
+    "test:unit": "npm run test:jasmineunit; jasmine_exit_code=$?; npm run test:mochaunit && exit \"$jasmine_exit_code\"",
     "test:jasmineunit": "USE_JASMINE=true karma start --single-run",
     "test:jasminewatch": "USE_JASMINE=true karma start --auto-watch",
     "test:mochaunit": "karma start --single-run",


### PR DESCRIPTION
Currently, `npm run test:unit` will incorrectly exit with success code 0 even if the Jasmine tests fail. This fixes to exit with code 1 if either Jasmine or Mocha tests fail, while still running the Mocha tests even if Jasmine tests fail.