### PR TITLE
refactor: avoid BEM naming for mixins

### DIFF
--- a/packages/mdc-button/_mixins.scss
+++ b/packages/mdc-button/_mixins.scss
@@ -68,7 +68,7 @@ $mdc-button-ripple-target: ".mdc-button__ripple";
     // overrides apply.
     .mdc-button__icon {
       @include mdc-feature-targets($feat-structure) {
-        @include mdc-button__icon_;
+        @include mdc-button-icon_;
       }
     }
 
@@ -82,14 +82,14 @@ $mdc-button-ripple-target: ".mdc-button__ripple";
 
   .mdc-button__label + .mdc-button__icon {
     @include mdc-feature-targets($feat-structure) {
-      @include mdc-button__icon-trailing_;
+      @include mdc-button-icon-trailing_;
     }
   }
 
   // stylelint-disable-next-line selector-no-qualifying-type
   svg.mdc-button__icon {
     @include mdc-feature-targets($feat-structure) {
-      @include mdc-button__icon-svg_;
+      @include mdc-button-icon-svg_;
     }
   }
 
@@ -99,28 +99,28 @@ $mdc-button-ripple-target: ".mdc-button__ripple";
     .mdc-button__icon {
       @include mdc-feature-targets($feat-structure) {
         // Icons inside contained buttons have different styles due to increased button padding
-        @include mdc-button__icon-contained_;
+        @include mdc-button-icon-contained_;
       }
     }
 
     .mdc-button__label + .mdc-button__icon {
       @include mdc-feature-targets($feat-structure) {
-        @include mdc-button__icon-contained-trailing_;
+        @include mdc-button-icon-contained-trailing_;
       }
     }
   }
 
   .mdc-button--raised,
   .mdc-button--unelevated {
-    @include mdc-button--filled_($query);
+    @include mdc-button-filled_($query);
   }
 
   .mdc-button--raised {
-    @include mdc-button--raised_($query);
+    @include mdc-button-raised_($query);
   }
 
   .mdc-button--outlined {
-    @include mdc-button--outlined_($query);
+    @include mdc-button-outlined_($query);
   }
 
   .mdc-button--touch {
@@ -446,7 +446,7 @@ $query: mdc-feature-all()) {
   }
 }
 
-@mixin mdc-button__icon_ {
+@mixin mdc-button-icon_ {
   @include mdc-rtl-reflexive-box(margin, right, 8px);
 
   display: inline-block;
@@ -456,23 +456,23 @@ $query: mdc-feature-all()) {
   vertical-align: top;
 }
 
-@mixin mdc-button__icon-trailing_ {
+@mixin mdc-button-icon-trailing_ {
   @include mdc-rtl-reflexive-box(margin, left, 8px);
 }
 
-@mixin mdc-button__icon-svg_ {
+@mixin mdc-button-icon-svg_ {
   fill: currentColor;
 }
 
-@mixin mdc-button__icon-contained_ {
+@mixin mdc-button-icon-contained_ {
   @include mdc-rtl-reflexive-property(margin, -4px, 8px);
 }
 
-@mixin mdc-button__icon-contained-trailing_ {
+@mixin mdc-button-icon-contained-trailing_ {
   @include mdc-rtl-reflexive-property(margin, 8px, -4px);
 }
 
-@mixin mdc-button--outlined_($query) {
+@mixin mdc-button-outlined_($query) {
   $feat-structure: mdc-feature-create-target($query, structure);
 
   @include mdc-button-outline-width($mdc-button-outlined-border-width, $query: $query);
@@ -484,7 +484,7 @@ $query: mdc-feature-all()) {
   }
 }
 
-@mixin mdc-button--filled_($query) {
+@mixin mdc-button-filled_($query) {
   @include mdc-button-horizontal-padding($mdc-button-contained-horizontal-padding, $query);
   @include mdc-button-container-fill-color(primary, $query);
   @include mdc-button-ink-color(on-primary, $query);
@@ -492,7 +492,7 @@ $query: mdc-feature-all()) {
   @include mdc-button-disabled-ink-color($mdc-button-disabled-ink-color, $query);
 }
 
-@mixin mdc-button--raised_($query) {
+@mixin mdc-button-raised_($query) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-color: mdc-feature-create-target($query, color);
 

--- a/packages/mdc-checkbox/_mixins.scss
+++ b/packages/mdc-checkbox/_mixins.scss
@@ -91,24 +91,24 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   // Needed to disable hover effects on CSS-only (non-JS) checkboxes
   .mdc-checkbox--disabled {
     @include mdc-feature-targets($feat-structure) {
-      @include mdc-checkbox--disabled_;
+      @include mdc-checkbox-disabled_;
     }
   }
 
   .mdc-checkbox__background {
-    @include mdc-checkbox__background_($query);
+    @include mdc-checkbox-background_($query);
   }
 
   .mdc-checkbox__checkmark {
-    @include mdc-checkbox__checkmark_($query);
+    @include mdc-checkbox-checkmark_($query);
   }
 
   .mdc-checkbox__checkmark-path {
-    @include mdc-checkbox__checkmark-path_($query);
+    @include mdc-checkbox-checkmark-path_($query);
   }
 
   .mdc-checkbox__mixedmark {
-    @include mdc-checkbox__mixedmark_($query);
+    @include mdc-checkbox-mixedmark_($query);
   }
 
   // JS checkbox
@@ -118,47 +118,47 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
     .mdc-checkbox__checkmark-path,
     .mdc-checkbox__mixedmark {
       @include mdc-feature-targets($feat-animation) {
-        @include mdc-checkbox__child--upgraded_;
+        @include mdc-checkbox-child--upgraded_;
       }
     }
   }
 
   .mdc-checkbox--anim {
     @include mdc-feature-targets($feat-animation) {
-      @include mdc-checkbox--anim_;
+      @include mdc-checkbox-anim_;
     }
   }
 
   .mdc-checkbox__native-control:checked ~ .mdc-checkbox__background,
   .mdc-checkbox__native-control:indeterminate ~ .mdc-checkbox__background {
     @include mdc-feature-targets($feat-animation) {
-      @include mdc-checkbox__background--marked_;
+      @include mdc-checkbox-background--marked_;
     }
 
     .mdc-checkbox__checkmark-path {
       @include mdc-feature-targets($feat-structure) {
-        @include mdc-checkbox__checkmark-path--marked_;
+        @include mdc-checkbox-checkmark-path--marked_;
       }
     }
   }
 
   // The frame's ::before element is used as a focus indicator for the checkbox
   .mdc-checkbox__background::before {
-    @include mdc-checkbox__focus-indicator_($query);
+    @include mdc-checkbox-focus-indicator_($query);
   }
 
   .mdc-checkbox__native-control:focus ~ .mdc-checkbox__background::before {
-    @include mdc-checkbox__focus-indicator--focused_($query);
+    @include mdc-checkbox-focus-indicator--focused_($query);
   }
 
   .mdc-checkbox__native-control {
     @include mdc-feature-targets($feat-structure) {
-      @include mdc-checkbox__native-control_;
+      @include mdc-checkbox-native-control_;
     }
 
     &:disabled {
       @include mdc-feature-targets($feat-structure) {
-        @include mdc-checkbox--disabled_;
+        @include mdc-checkbox-disabled_;
       }
     }
   }
@@ -173,24 +173,24 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
   .mdc-checkbox__native-control:checked ~ .mdc-checkbox__background {
     .mdc-checkbox__checkmark {
-      @include mdc-checkbox__checkmark--checked_($query);
+      @include mdc-checkbox-checkmark--checked_($query);
     }
 
     .mdc-checkbox__mixedmark {
       @include mdc-feature-targets($feat-structure) {
-        @include mdc-checkbox__mixedmark--checked_;
+        @include mdc-checkbox-mixedmark--checked_;
       }
     }
   }
 
   .mdc-checkbox__native-control:indeterminate ~ .mdc-checkbox__background {
     .mdc-checkbox__checkmark {
-      @include mdc-checkbox__checkmark--indeterminate_($query);
+      @include mdc-checkbox-checkmark--indeterminate_($query);
     }
 
     .mdc-checkbox__mixedmark {
       @include mdc-feature-targets($feat-structure) {
-        @include mdc-checkbox__mixedmark--indeterminate_;
+        @include mdc-checkbox-mixedmark--indeterminate_;
       }
     }
   }
@@ -447,12 +447,12 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   vertical-align: bottom;
 }
 
-@mixin mdc-checkbox--disabled_ {
+@mixin mdc-checkbox-disabled_ {
   cursor: default;
   pointer-events: none;
 }
 
-@mixin mdc-checkbox__child--upgraded_ {
+@mixin mdc-checkbox-child--upgraded_ {
   // Due to the myriad of selector combos used to properly style a CSS-only checkbox, all of
   // which have varying selector precedence and make use of transitions, it is cleaner and more
   // efficient here to simply use !important, since the mdc-checkbox--anim-* classes will take
@@ -462,7 +462,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
 // Animation
 
-@mixin mdc-checkbox--anim_ {
+@mixin mdc-checkbox-anim_ {
   $mdc-checkbox-indeterminate-change-duration_: 500ms;
 
   // stylelint-disable selector-max-type
@@ -617,7 +617,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox__background_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-background_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
   $feat-color: mdc-feature-create-target($query, color);
@@ -651,7 +651,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox__background--marked_ {
+@mixin mdc-checkbox-background--marked_ {
   transition:
     mdc-checkbox-transition-enter(border-color),
     mdc-checkbox-transition-enter(background-color);
@@ -676,7 +676,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
 // Focus indicator
 
-@mixin mdc-checkbox__focus-indicator_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-focus-indicator_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -697,7 +697,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox__focus-indicator--focused_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-focus-indicator--focused_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -715,7 +715,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
 // Native input
 
-@mixin mdc-checkbox__native-control_ {
+@mixin mdc-checkbox-native-control_ {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -725,7 +725,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
 // Check mark
 
-@mixin mdc-checkbox__checkmark_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-checkmark_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -750,7 +750,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox__checkmark--checked_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-checkmark--checked_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -765,7 +765,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox__checkmark--indeterminate_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-checkmark--indeterminate_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -807,7 +807,7 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
 
 // Check mark path
 
-@mixin mdc-checkbox__checkmark-path_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-checkmark-path_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -823,13 +823,13 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox__checkmark-path--marked_ {
+@mixin mdc-checkbox-checkmark-path--marked_ {
   stroke-dashoffset: 0;
 }
 
 // Mixed mark
 
-@mixin mdc-checkbox__mixedmark_($query: mdc-feature-all()) {
+@mixin mdc-checkbox-mixedmark_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -849,11 +849,11 @@ $mdc-checkbox-ripple-target: ".mdc-checkbox__ripple";
   }
 }
 
-@mixin mdc-checkbox__mixedmark--checked_ {
+@mixin mdc-checkbox-mixedmark--checked_ {
   transform: scaleX(1) rotate(-45deg);
 }
 
-@mixin mdc-checkbox__mixedmark--indeterminate_ {
+@mixin mdc-checkbox-mixedmark--indeterminate_ {
   transform: scaleX(1) rotate(0deg);
   opacity: 1;
 }

--- a/packages/mdc-fab/_mixins.scss
+++ b/packages/mdc-fab/_mixins.scss
@@ -55,11 +55,11 @@ $mdc-fab-ripple-target: ".mdc-fab__ripple";
   }
 
   .mdc-fab--mini {
-    @include mdc-fab--mini_($query: $query);
+    @include mdc-fab-mini_($query: $query);
   }
 
   .mdc-fab--extended {
-    @include mdc-fab--extended_($query: $query);
+    @include mdc-fab-extended_($query: $query);
   }
 
   .mdc-fab--touch {
@@ -74,21 +74,21 @@ $mdc-fab-ripple-target: ".mdc-fab__ripple";
   }
 
   .mdc-fab__label {
-    @include mdc-fab--label_($query: $query);
+    @include mdc-fab-label_($query: $query);
   }
 
   .mdc-fab__icon {
-    @include mdc-fab__icon_($query: $query);
+    @include mdc-fab-icon_($query: $query);
   }
 
   // Increase specificity for FAB icon styles that need to override styles defined for .material-icons
   // (which is loaded separately so the order of CSS definitions is not guaranteed)
   .mdc-fab .mdc-fab__icon {
-    @include mdc-fab__icon-overrides_($query: $query);
+    @include mdc-fab-icon-overrides_($query: $query);
   }
 
   .mdc-fab--exited {
-    @include mdc-fab--exited_($query: $query);
+    @include mdc-fab-exited_($query: $query);
   }
 
   // postcss-bem-linter: end
@@ -318,7 +318,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
   // stylelint-enable selector-max-type
 }
 
-@mixin mdc-fab--mini_($query: mdc-feature-all()) {
+@mixin mdc-fab-mini_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
 
   @include mdc-feature-targets($feat-structure) {
@@ -327,7 +327,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
   }
 }
 
-@mixin mdc-fab--extended_($query: mdc-feature-all()) {
+@mixin mdc-fab-extended_($query: mdc-feature-all()) {
   @include mdc-typography(button, $query: $query);
   @include mdc-fab-extended-shape-radius(50%, $query: $query);
   @include mdc-fab-extended-padding($mdc-fab-extended-icon-padding, $mdc-fab-extended-label-padding, $query: $query);
@@ -344,7 +344,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
   }
 }
 
-@mixin mdc-fab__icon_($query: mdc-feature-all()) {
+@mixin mdc-fab-icon_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 
@@ -358,7 +358,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
   }
 }
 
-@mixin mdc-fab__label_($query: mdc-feature-all()) {
+@mixin mdc-fab-label_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
 
   @include mdc-feature-targets($feat-structure) {
@@ -370,7 +370,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
   }
 }
 
-@mixin mdc-fab__icon-overrides_($query: mdc-feature-all()) {
+@mixin mdc-fab-icon-overrides_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
 
   @include mdc-feature-targets($feat-structure) {
@@ -380,7 +380,7 @@ $mdc-fab-icon-enter-duration_: 180ms;
   }
 }
 
-@mixin mdc-fab--exited_($query: mdc-feature-all()) {
+@mixin mdc-fab-exited_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
 

--- a/packages/mdc-switch/_mixins.scss
+++ b/packages/mdc-switch/_mixins.scss
@@ -62,48 +62,48 @@
 
   .mdc-switch__native-control {
     @include mdc-feature-targets($feat-structure) {
-      @include mdc-switch__native-control_;
+      @include mdc-switch-native-control_;
     }
   }
 
   .mdc-switch__track {
-    @include mdc-switch__track_($query);
+    @include mdc-switch-track_($query);
   }
 
   .mdc-switch__thumb-underlay {
-    @include mdc-switch__thumb-underlay_($query);
+    @include mdc-switch-thumb-underlay_($query);
   }
 
   .mdc-switch__thumb {
-    @include mdc-switch__thumb_($query);
+    @include mdc-switch-thumb_($query);
   }
 
   .mdc-switch--checked {
     @include mdc-feature-targets($feat-structure) {
       .mdc-switch__track {
-        @include mdc-switch__track-checked_;
+        @include mdc-switch-track-checked_;
       }
 
       .mdc-switch__thumb-underlay {
-        @include mdc-switch__thumb-underlay-checked_;
+        @include mdc-switch-thumb-underlay-checked_;
       }
 
       .mdc-switch__native-control {
-        @include mdc-switch__native-control-checked_;
+        @include mdc-switch-native-control-checked_;
       }
     }
   }
 
   .mdc-switch--disabled {
     @include mdc-feature-targets($feat-structure) {
-      @include mdc-switch--disabled-base_;
+      @include mdc-switch-disabled-base_;
 
       .mdc-switch__thumb {
-        @include mdc-switch__thumb-disabled_;
+        @include mdc-switch-thumb-disabled_;
       }
 
       .mdc-switch__native-control {
-        @include mdc-switch__native-control-disabled_;
+        @include mdc-switch-native-control-disabled_;
       }
     }
   }
@@ -266,7 +266,7 @@
   user-select: none;
 }
 
-@mixin mdc-switch__track_($query: mdc-feature-all()) {
+@mixin mdc-switch-track_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-structure: mdc-feature-create-target($query, structure);
   $feat-color: mdc-feature-create-target($query, color);
@@ -292,7 +292,7 @@
   }
 }
 
-@mixin mdc-switch__thumb-underlay_($query: mdc-feature-all()) {
+@mixin mdc-switch-thumb-underlay_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
   $feat-color: mdc-feature-create-target($query, color);
   $feat-structure: mdc-feature-create-target($query, structure);
@@ -313,7 +313,7 @@
   }
 }
 
-@mixin mdc-switch__native-control_ {
+@mixin mdc-switch-native-control_ {
   @include mdc-rtl-reflexive-position(left, 0);
 
   position: absolute;
@@ -324,7 +324,7 @@
   pointer-events: auto;
 }
 
-@mixin mdc-switch__thumb_($query: mdc-feature-all()) {
+@mixin mdc-switch-thumb_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
   $feat-color: mdc-feature-create-target($query, color);
 
@@ -344,11 +344,11 @@
 
 // Checked state
 
-@mixin mdc-switch__track-checked_ {
+@mixin mdc-switch-track-checked_ {
   opacity: .54;
 }
 
-@mixin mdc-switch__thumb-underlay-checked_ {
+@mixin mdc-switch-thumb-underlay-checked_ {
   transform: translateX($mdc-switch-thumb-active-margin);
 
   @include mdc-rtl {
@@ -356,7 +356,7 @@
   }
 }
 
-@mixin mdc-switch__native-control-checked_ {
+@mixin mdc-switch-native-control-checked_ {
   // Translate the native control the opposite direction so that the tap target stays the same.
   transform: translateX(-($mdc-switch-thumb-active-margin));
 
@@ -367,16 +367,16 @@
 
 // Disabled state
 
-@mixin mdc-switch--disabled-base_ {
+@mixin mdc-switch-disabled-base_ {
   opacity: .38;
   pointer-events: none;
 }
 
-@mixin mdc-switch__thumb-disabled_ {
+@mixin mdc-switch-thumb-disabled_ {
   border-width: 1px;  // In high contrast mode, only show outline of knob.
 }
 
-@mixin mdc-switch__native-control-disabled_ {
+@mixin mdc-switch-native-control-disabled_ {
   cursor: default;
   pointer-events: none;
 }

--- a/packages/mdc-tab-scroller/_mixins.scss
+++ b/packages/mdc-tab-scroller/_mixins.scss
@@ -97,7 +97,7 @@
   }
 
   .mdc-tab-scroller__scroll-content {
-    @include mdc-tab-scroller__scroll-content_($query);
+    @include mdc-tab-scroller-scroll-content_($query);
   }
 
   .mdc-tab-scroller--align-start .mdc-tab-scroller__scroll-content {
@@ -133,7 +133,7 @@
 // Private
 //
 
-@mixin mdc-tab-scroller__scroll-content_($query: mdc-feature-all()) {
+@mixin mdc-tab-scroller-scroll-content_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
   $feat-animation: mdc-feature-create-target($query, animation);
 

--- a/packages/mdc-tab/_mixins.scss
+++ b/packages/mdc-tab/_mixins.scss
@@ -55,7 +55,7 @@
   }
 
   .mdc-tab__content {
-    @include mdc-tab__content_($query);
+    @include mdc-tab-content_($query);
   }
 
   .mdc-tab__text-label {
@@ -88,11 +88,11 @@
   }
 
   .mdc-tab--stacked {
-    @include mdc-tab--stacked_($query);
+    @include mdc-tab-stacked_($query);
   }
 
   .mdc-tab--active {
-    @include mdc-tab--active_($query);
+    @include mdc-tab-active_($query);
   }
 
   .mdc-tab:not(.mdc-tab--stacked) .mdc-tab__icon + .mdc-tab__text-label {
@@ -110,7 +110,7 @@
   @include mdc-ripple-common($query); // COPYBARA_COMMENT_THIS_LINE
 
   .mdc-tab__ripple {
-    @include mdc-tab__ripple_($query);
+    @include mdc-tab-ripple_($query);
   }
 }
 
@@ -256,7 +256,7 @@
   }
 }
 
-@mixin mdc-tab__ripple_($query: mdc-feature-all()) {
+@mixin mdc-tab-ripple_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
 
   @include mdc-ripple-surface($query);
@@ -273,7 +273,7 @@
   }
 }
 
-@mixin mdc-tab__content_($query: mdc-feature-all()) {
+@mixin mdc-tab-content_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
 
   @include mdc-tab-indicator-surface($query);
@@ -287,7 +287,7 @@
   }
 }
 
-@mixin mdc-tab--stacked_($query: mdc-feature-all()) {
+@mixin mdc-tab-stacked_($query: mdc-feature-all()) {
   $feat-structure: mdc-feature-create-target($query, structure);
 
   @include mdc-feature-targets($feat-structure) {
@@ -304,7 +304,7 @@
   }
 }
 
-@mixin mdc-tab--active_($query: mdc-feature-all()) {
+@mixin mdc-tab-active_($query: mdc-feature-all()) {
   $feat-animation: mdc-feature-create-target($query, animation);
 
   @include mdc-tab-text-label-color($mdc-tab-text-label-color-active, $query);


### PR DESCRIPTION
This replaces `__` and `--` in certain mixin names with a single dash to
allow migrating to the module system without breaking downstream users
that use these pseudoprivate mixins.