### PR TITLE
[docs] Pointed directly to the document with the list of component libraries

### DIFF
--- a/docs/integrating-into-frameworks.md
+++ b/docs/integrating-into-frameworks.md
@@ -14,7 +14,7 @@ frameworks.
 
 ## Examples
 
-We maintain a list of component libraries, which wrap MDC Web for other frameworks, in our main [README](../README.md). Each library must:
+We maintain a list of component libraries, which wrap MDC Web for other frameworks, in our main [README](../README.md) (under the [MDC Web on other frameworks](./framework-wrappers.md) document). Each library must:
 - Serve components in an à-la-carte delivery model
 - Have existed for longer than 6 weeks and show continued maintenance over time
 - Provide usage documentation per component


### PR DESCRIPTION
Pointed to the [MDC Web on other frameworks](https://github.com/material-components/material-components-web/blob/master/docs/framework-wrappers.md) document