### PR TITLE
chore: update slider mixins indentation

### DIFF
--- a/packages/mdc-slider/_mixins.scss
+++ b/packages/mdc-slider/_mixins.scss
@@ -435,7 +435,7 @@
   $feat-color: feature-targeting-functions.create-target($query, color);
 
   .mdc-slider__track-container {
-	  @include feature-targeting-mixins.targets($feat-color) {
+    @include feature-targeting-mixins.targets($feat-color) {
       &::after {
         @include theme-mixins.prop(background-color, $color);
 


### PR DESCRIPTION
Changes tab to spaces. This was already changed to spaces internally with [cl/290088778](http://cl/290088778), so we just need to update GitHub to match.