### PR TITLE
docs: Update framework wrapper list to include Bootstrap 4

### DIFF
--- a/docs/framework-wrappers.md
+++ b/docs/framework-wrappers.md
@@ -23,5 +23,6 @@ Material Components for the web are architected to be adaptable to various major
     - [Ember Material Components](https://github.com/onehilltech/ember-cli-mdc): MDC Web integration for Ember (using [vanilla components](./integrating-into-frameworks.md#the-simple-approach-wrapping-mdc-web-vanilla-components))
     - [MatBlazor](https://github.com/SamProf/MatBlazor): Material Design components for Blazor
     - [Svelte Material UI](https://github.com/hperrin/svelte-material-ui): A library of Svelte 3 Material UI components.
+    - [Daemonite Material UI 2](https://github.com/djibe/material): Bootstrap 4 components reworked for Material Design.
 
   - More coming soon! Feel free to submit a pull request adding your library to this list, so long as you meet our [criteria](integrating-into-frameworks.md).


### PR DESCRIPTION
Hi,

I propose this framework I've been working on for 1 year 1/2.
Material Design brought to famous Bootstrap 4.