### PR TITLE
fix(layout-grid): "base" span class specificity

### DIFF
--- a/packages/mdc-layout-grid/_mixins.scss
+++ b/packages/mdc-layout-grid/_mixins.scss
@@ -80,19 +80,24 @@
     @error "Invalid style specified! Choose one of #{map.keys(variables.$columns)}";
   }
 
-  $percent: math.percentage($span / map.get(variables.$columns, $size));
+  @if $span == 0 {
+    display: none;
+  } @else {
+    $percent: math.percentage($span / map.get(variables.$columns, $size));
 
-  @if $percent > 100% {
-    $percent: 100%;
-  }
+    @if $percent > 100% {
+      $percent: 100%;
+    }
 
-  width: calc(#{$percent} - #{$gutter});
-  // stylelint-disable-next-line declaration-block-no-duplicate-properties
-  width: calc(#{$percent} - var(--mdc-layout-grid-gutter-#{$size}, #{$gutter}));
+    display: block;
+    width: calc(#{$percent} - #{$gutter});
+    // stylelint-disable-next-line declaration-block-no-duplicate-properties
+    width: calc(#{$percent} - var(--mdc-layout-grid-gutter-#{$size}, #{$gutter}));
 
-  @supports (display: grid) {
-    width: auto;
-    grid-column-end: span math.min($span, map.get(variables.$columns, $size));
+    @supports (display: grid) {
+      width: auto;
+      grid-column-end: span math.min($span, map.get(variables.$columns, $size));
+    }
   }
 }
 

--- a/packages/mdc-layout-grid/mdc-layout-grid.scss
+++ b/packages/mdc-layout-grid/mdc-layout-grid.scss
@@ -63,11 +63,18 @@
 
       @include mixins.cell($size, variables.$default-column-span, $gutter);
 
-      @for $span from 1 through map.get(variables.$columns, $upper-breakpoint) {
-        // Span classes.
+      // Base span classes.
+      // Base spans should have less specificity than size-specific spans
+      @for $span from 0 through map.get(variables.$columns, $upper-breakpoint) {
+        &--span-#{$span} {
+          @include mixins.cell-span_($size, $span, $gutter);
+        }
+      }
+
+      // Size specific span classes.
+      @for $span from 0 through map.get(variables.$columns, $upper-breakpoint) {
         // stylelint-disable max-nesting-depth
-        @at-root .mdc-layout-grid__cell--span-#{$span},
-        .mdc-layout-grid__cell--span-#{$span}-#{$size} {
+        &--span-#{$span}-#{$size} {
           @include mixins.cell-span_($size, $span, $gutter);
         }
         // stylelint-enable max-nesting-depth


### PR DESCRIPTION
"base" span classes should not be more specific than device-specific spans.
fixes #2228 

also added `span-0` classes to implement #2270