### PR TITLE
test(feature-targeting): Migrate feature targeting tests to jasmine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,14 @@ jobs:
       - name: Run dependency tests
         run: |
           npm run test:dependency
+  sass-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - name: Run Sass tests
+        run: |
+          npm run test:sass

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ packages/*/dist
 packages/**/*.js
 packages/**/*.d.ts
 packages/**/*.map
+packages/**/test/**.css
 
 # Material.io site generator test (`npm run test:site`)
 .site-generator-tmp/

--- a/jasmine-node.json
+++ b/jasmine-node.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": ".",
+  "spec_files": [
+    "packages/**/test/*.scss.test.ts"
+  ],
+  "helpers": [
+    "testing/helpers/ts-node.helper.js",
+    "testing/helpers/sass-test-compile.helper.ts"
+  ],
+  "stopSpecOnExpectationFailure": false
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -141,6 +141,12 @@ const mochaConfig = {
 const jasmineConfig = {
   basePath: '',
   files: FILES_TO_USE,
+  exclude: [
+    'packages/**/*.scss.test.ts',
+    'testing/helpers/sass-test-compile.helper.ts',
+    'testing/helpers/ts-node.helper.js',
+    'scripts/**/*.ts',
+  ],
   frameworks: ['jasmine', 'karma-typescript'],
   karmaTypescriptConfig: {
     coverageOptions: {
@@ -178,9 +184,6 @@ const jasmineConfig = {
         },
       },
     },
-    exclude: [
-      'scripts/**/*.ts',
-    ],
     reports: {
       html: 'coverage',
       lcovonly: 'coverage',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,6 +36,14 @@ const FILES_TO_USE = [
   'testing/**/*.ts',
 ];
 
+// Files to exclude in Jasmine tests.
+const EXCLUDE_FILES = [
+  'packages/**/*.scss.test.ts',
+  'testing/helpers/sass-test-compile.helper.ts',
+  'testing/helpers/ts-node.helper.js',
+  'scripts/**/*.ts',
+];
+
 const HEADLESS_LAUNCHERS = {
   'ChromeHeadlessNoSandbox': {
     base: 'ChromeHeadless',
@@ -141,14 +149,10 @@ const mochaConfig = {
 const jasmineConfig = {
   basePath: '',
   files: FILES_TO_USE,
-  exclude: [
-    'packages/**/*.scss.test.ts',
-    'testing/helpers/sass-test-compile.helper.ts',
-    'testing/helpers/ts-node.helper.js',
-    'scripts/**/*.ts',
-  ],
+  exclude: EXCLUDE_FILES,
   frameworks: ['jasmine', 'karma-typescript'],
   karmaTypescriptConfig: {
+    exclude: EXCLUDE_FILES,
     coverageOptions: {
       threshold: {
         global: {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "screenshot:watch": "node test/screenshot/run.js build --watch",
     "screenshot:webpack": "webpack --config=test/screenshot/webpack.config.js --progress --display=minimal",
     "start": "npm-run-all --parallel screenshot:serve screenshot:watch",
+    "test:sass": "jasmine --config=jasmine-node.json",
     "test:dependency": "./scripts/dependency-test.sh",
     "test:feature-targeting": "node test/scss/verify-feature-targeting.js",
     "test:site": "npm run clean:site && ./scripts/site-generator-test.sh",

--- a/packages/mdc-button/test/feature-targeting-all.test.scss
+++ b/packages/mdc-button/test/feature-targeting-all.test.scss
@@ -1,0 +1,5 @@
+@use "./feature-targeting-any.test" as feature-targeting-test;
+@use "@material/feature-targeting/functions" as feature;
+
+// Verify that the Sass compiles when we ask for all features.
+@include feature-targeting-test.test(feature.all());

--- a/packages/mdc-button/test/feature-targeting-any.test.scss
+++ b/packages/mdc-button/test/feature-targeting-any.test.scss
@@ -1,0 +1,25 @@
+@use "@material/button/mixins" as button;
+@use "@material/feature-targeting/functions" as feature;
+
+@mixin test($query) {
+  .test {
+    @include button.core-styles($query: $query);
+    @include button.filled-accessible(red, $query: $query);
+    @include button.container-fill-color(red, $query: $query);
+    @include button.outline-color(red, $query: $query);
+    @include button.icon-color(red, $query: $query);
+    @include button.ink-color(red, $query: $query);
+    @include button.shape-radius(0, $query: $query);
+    @include button.horizontal-padding(0, $query: $query);
+    @include button.outline-width(0, $query: $query);
+    @include button.ripple($query: $query);
+    @include button.without-ripple($query: $query);
+    @include button.theme-baseline($query: $query);
+    @include button.density(-1, $query: $query);
+    @include button.height(0, $query: $query);
+    @include button.label-overlow-ellipsis($query: $query);
+  }
+}
+
+// This shouldn't output any CSS.
+@include test(feature.any());

--- a/packages/mdc-button/test/mdc-button.scss.test.ts
+++ b/packages/mdc-button/test/mdc-button.scss.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import 'jasmine';
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('mdc-button.scss', () => {
+  it('Sass produces no CSS when we ask for no features in feature targeting', () => {
+    const filePath = path.join(__dirname, 'feature-targeting-any.test.css');
+    const css = fs.readFileSync(filePath, 'utf8').trim();
+    expect(css).toEqual('');
+  });
+});

--- a/test/scss/_feature-targeting-test.scss
+++ b/test/scss/_feature-targeting-test.scss
@@ -1,4 +1,3 @@
-@import "@material/button/mixins";
 @import "@material/card/mixins";
 @import "@material/checkbox/mixins";
 @import "@material/chips/mixins";
@@ -34,23 +33,6 @@
 
 @mixin mdc-feature-targeting-test($query) {
   .mdc-test {
-    // Button
-    @include mdc-button-core-styles($query: $query);
-    @include mdc-button-filled-accessible(red, $query: $query);
-    @include mdc-button-container-fill-color(red, $query: $query);
-    @include mdc-button-outline-color(red, $query: $query);
-    @include mdc-button-icon-color(red, $query: $query);
-    @include mdc-button-ink-color(red, $query: $query);
-    @include mdc-button-shape-radius(0, $query: $query);
-    @include mdc-button-horizontal-padding(0, $query: $query);
-    @include mdc-button-outline-width(0, $query: $query);
-    @include mdc-button-ripple($query: $query);
-    @include mdc-button-without-ripple($query: $query);
-    @include mdc-button-theme-baseline($query: $query);
-    @include mdc-button-density(-1, $query: $query);
-    @include mdc-button-height(0, $query: $query);
-    @include mdc-button-label-overlow-ellipsis($query: $query);
-
     // Card
     @include mdc-card-core-styles($query: $query);
     @include mdc-card-fill-color(red, $query: $query);

--- a/testing/helpers/sass-test-compile.helper.ts
+++ b/testing/helpers/sass-test-compile.helper.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2020 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * @fileoverview Compiles and outputs all Sass test files ending with '.test.scss' in test/ folder in packages.
+ * This helper file is executed before running jasmine node tests.
+ */
+
+// tslint:disable-next-line:no-var-requires No deceleration file for dart-sass, use require() instead.
+const sass = require('dart-sass');
+import fs from 'fs';
+import glob from 'glob';
+import path from 'path';
+
+// NOTE: This assumes it is run from the top-level directory (which is always the case when using npm run)
+const projectRoot = process.cwd();
+
+const tryAccess = (scssPath: string) => {
+  const fullPath = path.join(projectRoot, scssPath);
+  try {
+    fs.accessSync(fullPath);
+    return fullPath;
+  } catch (e) {
+    return undefined;
+  }
+};
+
+const materialImporter = (url: string) => {
+  if (url.startsWith('@material')) {
+    // Support omission of .scss extension
+    const normalizedUrl = url.endsWith('.scss') ? url : `${url}.scss`;
+    // Convert @material/foo to packages/mdc-foo to load directly from packages folder in repository
+    const scssPath = normalizedUrl.replace('@material/', 'packages/mdc-');
+    // Support omission of leading _ for partials
+    const resolved = tryAccess(scssPath) ||
+      tryAccess(path.join(path.dirname(scssPath), `_${path.basename(scssPath)}`));
+    return {file: resolved || url};
+  }
+  return {file: url};
+}
+
+interface RenderOptions {
+  outFile: string,
+}
+
+/**
+ * Converts Sass to CSS.
+ */
+const render = (filePath: string, options: Partial<RenderOptions> = {}): string => {
+  const result = sass.renderSync({
+    file: filePath,
+    importer: materialImporter,
+    outFile: options.outFile || null,
+  });
+  return result.css.toString('utf8').trim();
+};
+
+const compileSassTestFiles = () => {
+  const testFiles = glob.sync('packages/**/test/*.test.scss', {
+    ignore: ['node_modules/**', '**/node_modules/**'],
+  });
+
+  for (const testFile of testFiles) {
+    const outFile = testFile.replace('.scss', '.css');
+    const css = render(testFile, {outFile});
+    fs.writeFileSync(outFile, css);
+  }
+};
+
+compileSassTestFiles();

--- a/testing/helpers/sass-test-compile.helper.ts
+++ b/testing/helpers/sass-test-compile.helper.ts
@@ -26,7 +26,7 @@
  * This helper file is executed before running jasmine node tests.
  */
 
-// tslint:disable-next-line:no-var-requires No deceleration file for dart-sass, use require() instead.
+// tslint:disable-next-line:no-var-requires dart-sass does not have type information, use require() instead.
 const sass = require('dart-sass');
 import fs from 'fs';
 import glob from 'glob';

--- a/testing/helpers/ts-node.helper.js
+++ b/testing/helpers/ts-node.helper.js
@@ -1,0 +1,5 @@
+const path = require('path');
+const tsconfigPath = path.join(__dirname, '../../tsconfig-node.json');
+require('ts-node').register({
+  project: tsconfigPath,
+});

--- a/tsconfig-node.json
+++ b/tsconfig-node.json
@@ -1,0 +1,8 @@
+{
+  "include": [
+    "packages/**/test/*scss.test.ts",
+    "testing/helpers/sass-test-compile.helper.ts",
+  ],
+  "extends": "./tsconfig-base.json",
+  "types": ["node"]
+}


### PR DESCRIPTION
#### Description

* Moved button feature targeting tests from `test/scss/_feature-targeting-test.scss` to use Jasmine node test.
* `testing/helpers/sass-test-compile.helper.ts` helper is executed before tests to compile all Sass test files to CSS for Jasmine node test consumption.
* New tsconfig (`tsconfig-node.json`) for Node.js code written in TypeScript.
* Updated GitHub Actions `.github/workflows/test.yml` to run this on CI.