### PR TITLE
[Documentation] Fix require syntax for importing javascript

### DIFF
--- a/docs/importing-js.md
+++ b/docs/importing-js.md
@@ -53,7 +53,7 @@ There are corresponding `.d.ts` files for each foundation/component/adapter/etc.
 ### CommonJS
 
 ```js
-const mdcFoo = require('mdc-foo');
+const mdcFoo = require('@material/foo');
 const MDCFoo = mdcFoo.MDCFoo;
 const MDCFooFoundation = mdcFoo.MDCFooFoundation;
 ```
@@ -61,7 +61,7 @@ const MDCFooFoundation = mdcFoo.MDCFooFoundation;
 ### AMD
 
 ```js
-require(['path/to/mdc-foo'], mdcFoo => {
+require(['path/to/@material/foo'], mdcFoo => {
   const MDCFoo = mdcFoo.MDCFoo;
   const MDCFooFoundation = mdcFoo.MDCFooFoundation;
 });


### PR DESCRIPTION
`mdc-foo` is not consistent with other path examples. It let me to believe to require 'switch', for example, I'd use `require('mdc-switch')`. However, what you need is `require('@material/switch'`