### PR TITLE
feat: Enable custom property styling for base typography

### DIFF
--- a/packages/mdc-typography/_variables.scss
+++ b/packages/mdc-typography/_variables.scss
@@ -22,7 +22,11 @@
 
 @import "./functions";
 
-$mdc-typography-font-family: unquote("Roboto, sans-serif") !default;
+:root {
+  --mdc-typography-font-family: 'Roboto', sans-serif;
+}
+
+$mdc-typography-font-family: var(--mdc-typography-font-family), unquote("Roboto, sans-serif") !default;
 
 $mdc-typography-base: (
   font-family: $mdc-typography-font-family,

--- a/packages/mdc-typography/_variables.scss
+++ b/packages/mdc-typography/_variables.scss
@@ -23,7 +23,7 @@
 @import "./functions";
 
 :root {
-  --mdc-typography-font-family: 'Roboto', sans-serif;
+  --mdc-typography-font-family: "Roboto", sans-serif;
 }
 
 $mdc-typography-font-family: var(--mdc-typography-font-family), unquote("Roboto, sans-serif") !default;


### PR DESCRIPTION
See #5349

This would result in an output of: 

`font-family: var(--mdc-typography-font-family), Roboto, sans-serif;` instead of `font-family: Roboto, sans-serif;` for each base instance, enabling overrides with custom properties. Unsupported browsers will ignore the first font declaration for the second.

This would enable base styling overrides with custom properties:

```
root: {
  --mdc-typography-font-family: "fontName", serif;
}
```

And per-class overrides with custom properties:

```
.mdc-typography--headline2 {
  --mdc-typography-font-family: "myOtherFont", serif;
}
```