### PR TITLE
docs: Remove duplicate breaking change item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,7 +244,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **textfield:** mdc-text-field--dense and associated mixins/variables have been removed. Use the density() mixin instead.
 * **textfield:** removed the following variables: `$input-padding`, `$input-padding-top`, `$input-padding-bottom`, `$outlined-input-padding-top`, `$outlined-input-padding-bottom`, `$input-border-bottom`
 * **linear-progress:** DOM for linear progress buffer changed. MDCLinearProgressAdapter method `getBuffer`, `getPrimaryBar`, `setStyle` removed. MDCLinearProgressAdapter method `setBufferBarStyle`, `setPrimaryBarStyle` added.
-* **linear-progress:** DOM for linear progress buffer changed. MDCLinearProgressAdapter method `getBuffer`, `getPrimaryBar`, `setStyle` removed. MDCLinearProgressAdapter method `setBufferBarStyle`, `setPrimaryBarStyle` added.
 * **radio:** MDC radio _index Sass module will only export theme mixins
 
 


### PR DESCRIPTION
Remove duplicate item in breaking changes:

* **linear-progress:** DOM for linear progress buffer changed. MDCLinearProgressAdapter method `getBuffer`, `getPrimaryBar`, `setStyle` removed. MDCLinearProgressAdapter method `setBufferBarStyle`, `setPrimaryBarStyle` added.