### PR TITLE
fix: add missing dependencies

### DIFF
--- a/packages/mdc-checkbox/_functions.scss
+++ b/packages/mdc-checkbox/_functions.scss
@@ -20,7 +20,8 @@
 // THE SOFTWARE.
 //
 
-@import "@material/theme/functions";
+@import "@material/animation/functions";
+@import "./variables";
 
 @function mdc-checkbox-transition-enter($property, $delay: 0ms, $duration: $mdc-checkbox-transition-duration) {
   @return mdc-animation-enter($property, $duration, $delay);

--- a/packages/mdc-data-table/_variables.scss
+++ b/packages/mdc-data-table/_variables.scss
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 //
 
-@import "@material/theme/functions";
+@import "@material/theme/variables";
 @import "@material/density/variables";
 
 $mdc-data-table-fill-color: surface !default;

--- a/packages/mdc-list/_variables.scss
+++ b/packages/mdc-list/_variables.scss
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 @import "@material/density/variables";
+@import "@material/theme/variables";
 
 $mdc-list-divider-color-on-light-bg: rgba(0, 0, 0, .12) !default;
 $mdc-list-divider-color-on-dark-bg: rgba(255, 255, 255, .2) !default;

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -23,6 +23,7 @@
 @import "@material/density/variables";
 @import "@material/floating-label/variables";
 @import "@material/notched-outline/variables";
+@import "@material/theme/variables";
 
 ///
 /// Returns outlined text field floating label position for given height.

--- a/packages/mdc-textfield/icon/_mixins.scss
+++ b/packages/mdc-textfield/icon/_mixins.scss
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+@import "@material/rtl/mixins";
+
 // Public mixins
 
 ///


### PR DESCRIPTION
Add missing dependencies to five files that previously didn't depend on all the stylesheets they reference (even indirectly). This caused issues with the module system migrator (#5220), so this fix is necessary for that.