### PR TITLE
docs(textfield): Update icon README new and renamed Sass mixins

### DIFF
--- a/packages/mdc-textfield/icon/README.md
+++ b/packages/mdc-textfield/icon/README.md
@@ -156,9 +156,10 @@ CSS Class | Description
 
 Mixin | Description
 --- | ---
-`mdc-text-field-leading-icon-color($color)` | Customizes the color for the leading icon in an enabled text-field.
-`mdc-text-field-trailing-icon-color($color)` | Customizes the color for the trailing icon in an enabled text-field.
-`mdc-text-field-disabled-icon-color($color)` | Customizes the color for the leading/trailing icons in a disabled text-field.
+`leading-icon-color($color)` | Customizes the color for the leading icon in an enabled text-field.
+`trailing-icon-color($color)` | Customizes the color for the trailing icon in an enabled text-field.
+`disabled-icon-color($color)` | Customizes the color for the leading/trailing icons in a disabled text-field.
+`size($size)` | Sets the size of the leading and trailing icons.
 
 ## `MDCTextFieldIcon` properties and methods
 


### PR DESCRIPTION
Update the documentation for the three icon-color mixins to remove the  mdc-text-field prefix that was moved with the Sass upgrade. Add documentation for the size mixin.