### PR TITLE
fix(list): ensure sass mixin works if leading is provided in px

### DIFF
--- a/packages/mdc-list/_mixins.scss
+++ b/packages/mdc-list/_mixins.scss
@@ -292,7 +292,7 @@
   .mdc-list-group__subheader {
     $mdc-list-subheader-virtual-height: 3rem;
     $mdc-list-subheader-leading: map.get(map.get(typography-variables.$styles, body1), line-height);
-    $mdc-list-subheader-margin: ($mdc-list-subheader-virtual-height - $mdc-list-subheader-leading) / 2;
+    $mdc-list-subheader-margin: calc((#{$mdc-list-subheader-virtual-height} - #{$mdc-list-subheader-leading}) / 2);
 
     @include typography-mixins.typography(subtitle1, $query);
 


### PR DESCRIPTION
This switches the subheader margin calculation from static to dynamic so
that it will work if the `$mdc-list-subheader-leading` is provided in
`px` instead of `rem`. Angular Material's current typography settings
specify it in `px`. We do plan to move away from that and use `rem` like
MDC, but this fix will make it work in the mean time.