### PR TITLE
fix(segmented-button): Move include statements to avoid nested classes

### DIFF
--- a/packages/mdc-segmented-button/segment/_segment.scss
+++ b/packages/mdc-segmented-button/segment/_segment.scss
@@ -37,8 +37,8 @@
   @include touch-target.wrapper($query);
   @include elevation.overlay-common($query);
 
-  @include _unselected-themes($query);
-  @include _selected-themes($query);
+  @include _unselected($query);
+  @include _selected($query);
 
   .mdc-segmented-button__segment {
     @include base($query);
@@ -135,7 +135,7 @@
   }
 }
 
-@mixin _unselected-themes($query: feature-targeting.all()) {
+@mixin _unselected($query: feature-targeting.all()) {
   @include segment-theme.outline-color(segment-theme.$outline-color, $query);
   @include segment-theme.unselected-ink-color(
     segment-theme.$unselected-ink-color,
@@ -147,7 +147,7 @@
   );
 }
 
-@mixin _selected-themes($query: feature-targeting.all()) {
+@mixin _selected($query: feature-targeting.all()) {
   @include segment-theme.selected-ink-color(
     segment-theme.$selected-ink-color,
     $query

--- a/packages/mdc-segmented-button/segment/_segment.scss
+++ b/packages/mdc-segmented-button/segment/_segment.scss
@@ -37,9 +37,11 @@
   @include touch-target.wrapper($query);
   @include elevation.overlay-common($query);
 
+  @include _unselected-themes($query);
+  @include _selected-themes($query);
+
   .mdc-segmented-button__segment {
     @include base($query);
-    @include _unselected($query);
 
     &:hover {
       @include feature-targeting.targets($feat-structure) {
@@ -79,11 +81,6 @@
         $query: $query
       );
     }
-  }
-
-  // Style for when element is selected
-  .mdc-segmented-button__segment--selected {
-    @include _selected($query);
   }
 
   // maintains visual design when inside a touch-target-wrapper
@@ -126,7 +123,6 @@
   @include elevation-theme.overlay-surface-position($query: $query);
   @include elevation-theme.overlay-dimensions(100%, $query: $query);
   @include typography.typography(button, $query);
-  @include segment-theme.outline-color(segment-theme.$outline-color, $query);
   @include feature-targeting.targets($feat-structure) {
     display: inline-flex;
     vertical-align: top;
@@ -139,7 +135,8 @@
   }
 }
 
-@mixin _unselected($query: feature-targeting.all()) {
+@mixin _unselected-themes($query: feature-targeting.all()) {
+  @include segment-theme.outline-color(segment-theme.$outline-color, $query);
   @include segment-theme.unselected-ink-color(
     segment-theme.$unselected-ink-color,
     $query
@@ -150,7 +147,7 @@
   );
 }
 
-@mixin _selected($query: feature-targeting.all()) {
+@mixin _selected-themes($query: feature-targeting.all()) {
   @include segment-theme.selected-ink-color(
     segment-theme.$selected-ink-color,
     $query


### PR DESCRIPTION
Remove use of segment-theme mixins with references to css classes inside of references to css classes.