### PR TITLE
feat(list): support ctrl + a keyboard shortcut

### DIFF
--- a/packages/mdc-list/foundation.ts
+++ b/packages/mdc-list/foundation.ts
@@ -246,6 +246,9 @@ export class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
     const isEnter = normalizeKey(event) === 'Enter';
     const isSpace = normalizeKey(event) === 'Spacebar';
 
+    // Have to check both upper and lower case, because having caps lock on affects the value.
+    const isLetterA = event.key === 'A' || event.key === 'a';
+
     if (this.adapter.isRootFocused()) {
       if (isArrowUp || isEnd) {
         event.preventDefault();
@@ -299,6 +302,9 @@ export class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
     } else if (isEnd) {
       preventDefaultEvent(event);
       this.focusLastElement();
+    } else if (isLetterA && event.ctrlKey && this.isCheckboxList_) {
+      event.preventDefault();
+      this.toggleAll(this.selectedIndex_ === numbers.UNSET_INDEX ? [] : this.selectedIndex_ as number[]);
     } else if (isEnter || isSpace) {
       if (isRootListItem) {
         // Return early if enter key is pressed on anchor element which triggers
@@ -647,6 +653,25 @@ export class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
   private focusItemAtIndex(index: number) {
     this.adapter.focusItemAtIndex(index);
     this.focusedItemIndex = index;
+  }
+
+  private toggleAll(currentlySelectedIndexes: number[]) {
+    const count = this.adapter.getListItemCount();
+
+    // If all items are selected, deselect everything.
+    if (currentlySelectedIndexes.length === count) {
+      this.setCheckboxAtIndex_([]);
+    } else {
+      // Otherwise select all enabled options.
+      const allIndexes: number[] = [];
+      for (let i = 0; i < count; i++) {
+        if (!this.adapter.listItemAtIndexHasClass(i, cssClasses.LIST_ITEM_DISABLED_CLASS) ||
+            currentlySelectedIndexes.indexOf(i) > -1) {
+          allIndexes.push(i);
+        }
+      }
+      this.setCheckboxAtIndex_(allIndexes);
+    }
   }
 
   /**

--- a/packages/mdc-list/test/foundation.test.ts
+++ b/packages/mdc-list/test/foundation.test.ts
@@ -895,6 +895,141 @@ describe('MDCListFoundation', () => {
        expect(mockAdapter.focusItemAtIndex).toHaveBeenCalledTimes(1);
      });
 
+  it('#handleKeydown should select all items on ctrl + A, if nothing is selected', () => {
+    const {foundation, mockAdapter} = setupTest();
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const event = {key: 'A', ctrlKey: true, preventDefault};
+
+    mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(true);
+    mockAdapter.getListItemCount.and.returnValue(3);
+    foundation.layout();
+    foundation.handleKeydown(event, false, -1);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(3);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(0, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(1, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(2, true);
+  });
+
+  it('#handleKeydown should select all items on ctrl + lowercase A, if nothing is selected', () => {
+    const {foundation, mockAdapter} = setupTest();
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const event = {key: 'a', ctrlKey: true, preventDefault};
+
+    mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(true);
+    mockAdapter.getListItemCount.and.returnValue(3);
+    foundation.layout();
+    foundation.handleKeydown(event, false, -1);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(3);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(0, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(1, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(2, true);
+  });
+
+  it('#handleKeydown should select all items on ctrl + A, if some items are selected', () => {
+    const {foundation, mockAdapter} = setupTest();
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const event = {key: 'A', ctrlKey: true, preventDefault};
+
+    mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(true);
+    mockAdapter.getListItemCount.and.returnValue(4);
+    foundation.layout();
+    foundation.setSelectedIndex([1, 2]);
+
+    // Reset the calls since `setSelectedIndex` will throw it off.
+    mockAdapter.setCheckedCheckboxOrRadioAtIndex.calls.reset();
+    foundation.handleKeydown(event, false, -1);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(4);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(0, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(1, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(2, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(3, true);
+  });
+
+  it('#handleKeydown should deselect all items on ctrl + A, if all items are selected', () => {
+    const {foundation, mockAdapter} = setupTest();
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const event = {key: 'A', ctrlKey: true, preventDefault};
+
+    mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(true);
+    mockAdapter.getListItemCount.and.returnValue(3);
+    foundation.layout();
+    foundation.setSelectedIndex([0, 1, 2]);
+
+    // Reset the calls since `setSelectedIndex` will throw it off.
+    mockAdapter.setCheckedCheckboxOrRadioAtIndex.calls.reset();
+    foundation.handleKeydown(event, false, -1);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(3);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(0, false);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(1, false);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(2, false);
+  });
+
+  it('#handleKeydown should not select disabled items on ctrl + A', () => {
+    const {foundation, mockAdapter} = setupTest();
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const event = {key: 'A', ctrlKey: true, preventDefault};
+
+    mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(true);
+    mockAdapter.listItemAtIndexHasClass
+        .withArgs(1, cssClasses.LIST_ITEM_DISABLED_CLASS)
+        .and.returnValue(true);
+    mockAdapter.getListItemCount.and.returnValue(3);
+    foundation.layout();
+    foundation.handleKeydown(event, false, -1);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(3);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(0, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(1, false);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(2, true);
+  });
+
+  it('#handleKeydown should not handle ctrl + A on a non-checkbox list', () => {
+    const {foundation, mockAdapter} = setupTest();
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const event = {key: 'a', ctrlKey: true, preventDefault};
+
+    mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(false);
+    mockAdapter.getListItemCount.and.returnValue(3);
+    foundation.layout();
+    foundation.handleKeydown(event, false, -1);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).not.toHaveBeenCalled();
+  });
+
+  it('#handleKeydown should not deselect a selected disabled item on ctrl + A', () => {
+    const {foundation, mockAdapter} = setupTest();
+    const preventDefault = jasmine.createSpy('preventDefault');
+    const event = {key: 'A', ctrlKey: true, preventDefault};
+
+    mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(true);
+    mockAdapter.listItemAtIndexHasClass
+        .withArgs(1, cssClasses.LIST_ITEM_DISABLED_CLASS)
+        .and.returnValue(true);
+    mockAdapter.getListItemCount.and.returnValue(3);
+    foundation.layout();
+    foundation.setSelectedIndex([1]);
+
+    // Reset the calls since `setSelectedIndex` will throw it off.
+    mockAdapter.setCheckedCheckboxOrRadioAtIndex.calls.reset();
+    foundation.handleKeydown(event, false, -1);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(3);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(0, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(1, true);
+    expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(2, true);
+  });
+
   it('#focusNextElement retains the focus on last item when wrapFocus=false and returns that index',
      () => {
        const {foundation, mockAdapter} = setupTest();


### PR DESCRIPTION
Adds support for the ctrl + a shortcut in a checkbox-based list which will select all enabled deselected items, or deselect everything if all items are selected.

Fixes #6366.