### PR TITLE
fix(mdc-dialog): fix `data-mdc-dialog-initial-focus` to work in multiple dialogs

### DIFF
--- a/packages/mdc-dialog/component.ts
+++ b/packages/mdc-dialog/component.ts
@@ -197,6 +197,6 @@ export class MDCDialog extends MDCComponent<MDCDialogFoundation> {
   }
 
   private getInitialFocusEl_(): HTMLElement|null {
-    return document.querySelector(`[${strings.INITIAL_FOCUS_ATTRIBUTE}]`);
+    return this.root.querySelector(`[${strings.INITIAL_FOCUS_ATTRIBUTE}]`);
   }
 }

--- a/packages/mdc-dialog/test/component.test.ts
+++ b/packages/mdc-dialog/test/component.test.ts
@@ -25,7 +25,7 @@ import {supportsCssVariables} from '../../mdc-ripple/util';
 import {emitEvent} from '../../../testing/dom/events';
 import {createMockFoundation} from '../../../testing/helpers/foundation';
 import {setUpMdcTestEnvironment} from '../../../testing/helpers/setup';
-import {strings} from '../constants';
+import {strings, numbers} from '../constants';
 import {MDCDialog, MDCDialogFoundation, util} from '../index';
 
 function getFixture() {
@@ -592,14 +592,34 @@ describe('MDCDialog', () => {
     expect((component as any).foundation.layout).toHaveBeenCalled();
   });
 
-  it(`${strings.INITIAL_FOCUS_ATTRIBUTE} will focus when the dialog is opened`, () => {
-    const {component: component1, yesButton: yesButton1} = setupTest();
-    const {component: component2, yesButton: yesButton2} = setupTest();
+  it(`Button with ${strings.INITIAL_FOCUS_ATTRIBUTE} will be focused when the dialog is opened, with multiple initial focus buttons in DOM`, () => {
+    const {root: root1, component: component1, yesButton: yesButton1} = setupTest();
+    const {root: root2, component: component2, yesButton: yesButton2} = setupTest();
 
     const initialFocusEl1 = (component1.getDefaultFoundation() as any).adapter.getInitialFocusEl();
     expect(initialFocusEl1).toEqual(yesButton1);
 
     const initialFocusEl2 = (component2.getDefaultFoundation() as any).adapter.getInitialFocusEl();
     expect(initialFocusEl2).toEqual(yesButton2);
+
+    try {
+      document.body.appendChild(root1)
+      document.body.appendChild(root2)
+
+      component1.open()
+      jasmine.clock().tick(numbers.DIALOG_ANIMATION_OPEN_TIME_MS + 10);
+      expect(document.activeElement).toEqual(yesButton1);
+      component1.close()
+      jasmine.clock().tick(numbers.DIALOG_ANIMATION_CLOSE_TIME_MS);
+
+      component2.open()
+      jasmine.clock().tick(numbers.DIALOG_ANIMATION_OPEN_TIME_MS + 10);
+      expect(document.activeElement).toEqual(yesButton2);
+      component2.close()
+      jasmine.clock().tick(numbers.DIALOG_ANIMATION_CLOSE_TIME_MS);
+    } finally {
+      document.body.removeChild(root1)
+      document.body.removeChild(root2)
+    }
   });
 });

--- a/packages/mdc-dialog/test/component.test.ts
+++ b/packages/mdc-dialog/test/component.test.ts
@@ -53,7 +53,7 @@ function getFixture() {
               <button class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no" type="button">
                 <span class="mdc-button__label">No</span>
               </button>
-              <button class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes" type="button">
+              <button class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes" type="button" data-mdc-dialog-initial-focus>
                 <span class="mdc-button__label">Yes</span>
               </button>
             </div>
@@ -590,5 +590,16 @@ describe('MDCDialog', () => {
         jasmine.createSpy('component.foundation.layout');
     component.layout();
     expect((component as any).foundation.layout).toHaveBeenCalled();
+  });
+
+  it(`${strings.INITIAL_FOCUS_ATTRIBUTE} will focus when the dialog is opened`, () => {
+    const {component: component1, yesButton: yesButton1} = setupTest();
+    const {component: component2, yesButton: yesButton2} = setupTest();
+
+    const initialFocusEl1 = (component1.getDefaultFoundation() as any).adapter.getInitialFocusEl();
+    expect(initialFocusEl1).toEqual(yesButton1);
+
+    const initialFocusEl2 = (component2.getDefaultFoundation() as any).adapter.getInitialFocusEl();
+    expect(initialFocusEl2).toEqual(yesButton2);
   });
 });

--- a/packages/mdc-dialog/test/component.test.ts
+++ b/packages/mdc-dialog/test/component.test.ts
@@ -53,7 +53,7 @@ function getFixture() {
               <button class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no" type="button">
                 <span class="mdc-button__label">No</span>
               </button>
-              <button class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes" type="button" data-mdc-dialog-initial-focus>
+              <button class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes" type="button" ${strings.INITIAL_FOCUS_ATTRIBUTE}>
                 <span class="mdc-button__label">Yes</span>
               </button>
             </div>
@@ -596,11 +596,8 @@ describe('MDCDialog', () => {
     const {root: root1, component: component1, yesButton: yesButton1} = setupTest();
     const {root: root2, component: component2, yesButton: yesButton2} = setupTest();
 
-    const initialFocusEl1 = (component1.getDefaultFoundation() as any).adapter.getInitialFocusEl();
-    expect(initialFocusEl1).toEqual(yesButton1);
-
-    const initialFocusEl2 = (component2.getDefaultFoundation() as any).adapter.getInitialFocusEl();
-    expect(initialFocusEl2).toEqual(yesButton2);
+    expect(yesButton1.hasAttribute(strings.INITIAL_FOCUS_ATTRIBUTE)).toBe(true);
+    expect(yesButton2.hasAttribute(strings.INITIAL_FOCUS_ATTRIBUTE)).toBe(true);
 
     try {
       document.body.appendChild(root1)


### PR DESCRIPTION
This PR fix `data-mdc-dialog-initial-focus` to work in multiple dialogs.

Fixes #6142