### PR TITLE
test: Run conventional-commit-check only on PR's, not pushes.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       - run: npm install
       - run: npm run lint
   conventional-commit-check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v1.2.0


### PR DESCRIPTION
Our current build is failing on pushes with `conventional-commit-check` error: "Error: This action can only be invoked in `pull_request` events. Otherwise the pull request can't be inferred."

Workflow syntax: https://github.blog/changelog/2019-10-01-github-actions-new-workflow-syntax-features/#if-at-the-job-level