### PR TITLE
fix(circular-progress): Correctly position circle-right

### DIFF
--- a/packages/mdc-circular-progress/_mixins.scss
+++ b/packages/mdc-circular-progress/_mixins.scss
@@ -146,8 +146,10 @@
   }
 
   .mdc-circular-progress__circle-right {
-    .mdc-circular-progress__indeterminate-circle-graphic {
-      @include feature-targeting-mixins.targets($feat-structure) {
+    @include feature-targeting-mixins.targets($feat-structure) {
+      position: absolute;
+
+      .mdc-circular-progress__indeterminate-circle-graphic {
         /* @noflip */
         left: -100%;
       }


### PR DESCRIPTION
The circular-progress animation does not currently work without this change.  Being relatively positioned from the circle-clipper class, the circle-right goes off to the side instead of being on top of the circle-left.

Additionally, the README for the circular-progress component looks very different, and is missing some of the information provided by all other MDC READMEs. This PR tries to fix that too.