### PR TITLE
test: Add core-js to dev deps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4183,6 +4183,12 @@
         "source-map-support": "^0.4.2"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -4202,6 +4208,14 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.10.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
       }
     },
     "babel-template": {
@@ -6764,9 +6778,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
       "dev": true
     },
     "core-util-is": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-types": "^6.24.1",
     "camel-case": "^3.0.0",
     "conventional-changelog-cli": "^2.0.31",
+    "core-js": "^3.6.5",
     "cp-file": "^7.0.0",
     "cross-env": "^5.0.0",
     "css-loader": "^2.0.0",


### PR DESCRIPTION
This will be used with https://github.com/material-components/material-components-web/pull/6257 to add ES polyfills (Array.from, Object.assign, etc.) to our external tests.