### PR TITLE
fix(circular-progress): Default all variables

### DIFF
--- a/packages/mdc-circular-progress/_variables.scss
+++ b/packages/mdc-circular-progress/_variables.scss
@@ -23,28 +23,28 @@
 $color: primary !default;
 
 /// size parameters
-$default-size: large;
+$default-size: large !default;
 $container-side-length: (
   large: 48px,
   medium: 36px,
   small: 24px,
-);
+) !default;
 $stroke-width: (
   large: 4px,
   medium: 3px,
   small: 2.5px,
-);
+) !default;
 
 /// The rotation position of the arcs that corresponds to their fully contracted state
-$base-angle: 135deg;
+$base-angle: 135deg !default;
 /// Amount of circle the arc takes up
-$arc-size: 270deg;
+$arc-size: 270deg !default;
 /// Time it takes to expand and contract arc
-$arc-time: 1333ms;
+$arc-time: 1333ms !default;
 /// Time for inactive indicator to disappear
-$shrink-time: 400ms;
+$shrink-time: 400ms !default;
 /// How much the start location of the arc should rotate each time; 216 gives
 /// us a 5 pointed star shape (it's 360/5 * 3)
-$arc-start-rotation-interval: 216deg;
+$arc-start-rotation-interval: 216deg !default;
 /// The timing function used for the core spinner animations.
-$timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+$timing-function: cubic-bezier(0.4, 0, 0.2, 1) !default;


### PR DESCRIPTION
Every other package !default's all of their variables, giving consumers the ability to customize them.

Circular Progress for some reason only currently !default's one, not giving full flexibility to consumers.