### PR TITLE
fix(slider): slider track not visible

### DIFF
--- a/packages/mdc-slider/_mixins.scss
+++ b/packages/mdc-slider/_mixins.scss
@@ -449,6 +449,7 @@
   .mdc-slider__track-container::after {
     @include feature-targeting-mixins.targets($feat-color) {
       @include theme-mixins.prop(background-color, $color);
+
       opacity: $opacity;
     }
   }

--- a/packages/mdc-slider/_mixins.scss
+++ b/packages/mdc-slider/_mixins.scss
@@ -262,6 +262,18 @@
       height: 2px;
       overflow: hidden;
     }
+
+    &::after {
+      @include feature-targeting-mixins.targets($feat-structure) {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: block;
+        width: 100%;
+        height: 100%;
+        content: "";
+      }
+    }
   }
 
   &__track {
@@ -434,17 +446,10 @@
 @mixin rail-color_($color, $opacity: variables.$baseline-rail-opacity, $query: feature-targeting-functions.all()) {
   $feat-color: feature-targeting-functions.create-target($query, color);
 
-  .mdc-slider__track-container {
+  .mdc-slider__track-container::after {
     @include feature-targeting-mixins.targets($feat-color) {
-      &::after {
-        @include theme-mixins.prop(background-color, $color);
-
-        display: block;
-        width: 100%;
-        height: 100%;
-        opacity: $opacity;
-        content: "";
-      }
+      @include theme-mixins.prop(background-color, $color);
+      opacity: $opacity;
     }
   }
 }


### PR DESCRIPTION
These changes fix the following issues which were introduced by #5132:
1. The background of track is now provided by `.mdc-slider__track-container::after`, however `::after` wasn't positioned correctly which made it invisible.
2. The `::after` structural styles were set inside the `color` feature target. This means that they'll end up being included multiple times and in the wrong place.

Screenshot for reference:
<img width="367" alt="Screenshot at Jan 23 21-36-34" src="https://user-images.githubusercontent.com/4450522/73022408-d668e000-3e29-11ea-8731-16225b815763.png">
