### PR TITLE
test(infra): Remove number-leading-zero rule.

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -27,7 +27,6 @@ rules:
   no-extra-semicolons: true
   # In MDC, @keyframe's are defined in a separate file.
   # no-unknown-animations: true
-  number-leading-zero: never
   # Requires known-css-parser, not yet imported into third_party.
   # property-no-unknown: true
   rule-empty-line-before:


### PR DESCRIPTION
This was removed recently in internal sass/stylelint/stylelintrc.yaml, since we now use Prettier for formatting, which auto-adds leading zeros.