### PR TITLE
fix: server-side rendering errors in linear progress and slider

### DIFF
--- a/packages/mdc-linear-progress/foundation.ts
+++ b/packages/mdc-linear-progress/foundation.ts
@@ -151,8 +151,11 @@ export class MDCLinearProgressFoundation extends
 
   private setPrimaryBarProgress_(progressValue: number) {
     const value = `scaleX(${progressValue})`;
-    this.adapter_.setPrimaryBarStyle(
-        getCorrectPropertyName(window, 'transform'), value);
+
+    // Accessing `window` without a `typeof` check will throw on Node environments.
+    const transformProp = typeof window !== 'undefined' ?
+        getCorrectPropertyName(window, 'transform') : 'transform';
+    this.adapter_.setPrimaryBarStyle(transformProp, value);
   }
 
   private setBufferBarProgress_(progressValue: number) {

--- a/packages/mdc-slider/foundation.ts
+++ b/packages/mdc-slider/foundation.ts
@@ -496,9 +496,11 @@ export class MDCSliderFoundation extends MDCFoundation<MDCSliderAdapter> {
       translatePx = this.rect_.width - translatePx;
     }
 
-    const transformProp = getCorrectPropertyName(window, 'transform');
+    // Accessing `window` without a `typeof` check will throw on Node environments.
+    const hasWindow = typeof window !== 'undefined';
+    const transformProp = hasWindow ? getCorrectPropertyName(window, 'transform') : 'transform';
     const transitionendEvtName =
-        getCorrectEventName(window, 'transitionend') as EventType;
+        hasWindow ? getCorrectEventName(window, 'transitionend') as EventType : 'transitionend';
 
     if (this.inTransit_) {
       const onTransitionEnd = () => {


### PR DESCRIPTION
The linear progress and slider components were trying to access `window` as a global directly which will throw under Node environments. These changes add a `typeof` guard infront of it to avoid the error.

**Note:** ideally `getCorrectPropertyName` and `getCorrectEventName` would get the `window` themselves manually and would do the `typeof` check internally, but it seems like the `windowObj` parameter is used when unit testing and there's no nice way around it. Also changing the signature would be a breaking change.