### PR TITLE
chore: possible fix for package-lock issue on npm i

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:js": "eslint scripts webpack.config.js karma.conf.js",
     "lint:ts": "tslint --exclude \"**/*.d.ts\" --exclude \"packages/**/test/*.ts\" \"packages/test/*.ts\" \"test/**/*.ts\" \"scripts/**/*.ts\"",
     "lint": "npm-run-all --parallel lint:*",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap --no-ci",
     "pretest": "npm run lint",
     "test": "npm run test:unit && npm run test:dependency && npm run build && npm run clean",
     "test:sass": "jasmine --config=jasmine-node.json",


### PR DESCRIPTION
Tests are failing at `npm i` (`postinstall: lerna bootstrap`) step with following error message:

```
> undefined postinstall /home/runner/work/material-components-web/material-components-web
> lerna bootstrap

lerna notice cli v3.20.2
lerna info ci enabled
lerna info Bootstrapping 46 packages
lerna info Installing external dependencies
lerna ERR! npm ci exited 1 in '@material/auto-init'
lerna ERR! npm ci stderr:
npm ERR! cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-04-02T17_49_14_281Z-debug.log

lerna ERR! npm ci exited 1 in '@material/auto-init'
lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! undefined postinstall: `lerna bootstrap`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the undefined postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-04-02T17_49_14_343Z-debug.log
##[error]Process completed with exit code 1.
```

Not able to reproduce this error locally. (Node v10.16.3, npm v6.13.4)

**Possible fix:**

lerna boostrap command seem to use clean install that mandates the existence of package-lock.json file. See [lerna/boostrap](https://github.com/lerna/lerna/tree/master/commands/bootstrap#--no-ci) docs. But  PR #5697 removed all package-lock.json files from our components. Use `--no-ci` skips clean install.

