### PR TITLE
feat(line-ripple): add active/inactive states to line-ripple

### DIFF
--- a/packages/mdc-floating-label/README.md
+++ b/packages/mdc-floating-label/README.md
@@ -60,7 +60,7 @@ a unique `id` to each `<input>` by wrapping `mdc-text-field__input` within a `<l
 <label class="mdc-text-field">
   <input type="text" class="mdc-text-field__input">
   <span class="mdc-floating-label">Hint Text</span>
-  <div class="mdc-text-field__bottom-line"></div>
+  <div class="mdc-line-ripple"></div>
 </label>
 ```
 

--- a/packages/mdc-line-ripple/README.md
+++ b/packages/mdc-line-ripple/README.md
@@ -63,7 +63,8 @@ CSS Class | Description
 
 Mixin | Description
 --- | ---
-`mdc-line-ripple-color($color)` | Customizes the color of the line ripple when active.
+`mdc-line-ripple-inactive-color($color)` | Customizes the color of the line ripple when inactive.
+`mdc-line-ripple-active-color($color)` | Customizes the color of the line ripple when active.
 
 ## `MDCLineRipple` Properties and Methods
 

--- a/packages/mdc-line-ripple/_mixins.scss
+++ b/packages/mdc-line-ripple/_mixins.scss
@@ -34,39 +34,68 @@
   // postcss-bem-linter: define line-ripple
   .mdc-line-ripple {
     @include mdc-feature-targets($feat-structure) {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 2px;
-      transform: scaleX(0);
-      opacity: 0;
-      z-index: 2;
+      &::before,
+      &::after {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        border-bottom-style: solid;
+        content: "";
+      }
+
+      &::before {
+        border-bottom-width: 1px;
+        z-index: 1;
+      }
+
+      &::after {
+        transform: scaleX(0);
+        border-bottom-width: 2px;
+        opacity: 0;
+        z-index: 2;
+      }
     }
 
     @include mdc-feature-targets($feat-animation) {
-      transition: mdc-line-ripple-transition-value(transform), mdc-line-ripple-transition-value(opacity);
+      &::after {
+        transition: mdc-line-ripple-transition-value(transform), mdc-line-ripple-transition-value(opacity);
+      }
     }
   }
 
-  .mdc-line-ripple--active {
+  .mdc-line-ripple--active::after {
     @include mdc-feature-targets($feat-structure) {
       transform: scaleX(1);
       opacity: 1;
     }
   }
 
-  .mdc-line-ripple--deactivating {
+  .mdc-line-ripple--deactivating::after {
     @include mdc-feature-targets($feat-structure) {
       opacity: 0;
     }
   }
 }
 
-@mixin mdc-line-ripple-color($color, $query: mdc-feature-all()) {
+// Public
+
+@mixin mdc-line-ripple-active-color($color, $query: mdc-feature-all()) {
   $feat-color: mdc-feature-create-target($query, color);
 
   @include mdc-feature-targets($feat-color) {
-    @include mdc-theme-prop(background-color, $color);
+    &::after {
+      @include mdc-theme-prop(border-bottom-color, $color);
+    }
+  }
+}
+
+@mixin mdc-line-ripple-inactive-color($color, $query: mdc-feature-all()) {
+  $feat-color: mdc-feature-create-target($query, color);
+
+  @include mdc-feature-targets($feat-color) {
+    &::before {
+      @include mdc-theme-prop(border-bottom-color, $color);
+    }
   }
 }

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -53,8 +53,8 @@
 }
 
 @mixin mdc-select-hover-bottom-line-color($color) {
-  &:not(.mdc-select--disabled) .mdc-select__selected-text:hover {
-    @include mdc-select-native-control-bottom-line-color_($color);
+  &:not(.mdc-select--disabled):hover {
+    @include mdc-select-bottom-line-color_($color);
   }
 }
 
@@ -174,18 +174,14 @@
 }
 
 @mixin mdc-select-bottom-line-color_($color) {
-  .mdc-select__selected-text {
-    @include mdc-select-native-control-bottom-line-color_($color);
+  .mdc-line-ripple {
+    @include mdc-line-ripple-inactive-color($color);
   }
-}
-
-@mixin mdc-select-native-control-bottom-line-color_($color) {
-  @include mdc-theme-prop(border-bottom-color, $color);
 }
 
 @mixin mdc-select-focused-line-ripple-color_($color) {
   @include mdc-select-focused-line-ripple_ {
-    @include mdc-line-ripple-color($color);
+    @include mdc-line-ripple-active-color($color);
   }
 }
 
@@ -298,7 +294,6 @@
     padding-top: 20px;
     padding-bottom: 4px;
     border: none;
-    border-bottom: 1px solid;
     outline: none;
     background-color: transparent;
     color: inherit; // Override default user agent stylesheet
@@ -320,7 +315,12 @@
   }
 
   .mdc-line-ripple {
-    display: none;
+    @include mdc-line-ripple-inactive-color($mdc-select-disabled-ink-color);
+
+    &::before {
+      // TODO(lizmitchell): http://b/146080006
+      border-bottom-style: dotted;
+    }
   }
 
   .mdc-select__icon {
@@ -330,17 +330,12 @@
   .mdc-select__selected-text {
     @include mdc-theme-prop(color, $mdc-select-disabled-ink-color);
 
-    border-bottom-style: dotted;
     pointer-events: none;
   }
 
   &.mdc-select--outlined {
     @include mdc-select-container-fill-color_(transparent);
     @include mdc-select-outline-color_($mdc-select-outlined-disabled-border);
-
-    .mdc-select__selected-text {
-      border-bottom-style: none;
-    }
   }
 
   cursor: default;

--- a/packages/mdc-textfield/README.md
+++ b/packages/mdc-textfield/README.md
@@ -285,7 +285,7 @@ these mixins within CSS selectors like `.foo-text-field:not(.mdc-text-field--foc
 and `.foo-text-field.mdc-text-field--focused` to select your focused text-fields. To change the invalid state of your text fields,
 apply these mixins with CSS selectors such as `.foo-text-field.mdc-text-field--invalid`.
 
-> _NOTE_: the `mdc-line-ripple-color` mixin should be applied from the not focused class `foo-text-field:not(.mdc-text-field--focused)`).
+> _NOTE_: the `mdc-line-ripple-active-color` mixin should be applied from the not focused class `foo-text-field:not(.mdc-text-field--focused)`).
 
 #### Mixins for all Text Fields
 

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -518,10 +518,6 @@
 @mixin mdc-text-field-outlined-disabled_ {
   @include mdc-notched-outline-color($mdc-text-field-outlined-disabled-border);
   @include mdc-text-field-fill-color_(transparent);
-
-  .mdc-text-field__input {
-    border-bottom: none;
-  }
 }
 
 @mixin mdc-text-field-outlined-invalid_ {
@@ -589,13 +585,9 @@
 }
 
 @mixin mdc-text-field-hover-outline-color_($color) {
-  &:not(.mdc-text-field--focused) {
-    // stylelint-disable-next-line selector-combinator-space-after
-    .mdc-text-field__input:hover ~,
-    .mdc-text-field__icon:hover ~ {
-      .mdc-notched-outline {
-        @include mdc-notched-outline-color($color);
-      }
+  &:not(.mdc-text-field--focused):hover {
+    .mdc-notched-outline {
+      @include mdc-notched-outline-color($color);
     }
   }
 }
@@ -730,7 +722,7 @@
     display: block;
 
     .mdc-text-field__input {
-      padding: 0;
+      padding: 0 0 $mdc-text-field-input-border-bottom;
     }
   }
 
@@ -821,20 +813,20 @@
 }
 
 @mixin mdc-text-field-bottom-line-color_($color) {
-  .mdc-text-field__input {
-    @include mdc-theme-prop(border-bottom-color, $color);
+  .mdc-line-ripple {
+    @include mdc-line-ripple-inactive-color($color);
   }
 }
 
 @mixin mdc-text-field-hover-bottom-line-color_($color) {
-  .mdc-text-field__input:hover {
-    @include mdc-theme-prop(border-bottom-color, $color);
+  &:hover .mdc-line-ripple {
+    @include mdc-line-ripple-inactive-color($color);
   }
 }
 
 @mixin mdc-text-field-line-ripple-color_($color) {
   .mdc-line-ripple {
-    @include mdc-line-ripple-color($color);
+    @include mdc-line-ripple-active-color($color);
   }
 }
 

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -87,11 +87,9 @@
   padding:
     $mdc-text-field-input-padding-top
     $mdc-text-field-input-padding
-    $mdc-text-field-input-padding-bottom;
+    $mdc-text-field-input-padding-bottom + $mdc-text-field-input-border-bottom;
   transition: mdc-text-field-transition(opacity);
   border: none;
-  border-bottom: 1px solid;
-  border-radius: 0;
   background: none;
   appearance: none;
 
@@ -133,7 +131,7 @@
   // Vertically center aligns the text input placeholder and value for only filled variant.
   .mdc-text-field--no-label:not(.mdc-text-field--outlined):not(.mdc-text-field--textarea) & {
     padding-top: 16px;
-    padding-bottom: 16px;
+    padding-bottom: 16px + $mdc-text-field-input-border-bottom;
   }
 }
 // stylelint-disable-next-line plugin/selector-bem-pattern

--- a/test/screenshot/golden.json
+++ b/test/screenshot/golden.json
@@ -1360,11 +1360,11 @@
     }
   },
   "spec/mdc-textfield/classes/baseline-placeholder.html": {
-    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/11/01/18_25_15_143/spec/mdc-textfield/classes/baseline-placeholder.html?utm_source=golden_json",
+    "public_url": "https://storage.googleapis.com/mdc-web-screenshot-tests/lizmitchell/2019/12/19/21_35_42_112/spec/mdc-textfield/classes/baseline-placeholder.html?utm_source=golden_json",
     "screenshots": {
       "desktop_windows_chrome@77": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/11/01/18_25_15_143/spec/mdc-textfield/classes/baseline-placeholder.html.windows_chrome_77.png",
       "desktop_windows_firefox@69": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/11/01/18_25_15_143/spec/mdc-textfield/classes/baseline-placeholder.html.windows_firefox_69.png",
-      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/abhiomkar/2019/11/01/18_25_15_143/spec/mdc-textfield/classes/baseline-placeholder.html.windows_ie_11.png"
+      "desktop_windows_ie@11": "https://storage.googleapis.com/mdc-web-screenshot-tests/lizmitchell/2019/12/19/21_35_42_112/spec/mdc-textfield/classes/baseline-placeholder.html.windows_ie_11.png"
     }
   },
   "spec/mdc-textfield/classes/baseline-trailing-icon.html": {

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-fullwidth.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-fullwidth.html
@@ -51,6 +51,7 @@
                     placeholder="Full-Width Text Field"
                     aria-label="Full-Width Text Field">
             <!-- htmllint-enable -->
+            <div class="mdc-line-ripple"></div>
           </div>
         </div>
       </div>

--- a/test/screenshot/spec/mdc-textfield/mixins/disabled-1.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/disabled-1.html
@@ -204,6 +204,7 @@
                     aria-label="Full-Width Text Field"
                     disabled>
             <!-- htmllint-enable -->
+            <div class="mdc-line-ripple"></div>
           </div>
         </div>
       </div>

--- a/test/scss/_feature-targeting-test.scss
+++ b/test/scss/_feature-targeting-test.scss
@@ -215,7 +215,8 @@
 
     // Line ripple
     @include mdc-line-ripple-core-styles($query: $query);
-    @include mdc-line-ripple-color(red, $query: $query);
+    @include mdc-line-ripple-active-color(red, $query: $query);
+    @include mdc-line-ripple-inactive-color(red, $query: $query);
 
     // List
     @include mdc-list-core-styles($query: $query);


### PR DESCRIPTION
BREAKING CHANGE: `mdc-line-ripple-color()` mixin has been renamed to `mdc-line-ripple-active-color()`