### PR TITLE
fix(chips): .d.ts file generated with syntax error

### DIFF
--- a/packages/mdc-chips/chip/foundation.ts
+++ b/packages/mdc-chips/chip/foundation.ts
@@ -71,9 +71,7 @@ export class MDCChipFoundation extends MDCFoundation<MDCChipAdapter> {
     };
   }
 
-  /**
-   * Whether a trailing icon click should immediately trigger exit/removal of the chip.
-   */
+  /** Whether a trailing icon click should immediately trigger exit/removal of the chip. */
   private shouldRemoveOnTrailingIconClick_ = true;
 
   constructor(adapter?: Partial<MDCChipAdapter>) {


### PR DESCRIPTION
Due to the way a comment was formatted in the chip foundation the .d.ts bundler ended up generating a file with a syntax error.

For reference, here's what was being generated:
![●_mdc chips d ts_-_material-components-web_-_Visua_2020-02-07_19-24-23](https://user-images.githubusercontent.com/4450522/74055266-fa0e5780-49df-11ea-9a05-ad6e0adba4fa.png)
