### PR TITLE
fix(chips): Fix browser back nav in FF when removing chip with backspace key.

### DIFF
--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -310,6 +310,9 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
 
   private removeChip_(evt: MouseEvent|KeyboardEvent) {
     evt.stopPropagation();
+    // Prevent default behavior for backspace on Firefox which causes a page
+    // navigation.
+    evt.preventDefault();
     if (this.shouldRemoveOnTrailingIconClick_) {
       this.beginExit();
     }

--- a/packages/mdc-chips/chip/test/foundation.test.ts
+++ b/packages/mdc-chips/chip/test/foundation.test.ts
@@ -379,6 +379,7 @@ describe('MDCChipFoundation', () => {
        const mockEvt = {
          type: 'click',
          stopPropagation: jasmine.createSpy('stopPropagation'),
+         preventDefault: jasmine.createSpy('preventDefault'),
          key: '',
        };
 
@@ -386,6 +387,7 @@ describe('MDCChipFoundation', () => {
        expect(mockAdapter.notifyTrailingIconInteraction)
            .toHaveBeenCalledTimes(1);
        expect(mockEvt.stopPropagation).toHaveBeenCalledTimes(1);
+       expect(mockEvt.preventDefault).toHaveBeenCalledTimes(1);
 
        mockEvt.type = 'keydown';
        mockEvt.key = ' ';
@@ -393,6 +395,7 @@ describe('MDCChipFoundation', () => {
        expect(mockAdapter.notifyTrailingIconInteraction)
            .toHaveBeenCalledTimes(2);
        expect(mockEvt.stopPropagation).toHaveBeenCalledTimes(2);
+       expect(mockEvt.preventDefault).toHaveBeenCalledTimes(2);
 
        mockEvt.type = 'keydown';
        mockEvt.key = 'Enter';
@@ -400,6 +403,7 @@ describe('MDCChipFoundation', () => {
        expect(mockAdapter.notifyTrailingIconInteraction)
            .toHaveBeenCalledTimes(3);
        expect(mockEvt.stopPropagation).toHaveBeenCalledTimes(3);
+       expect(mockEvt.preventDefault).toHaveBeenCalledTimes(3);
      });
 
   it(`#handleTrailingIconInteraction adds ${
@@ -409,6 +413,7 @@ describe('MDCChipFoundation', () => {
        const mockEvt = {
          type: 'click',
          stopPropagation: jasmine.createSpy('stopPropagation'),
+         preventDefault: jasmine.createSpy('preventDefault'),
        };
 
        foundation.handleTrailingIconInteraction(mockEvt);
@@ -416,6 +421,7 @@ describe('MDCChipFoundation', () => {
        expect(foundation.getShouldRemoveOnTrailingIconClick()).toBe(true);
        expect(mockAdapter.addClass).toHaveBeenCalledWith(cssClasses.CHIP_EXIT);
        expect(mockEvt.stopPropagation).toHaveBeenCalled();
+       expect(mockEvt.preventDefault).toHaveBeenCalled();
      });
 
   it(`#handleTrailingIconInteraction does not add ${
@@ -426,6 +432,7 @@ describe('MDCChipFoundation', () => {
        const mockEvt = {
          type: 'click',
          stopPropagation: jasmine.createSpy('stopPropagation'),
+         preventDefault: jasmine.createSpy('preventDefault'),
        };
 
        foundation.setShouldRemoveOnTrailingIconClick(false);
@@ -435,6 +442,7 @@ describe('MDCChipFoundation', () => {
        expect(mockAdapter.addClass)
            .not.toHaveBeenCalledWith(cssClasses.CHIP_EXIT);
        expect(mockEvt.stopPropagation).toHaveBeenCalled();
+       expect(mockEvt.preventDefault).toHaveBeenCalled();
      });
 
   it('#handleKeydown emits custom event with appropriate keys', () => {


### PR DESCRIPTION
Project import generated by Copybara.
cl/292049726
