### PR TITLE
feat(chips): Announce when chips are removed

### DIFF
--- a/packages/mdc-chips/README.md
+++ b/packages/mdc-chips/README.md
@@ -360,7 +360,7 @@ Event Name | `event.detail` | Description
 --- | --- | ---
 `MDCChip:interaction` | `{chipId: string}` | Indicates the chip was interacted with (via click/tap or Enter key)
 `MDCChip:selection` | `{chipId: string, selected: boolean}` | Indicates the chip's selection state has changed (for choice/filter chips)
-`MDCChip:removal` | `{chipId: string, root: Element}` | Indicates the chip is ready to be removed from the DOM
+`MDCChip:removal` | `{chipId: string, removedAnnouncement: string|null}` | Indicates the chip is ready to be removed from the DOM
 `MDCChip:trailingIconInteraction` | `{chipId: string}` | Indicates the chip's trailing icon was interacted with (via click/tap or Enter key)
 `MDCChip:navigation` | `{chipId: string, key: string, source: FocusSource}` | Indicates a navigation event has occurred on a chip
 
@@ -410,6 +410,7 @@ Method Signature | Description
 `hasTrailingAction() => boolean` | Returns `true` if the chip has a trailing action element
 `setTrailingActionAttr(attr: string, value: string) => void` | Sets an attribute on the trailing action element to the given value, if the element exists
 `focusTrailingAction() => void` | Gives focus to the trailing action element if present
+`getAttribute(attr: string) => string|null` | Returns the string value of the attribute if it exists, otherwise `null`
 
 
 > \*_NOTE_: `notifyInteraction` and `notifyTrailingIconInteraction` must pass along the target chip's ID, and must be observable by the parent `mdc-chip-set` element (e.g. via DOM event bubbling).
@@ -431,6 +432,7 @@ Method Signature | Description
 `isRTL() => boolean` | Returns `true` if the text direction is RTL
 `getChipListCount() => number` | Returns the number of chips inside the chip set
 `removeFocusFromChipAtIndex(index: number) => void` | Calls `MDCChip#removeFocus()` on the chip at the given `index`
+`announceMessage(message: string) => void` | Announces the message via [an `aria-live` region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
 
 ### Foundations: `MDCChipFoundation` and `MDCChipSetFoundation`
 
@@ -468,10 +470,10 @@ Method Signature | Description
 --- | ---
 `getSelectedChipIds() => ReadonlyArray<string>` | Returns an array of the IDs of all selected chips
 `select(chipId: string) => void` | Selects the chip with the given id
-`handleChipInteraction(chipId: string) => void` | Handles a custom `MDCChip:interaction` event on the root element
-`handleChipSelection(chipId: string, selected: boolean, chipSetShouldIgnore: boolean) => void` | Handles a custom `MDCChip:selection` event on the root element. When `chipSetShouldIgnore` is true, the chip set does not process the event.
-`handleChipRemoval(chipId: string) => void` | Handles a custom `MDCChip:removal` event on the root element
-`handleChipNavigation(chipId: string, key: string) => void` | Handles a custom `MDCChip:navigation` event on the root element
+`handleChipInteraction(detail: MDCChipInteractionEventDetail) => void` | Handles a custom `MDCChip:interaction` event on the root element
+`handleChipSelection(detail: MDCChipSelectionEventDetail) => void` | Handles a custom `MDCChip:selection` event on the root element. When `chipSetShouldIgnore` is true, the chip set does not process the event.
+`handleChipRemoval(detail: MDCChipRemovalEventDetail) => void` | Handles a custom `MDCChip:removal` event on the root element
+`handleChipNavigation(detail: MDCChipNavigationEventDetail) => void` | Handles a custom `MDCChip:navigation` event on the root element
 
 #### `MDCChipSetFoundation` Event Handlers
 

--- a/packages/mdc-chips/chip-set/adapter.ts
+++ b/packages/mdc-chips/chip-set/adapter.ts
@@ -79,4 +79,9 @@ export interface MDCChipSetAdapter {
    * @return the number of chips in the chip set.
    */
   getChipListCount(): number;
+
+  /**
+   * Announces the message via an aria-live region.
+   */
+  announceMessage(message: string): void;
 }

--- a/packages/mdc-chips/chip-set/component.ts
+++ b/packages/mdc-chips/chip-set/component.ts
@@ -22,6 +22,7 @@
  */
 
 import {MDCComponent} from '@material/base/component';
+import {announce} from '@material/dom/announce';
 import {MDCChip, MDCChipFactory} from '../chip/component';
 import {MDCChipFoundation} from '../chip/foundation';
 import {MDCChipInteractionEvent, MDCChipNavigationEvent, MDCChipRemovalEvent,
@@ -72,13 +73,14 @@ export class MDCChipSet extends MDCComponent<MDCChipSetFoundation> {
       }
     });
 
-    this.handleChipInteraction_ = (evt) => this.foundation_.handleChipInteraction(evt.detail.chipId);
-    this.handleChipSelection_ = (evt) => {
-      this.foundation_.handleChipSelection(evt.detail.chipId, evt.detail.selected, evt.detail.shouldIgnore);
-    };
-    this.handleChipRemoval_ = (evt) => this.foundation_.handleChipRemoval(evt.detail.chipId);
-    this.handleChipNavigation_ = (evt) => this.foundation_.handleChipNavigation(
-        evt.detail.chipId, evt.detail.key, evt.detail.source);
+    this.handleChipInteraction_ = (evt) =>
+        this.foundation_.handleChipInteraction(evt.detail);
+    this.handleChipSelection_ = (evt) =>
+        this.foundation_.handleChipSelection(evt.detail);
+    this.handleChipRemoval_ = (evt) =>
+        this.foundation_.handleChipRemoval(evt.detail);
+    this.handleChipNavigation_ = (evt) =>
+        this.foundation_.handleChipNavigation(evt.detail);
     this.listen(INTERACTION_EVENT, this.handleChipInteraction_);
     this.listen(SELECTION_EVENT, this.handleChipSelection_);
     this.listen(REMOVAL_EVENT, this.handleChipRemoval_);
@@ -110,6 +112,7 @@ export class MDCChipSet extends MDCComponent<MDCChipSetFoundation> {
     // DO NOT INLINE this variable. For backward compatibility, foundations take a Partial<MDCFooAdapter>.
     // To ensure we don't accidentally omit any methods, we need a separate, strongly typed adapter variable.
     const adapter: MDCChipSetAdapter = {
+      announceMessage: (message) => announce(message),
       focusChipPrimaryActionAtIndex: (index) => {
         this.chips_[index].focusPrimaryAction();
       },
@@ -121,7 +124,9 @@ export class MDCChipSet extends MDCComponent<MDCChipSetFoundation> {
         return this.findChipIndex_(chipId);
       },
       hasClass: (className) => this.root_.classList.contains(className),
-      isRTL: () => window.getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
+      isRTL: () =>
+          window.getComputedStyle(this.root_).getPropertyValue('direction') ===
+          'rtl',
       removeChipAtIndex: (index) => {
         if (index >= 0 && index < this.chips_.length) {
           this.chips_[index].destroy();

--- a/packages/mdc-chips/chip-set/foundation.ts
+++ b/packages/mdc-chips/chip-set/foundation.ts
@@ -22,7 +22,10 @@
  */
 
 import {MDCFoundation} from '@material/base/foundation';
+
 import {Direction, EventSource, jumpChipKeys, navigationKeys, strings as chipStrings} from '../chip/constants';
+import {MDCChipInteractionEventDetail, MDCChipNavigationEventDetail, MDCChipRemovalEventDetail, MDCChipSelectionEventDetail} from '../chip/types';
+
 import {MDCChipSetAdapter} from './adapter';
 import {cssClasses, strings} from './constants';
 
@@ -37,6 +40,7 @@ export class MDCChipSetFoundation extends MDCFoundation<MDCChipSetAdapter> {
 
   static get defaultAdapter(): MDCChipSetAdapter {
     return {
+      announceMessage: () => undefined,
       focusChipPrimaryActionAtIndex: () => undefined,
       focusChipTrailingActionAtIndex: () => undefined,
       getChipListCount: () => -1,
@@ -76,7 +80,8 @@ export class MDCChipSetFoundation extends MDCFoundation<MDCChipSetAdapter> {
   /**
    * Handles a chip interaction event
    */
-  handleChipInteraction(chipId: string) {
+  handleChipInteraction(detail: MDCChipInteractionEventDetail) {
+    const {chipId} = detail;
     const index = this.adapter_.getIndexOfChipById(chipId);
     this.removeFocusFromChipsExcept_(index);
     if (this.adapter_.hasClass(cssClasses.CHOICE) || this.adapter_.hasClass(cssClasses.FILTER)) {
@@ -87,7 +92,8 @@ export class MDCChipSetFoundation extends MDCFoundation<MDCChipSetAdapter> {
   /**
    * Handles a chip selection event, used to handle discrepancy when selection state is set directly on the Chip.
    */
-  handleChipSelection(chipId: string, selected: boolean, shouldIgnore: boolean) {
+  handleChipSelection(detail: MDCChipSelectionEventDetail) {
+    const {chipId, selected, shouldIgnore} = detail;
     // Early exit if we should ignore the event
     if (shouldIgnore) {
       return;
@@ -104,7 +110,12 @@ export class MDCChipSetFoundation extends MDCFoundation<MDCChipSetAdapter> {
   /**
    * Handles the event when a chip is removed.
    */
-  handleChipRemoval(chipId: string) {
+  handleChipRemoval(detail: MDCChipRemovalEventDetail) {
+    const {chipId, removedAnnouncement} = detail;
+    if (removedAnnouncement) {
+      this.adapter_.announceMessage(removedAnnouncement);
+    }
+
     const index = this.adapter_.getIndexOfChipById(chipId);
     this.deselectAndNotifyClients_(chipId);
     this.adapter_.removeChipAtIndex(index);
@@ -118,7 +129,8 @@ export class MDCChipSetFoundation extends MDCFoundation<MDCChipSetAdapter> {
   /**
    * Handles a chip navigation event.
    */
-  handleChipNavigation(chipId: string, key: string, source: EventSource) {
+  handleChipNavigation(detail: MDCChipNavigationEventDetail) {
+    const {chipId, key, source} = detail;
     const maxIndex = this.adapter_.getChipListCount() - 1;
     let index = this.adapter_.getIndexOfChipById(chipId);
     // Early exit if the index is out of range or the key is unusable

--- a/packages/mdc-chips/chip-set/test/component.test.ts
+++ b/packages/mdc-chips/chip-set/test/component.test.ts
@@ -119,36 +119,49 @@ describe('MDCChipSet', () => {
       REMOVAL_EVENT,
       SELECTION_EVENT
     } = MDCChipFoundation.strings;
-    const evtData = {
-      chipId: 'chipA',
-      selected: true,
-      key: ARROW_LEFT_KEY,
-      source: 1,
-      shouldIgnore: false,
-    };
     const evt1 = document.createEvent('CustomEvent');
     const evt2 = document.createEvent('CustomEvent');
     const evt3 = document.createEvent('CustomEvent');
     const evt4 = document.createEvent('CustomEvent');
-    evt1.initCustomEvent(INTERACTION_EVENT, true, true, evtData);
-    evt2.initCustomEvent(REMOVAL_EVENT, true, true, evtData);
-    evt3.initCustomEvent(SELECTION_EVENT, true, true, evtData);
-    evt4.initCustomEvent(NAVIGATION_EVENT, true, true, evtData);
+    evt1.initCustomEvent(INTERACTION_EVENT, true, true, {
+      chipId: 'chipA',
+    });
+    evt2.initCustomEvent(REMOVAL_EVENT, true, true, {
+      chipId: 'chipA',
+      removedAnnouncement: 'Removed foo',
+    });
+    evt3.initCustomEvent(SELECTION_EVENT, true, true, {
+      chipId: 'chipA',
+      selected: true,
+      shouldIgnore: false,
+    });
+    evt4.initCustomEvent(NAVIGATION_EVENT, true, true, {
+      chipId: 'chipA',
+      key: ARROW_LEFT_KEY,
+      source: 1,
+    });
 
     root.dispatchEvent(evt1);
     root.dispatchEvent(evt2);
     root.dispatchEvent(evt3);
     root.dispatchEvent(evt4);
 
-    expect(mockFoundation.handleChipInteraction).toHaveBeenCalledWith('chipA');
+    expect(mockFoundation.handleChipInteraction).toHaveBeenCalledWith({
+      chipId: 'chipA'
+    });
     expect(mockFoundation.handleChipInteraction).toHaveBeenCalledTimes(1);
     expect(mockFoundation.handleChipSelection)
-        .toHaveBeenCalledWith('chipA', true, false);
+        .toHaveBeenCalledWith(
+            {chipId: 'chipA', selected: true, shouldIgnore: false});
     expect(mockFoundation.handleChipSelection).toHaveBeenCalledTimes(1);
-    expect(mockFoundation.handleChipRemoval).toHaveBeenCalledWith('chipA');
+    expect(mockFoundation.handleChipRemoval).toHaveBeenCalledWith({
+      chipId: 'chipA',
+      removedAnnouncement: 'Removed foo'
+    });
     expect(mockFoundation.handleChipRemoval).toHaveBeenCalledTimes(1);
     expect(mockFoundation.handleChipNavigation)
-        .toHaveBeenCalledWith('chipA', ARROW_LEFT_KEY, 1);
+        .toHaveBeenCalledWith(
+            {chipId: 'chipA', key: ARROW_LEFT_KEY, source: 1});
     expect(mockFoundation.handleChipNavigation).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/mdc-chips/chip-set/test/foundation.test.ts
+++ b/packages/mdc-chips/chip-set/test/foundation.test.ts
@@ -49,6 +49,7 @@ describe('MDCChipSetFoundation', () => {
       'isRTL',
       'getChipListCount',
       'removeFocusFromChipAtIndex',
+      'announceMessage',
     ]);
   });
 
@@ -132,16 +133,16 @@ describe('MDCChipSetFoundation', () => {
        const {foundation, mockAdapter} =
            setupChipNavigationTest(['chipA', 'chipB']);
        mockAdapter.hasClass.withArgs(cssClasses.FILTER).and.returnValue(true);
-       foundation.handleChipInteraction('chipA');
-       foundation.handleChipInteraction('chipB');
+       foundation.handleChipInteraction({chipId: 'chipA'});
+       foundation.handleChipInteraction({chipId: 'chipB'});
        expect(foundation.getSelectedChipIds().length).toEqual(2);
 
-       foundation.handleChipInteraction('chipB');
+       foundation.handleChipInteraction({chipId: 'chipB'});
        expect(mockAdapter.selectChipAtIndex)
            .toHaveBeenCalledWith(1, false, true);
        expect(foundation.getSelectedChipIds().length).toEqual(1);
 
-       foundation.handleChipInteraction('chipA');
+       foundation.handleChipInteraction({chipId: 'chipA'});
        expect(mockAdapter.selectChipAtIndex)
            .toHaveBeenCalledWith(0, false, true);
        expect(foundation.getSelectedChipIds().length).toEqual(0);
@@ -153,7 +154,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chipA', 'chipB']);
        mockAdapter.hasClass.withArgs(cssClasses.FILTER).and.returnValue(true);
 
-       foundation.handleChipInteraction('chipA');
+       foundation.handleChipInteraction({chipId: 'chipA'});
        expect(mockAdapter.selectChipAtIndex)
            .toHaveBeenCalledWith(0, true, /** notifies clients */ true);
      });
@@ -164,7 +165,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chipA', 'chipB']);
        mockAdapter.hasClass.withArgs(cssClasses.CHOICE).and.returnValue(true);
 
-       foundation.handleChipInteraction('chipA');
+       foundation.handleChipInteraction({chipId: 'chipA'});
        expect(mockAdapter.selectChipAtIndex)
            .toHaveBeenCalledWith(0, true, /** notifies clients */ true);
      });
@@ -175,7 +176,7 @@ describe('MDCChipSetFoundation', () => {
        mockAdapter.getChipListCount.and.returnValue(4);
        mockAdapter.getIndexOfChipById.and.returnValue(1);
 
-       foundation.handleChipInteraction('chipA');
+       foundation.handleChipInteraction({chipId: 'chipA'});
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(0);
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(2);
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(3);
@@ -186,7 +187,7 @@ describe('MDCChipSetFoundation', () => {
        const {foundation, mockAdapter} =
            setupChipNavigationTest(['chipA', 'chipB', 'chipC']);
 
-       foundation.handleChipInteraction('chipA');
+       foundation.handleChipInteraction({chipId: 'chipA'});
        expect(mockAdapter.selectChipAtIndex).not.toHaveBeenCalledWith(0, true);
      });
 
@@ -196,7 +197,8 @@ describe('MDCChipSetFoundation', () => {
 
        foundation['selectedChipIds_'] = [];
        foundation.select = jasmine.createSpy('');
-       foundation.handleChipSelection('chipA', true, false);
+       foundation.handleChipSelection(
+           {chipId: 'chipA', selected: true, shouldIgnore: false});
        expect(foundation.select).toHaveBeenCalledWith('chipA');
      });
 
@@ -206,7 +208,8 @@ describe('MDCChipSetFoundation', () => {
 
        foundation['selectedChipIds_'] = ['chipA'];
        foundation.select = jasmine.createSpy('');
-       foundation.handleChipSelection('chipA', true, false);
+       foundation.handleChipSelection(
+           {chipId: 'chipA', selected: true, shouldIgnore: false});
        expect(foundation.select).not.toHaveBeenCalledWith('chipA');
      });
 
@@ -215,7 +218,8 @@ describe('MDCChipSetFoundation', () => {
        const {foundation} = setupTest();
 
        foundation['selectedChipIds_'] = ['chipA'];
-       foundation.handleChipSelection('chipA', false, false);
+       foundation.handleChipSelection(
+           {chipId: 'chipA', selected: false, shouldIgnore: false});
        expect(foundation['selectedChipIds_'].length).toEqual(0);
      });
 
@@ -224,7 +228,8 @@ describe('MDCChipSetFoundation', () => {
        const {foundation} = setupTest();
 
        foundation['selectedChipIds_'] = ['chipB'];
-       foundation.handleChipSelection('chipA', false, false);
+       foundation.handleChipSelection(
+           {chipId: 'chipA', selected: false, shouldIgnore: false});
        expect(foundation['selectedChipIds_'].length).toEqual(1);
      });
 
@@ -233,7 +238,8 @@ describe('MDCChipSetFoundation', () => {
 
     foundation['selectedChipIds_'] = ['chipB'];
     foundation.select = jasmine.createSpy('');
-    foundation.handleChipSelection('chipA', true, true);
+    foundation.handleChipSelection(
+        {chipId: 'chipA', selected: true, shouldIgnore: true});
     expect(foundation.select).not.toHaveBeenCalledWith('chipA');
   });
 
@@ -243,10 +249,12 @@ describe('MDCChipSetFoundation', () => {
     foundation['selectedChipIds_'] = [];
     mockAdapter.getIndexOfChipById.and.returnValue(0);
 
-    foundation.handleChipSelection('chipA', true, /** shouldIgnore */ false);
+    foundation.handleChipSelection(
+        {chipId: 'chipA', selected: true, shouldIgnore: false});
     expect(mockAdapter.selectChipAtIndex)
         .toHaveBeenCalledWith(0, true, /** shouldNotify */ false);
-    foundation.handleChipSelection('chipA', false, /** shouldIgnore */ false);
+    foundation.handleChipSelection(
+        {chipId: 'chipA', selected: false, shouldIgnore: false});
     expect(mockAdapter.selectChipAtIndex)
         .toHaveBeenCalledWith(0, false, /** shouldNotify */ false);
   });
@@ -255,7 +263,7 @@ describe('MDCChipSetFoundation', () => {
     const {foundation, mockAdapter} = setupTest();
     mockAdapter.getIndexOfChipById.and.returnValue(1);
 
-    foundation.handleChipRemoval('chipA');
+    foundation.handleChipRemoval({chipId: 'chipA', removedAnnouncement: null});
     expect(mockAdapter.removeChipAtIndex).toHaveBeenCalledWith(1);
   });
 
@@ -265,7 +273,8 @@ describe('MDCChipSetFoundation', () => {
        mockAdapter.getChipListCount.and.returnValue(4);
        mockAdapter.getIndexOfChipById.and.returnValue(1);
 
-       foundation.handleChipRemoval('chipA');
+       foundation.handleChipRemoval(
+           {chipId: 'chipA', removedAnnouncement: null});
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(0);
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(2);
      });
@@ -275,7 +284,7 @@ describe('MDCChipSetFoundation', () => {
     mockAdapter.getChipListCount.and.returnValue(4);
     mockAdapter.getIndexOfChipById.and.returnValue(1);
 
-    foundation.handleChipRemoval('chipA');
+    foundation.handleChipRemoval({chipId: 'chipA', removedAnnouncement: null});
     expect(mockAdapter.focusChipTrailingActionAtIndex).toHaveBeenCalledWith(1);
   });
 
@@ -298,7 +307,8 @@ describe('MDCChipSetFoundation', () => {
     const {foundation, mockAdapter} =
         setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
-    foundation.handleChipNavigation('chip1', 'Space', EventSource.NONE);
+    foundation.handleChipNavigation(
+        {chipId: 'chip1', key: 'Space', source: EventSource.NONE});
     expect(mockAdapter.focusChipPrimaryActionAtIndex)
         .not.toHaveBeenCalledWith(jasmine.any(Number));
     expect(mockAdapter.focusChipTrailingActionAtIndex)
@@ -311,7 +321,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
        foundation.handleChipNavigation(
-           'chip1', 'ArrowRight', EventSource.PRIMARY);
+           {chipId: 'chip1', key: 'ArrowRight', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .toHaveBeenCalledWith(2);
      });
@@ -322,7 +332,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2', 'chip3']);
 
        foundation.handleChipNavigation(
-           'chip1', 'ArrowRight', EventSource.PRIMARY);
+           {chipId: 'chip1', key: 'ArrowRight', source: EventSource.PRIMARY});
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(0);
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(1);
        expect(mockAdapter.removeFocusFromChipAtIndex).toHaveBeenCalledWith(3);
@@ -341,7 +351,8 @@ describe('MDCChipSetFoundation', () => {
          const {foundation, mockAdapter} =
              setupChipNavigationTest(['chip0', 'chip1', 'chip2', 'chip3']);
 
-         foundation.handleChipNavigation('chip1', key, EventSource.PRIMARY);
+         foundation.handleChipNavigation(
+             {chipId: 'chip1', source: EventSource.PRIMARY, key});
          expect(mockAdapter.removeFocusFromChipAtIndex)
              .toHaveBeenCalledWith(jasmine.any(Number));
          expect(mockAdapter.removeFocusFromChipAtIndex)
@@ -355,7 +366,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2'], true);
 
        foundation.handleChipNavigation(
-           'chip1', 'ArrowRight', EventSource.PRIMARY);
+           {chipId: 'chip1', key: 'ArrowRight', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipTrailingActionAtIndex)
            .toHaveBeenCalledWith(0);
      });
@@ -366,7 +377,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
        foundation.handleChipNavigation(
-           'chip1', 'ArrowDown', EventSource.PRIMARY);
+           {chipId: 'chip1', key: 'ArrowDown', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .toHaveBeenCalledWith(2);
      });
@@ -377,7 +388,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
        foundation.handleChipNavigation(
-           'chip1', 'ArrowDown', EventSource.TRAILING);
+           {chipId: 'chip1', key: 'ArrowDown', source: EventSource.TRAILING});
        expect(mockAdapter.focusChipTrailingActionAtIndex)
            .toHaveBeenCalledWith(2);
      });
@@ -387,7 +398,8 @@ describe('MDCChipSetFoundation', () => {
        const {foundation, mockAdapter} =
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
-       foundation.handleChipNavigation('chip1', 'Home', EventSource.PRIMARY);
+       foundation.handleChipNavigation(
+           {chipId: 'chip1', key: 'Home', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .toHaveBeenCalledWith(0);
      });
@@ -396,7 +408,8 @@ describe('MDCChipSetFoundation', () => {
     const {foundation, mockAdapter} =
         setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
-    foundation.handleChipNavigation('chip1', 'End', EventSource.PRIMARY);
+    foundation.handleChipNavigation(
+        {chipId: 'chip1', key: 'End', source: EventSource.PRIMARY});
     expect(mockAdapter.focusChipPrimaryActionAtIndex).toHaveBeenCalledWith(2);
   });
 
@@ -406,7 +419,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
        foundation.handleChipNavigation(
-           'chip2', 'ArrowRight', EventSource.PRIMARY);
+           {chipId: 'chip2', key: 'ArrowRight', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .not.toHaveBeenCalledWith(jasmine.any(Number));
        expect(mockAdapter.focusChipTrailingActionAtIndex)
@@ -419,7 +432,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
        foundation.handleChipNavigation(
-           'chip2', 'ArrowDown', EventSource.PRIMARY);
+           {chipId: 'chip2', key: 'ArrowDown', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .not.toHaveBeenCalledWith(jasmine.any(Number));
        expect(mockAdapter.focusChipTrailingActionAtIndex)
@@ -432,7 +445,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
        foundation.handleChipNavigation(
-           'chip1', 'ArrowLeft', EventSource.TRAILING);
+           {chipId: 'chip1', key: 'ArrowLeft', source: EventSource.TRAILING});
        expect(mockAdapter.focusChipTrailingActionAtIndex)
            .toHaveBeenCalledWith(0);
      });
@@ -443,7 +456,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2'], true);
 
        foundation.handleChipNavigation(
-           'chip1', 'ArrowLeft', EventSource.TRAILING);
+           {chipId: 'chip1', key: 'ArrowLeft', source: EventSource.TRAILING});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .toHaveBeenCalledWith(2);
      });
@@ -454,7 +467,7 @@ describe('MDCChipSetFoundation', () => {
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
        foundation.handleChipNavigation(
-           'chip0', 'ArrowLeft', EventSource.PRIMARY);
+           {chipId: 'chip0', key: 'ArrowLeft', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .not.toHaveBeenCalledWith(jasmine.any(Number));
        expect(mockAdapter.focusChipTrailingActionAtIndex)
@@ -466,7 +479,8 @@ describe('MDCChipSetFoundation', () => {
        const {foundation, mockAdapter} =
            setupChipNavigationTest(['chip0', 'chip1', 'chip2']);
 
-       foundation.handleChipNavigation('chip0', 'ArrowUp', EventSource.PRIMARY);
+       foundation.handleChipNavigation(
+           {chipId: 'chip0', key: 'ArrowUp', source: EventSource.PRIMARY});
        expect(mockAdapter.focusChipPrimaryActionAtIndex)
            .not.toHaveBeenCalledWith(jasmine.any(Number));
        expect(mockAdapter.focusChipTrailingActionAtIndex)

--- a/packages/mdc-chips/chip/adapter.ts
+++ b/packages/mdc-chips/chip/adapter.ts
@@ -62,6 +62,11 @@ export interface MDCChipAdapter {
   eventTargetHasClass(target: EventTarget | null, className: string): boolean;
 
   /**
+   * @return the attribute string value if present, otherwise null
+   */
+  getAttribute(attr: string): string|null;
+
+  /**
    * Emits a custom "MDCChip:interaction" event denoting the chip has been
    * interacted with (typically on click or keydown).
    */
@@ -81,7 +86,7 @@ export interface MDCChipAdapter {
   /**
    * Emits a custom event "MDCChip:removal" denoting the chip will be removed.
    */
-  notifyRemoval(): void;
+  notifyRemoval(removedAnnouncement: string|null): void;
 
   /**
    * Emits a custom event "MDCChip:navigation" denoting a focus navigation event.

--- a/packages/mdc-chips/chip/component.ts
+++ b/packages/mdc-chips/chip/component.ts
@@ -166,7 +166,8 @@ export class MDCChip extends MDCComponent<MDCChipFoundation> implements MDCRippl
           this.leadingIcon_.classList.add(className);
         }
       },
-      eventTargetHasClass: (target, className) => target ? (target as Element).classList.contains(className) : false,
+      eventTargetHasClass: (target, className) =>
+          target ? (target as Element).classList.contains(className) : false,
       focusPrimaryAction: () => {
         if (this.primaryAction_) {
           (this.primaryAction_ as HTMLElement).focus();
@@ -177,25 +178,39 @@ export class MDCChip extends MDCComponent<MDCChipFoundation> implements MDCRippl
           (this.trailingAction_ as HTMLElement).focus();
         }
       },
-      getCheckmarkBoundingClientRect: () => this.checkmark_ ? this.checkmark_.getBoundingClientRect() : null,
-      getComputedStyleValue: (propertyName) => window.getComputedStyle(this.root_).getPropertyValue(propertyName),
+      getAttribute: (attr) => this.root_.getAttribute(attr),
+      getCheckmarkBoundingClientRect: () =>
+          this.checkmark_ ? this.checkmark_.getBoundingClientRect() : null,
+      getComputedStyleValue: (propertyName) =>
+          window.getComputedStyle(this.root_).getPropertyValue(propertyName),
       getRootBoundingClientRect: () => this.root_.getBoundingClientRect(),
       hasClass: (className) => this.root_.classList.contains(className),
       hasLeadingIcon: () => !!this.leadingIcon_,
       hasTrailingAction: () => !!this.trailingAction_,
-      isRTL: () => window.getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
+      isRTL: () =>
+          window.getComputedStyle(this.root_).getPropertyValue('direction') ===
+          'rtl',
       notifyInteraction: () => this.emit<MDCChipInteractionEventDetail>(
-          strings.INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
-      notifyNavigation: (key, source) => this.emit<MDCChipNavigationEventDetail>(
-          strings.NAVIGATION_EVENT,  {chipId: this.id, key, source}, true /* shouldBubble */),
-      notifyRemoval: () => {
+          strings.INTERACTION_EVENT, {chipId: this.id},
+          true /* shouldBubble */),
+      notifyNavigation: (key, source) =>
+          this.emit<MDCChipNavigationEventDetail>(
+              strings.NAVIGATION_EVENT, {chipId: this.id, key, source},
+              true /* shouldBubble */),
+      notifyRemoval: (removedAnnouncement) => {
         this.emit<MDCChipRemovalEventDetail>(
-          strings.REMOVAL_EVENT, {chipId: this.id, root: this.root_}, true /* shouldBubble */);
+            strings.REMOVAL_EVENT, {chipId: this.id, removedAnnouncement},
+            true /* shouldBubble */);
       },
-      notifySelection: (selected, shouldIgnore) => this.emit<MDCChipSelectionEventDetail>(
-          strings.SELECTION_EVENT, {chipId: this.id, selected, shouldIgnore}, true /* shouldBubble */),
-      notifyTrailingIconInteraction: () => this.emit<MDCChipInteractionEventDetail>(
-          strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id}, true /* shouldBubble */),
+      notifySelection: (selected, shouldIgnore) =>
+          this.emit<MDCChipSelectionEventDetail>(
+              strings.SELECTION_EVENT,
+              {chipId: this.id, selected, shouldIgnore},
+              true /* shouldBubble */),
+      notifyTrailingIconInteraction: () =>
+          this.emit<MDCChipInteractionEventDetail>(
+              strings.TRAILING_ICON_INTERACTION_EVENT, {chipId: this.id},
+              true /* shouldBubble */),
       removeClass: (className) => this.root_.classList.remove(className),
       removeClassFromLeadingIcon: (className) => {
         if (this.leadingIcon_) {
@@ -207,7 +222,8 @@ export class MDCChip extends MDCComponent<MDCChipFoundation> implements MDCRippl
           this.primaryAction_.setAttribute(attr, value);
         }
       },
-      setStyleProperty: (propertyName, value) => this.root_.style.setProperty(propertyName, value),
+      setStyleProperty: (propertyName, value) =>
+          this.root_.style.setProperty(propertyName, value),
       setTrailingActionAttr: (attr, value) => {
         if (this.trailingAction_) {
           this.trailingAction_.setAttribute(attr, value);

--- a/packages/mdc-chips/chip/constants.ts
+++ b/packages/mdc-chips/chip/constants.ts
@@ -33,6 +33,7 @@ export enum EventSource {
 }
 
 export const strings = {
+  ADDED_ANNOUNCEMENT_ATTRIBUTE: 'data-added-announcement',
   ARIA_CHECKED: 'aria-checked',
   ARROW_DOWN_KEY: 'ArrowDown',
   ARROW_LEFT_KEY: 'ArrowLeft',
@@ -49,6 +50,7 @@ export const strings = {
   LEADING_ICON_SELECTOR: '.mdc-chip__icon--leading',
   NAVIGATION_EVENT: 'MDCChip:navigation',
   PRIMARY_ACTION_SELECTOR: '.mdc-chip__primary-action',
+  REMOVED_ANNOUNCEMENT_ATTRIBUTE: 'data-removed-announcement',
   REMOVAL_EVENT: 'MDCChip:removal',
   SELECTION_EVENT: 'MDCChip:selection',
   SPACEBAR_KEY: ' ',

--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -50,6 +50,7 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
       eventTargetHasClass: () => false,
       focusPrimaryAction: () => undefined,
       focusTrailingAction: () => undefined,
+      getAttribute: () => null,
       getCheckmarkBoundingClientRect: () => emptyClientRect,
       getComputedStyleValue: () => '',
       getRootBoundingClientRect: () => emptyClientRect,
@@ -180,7 +181,10 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
 
     if (shouldHandle && widthIsAnimating) {
       this.removeFocus_();
-      this.adapter_.notifyRemoval();
+      const removedAnnouncement =
+          this.adapter_.getAttribute(strings.REMOVED_ANNOUNCEMENT_ATTRIBUTE);
+
+      this.adapter_.notifyRemoval(removedAnnouncement);
     }
 
     // Handle a transition end event on the leading icon or checkmark, since the transition end event bubbles.

--- a/packages/mdc-chips/chip/test/foundation.test.ts
+++ b/packages/mdc-chips/chip/test/foundation.test.ts
@@ -64,6 +64,7 @@ describe('MDCChipFoundation', () => {
       'isRTL',
       'setPrimaryActionAttr',
       'setTrailingActionAttr',
+      'getAttribute',
     ]);
   });
 
@@ -239,6 +240,22 @@ describe('MDCChipFoundation', () => {
        foundation.handleTransitionEnd(mockEvt);
 
        expect(mockAdapter.notifyRemoval).toHaveBeenCalled();
+     });
+
+  it('#handleTransitionEnd notifies removal of chip with removal announcement if present',
+     () => {
+       const {foundation, mockAdapter} = setupTest();
+       const mockEvt = {
+         type: 'transitionend',
+         target: {},
+         propertyName: 'width',
+       };
+       mockAdapter.eventTargetHasClass.and.returnValue(true);
+       mockAdapter.getAttribute.and.returnValue('Removed foo');
+
+       foundation.handleTransitionEnd(mockEvt);
+
+       expect(mockAdapter.notifyRemoval).toHaveBeenCalledWith('Removed foo');
      });
 
   it('#handleTransitionEnd animates width if chip is exiting on chip opacity transition end',

--- a/packages/mdc-chips/chip/types.ts
+++ b/packages/mdc-chips/chip/types.ts
@@ -33,7 +33,7 @@ export interface MDCChipSelectionEventDetail extends MDCChipInteractionEventDeta
 }
 
 export interface MDCChipRemovalEventDetail extends MDCChipInteractionEventDetail {
-  root: Element;
+  removedAnnouncement: string|null;
 }
 
 export interface MDCChipNavigationEventDetail extends MDCChipInteractionEventDetail {

--- a/packages/mdc-chips/package.json
+++ b/packages/mdc-chips/package.json
@@ -24,6 +24,7 @@
     "@material/animation": "^4.0.0",
     "@material/base": "^4.0.0",
     "@material/checkbox": "^4.0.0",
+    "@material/dom": "^4.0.0",
     "@material/density": "^4.0.0",
     "@material/elevation": "^4.0.0",
     "@material/feature-targeting": "^4.0.0",


### PR DESCRIPTION
- Update MDCChipAdapter to include a `getAttribute` method
- Update MDCChipRemovalEventDetail to include a nullable `removedAnnouncement` property
- Update MDCChipsetAdapter to include a `announceMessage` method

BREAKING CHANGE: Both `MDCChipAdapter` and `MDCChipSetAdapter` have new methods. `MDCChipSetFoundation` event handlers now accept the corresponding chip event detail interface as the sole argument. The `root` property has been removed from the `MDCChipRemovalEventDetail` interface.