### PR TITLE
docs: Update to work with Webpack 5

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ We’re going to use `webpack-dev-server` to demonstrate how webpack bundles our
 ```json
 {
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack serve"
   }
 }
 ```
@@ -229,12 +229,16 @@ Then add `postcss-loader`, using `autoprefixer` as a plugin:
 ```js
 { loader: 'extract-loader' },
 { loader: 'css-loader' },
-{
-  loader: 'postcss-loader',
-  options: {
-     plugins: () => [autoprefixer()]
-  }
-},
+  {
+    loader: 'postcss-loader',
+    options: {
+      postcssOptions: {
+        plugins: [
+          autoprefixer()
+        ]
+      }
+    } 
+  },
 {
   loader: 'sass-loader',
   options: {
@@ -340,8 +344,12 @@ module.exports = {
           {
             loader: 'postcss-loader',
             options: {
-              plugins: () => [autoprefixer()]
-            }
+              postcssOptions: {
+                plugins: [
+                  autoprefixer()
+                ]
+              }
+            } 
           },
           {
             loader: 'sass-loader',
@@ -404,7 +412,7 @@ Add another script to `package.json`:
 ```json
   "scripts": {
     "build": "webpack",
-    "start": "webpack-dev-server"
+    "start": "webpack serve"
   }
 ```
 
@@ -460,10 +468,18 @@ function materialImporter(url, prev) {
 Then update your `sass-loader` config to the following:
 
 ```js
-{
-  loader: 'sass-loader',
-  options: {
-    importer: materialImporter
-  },
-}
+ {
+   loader: 'sass-loader',
+   options: {   
+     // Prefer Dart Sass
+     implementation: require('sass'),
+
+     // See https://github.com/webpack-contrib/sass-loader/issues/804
+     webpackImporter: false,
+     sassOptions: {
+       importer: materialImporter,
+       includePaths: ['./node_modules'],
+     },
+   },
+ }
 ```


### PR DESCRIPTION
Changed "Webpack-dev-server" to "webpack serve" to work with Webpack 5.
Changed the material importer to be put under 'sassOptions' rather than just options. Similar with the autoprefixer; put it under postcssOptions under options. 
Don't have issues going through the Getting Started walkthrough now