### PR TITLE
feat(line-ripple): add active/inactive states to line-ripple

### DIFF
--- a/packages/mdc-line-ripple/_mixins.scss
+++ b/packages/mdc-line-ripple/_mixins.scss
@@ -34,39 +34,66 @@
   // postcss-bem-linter: define line-ripple
   .mdc-line-ripple {
     @include feature-targeting-mixins.targets($feat-structure) {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 2px;
-      transform: scaleX(0);
-      opacity: 0;
-      z-index: 2;
+      &::before,
+      &::after {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        border-bottom-style: solid;
+        content: "";
+      }
+
+      &::before {
+        border-bottom-width: 1px;
+        z-index: 1;
+      }
+
+      &::after {
+        transform: scaleX(0);
+        border-bottom-width: 2px;
+        opacity: 0;
+        z-index: 2;
+      }
     }
 
     @include feature-targeting-mixins.targets($feat-animation) {
-      transition: functions.transition-value(transform), functions.transition-value(opacity);
+      &::after {
+        transition: functions.transition-value(transform), functions.transition-value(opacity);
+      }
     }
   }
 
-  .mdc-line-ripple--active {
+  .mdc-line-ripple--active::after {
     @include feature-targeting-mixins.targets($feat-structure) {
       transform: scaleX(1);
       opacity: 1;
     }
   }
 
-  .mdc-line-ripple--deactivating {
+  .mdc-line-ripple--deactivating::after {
     @include feature-targeting-mixins.targets($feat-structure) {
       opacity: 0;
     }
   }
 }
 
-@mixin color($color, $query: feature-targeting-functions.all()) {
+@mixin active-color($color, $query: feature-targeting-functions.all()) {
   $feat-color: feature-targeting-functions.create-target($query, color);
 
   @include feature-targeting-mixins.targets($feat-color) {
-    @include theme-mixins.prop(background-color, $color);
+    &::after {
+      @include theme-mixins.prop(border-bottom-color, $color);
+    }
+  }
+}
+
+@mixin inactive-color($color, $query: feature-targeting-functions.all()) {
+  $feat-color: feature-targeting-functions.create-target($query, color);
+
+  @include feature-targeting-mixins.targets($feat-color) {
+    &::before {
+      @include theme-mixins.prop(border-bottom-color, $color);
+    }
   }
 }

--- a/packages/mdc-line-ripple/test/feature-targeting-any.test.scss
+++ b/packages/mdc-line-ripple/test/feature-targeting-any.test.scss
@@ -4,7 +4,7 @@
 @mixin test($query) {
   .test {
     @include line-ripple.core-styles($query: $query);
-    @include line-ripple.color(red, $query: $query);
+    @include line-ripple.active-color(red, $query: $query);
   }
 }
 

--- a/packages/mdc-select/_mixins.scss
+++ b/packages/mdc-select/_mixins.scss
@@ -59,8 +59,8 @@
 }
 
 @mixin hover-bottom-line-color($color) {
-  &:not(.mdc-select--disabled) .mdc-select__selected-text:hover {
-    @include native-control-bottom-line-color_($color);
+  &:not(.mdc-select--disabled):hover {
+    @include bottom-line-color_($color);
   }
 }
 
@@ -180,18 +180,14 @@
 }
 
 @mixin bottom-line-color_($color) {
-  .mdc-select__selected-text {
-    @include native-control-bottom-line-color_($color);
+  .mdc-line-ripple {
+    @include line-ripple-mixins.inactive-color($color);
   }
-}
-
-@mixin native-control-bottom-line-color_($color) {
-  @include theme-mixins.prop(border-bottom-color, $color);
 }
 
 @mixin focused-line-ripple-color_($color) {
   @include focused-line-ripple_ {
-    @include line-ripple-mixins.color($color);
+    @include line-ripple-mixins.active-color($color);
   }
 }
 
@@ -305,7 +301,6 @@
     padding-top: 20px;
     padding-bottom: 4px;
     border: none;
-    border-bottom: 1px solid;
     outline: none;
     background-color: transparent;
     color: inherit; // Override default user agent stylesheet
@@ -327,7 +322,12 @@
   }
 
   .mdc-line-ripple {
-    display: none;
+    @include line-ripple-mixins.inactive-color(variables.$disabled-ink-color);
+
+    &::before {
+      // TODO(b/146080006)
+      border-bottom-style: dotted;
+    }
   }
 
   .mdc-select__icon {
@@ -337,17 +337,12 @@
   .mdc-select__selected-text {
     @include theme-mixins.prop(color, variables.$disabled-ink-color);
 
-    border-bottom-style: dotted;
     pointer-events: none;
   }
 
   &.mdc-select--outlined {
     @include container-fill-color_(transparent);
     @include outline-color_(variables.$outlined-disabled-border);
-
-    .mdc-select__selected-text {
-      border-bottom-style: none;
-    }
   }
 
   cursor: default;

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -104,9 +104,8 @@
       padding:
         variables.$input-padding-top
         variables.$input-padding
-        variables.$input-padding-bottom;
+        variables.$input-padding-bottom + variables.$input-border-bottom;
       border: none;
-      border-bottom: 1px solid;
       border-radius: 0;
       background: none;
       appearance: none;
@@ -165,7 +164,7 @@
     .mdc-text-field--no-label:not(.mdc-text-field--outlined):not(.mdc-text-field--textarea) & {
       @include feature-targeting-mixins.targets($feat-structure) {
         padding-top: 16px;
-        padding-bottom: 16px;
+        padding-bottom: 16px + variables.$input-border-bottom;
       }
     }
   }
@@ -755,8 +754,11 @@
   @include icon-mixins.trailing-icon-color_(variables.$disabled-icon, $query: $query);
   @include fill-color_(variables.$disabled-background, $query: $query);
 
+  @media screen and (-ms-high-contrast: active) {
+    @include bottom-line-color_(GrayText, $query: $query);
+  }
+
   @include feature-targeting-mixins.targets($feat-structure) {
-    border-bottom: none;
     pointer-events: none;
   }
 
@@ -938,16 +940,8 @@
 // Outlined
 
 @mixin outlined-disabled_($query: feature-targeting-functions.all()) {
-  $feat-structure: feature-targeting-functions.create-target($query, structure);
-
   @include notched-outline-mixins.color(variables.$outlined-disabled-border, $query: $query);
   @include fill-color_(transparent, $query);
-
-  .mdc-text-field__input {
-    @include feature-targeting-mixins.targets($feat-structure) {
-      border-bottom: none;
-    }
-  }
 }
 
 @mixin outlined-invalid_($query: feature-targeting-functions.all()) {
@@ -1008,7 +1002,6 @@
   @include fill-color(transparent, $query: $query);
 
   @include feature-targeting-mixins.targets($feat-structure) {
-    border: none;
     overflow: visible;
   }
 
@@ -1034,13 +1027,9 @@
 }
 
 @mixin hover-outline-color_($color, $query: feature-targeting-functions.all()) {
-  &:not(.mdc-text-field--focused) {
-    // stylelint-disable-next-line selector-combinator-space-after
-    .mdc-text-field__input:hover ~,
-    .mdc-text-field__icon:hover ~ {
-      .mdc-notched-outline {
-        @include notched-outline-mixins.color($color, $query: $query);
-      }
+  &:not(.mdc-text-field--focused):hover {
+    .mdc-notched-outline {
+      @include notched-outline-mixins.color($color, $query: $query);
     }
   }
 }
@@ -1212,7 +1201,7 @@
 
     .mdc-text-field__input {
       @include feature-targeting-mixins.targets($feat-structure) {
-        padding: 0;
+        padding: 0 0 variables.$input-border-bottom;
       }
     }
   }
@@ -1276,7 +1265,6 @@
       height: auto;
       margin: $padding-inset / 2 1px 1px 0;
       padding: 0 $padding-inset $padding-inset;
-      border: none;
     }
 
     @include feature-targeting-mixins.targets($feat-typography) {
@@ -1385,28 +1373,22 @@
 }
 
 @mixin bottom-line-color_($color, $query: feature-targeting-functions.all()) {
-  $feat-color: feature-targeting-functions.create-target($query, color);
-
-  .mdc-text-field__input {
-    @include feature-targeting-mixins.targets($feat-color) {
-      @include theme-mixins.prop(border-bottom-color, $color);
-    }
+  .mdc-line-ripple {
+    @include line-ripple-mixins.inactive-color($color, $query: $query);
   }
 }
 
 @mixin hover-bottom-line-color_($color, $query: feature-targeting-functions.all()) {
   $feat-color: feature-targeting-functions.create-target($query, color);
 
-  .mdc-text-field__input:hover {
-    @include feature-targeting-mixins.targets($feat-color) {
-      @include theme-mixins.prop(border-bottom-color, $color);
-    }
+  &:hover .mdc-line-ripple {
+    @include line-ripple-mixins.inactive-color($color, $query: $query);
   }
 }
 
 @mixin line-ripple-color_($color, $query: feature-targeting-functions.all()) {
   .mdc-line-ripple {
-    @include line-ripple-mixins.color($color, $query: $query);
+    @include line-ripple-mixins.active-color($color, $query: $query);
   }
 }
 


### PR DESCRIPTION
Project import generated by Copybara.

BREAKING CHANGE: `mdc-line-ripple-color()` mixin has been renamed to `mdc-line-ripple-active-color()`