### PR TITLE
fix(data-table): not inverting text alignment in rtl

### DIFF
--- a/packages/mdc-data-table/_data-table.scss
+++ b/packages/mdc-data-table/_data-table.scss
@@ -170,6 +170,11 @@
       overflow: hidden;
       text-align: left;
       text-overflow: ellipsis;
+
+      @include rtl-mixins.rtl {
+        /* @noflip */
+        text-align: right;
+      }
     }
   }
 


### PR DESCRIPTION
The table cell has `text-align: left` which means that it won't invert automatically in RTL. These changes add the inversion, similar to the one on the table headers.