### PR TITLE
fix: mark all packages as side-effect-free

### DIFF
--- a/packages/mdc-button/package.json
+++ b/packages/mdc-button/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/material-components/material-components-web.git",
     "directory": "packages/mdc-button"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/density": "^6.0.0",
     "@material/elevation": "^6.0.0",

--- a/packages/mdc-card/package.json
+++ b/packages/mdc-card/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/material-components/material-components-web.git",
     "directory": "packages/mdc-card"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/elevation": "^6.0.0",
     "@material/feature-targeting": "^6.0.0",

--- a/packages/mdc-density/package.json
+++ b/packages/mdc-density/package.json
@@ -9,6 +9,7 @@
     "density",
     "adaptive layout"
   ],
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-elevation/package.json
+++ b/packages/mdc-elevation/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/material-components/material-components-web.git",
     "directory": "packages/mdc-elevation"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/animation": "^6.0.0",
     "@material/base": "^6.0.0",

--- a/packages/mdc-fab/package.json
+++ b/packages/mdc-fab/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/material-components/material-components-web.git",
     "directory": "packages/mdc-fab"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/animation": "^6.0.0",
     "@material/dom": "^6.0.0",

--- a/packages/mdc-feature-targeting/package.json
+++ b/packages/mdc-feature-targeting/package.json
@@ -8,6 +8,7 @@
     "material design",
     "feature targeting"
   ],
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-image-list/package.json
+++ b/packages/mdc-image-list/package.json
@@ -13,6 +13,7 @@
     "material design",
     "image list"
   ],
+  "sideEffects": false,
   "dependencies": {
     "@material/feature-targeting": "^6.0.0",
     "@material/shape": "^6.0.0",

--- a/packages/mdc-layout-grid/package.json
+++ b/packages/mdc-layout-grid/package.json
@@ -9,6 +9,7 @@
     "grid",
     "layout"
   ],
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-rtl/package.json
+++ b/packages/mdc-rtl/package.json
@@ -9,6 +9,7 @@
     "rtl",
     "right to left"
   ],
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-shape/package.json
+++ b/packages/mdc-shape/package.json
@@ -16,6 +16,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/feature-targeting": "^6.0.0",
     "@material/rtl": "^6.0.0",

--- a/packages/mdc-theme/package.json
+++ b/packages/mdc-theme/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/material-components/material-components-web.git",
     "directory": "packages/mdc-theme"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/feature-targeting": "^6.0.0"
   }

--- a/packages/mdc-touch-target/package.json
+++ b/packages/mdc-touch-target/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/material-components/material-components-web.git",
     "directory": "packages/mdc-touch-target"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/base": "^6.0.0",
     "@material/feature-targeting": "^6.0.0"

--- a/packages/mdc-typography/package.json
+++ b/packages/mdc-typography/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/material-components/material-components-web.git",
     "directory": "packages/mdc-typography"
   },
+  "sideEffects": false,
   "dependencies": {
     "@material/feature-targeting": "^6.0.0",
     "@material/theme": "^6.0.0"


### PR DESCRIPTION
Currently some packages aren't marked with `sideEffects: false` which can have an effect on dead code elimination. These changes add the flag to all of the packages.