### PR TITLE
chore: update sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18734,9 +18734,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.26.10",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.10.tgz",
-      "integrity": "sha512-bzN0uvmzfsTvjz0qwccN1sPm2HxxpNI/Xa+7PlUEMS+nQvbyuEK7Y0qFqxlPHhiNHb1Ze8WQJtU31olMObkAMw==",
+      "version": "1.32.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
+      "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
       "dev": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "prettier": "^2.0.5",
     "recast": "^0.17.3",
     "resolve": "^1.3.2",
-    "sass": "^1.26.10",
+    "sass": "^1.32.6",
     "sass-loader": "^7.1.0",
     "semver": "^5.3.0",
     "stylelint": "^13.8.0",


### PR DESCRIPTION
We need to bump our Sass dependency, since some of the newer internal features (like `map.set()`) are not available in our current version and causing [build failures](https://github.com/material-components/material-components-web/pull/6810/checks?check_run_id=1834195921).