### PR TITLE
test(infra): Reduce screenshot test flakiness.

### DIFF
--- a/test/screenshot/diffing.json
+++ b/test/screenshot/diffing.json
@@ -89,6 +89,19 @@
         "custom_config": {
           "skip_all": true
         }
+      },
+      {
+        "description": "FF flakes for menu, screenshotting before animation is complete. `fonts_loaded_reflow_delay_ms` is increased, as it's also used for the animation delay.",
+        "browser_regex_patterns": [
+          "desktop_windows_firefox@69"
+        ],
+        "url_regex_patterns": [
+          "mdc-menu/classes/menu-selection-group-only.html",
+          "mdc-menu/classes/menu-selection-group.html"
+        ],
+        "custom_config": {
+          "fonts_loaded_reflow_delay_ms": 250
+        }
       }
     ]
   }

--- a/test/screenshot/diffing.json
+++ b/test/screenshot/diffing.json
@@ -84,7 +84,8 @@
           "desktop_windows_firefox@69"
         ],
         "url_regex_patterns": [
-          "mdc-textfield/classes/textarea-invalid.html"
+          "mdc-textfield/classes/textarea-invalid.html",
+          "mdc-textfield/mixins/density-invalid.html"
         ],
         "custom_config": {
           "skip_all": true

--- a/test/screenshot/diffing.json
+++ b/test/screenshot/diffing.json
@@ -77,6 +77,18 @@
         "custom_config": {
           "skip_all": true
         }
+      },
+      {
+        "description": "FF flakes frequently with invalid textarea.",
+        "browser_regex_patterns": [
+          "desktop_windows_firefox@69"
+        ],
+        "url_regex_patterns": [
+          "mdc-textfield/classes/textarea-invalid.html"
+        ],
+        "custom_config": {
+          "skip_all": true
+        }
       }
     ]
   }


### PR DESCRIPTION
- Skip invalid textarea on FF, as this is consistently flaking
- Increase animation delay for menu on FF