### PR TITLE
fix(data-table): update `get-header-cell-height` function body for allowing incompatible units

### DIFF
--- a/packages/mdc-data-table/_variables.scss
+++ b/packages/mdc-data-table/_variables.scss
@@ -45,7 +45,7 @@ $stroke-size: 1px !default;
 $stroke-color: rgba(theme-variables.prop-value(on-surface), .12) !default;
 
 $cell-height: 52px !default;
-$header-cell-height: get-header-cell-height($cell-height) !default;
+$header-cell-height: 56px !default; // $cell-height + 4
 $cell-leading-padding: 16px !default;
 $cell-trailing-padding: 16px !default;
 
@@ -59,7 +59,3 @@ $density-config: (
     minimum: $minimum-cell-height,
   )
 );
-
-@function get-header-cell-height($height) {
-  @return $height + 4px;
-}

--- a/packages/mdc-data-table/_variables.scss
+++ b/packages/mdc-data-table/_variables.scss
@@ -45,7 +45,7 @@ $stroke-size: 1px !default;
 $stroke-color: rgba(theme-variables.prop-value(on-surface), .12) !default;
 
 $cell-height: 52px !default;
-$header-cell-height: 56px !default; // $cell-height + 4
+$header-cell-height: get-header-cell-height($cell-height) !default;
 $cell-leading-padding: 16px !default;
 $cell-trailing-padding: 16px !default;
 
@@ -59,3 +59,11 @@ $density-config: (
     minimum: $minimum-cell-height,
   )
 );
+
+@function get-header-cell-height($height) {
+  @if (index('px', unit($height)) != null) {
+    @return $height + 4px;
+  } @else {
+    @return $height;
+  }
+}


### PR DESCRIPTION
The internal function `get-header-cell-height` does not allow me to change the unit not pixels but rem or em for `$header-cell-height` variable. 

Even if I override the variable before use it, the function still executes. As far as I understand this is feature of the preprocessor and encapsulations of `@use/@forward` directives.

Therefore, I propose to simply remove this function.