### PR TITLE
fix(textfield): add separate classes for leading/trailing icons

### DIFF
--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -602,10 +602,13 @@
 }
 
 @mixin mdc-text-field-hover-outline-color_($color) {
-  &:not(.mdc-text-field--focused):hover {
-    .mdc-notched-outline {
-      @include mdc-notched-outline-color($color);
-    }
+  &:not(.mdc-text-field--focused) {
+    // stylelint-disable-next-line selector-combinator-space-after
+    .mdc-text-field__input:hover ~,
+    .mdc-text-field__icon:hover ~ {
+      .mdc-notched-outline {
+        @include mdc-notched-outline-color($color);
+      }
   }
 }
 

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -565,8 +565,7 @@
     top: 14px;
   }
 
-  .mdc-text-field__leading-icon,
-  .mdc-text-field__trailing-icon {
+  .mdc-text-field__icon {
     top: 12px;
   }
 }
@@ -593,8 +592,7 @@
     z-index: 1;
   }
 
-  .mdc-text-field__leading-icon,
-  .mdc-text-field__trailing-icon {
+  .mdc-text-field__icon {
     z-index: 2;
   }
 
@@ -621,12 +619,13 @@
 
 @mixin mdc-text-field-with-leading-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
-    leading,
     left,
-    $mdc-text-field-icon-position,
-    $mdc-text-field-icon-padding,
-    $mdc-text-field-input-padding
+    $mdc-text-field-icon-position
   );
+
+  .mdc-text-field__input {
+    @include mdc-rtl-reflexive-property(padding, $mdc-text-field-icon-padding, $mdc-text-field-input-padding);
+  }
 
   .mdc-floating-label {
     @include mdc-rtl-reflexive-position(left, $mdc-text-field-icon-padding);
@@ -635,12 +634,13 @@
 
 @mixin mdc-text-field-dense-with-leading-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
-    leading,
     left,
-    $mdc-text-field-dense-icon-position,
-    $mdc-text-field-dense-icon-padding,
-    $mdc-text-field-input-padding
+    $mdc-text-field-dense-icon-position
   );
+
+  .mdc-text-field__input {
+    @include mdc-rtl-reflexive-property(padding, $mdc-text-field-dense-icon-padding, $mdc-text-field-input-padding);
+  }
 
   .mdc-floating-label {
     @include mdc-rtl-reflexive-position(left, $mdc-text-field-dense-icon-padding);
@@ -649,11 +649,8 @@
 
 @mixin mdc-text-field-outlined-with-leading-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
-    leading,
     left,
-    $mdc-text-field-icon-position,
-    $mdc-text-field-icon-padding,
-    $mdc-text-field-input-padding
+    $mdc-text-field-icon-position
   );
   @include mdc-notched-outline-floating-label-float-position-absolute($mdc-text-field-outlined-label-position-y, 32px);
   @include mdc-floating-label-shake-animation(text-field-outlined-leading-icon);
@@ -686,51 +683,56 @@
 
 @mixin mdc-text-field-with-trailing-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
-    trailing,
     right,
-    $mdc-text-field-trailing-icon-position,
-    $mdc-text-field-icon-padding,
-    $mdc-text-field-input-padding
+    $mdc-text-field-trailing-icon-position
   );
+
+  .mdc-text-field__input {
+    @include mdc-rtl-reflexive-property(padding, $mdc-text-field-input-padding, $mdc-text-field-icon-padding);
+  }
 
   // Outlined uses 16px for text alignment when using a trailing icon.
   &.mdc-text-field--outlined {
     @include mdc-text-field-icon-horizontal-position_(
-      trailing,
       right,
-      $mdc-text-field-icon-position,
-      $mdc-text-field-icon-padding,
-      $mdc-text-field-input-padding
+      $mdc-text-field-icon-position
     );
   }
 }
 
 @mixin mdc-text-field-dense-with-trailing-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
-    trailing,
     right,
-    $mdc-text-field-dense-icon-position,
-    $mdc-text-field-dense-icon-padding,
-    $mdc-text-field-input-padding
+    $mdc-text-field-dense-icon-position
   );
+
+  .mdc-text-field__input {
+    @include mdc-rtl-reflexive-property(padding, $mdc-text-field-input-padding, $mdc-text-field-dense-icon-padding);
+  }
 }
 
 @mixin mdc-text-field-with-both-icons_ {
   @include mdc-text-field-icon-horizontal-position-two-icons_(
     $mdc-text-field-icon-position,
-    $mdc-text-field-icon-padding,
-    $mdc-text-field-trailing-icon-position,
-    $mdc-text-field-icon-padding
+    $mdc-text-field-trailing-icon-position
   );
+
+  .mdc-text-field__input {
+    padding-right: $mdc-text-field-icon-padding;
+    padding-left: $mdc-text-field-icon-padding;
+  }
 }
 
 @mixin mdc-text-field-dense-with-both-icons_ {
   @include mdc-text-field-icon-horizontal-position-two-icons_(
     $mdc-text-field-dense-icon-position,
-    $mdc-text-field-dense-icon-padding,
-    $mdc-text-field-dense-icon-position,
-    $mdc-text-field-dense-icon-padding
+    $mdc-text-field-dense-icon-position
   );
+
+  .mdc-text-field__input {
+    padding-right: $mdc-text-field-dense-icon-padding;
+    padding-left: $mdc-text-field-dense-icon-padding;
+  }
 }
 
 // Full Width

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -382,7 +382,8 @@
   @include mdc-text-field-label-ink-color_($mdc-text-field-disabled-label-color);
   @include mdc-text-field-helper-text-color_($mdc-text-field-disabled-helper-text-color);
   @include mdc-text-field-character-counter-color_($mdc-text-field-disabled-helper-text-color);
-  @include mdc-text-field-icon-color_($mdc-text-field-disabled-icon);
+  @include mdc-text-field-leading-icon-color_($mdc-text-field-disabled-icon);
+  @include mdc-text-field-trailing-icon-color_($mdc-text-field-disabled-icon);
   @include mdc-text-field-fill-color_($mdc-text-field-disabled-background);
 
   border-bottom: none;
@@ -400,16 +401,7 @@
   @include mdc-text-field-label-color($mdc-text-field-error);
   @include mdc-text-field-helper-text-validation-color($mdc-text-field-error);
   @include mdc-text-field-caret-color($mdc-text-field-error);
-
-  &.mdc-text-field--with-trailing-icon {
-    &:not(.mdc-text-field--with-leading-icon) {
-      @include mdc-text-field-icon-color($mdc-text-field-error);
-    }
-
-    &.mdc-text-field--with-leading-icon {
-      @include mdc-text-field-icon-color($mdc-text-field-error, /* styleSecondIcon */ true);
-    }
-  }
+  @include mdc-text-field-trailing-icon-color($mdc-text-field-error);
 
   + .mdc-text-field-helper-line .mdc-text-field-helper-text--validation-msg {
     opacity: 1;
@@ -573,7 +565,8 @@
     top: 14px;
   }
 
-  .mdc-text-field__icon {
+  .mdc-text-field__leading-icon,
+  .mdc-text-field__trailing-icon {
     top: 12px;
   }
 }
@@ -600,7 +593,8 @@
     z-index: 1;
   }
 
-  .mdc-text-field__icon {
+  .mdc-text-field__leading-icon,
+  .mdc-text-field__trailing-icon {
     z-index: 2;
   }
 
@@ -610,13 +604,9 @@
 }
 
 @mixin mdc-text-field-hover-outline-color_($color) {
-  &:not(.mdc-text-field--focused) {
-    // stylelint-disable-next-line selector-combinator-space-after
-    .mdc-text-field__input:hover ~,
-    .mdc-text-field__icon:hover ~ {
-      .mdc-notched-outline {
-        @include mdc-notched-outline-color($color);
-      }
+  &:not(.mdc-text-field--focused):hover {
+    .mdc-notched-outline {
+      @include mdc-notched-outline-color($color);
     }
   }
 }
@@ -631,6 +621,7 @@
 
 @mixin mdc-text-field-with-leading-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
+    leading,
     left,
     $mdc-text-field-icon-position,
     $mdc-text-field-icon-padding,
@@ -644,6 +635,7 @@
 
 @mixin mdc-text-field-dense-with-leading-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
+    leading,
     left,
     $mdc-text-field-dense-icon-position,
     $mdc-text-field-dense-icon-padding,
@@ -657,6 +649,7 @@
 
 @mixin mdc-text-field-outlined-with-leading-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
+    leading,
     left,
     $mdc-text-field-icon-position,
     $mdc-text-field-icon-padding,
@@ -693,6 +686,7 @@
 
 @mixin mdc-text-field-with-trailing-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
+    trailing,
     right,
     $mdc-text-field-trailing-icon-position,
     $mdc-text-field-icon-padding,
@@ -702,6 +696,7 @@
   // Outlined uses 16px for text alignment when using a trailing icon.
   &.mdc-text-field--outlined {
     @include mdc-text-field-icon-horizontal-position_(
+      trailing,
       right,
       $mdc-text-field-icon-position,
       $mdc-text-field-icon-padding,
@@ -712,6 +707,7 @@
 
 @mixin mdc-text-field-dense-with-trailing-icon_ {
   @include mdc-text-field-icon-horizontal-position_(
+    trailing,
     right,
     $mdc-text-field-dense-icon-position,
     $mdc-text-field-dense-icon-padding,

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -622,10 +622,7 @@
 // Icons
 
 @mixin mdc-text-field-with-leading-icon_ {
-  @include mdc-text-field-icon-horizontal-position_(
-    left,
-    $mdc-text-field-icon-position
-  );
+  @include mdc-text-field-leading-icon-horizontal-position_($mdc-text-field-icon-position);
 
   .mdc-text-field__input {
     @include mdc-rtl-reflexive-property(padding, $mdc-text-field-icon-padding, $mdc-text-field-input-padding);
@@ -637,10 +634,7 @@
 }
 
 @mixin mdc-text-field-dense-with-leading-icon_ {
-  @include mdc-text-field-icon-horizontal-position_(
-    left,
-    $mdc-text-field-dense-icon-position
-  );
+  @include mdc-text-field-leading-icon-horizontal-position_($mdc-text-field-dense-icon-position);
 
   .mdc-text-field__input {
     @include mdc-rtl-reflexive-property(padding, $mdc-text-field-dense-icon-padding, $mdc-text-field-input-padding);
@@ -652,10 +646,7 @@
 }
 
 @mixin mdc-text-field-outlined-with-leading-icon_ {
-  @include mdc-text-field-icon-horizontal-position_(
-    left,
-    $mdc-text-field-icon-position
-  );
+  @include mdc-text-field-leading-icon-horizontal-position_($mdc-text-field-icon-position);
   @include mdc-notched-outline-floating-label-float-position-absolute($mdc-text-field-outlined-label-position-y, 32px);
   @include mdc-floating-label-shake-animation(text-field-outlined-leading-icon);
 
@@ -686,10 +677,7 @@
 }
 
 @mixin mdc-text-field-with-trailing-icon_ {
-  @include mdc-text-field-icon-horizontal-position_(
-    right,
-    $mdc-text-field-trailing-icon-position
-  );
+  @include mdc-text-field-trailing-icon-horizontal-position_($mdc-text-field-trailing-icon-position);
 
   .mdc-text-field__input {
     @include mdc-rtl-reflexive-property(padding, $mdc-text-field-input-padding, $mdc-text-field-icon-padding);
@@ -697,18 +685,12 @@
 
   // Outlined uses 16px for text alignment when using a trailing icon.
   &.mdc-text-field--outlined {
-    @include mdc-text-field-icon-horizontal-position_(
-      right,
-      $mdc-text-field-icon-position
-    );
+    @include mdc-text-field-trailing-icon-horizontal-position_($mdc-text-field-icon-position);
   }
 }
 
 @mixin mdc-text-field-dense-with-trailing-icon_ {
-  @include mdc-text-field-icon-horizontal-position_(
-    right,
-    $mdc-text-field-dense-icon-position
-  );
+  @include mdc-text-field-trailing-icon-horizontal-position_($mdc-text-field-dense-icon-position);
 
   .mdc-text-field__input {
     @include mdc-rtl-reflexive-property(padding, $mdc-text-field-input-padding, $mdc-text-field-dense-icon-padding);
@@ -716,11 +698,6 @@
 }
 
 @mixin mdc-text-field-with-both-icons_ {
-  @include mdc-text-field-icon-horizontal-position-two-icons_(
-    $mdc-text-field-icon-position,
-    $mdc-text-field-trailing-icon-position
-  );
-
   .mdc-text-field__input {
     padding-right: $mdc-text-field-icon-padding;
     padding-left: $mdc-text-field-icon-padding;
@@ -728,11 +705,6 @@
 }
 
 @mixin mdc-text-field-dense-with-both-icons_ {
-  @include mdc-text-field-icon-horizontal-position-two-icons_(
-    $mdc-text-field-dense-icon-position,
-    $mdc-text-field-dense-icon-position
-  );
-
   .mdc-text-field__input {
     padding-right: $mdc-text-field-dense-icon-padding;
     padding-left: $mdc-text-field-dense-icon-padding;

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -609,6 +609,7 @@
       .mdc-notched-outline {
         @include mdc-notched-outline-color($color);
       }
+    }
   }
 }
 

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -698,6 +698,11 @@
 }
 
 @mixin mdc-text-field-with-both-icons_ {
+  @include mdc-text-field-icon-horizontal-position-two-icons_(
+    $mdc-text-field-icon-position,
+    $mdc-text-field-trailing-icon-position
+  );
+
   .mdc-text-field__input {
     padding-right: $mdc-text-field-icon-padding;
     padding-left: $mdc-text-field-icon-padding;
@@ -705,6 +710,11 @@
 }
 
 @mixin mdc-text-field-dense-with-both-icons_ {
+  @include mdc-text-field-icon-horizontal-position-two-icons_(
+    $mdc-text-field-dense-icon-position,
+    $mdc-text-field-dense-icon-position
+  );
+
   .mdc-text-field__input {
     padding-right: $mdc-text-field-dense-icon-padding;
     padding-left: $mdc-text-field-dense-icon-padding;

--- a/packages/mdc-textfield/component.ts
+++ b/packages/mdc-textfield/component.ts
@@ -113,21 +113,13 @@ export class MDCTextField extends MDCComponent<MDCTextFieldFoundation> implement
     }
     this.characterCounter_ = characterCounterEl ? characterCounterFactory(characterCounterEl) : null;
 
-    this.leadingIcon_ = null;
-    this.trailingIcon_ = null;
-    const iconElements = this.root_.querySelectorAll(strings.ICON_SELECTOR);
-    if (iconElements.length > 0) {
-      if (iconElements.length > 1) { // Has both icons.
-        this.leadingIcon_ = iconFactory(iconElements[0]);
-        this.trailingIcon_ = iconFactory(iconElements[1]);
-      } else {
-        if (this.root_.classList.contains(cssClasses.WITH_LEADING_ICON)) {
-          this.leadingIcon_ = iconFactory(iconElements[0]);
-        } else {
-          this.trailingIcon_ = iconFactory(iconElements[0]);
-        }
-      }
-    }
+    // Leading icon
+    const leadingIconEl = this.root_.querySelector(strings.LEADING_ICON_SELECTOR);
+    this.leadingIcon_ = leadingIconEl ? iconFactory(leadingIconEl) : null;
+
+    // Trailing icon
+    const trailingIconEl = this.root_.querySelector(strings.TRAILING_ICON_SELECTOR);
+    this.trailingIcon_ = trailingIconEl ? iconFactory(trailingIconEl) : null;
 
     this.ripple = this.createRipple_(rippleFactory);
   }

--- a/packages/mdc-textfield/constants.ts
+++ b/packages/mdc-textfield/constants.ts
@@ -23,11 +23,12 @@
 
 const strings = {
   ARIA_CONTROLS: 'aria-controls',
-  ICON_SELECTOR: '.mdc-text-field__icon',
   INPUT_SELECTOR: '.mdc-text-field__input',
   LABEL_SELECTOR: '.mdc-floating-label',
+  LEADING_ICON_SELECTOR: '.mdc-text-field__leading-icon',
   LINE_RIPPLE_SELECTOR: '.mdc-line-ripple',
   OUTLINE_SELECTOR: '.mdc-notched-outline',
+  TRAILING_ICON_SELECTOR: '.mdc-text-field__trailing-icon'
 };
 
 const cssClasses = {

--- a/packages/mdc-textfield/constants.ts
+++ b/packages/mdc-textfield/constants.ts
@@ -25,10 +25,10 @@ const strings = {
   ARIA_CONTROLS: 'aria-controls',
   INPUT_SELECTOR: '.mdc-text-field__input',
   LABEL_SELECTOR: '.mdc-floating-label',
-  LEADING_ICON_SELECTOR: '.mdc-text-field__leading-icon',
+  LEADING_ICON_SELECTOR: '.mdc-text-field__icon--leading',
   LINE_RIPPLE_SELECTOR: '.mdc-line-ripple',
   OUTLINE_SELECTOR: '.mdc-notched-outline',
-  TRAILING_ICON_SELECTOR: '.mdc-text-field__trailing-icon'
+  TRAILING_ICON_SELECTOR: '.mdc-text-field__icon--trailing'
 };
 
 const cssClasses = {

--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -24,7 +24,7 @@ Icons describe the type of input a text field requires. They can also be interac
 ### HTML Structure
 
 ```html
-<i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+<i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
 ```
 
 #### Icon Set
@@ -55,7 +55,7 @@ const icon = new MDCTextFieldIcon(document.querySelector('.mdc-text-field-icon')
 
 ## Variants
 
-Leading and trailing icons can be applied to default or `mdc-text-field--outlined` Text Fields. To add an icon, add the relevant class (`mdc-text-field--with-leading-icon` and/or `mdc-text-field--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-text-field__leading-icon` or `mdc-text-field__trailing-icon`.
+Leading and trailing icons can be applied to default or `mdc-text-field--outlined` Text Fields. To add an icon, add the relevant class (`mdc-text-field--with-leading-icon` and/or `mdc-text-field--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-text-field__icon` with the modifier`mdc-text-field__icon--leading` or `mdc-text-field__icon--trailing`.
 
 > **NOTE:** if you would like to display un-clickable icons, simply omit `tabindex="0"` and `role="button"`, and the CSS will ensure the cursor is set to default, and that interacting with an icon doesn't do anything unexpected.
 
@@ -65,7 +65,7 @@ In text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--with-leading-icon">
-  <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
   <label for="my-input" class="mdc-floating-label">Your Name</label>
   <div class="mdc-line-ripple"></div>
@@ -76,7 +76,7 @@ In outlined text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon">
-  <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
   <div class="mdc-notched-outline">
     <div class="mdc-notched-outline__leading"></div>
@@ -95,7 +95,7 @@ In text field:
 ```html
 <div class="mdc-text-field mdc-text-field--with-trailing-icon">
   <input type="text" id="my-input" class="mdc-text-field__input">
-  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
   <label for="my-input" class="mdc-floating-label">Your Name</label>
   <div class="mdc-line-ripple"></div>
 </div>
@@ -106,7 +106,7 @@ In outlined text field:
 ```html
 <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
   <input type="text" id="my-input" class="mdc-text-field__input">
-  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
   <div class="mdc-notched-outline">
     <div class="mdc-notched-outline__leading"></div>
     <div class="mdc-notched-outline__notch">
@@ -123,9 +123,9 @@ In text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-  <i class="material-icons mdc-text-field__leading-icon">phone</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">phone</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
-  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
   <label for="my-input" class="mdc-floating-label">Phone Number</label>
   <div class="mdc-line-ripple"></div>
 </div>
@@ -135,9 +135,9 @@ In outlined text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-  <i class="material-icons mdc-text-field__leading-icon">phone</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">phone</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
-  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">clear</i>
+  <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">clear</i>
   <div class="mdc-notched-outline">
    <div class="mdc-notched-outline__leading"></div>
     <div class="mdc-notched-outline__notch">
@@ -154,8 +154,9 @@ In outlined text field:
 
 CSS Class | Description
 --- | ---
-`mdc-text-field__leading-icon` | Mandatory for leading icons.
-`mdc-text-field__trailing-icon` | Mandatory for trailing icons.
+`mdc-text-field__icon` | Mandatory.
+`mdc-text-field__icon--leading` | Mandatory for leading icons.
+`mdc-text-field__icon--trailing` | Mandatory for trailing icons.
 
 ### Sass Mixins
 

--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -24,7 +24,7 @@ Icons describe the type of input a text field requires. They can also be interac
 ### HTML Structure
 
 ```html
-<i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+<i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
 ```
 
 #### Icon Set
@@ -55,7 +55,7 @@ const icon = new MDCTextFieldIcon(document.querySelector('.mdc-text-field-icon')
 
 ## Variants
 
-Leading and trailing icons can be applied to default or `mdc-text-field--outlined` Text Fields. To add an icon, add the relevant class (`mdc-text-field--with-leading-icon` and/or `mdc-text-field--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-text-field__icon`. If using 2 icons at the same time, the first icon inside the `mdc-text-field` element will be interpreted as the leading icon and the second icon will be interpreted as the trailing icon.
+Leading and trailing icons can be applied to default or `mdc-text-field--outlined` Text Fields. To add an icon, add the relevant class (`mdc-text-field--with-leading-icon` and/or `mdc-text-field--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-text-field__leading-icon` or `mdc-text-field__trailing-icon`.
 
 > **NOTE:** if you would like to display un-clickable icons, simply omit `tabindex="0"` and `role="button"`, and the CSS will ensure the cursor is set to default, and that interacting with an icon doesn't do anything unexpected.
 
@@ -65,7 +65,7 @@ In text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--with-leading-icon">
-  <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
   <label for="my-input" class="mdc-floating-label">Your Name</label>
   <div class="mdc-line-ripple"></div>
@@ -76,7 +76,7 @@ In outlined text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon">
-  <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
   <div class="mdc-notched-outline">
     <div class="mdc-notched-outline__leading"></div>
@@ -95,8 +95,8 @@ In text field:
 ```html
 <div class="mdc-text-field mdc-text-field--with-trailing-icon">
   <input type="text" id="my-input" class="mdc-text-field__input">
+  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
   <label for="my-input" class="mdc-floating-label">Your Name</label>
-  <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
   <div class="mdc-line-ripple"></div>
 </div>
 ```
@@ -106,7 +106,7 @@ In outlined text field:
 ```html
 <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
   <input type="text" id="my-input" class="mdc-text-field__input">
-  <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
   <div class="mdc-notched-outline">
     <div class="mdc-notched-outline__leading"></div>
     <div class="mdc-notched-outline__notch">
@@ -123,10 +123,10 @@ In text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-  <i class="material-icons mdc-text-field__icon">phone</i>
+  <i class="material-icons mdc-text-field__leading-icon">phone</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
+  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
   <label for="my-input" class="mdc-floating-label">Phone Number</label>
-  <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
   <div class="mdc-line-ripple"></div>
 </div>
 ```
@@ -135,9 +135,9 @@ In outlined text field:
 
 ```html
 <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-  <i class="material-icons mdc-text-field__icon">phone</i>
+  <i class="material-icons mdc-text-field__leading-icon">phone</i>
   <input type="text" id="my-input" class="mdc-text-field__input">
-  <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">clear</i>
+  <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">clear</i>
   <div class="mdc-notched-outline">
    <div class="mdc-notched-outline__leading"></div>
     <div class="mdc-notched-outline__notch">
@@ -154,13 +154,15 @@ In outlined text field:
 
 CSS Class | Description
 --- | ---
-`mdc-text-field-icon` | Mandatory.
+`mdc-text-field__leading-icon` | Mandatory for leading icons.
+`mdc-text-field__trailing-icon` | Mandatory for trailing icons.
 
 ### Sass Mixins
 
 Mixin | Description
 --- | ---
-`mdc-text-field-icon-color($color, $styleSecondIcon: false)` | Customizes the color for the leading/trailing icons in an enabled text-field. If the `$styleSecondIcon` is `true` it will apply the color to only the trailing icon when used with a leading icon.
+`mdc-text-field-leading-icon-color($color)` | Customizes the color for the leading icon in an enabled text-field.
+`mdc-text-field-trailing-icon-color($color)` | Customizes the color for the trailing icon in an enabled text-field.
 `mdc-text-field-disabled-icon-color($color)` | Customizes the color for the leading/trailing icons in a disabled text-field.
 
 ## `MDCTextFieldIcon` Properties and Methods

--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -55,7 +55,7 @@ const icon = new MDCTextFieldIcon(document.querySelector('.mdc-text-field-icon')
 
 ## Variants
 
-Leading and trailing icons can be applied to default or `mdc-text-field--outlined` Text Fields. To add an icon, add the relevant class (`mdc-text-field--with-leading-icon` and/or `mdc-text-field--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-text-field__icon` with the modifier`mdc-text-field__icon--leading` or `mdc-text-field__icon--trailing`.
+Leading and trailing icons can be applied to default or `mdc-text-field--outlined` Text Fields. To add an icon, add the relevant class (`mdc-text-field--with-leading-icon` and/or `mdc-text-field--with-trailing-icon`) to the root element, add an `i` element with your preferred icon, and give it a class of `mdc-text-field__icon` with the modifier `mdc-text-field__icon--leading` or `mdc-text-field__icon--trailing`.
 
 > **NOTE:** if you would like to display un-clickable icons, simply omit `tabindex="0"` and `role="button"`, and the CSS will ensure the cursor is set to default, and that interacting with an icon doesn't do anything unexpected.
 

--- a/packages/mdc-textfield/icon/_mixins.scss
+++ b/packages/mdc-textfield/icon/_mixins.scss
@@ -21,18 +21,28 @@
 //
 
 @import "@material/rtl/mixins";
+@import "@material/theme/variables";
+@import "@material/theme/mixins";
 
 // Public mixins
 
 ///
-/// Customizes the color for the leading/trailing icons in an enabled text-field.
+/// Customizes the color for the leading icon in an enabled text-field.
 /// @param {Color} $color - The desired icon color.
-/// @param {Boolean} $styleSecondIcon [false] - whether to apply the color to only
-///     the trailing icon when used with a leading icon
 ///
-@mixin mdc-text-field-icon-color($color, $styleSecondIcon: false) {
+@mixin mdc-text-field-leading-icon-color($color) {
   &:not(.mdc-text-field--disabled) {
-    @include mdc-text-field-icon-color_($color, $styleSecondIcon);
+    @include mdc-text-field-leading-icon-color_($color);
+  }
+}
+
+///
+/// Customizes the color for the trailing icon in an enabled text-field.
+/// @param {Color} $color - The desired icon color.
+///
+@mixin mdc-text-field-trailing-icon-color($color) {
+  &:not(.mdc-text-field--disabled) {
+    @include mdc-text-field-trailing-icon-color_($color);
   }
 }
 
@@ -42,14 +52,21 @@
 ///
 @mixin mdc-text-field-disabled-icon-color($color) {
   &.mdc-text-field--disabled {
-    @include mdc-text-field-icon-color_($color);
+    @include mdc-text-field-leading-icon-color_($color);
+    @include mdc-text-field-trailing-icon-color_($color);
   }
 }
 
 // Private mixins
 
-@mixin mdc-text-field-icon-horizontal-position_($position-property, $position, $padding, $input-padding) {
-  .mdc-text-field__icon {
+@mixin mdc-text-field-icon-horizontal-position_(
+  $icon-position,
+  $position-property,
+  $position,
+  $padding,
+  $input-padding
+) {
+  .mdc-text-field__#{$icon-position}-icon {
     @include mdc-rtl-reflexive-position($position-property, $position);
   }
 
@@ -71,12 +88,12 @@
   $position-right,
   $padding-right
 ) {
-  .mdc-text-field__icon {
+  .mdc-text-field__leading-icon {
     @include mdc-rtl-reflexive(left, $position-left, right, auto);
+  }
 
-    ~ .mdc-text-field__icon {
-      @include mdc-rtl-reflexive(right, $position-right, left, auto);
-    }
+  .mdc-text-field__trailing-icon {
+    @include mdc-rtl-reflexive(right, $position-right, left, auto);
   }
 
   // Move the input's position, to allow room for the icons.
@@ -85,15 +102,35 @@
   }
 }
 
-@mixin mdc-text-field-icon-color_($color, $styleSecondIcon: false) {
-  .mdc-text-field__icon {
-    @if ($styleSecondIcon) {
-      // Select the second instance of this class regardless of element type.
-      ~ .mdc-text-field__icon {
-        @include mdc-theme-prop(color, $color);
-      }
-    } @else {
-      @include mdc-theme-prop(color, $color);
-    }
+@mixin mdc-text-field-leading-icon_ {
+  @include mdc-text-field-icon_;
+}
+
+@mixin mdc-text-field-trailing-icon_ {
+  @include mdc-text-field-icon_;
+}
+
+@mixin mdc-text-field-icon_ {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+
+  &:not([tabindex]),
+  &[tabindex="-1"] {
+    cursor: default;
+    pointer-events: none;
+  }
+}
+
+@mixin mdc-text-field-leading-icon-color_($color) {
+  .mdc-text-field__leading-icon {
+    @include mdc-theme-prop(color, $color);
+  }
+}
+
+@mixin mdc-text-field-trailing-icon-color_($color) {
+  .mdc-text-field__trailing-icon {
+    @include mdc-theme-prop(color, $color);
   }
 }

--- a/packages/mdc-textfield/icon/_mixins.scss
+++ b/packages/mdc-textfield/icon/_mixins.scss
@@ -59,55 +59,26 @@
 
 // Private mixins
 
-@mixin mdc-text-field-icon-horizontal-position_(
-  $icon-position,
-  $position-property,
-  $position,
-  $padding,
-  $input-padding
-) {
-  .mdc-text-field__#{$icon-position}-icon {
-    @include mdc-rtl-reflexive-position($position-property, $position);
-  }
-
-  // Move the input's position, to allow room for the icon
+@mixin mdc-text-field-icon-horizontal-position_($position-property, $position) {
   @if ($position-property == left) {
-    .mdc-text-field__input {
-      @include mdc-rtl-reflexive-property(padding, $padding, $input-padding);
+    .mdc-text-field__icon--leading {
+      @include mdc-rtl-reflexive-position($position-property, $position);
     }
   } @else {
-    .mdc-text-field__input {
-      @include mdc-rtl-reflexive-property(padding, $input-padding, $padding);
+    .mdc-text-field__icon--trailing {
+      @include mdc-rtl-reflexive-position($position-property, $position);
     }
   }
 }
 
-@mixin mdc-text-field-icon-horizontal-position-two-icons_(
-  $position-left,
-  $padding-left,
-  $position-right,
-  $padding-right
-) {
-  .mdc-text-field__leading-icon {
+@mixin mdc-text-field-icon-horizontal-position-two-icons_($position-left, $position-right) {
+  .mdc-text-field__icon--leading {
     @include mdc-rtl-reflexive(left, $position-left, right, auto);
   }
 
-  .mdc-text-field__trailing-icon {
+  .mdc-text-field__icon--trailing {
     @include mdc-rtl-reflexive(right, $position-right, left, auto);
   }
-
-  // Move the input's position, to allow room for the icons.
-  .mdc-text-field__input {
-    @include mdc-rtl-reflexive-property(padding, $padding-left, $padding-right);
-  }
-}
-
-@mixin mdc-text-field-leading-icon_ {
-  @include mdc-text-field-icon_;
-}
-
-@mixin mdc-text-field-trailing-icon_ {
-  @include mdc-text-field-icon_;
 }
 
 @mixin mdc-text-field-icon_ {
@@ -124,13 +95,13 @@
 }
 
 @mixin mdc-text-field-leading-icon-color_($color) {
-  .mdc-text-field__leading-icon {
+  .mdc-text-field__icon--leading {
     @include mdc-theme-prop(color, $color);
   }
 }
 
 @mixin mdc-text-field-trailing-icon-color_($color) {
-  .mdc-text-field__trailing-icon {
+  .mdc-text-field__icon--trailing {
     @include mdc-theme-prop(color, $color);
   }
 }

--- a/packages/mdc-textfield/icon/_mixins.scss
+++ b/packages/mdc-textfield/icon/_mixins.scss
@@ -59,25 +59,15 @@
 
 // Private mixins
 
-@mixin mdc-text-field-icon-horizontal-position_($position-property, $position) {
-  @if ($position-property == left) {
-    .mdc-text-field__icon--leading {
-      @include mdc-rtl-reflexive-position($position-property, $position);
-    }
-  } @else {
-    .mdc-text-field__icon--trailing {
-      @include mdc-rtl-reflexive-position($position-property, $position);
-    }
+@mixin mdc-text-field-leading-icon-horizontal-position_($position) {
+  .mdc-text-field__icon--leading {
+    @include mdc-rtl-reflexive-position(left, $position);
   }
 }
 
-@mixin mdc-text-field-icon-horizontal-position-two-icons_($position-left, $position-right) {
-  .mdc-text-field__icon--leading {
-    @include mdc-rtl-reflexive(left, $position-left, right, auto);
-  }
-
+@mixin mdc-text-field-trailing-icon-horizontal-position_($position) {
   .mdc-text-field__icon--trailing {
-    @include mdc-rtl-reflexive(right, $position-right, left, auto);
+    @include mdc-rtl-reflexive-position(right, $position);
   }
 }
 

--- a/packages/mdc-textfield/icon/_mixins.scss
+++ b/packages/mdc-textfield/icon/_mixins.scss
@@ -71,6 +71,11 @@
   }
 }
 
+@mixin mdc-text-field-icon-horizontal-position-two-icons_($position-left, $position-right) {
+  @include mdc-text-field-leading-icon-horizontal-position_($position-left);
+  @include mdc-text-field-trailing-icon-horizontal-position_($position-right);
+}
+
 @mixin mdc-text-field-icon_ {
   position: absolute;
   top: 50%;

--- a/packages/mdc-textfield/icon/constants.ts
+++ b/packages/mdc-textfield/icon/constants.ts
@@ -27,8 +27,7 @@ const strings = {
 };
 
 const cssClasses = {
-  LEADING: 'mdc-text-field__leading-icon',
-  TRAILING: 'mdc-text-field__trailing-icon',
+  ROOT: 'mdc-text-field__icon',
 };
 
 export {strings, cssClasses};

--- a/packages/mdc-textfield/icon/constants.ts
+++ b/packages/mdc-textfield/icon/constants.ts
@@ -27,7 +27,8 @@ const strings = {
 };
 
 const cssClasses = {
-  ROOT: 'mdc-text-field__icon',
+  LEADING: 'mdc-text-field__leading-icon',
+  TRAILING: 'mdc-text-field__trailing-icon',
 };
 
 export {strings, cssClasses};

--- a/packages/mdc-textfield/icon/mdc-text-field-icon.scss
+++ b/packages/mdc-textfield/icon/mdc-text-field-icon.scss
@@ -22,10 +22,6 @@
 
 @import "./mixins";
 
-.mdc-text-field__leading-icon {
-  @include mdc-text-field-leading-icon_;
-}
-
-.mdc-text-field__trailing-icon {
-  @include mdc-text-field-trailing-icon_;
+.mdc-text-field__icon {
+  @include mdc-text-field-icon_;
 }

--- a/packages/mdc-textfield/icon/mdc-text-field-icon.scss
+++ b/packages/mdc-textfield/icon/mdc-text-field-icon.scss
@@ -20,19 +20,12 @@
 // THE SOFTWARE.
 //
 
-@import "@material/theme/variables";
-@import "@material/theme/mixins";
+@import "./mixins";
 
-.mdc-text-field--with-leading-icon .mdc-text-field__icon,
-.mdc-text-field--with-trailing-icon .mdc-text-field__icon {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  cursor: pointer;
+.mdc-text-field__leading-icon {
+  @include mdc-text-field-leading-icon_;
 }
 
-.mdc-text-field__icon:not([tabindex]),
-.mdc-text-field__icon[tabindex="-1"] {
-  cursor: default;
-  pointer-events: none;
+.mdc-text-field__trailing-icon {
+  @include mdc-text-field-trailing-icon_;
 }

--- a/packages/mdc-textfield/icon/test/foundation.test.ts
+++ b/packages/mdc-textfield/icon/test/foundation.test.ts
@@ -148,6 +148,7 @@ describe('MDCTextFieldIconFoundation', () => {
     const evt = {
       target: {},
       type: 'click',
+      preventDefault: () => {}
     };
     let click: Function|undefined;
 

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -175,8 +175,7 @@
 }
 
 // stylelint-disable plugin/selector-bem-pattern
-.mdc-text-field--dense .mdc-text-field__leading-icon,
-.mdc-text-field--dense .mdc-text-field__trailing-icon {
+.mdc-text-field--dense .mdc-text-field__icon {
   bottom: 16px;
   transform: scale(.8);
 }

--- a/packages/mdc-textfield/mdc-text-field.scss
+++ b/packages/mdc-textfield/mdc-text-field.scss
@@ -63,7 +63,8 @@
   @include mdc-text-field-line-ripple-color_(primary);
   @include mdc-text-field-helper-text-color($mdc-text-field-helper-text-color);
   @include mdc-text-field-character-counter-color($mdc-text-field-helper-text-color);
-  @include mdc-text-field-icon-color($mdc-text-field-icon-color);
+  @include mdc-text-field-leading-icon-color($mdc-text-field-icon-color);
+  @include mdc-text-field-trailing-icon-color($mdc-text-field-icon-color);
   @include mdc-text-field-fill-color($mdc-text-field-background);
 
   // Floating Label
@@ -174,8 +175,8 @@
 }
 
 // stylelint-disable plugin/selector-bem-pattern
-.mdc-text-field--with-leading-icon.mdc-text-field--dense .mdc-text-field__icon,
-.mdc-text-field--with-trailing-icon.mdc-text-field--dense .mdc-text-field__icon {
+.mdc-text-field--dense .mdc-text-field__leading-icon,
+.mdc-text-field--dense .mdc-text-field__trailing-icon {
   bottom: 16px;
   transform: scale(.8);
 }

--- a/packages/mdc-textfield/test/component.test.ts
+++ b/packages/mdc-textfield/test/component.test.ts
@@ -37,7 +37,7 @@ const getFixture = () => {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = `
     <div class="mdc-text-field mdc-text-field--with-leading-icon">
-      <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+      <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
       <input type="text" class="mdc-text-field__input" id="my-text-field">
       <label class="mdc-floating-label" for="my-text-field">My Label</label>
       <div class="mdc-line-ripple"></div>
@@ -220,7 +220,7 @@ describe('MDCTextField', () => {
 
        const wrapper = document.createElement('div');
        wrapper.innerHTML =
-           `<i class="mdc-text-field__icon material-icons">3d_rotations</i>`;
+           `<i class="mdc-text-field__icon mdc-text-field__icon--trailing material-icons">3d_rotations</i>`;
        const el = wrapper.firstElementChild as HTMLElement;
        wrapper.removeChild(el);
        root.appendChild(el);
@@ -232,9 +232,13 @@ describe('MDCTextField', () => {
 
   it('#constructor instantiates a trailing icon if the icon is present', () => {
     const root = getFixture();
-    const icon = root.querySelector('.mdc-text-field__icon');
-    root.removeChild(icon as HTMLElement);
-    root.appendChild(icon as HTMLElement);
+    const leadingIcon = root.querySelector('.mdc-text-field__icon');
+    root.removeChild(leadingIcon as HTMLElement);
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML =
+        `<i class="mdc-text-field__icon mdc-text-field__icon--trailing material-icons">3d_rotations</i>`;
+    const trailingIcon = wrapper.firstElementChild as HTMLElement;
+    root.appendChild(trailingIcon);
     root.classList.add('mdc-text-field--with-trailing-icon');
     root.classList.remove('mdc-text-field--with-leading-icon');
     const component = new MDCTextField(root);
@@ -444,7 +448,7 @@ describe('MDCTextField', () => {
 
     const wrapper = document.createElement('div');
     wrapper.innerHTML =
-        `<i class="mdc-text-field__icon material-icons">3d_rotations</i>`;
+        `<i class="mdc-text-field__icon mdc-text-field__icon--trailing material-icons">3d_rotations</i>`;
     const child = wrapper.firstElementChild as HTMLElement;
     wrapper.removeChild(child);
     root.appendChild(child);

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-leading-icon.html
@@ -37,7 +37,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
           <label class="mdc-floating-label" for="filled-text-field">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -46,7 +46,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
           <div class="mdc-notched-outline">
             <div class="mdc-notched-outline__leading"></div>
@@ -60,7 +60,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -69,7 +69,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <div class="mdc-notched-outline mdc-notched-outline--notched">
             <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-leading-icon.html
@@ -37,7 +37,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
           <label class="mdc-floating-label" for="filled-text-field">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -46,7 +46,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
           <div class="mdc-notched-outline">
             <div class="mdc-notched-outline__leading"></div>
@@ -60,7 +60,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -69,7 +69,7 @@
 
       <div class="test-cell test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <div class="mdc-notched-outline mdc-notched-outline--notched">
             <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html
@@ -46,9 +46,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -56,9 +56,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -71,9 +71,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -81,9 +81,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-leading-trailing-icons.html
@@ -46,19 +46,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -71,19 +71,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-trailing-icon.html
@@ -38,8 +38,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
@@ -47,7 +47,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -61,8 +61,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
@@ -70,7 +70,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-trailing-icon.html
@@ -38,7 +38,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -47,7 +47,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -61,7 +61,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -70,7 +70,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-without-label-with-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-without-label-with-icon.html
@@ -46,7 +46,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--no-label mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->
@@ -56,7 +56,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--no-label mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->
@@ -69,7 +69,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--no-label mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" value="Filled value" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->
@@ -79,7 +79,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--no-label mdc-text-field--outlined mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" value="Filled value" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->

--- a/test/screenshot/spec/mdc-textfield/classes/baseline-without-label-with-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/baseline-without-label-with-icon.html
@@ -46,7 +46,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--no-label mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->
@@ -56,7 +56,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--no-label mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->
@@ -69,7 +69,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--no-label mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" value="Filled value" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->
@@ -79,7 +79,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--no-label mdc-text-field--outlined mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <!-- htmllint-disable -->
             <input type="text" class="mdc-text-field__input test-text-field__input" value="Filled value" placeholder="Placeholder" aria-label="Label">
             <!-- htmllint-enable -->

--- a/test/screenshot/spec/mdc-textfield/classes/disabled-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/disabled-leading-icon.html
@@ -37,7 +37,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" disabled>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -46,7 +46,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" disabled>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
@@ -60,7 +60,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -69,7 +69,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/disabled-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/disabled-leading-icon.html
@@ -37,7 +37,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" disabled>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -46,7 +46,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" disabled>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
@@ -60,7 +60,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -69,7 +69,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html
@@ -46,19 +46,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" disabled>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" disabled>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -71,19 +71,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/disabled-leading-trailing-icons.html
@@ -46,9 +46,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -56,9 +56,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -71,9 +71,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -81,9 +81,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--with-trailing-icon mdc-text-field--disabled">
-            <i class="material-icons mdc-text-field__leading-icon">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/disabled-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/disabled-trailing-icon.html
@@ -38,7 +38,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -47,7 +47,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -61,7 +61,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -70,7 +70,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/disabled-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/disabled-trailing-icon.html
@@ -38,8 +38,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" disabled>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
@@ -47,7 +47,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" disabled>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -61,8 +61,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
@@ -70,7 +70,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-trailing-icon mdc-text-field--disabled">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/focused-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/focused-leading-icon.html
@@ -38,7 +38,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -47,7 +47,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" ">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
@@ -62,7 +62,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -71,7 +71,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/focused-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/focused-leading-icon.html
@@ -38,7 +38,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -47,7 +47,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" ">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
@@ -62,7 +62,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -71,7 +71,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/focused-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/focused-leading-trailing-icons.html
@@ -47,9 +47,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -58,9 +58,9 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" ">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -73,9 +73,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -83,9 +83,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/focused-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/focused-leading-trailing-icons.html
@@ -47,10 +47,10 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
@@ -58,9 +58,9 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" ">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -73,19 +73,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/focused-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/focused-trailing-icon.html
@@ -39,7 +39,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -49,7 +49,7 @@
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" ">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -63,7 +63,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -72,7 +72,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/focused-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/focused-trailing-icon.html
@@ -39,8 +39,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
@@ -49,7 +49,7 @@
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" ">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -63,8 +63,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
@@ -72,7 +72,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-icon.html
@@ -38,7 +38,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
             <label class="mdc-floating-label mdc-floating-label--float-above" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -47,7 +47,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
@@ -62,7 +62,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -71,7 +71,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-icon.html
@@ -38,7 +38,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
             <label class="mdc-floating-label mdc-floating-label--float-above" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -47,7 +47,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
@@ -62,7 +62,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
@@ -71,7 +71,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html
@@ -47,10 +47,10 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label mdc-floating-label--float-above" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
@@ -58,9 +58,9 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -73,19 +73,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-focused-leading-trailing-icons.html
@@ -47,9 +47,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label mdc-floating-label--float-above" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -58,9 +58,9 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -73,9 +73,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -83,9 +83,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html
@@ -39,8 +39,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label mdc-floating-label--float-above" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
@@ -49,7 +49,7 @@
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -63,8 +63,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
         </div>
@@ -72,7 +72,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-focused-trailing-icon.html
@@ -39,7 +39,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label mdc-floating-label--float-above" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -49,7 +49,7 @@
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <!-- The single space value is to overcome an issue where the component does not draw the SVG path when created unless there is a value. -->
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" value=" " required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -63,7 +63,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple mdc-line-ripple--active"></div>
           </div>
@@ -72,7 +72,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--focused mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-leading-icon.html
@@ -38,7 +38,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -47,7 +47,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
@@ -61,7 +61,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -70,7 +70,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-leading-icon.html
@@ -38,7 +38,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -47,7 +47,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
@@ -61,7 +61,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -70,7 +70,7 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html
@@ -47,19 +47,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -72,19 +72,19 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-leading-trailing-icons.html
@@ -47,9 +47,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -57,9 +57,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -72,9 +72,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -82,9 +82,9 @@
 
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon mdc-text-field--with-leading-icon">
-            <i class="material-icons mdc-text-field__leading-icon" role="button">3d_rotation</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" role="button">3d_rotation</i>
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-trailing-icon.html
@@ -39,8 +39,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
@@ -48,7 +48,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -62,8 +62,8 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
             <div class="mdc-line-ripple"></div>
           </div>
         </div>
@@ -71,7 +71,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/classes/invalid-trailing-icon.html
+++ b/test/screenshot/spec/mdc-textfield/classes/invalid-trailing-icon.html
@@ -39,7 +39,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label class="mdc-floating-label" for="filled-text-field">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -48,7 +48,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">
@@ -62,7 +62,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
           </div>
@@ -71,7 +71,7 @@
         <div class="test-cell test-cell--textfield">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--invalid mdc-text-field--with-trailing-icon">
             <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value" required pattern=".{4,8}">
-            <i class="material-icons mdc-text-field__trailing-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" tabindex="0" role="button">event</i>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>
               <div class="mdc-notched-outline__notch">

--- a/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon-invalid.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon-invalid.html
@@ -37,7 +37,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--default" data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
           <label class="mdc-floating-label" for="filled-text-field">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -47,7 +47,7 @@
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--outlined"
             data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
           <div class="mdc-notched-outline">
             <div class="mdc-notched-outline__leading"></div>
@@ -61,7 +61,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--default" data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -71,7 +71,7 @@
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--outlined"
             data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <div class="mdc-notched-outline mdc-notched-outline--notched">
             <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon-invalid.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon-invalid.html
@@ -37,7 +37,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--default" data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
           <label class="mdc-floating-label" for="filled-text-field">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -47,7 +47,7 @@
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--outlined"
             data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
           <div class="mdc-notched-outline">
             <div class="mdc-notched-outline__leading"></div>
@@ -61,7 +61,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--default" data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -71,7 +71,7 @@
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--invalid custom-density-text-field-leading-icon--outlined"
             data-native-input-validation="false">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <div class="mdc-notched-outline mdc-notched-outline--notched">
             <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon.html
@@ -37,7 +37,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--default">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
           <label class="mdc-floating-label" for="filled-text-field">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -46,7 +46,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--outlined">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
           <div class="mdc-notched-outline">
             <div class="mdc-notched-outline__leading"></div>
@@ -60,7 +60,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--default">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -69,7 +69,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--outlined">
-          <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <div class="mdc-notched-outline mdc-notched-outline--notched">
             <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/density-leading-icon.html
@@ -37,7 +37,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--default">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field" class="mdc-text-field__input test-text-field__input">
           <label class="mdc-floating-label" for="filled-text-field">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -46,7 +46,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--outlined">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field" class="mdc-text-field__input test-text-field__input">
           <div class="mdc-notched-outline">
             <div class="mdc-notched-outline__leading"></div>
@@ -60,7 +60,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--default">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="filled-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <label for="filled-text-field-with-value" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
           <div class="mdc-line-ripple"></div>
@@ -69,7 +69,7 @@
 
       <div class="test-cell test-cell--light test-cell--textfield">
         <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon custom-density-text-field-leading-icon--outlined">
-          <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+          <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
           <input type="text" id="outlined-text-field-with-value" class="mdc-text-field__input test-text-field__input" value="Filled value">
           <div class="mdc-notched-outline mdc-notched-outline--notched">
             <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/mixins/disabled-1.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/disabled-1.html
@@ -270,7 +270,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field--icon-color" class="mdc-text-field__input test-text-field__input" disabled>
             <label class="mdc-floating-label" for="filled-text-field--icon-color">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -279,7 +279,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field--icon-color" class="mdc-text-field__input test-text-field__input" disabled>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
@@ -293,7 +293,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value--icon-color" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <label for="filled-text-field-with-value--icon-color" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -302,7 +302,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value--icon-color" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/screenshot/spec/mdc-textfield/mixins/disabled-1.html
+++ b/test/screenshot/spec/mdc-textfield/mixins/disabled-1.html
@@ -270,7 +270,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field--icon-color" class="mdc-text-field__input test-text-field__input" disabled>
             <label class="mdc-floating-label" for="filled-text-field--icon-color">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -279,7 +279,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field--icon-color" class="mdc-text-field__input test-text-field__input" disabled>
             <div class="mdc-notched-outline">
               <div class="mdc-notched-outline__leading"></div>
@@ -293,7 +293,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="filled-text-field-with-value--icon-color" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <label for="filled-text-field-with-value--icon-color" class="mdc-floating-label mdc-floating-label--float-above">Label</label>
             <div class="mdc-line-ripple"></div>
@@ -302,7 +302,7 @@
 
         <div class="test-cell test-cell--light test-cell--textfield-small">
           <div class="mdc-text-field mdc-text-field--outlined mdc-text-field--with-leading-icon mdc-text-field--disabled custom-disabled-colors-text-field--icon-color">
-            <i class="material-icons mdc-text-field__leading-icon" tabindex="0" role="button">event</i>
+            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--leading" tabindex="0" role="button">event</i>
             <input type="text" id="outlined-text-field-with-value--icon-color" class="mdc-text-field__input test-text-field__input" value="Filled value" disabled>
             <div class="mdc-notched-outline mdc-notched-outline--notched">
               <div class="mdc-notched-outline__leading"></div>

--- a/test/unit/mdc-textfield/mdc-text-field-icon.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-icon.test.js
@@ -29,7 +29,7 @@ import domEvents from 'dom-events';
 import {MDCTextFieldIcon, MDCTextFieldIconFoundation} from '../../../packages/mdc-textfield/icon/index';
 
 const getFixture = () => bel`
-  <div class="mdc-text-field__icon"></div>
+  <div class="mdc-text-field__leading-icon"></div>
 `;
 
 suite('MDCTextFieldIcon');

--- a/test/unit/mdc-textfield/mdc-text-field-icon.test.js
+++ b/test/unit/mdc-textfield/mdc-text-field-icon.test.js
@@ -29,7 +29,7 @@ import domEvents from 'dom-events';
 import {MDCTextFieldIcon, MDCTextFieldIconFoundation} from '../../../packages/mdc-textfield/icon/index';
 
 const getFixture = () => bel`
-  <div class="mdc-text-field__leading-icon"></div>
+  <div class="mdc-text-field__icon mdc-text-field__icon--leading"></div>
 `;
 
 suite('MDCTextFieldIcon');


### PR DESCRIPTION
BREAKING_CHANGE: icons must use `.mdc-text-field__leading-icon` or `.mdc-text-field__trailing-icon` classes. `mdc-text-field-icon-color()` mixin has been split into `mdc-text-field-leading-icon-color()` and `mdc-text-field-trailing-icon-color()`.