### PR TITLE
chore: Removed number-leading-zero from Sass lint rule

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -27,7 +27,6 @@ rules:
   no-extra-semicolons: true
   # In MDC, @keyframe's are defined in a separate file.
   # no-unknown-animations: true
-  number-leading-zero: never
   # Requires known-css-parser, not yet imported into third_party.
   # property-no-unknown: true
   rule-empty-line-before:


### PR DESCRIPTION
Syncs with internal Sass lint rules.