### PR TITLE
fix(notched-outline): remove unnecessary padding from notched outline

### DIFF
--- a/packages/mdc-notched-outline/_mixins.scss
+++ b/packages/mdc-notched-outline/_mixins.scss
@@ -114,7 +114,7 @@
     }
   }
 
-  .mdc-notched-outline--no-label {
+  .mdc-notched-outline--no-label.mdc-notched-outline--notched {
     .mdc-notched-outline__notch {
       @include feature-targeting.targets($feat-structure) {
         padding: 0;


### PR DESCRIPTION
This padding is not correctly overwritten in rtl mode when there is no label
Example:
![Screen Shot 2020-10-29 at 3 55 13 PM](https://user-images.githubusercontent.com/20130030/98597314-b35ece00-228d-11eb-8a5d-dd4edd341974.png)
It also does not seem to actually adding any visible spacing after removing the padding on this demo: https://material.io/components/text-fields#usage
