### PR TITLE
docs(line-ripple): update README for active/inactive color change

### DIFF
--- a/packages/mdc-line-ripple/README.md
+++ b/packages/mdc-line-ripple/README.md
@@ -63,7 +63,8 @@ CSS Class | Description
 
 Mixin | Description
 --- | ---
-`color($color)` | Customizes the color of the line ripple when active.
+`active-color($color)` | Customizes the color of the line ripple when active.\
+`inactive-color($color)` | Customizes the color of the line ripple when inactive.
 
 ## `MDCLineRipple` Properties and Methods
 

--- a/packages/mdc-line-ripple/README.md
+++ b/packages/mdc-line-ripple/README.md
@@ -63,7 +63,7 @@ CSS Class | Description
 
 Mixin | Description
 --- | ---
-`active-color($color)` | Customizes the color of the line ripple when active.\
+`active-color($color)` | Customizes the color of the line ripple when active.
 `inactive-color($color)` | Customizes the color of the line ripple when inactive.
 
 ## `MDCLineRipple` Properties and Methods


### PR DESCRIPTION
Change Sass mixin listing to include both active-color() and inactive-color(), instead of the deprecated color() mixin