### PR TITLE
fix(checkbox): Use secondary and on-secondary as default colors

### DIFF
--- a/packages/mdc-checkbox/_variables.scss
+++ b/packages/mdc-checkbox/_variables.scss
@@ -25,10 +25,10 @@
 @use "@material/theme/variables" as theme-variables;
 @use "@material/density/variables" as density-variables;
 
-$mark-color: theme-variables.prop-value(on-primary) !default;
+$baseline-theme-color: secondary !default;
+$mark-color: theme-variables.prop-value(on-secondary) !default;
 $border-color: rgba(theme-variables.prop-value(on-surface), .54) !default;
 $disabled-color: rgba(theme-variables.prop-value(on-surface), .38) !default;
-$baseline-theme-color: secondary !default;
 
 $ripple-size: 40px !default;
 $icon-size: 18px !default;


### PR DESCRIPTION
Previously, the secondary color was by default used for the background
of the checkbox and on-primary was used for the color of the checkmark.

Fixes #5730