### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -312,7 +312,7 @@ Then configure webpack to convert `app.js` into `bundle.js` by modifying the fol
    {
      test: /\.js$/,
      loader: 'babel-loader',
-     query: {
+     options: {
        presets: ['@babel/preset-env'],
      },
    }
@@ -369,7 +369,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['@babel/preset-env'],
         },
       }


### PR DESCRIPTION
According to https://webpack.js.org/concepts/loaders/#example:
"Loaders can be configured with an `options` object (using `query` parameters to set options is still supported but has been deprecated)."

However with babel-loader@8.2.2, when using `query` within rules, you get:

```
[webpack-cli] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration[0].module.rules[1] has an unknown property 'query'.
```

Replacing `query` with `options` fixes this.