### PR TITLE
build: Update to create-pull-request@v3.

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           npx lerna version --conventional-commits --no-git-tag-version --no-push --yes
       - name: Create PR
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: Release"


### PR DESCRIPTION
Current build is failing with error:

```
Run peter-evans/create-pull-request@v2
Error: Unable to process command '::set-env name=pythonLocation::/opt/hostedtoolcache/Python/3.9.0/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands
```