### PR TITLE
docs: Update getting-started.md. Fixes #6981

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -142,9 +142,6 @@ module.exports = [{
             options: {
               // Prefer Dart Sass
               implementation: require('sass'),
-
-              // See https://github.com/webpack-contrib/sass-loader/issues/804
-              webpackImporter: false,
             },
           },
         ]
@@ -175,7 +172,7 @@ npm install @material/button
 We need to tell our `app.scss` to import the Sass files for `@material/button`. We can also use Sass mixins to customize the button. Replace your “hello world” version of `app.scss` with this code:
 
 ```scss
-@use '@material/button/mdc-button';
+@use '@material/button/styles';
 @use '@material/button';
 
 .foo-button {
@@ -191,9 +188,6 @@ We also need to configure sass-loader to understand the `@material` imports used
   options: {
     // Prefer Dart Sass
     implementation: require('sass'),
-
-    // See https://github.com/webpack-contrib/sass-loader/issues/804
-    webpackImporter: false,
     sassOptions: {
       includePaths: ['./node_modules']
     },
@@ -242,14 +236,11 @@ Then add `postcss-loader`, using `autoprefixer` as a plugin:
 {
   loader: 'sass-loader',
   options: {
+    // Prefer Dart Sass
+    implementation: require('sass'),
     sassOptions: {
       includePaths: ['./node_modules']
     },
-    // Prefer Dart Sass
-    implementation: require('sass'),
-
-    // See https://github.com/webpack-contrib/sass-loader/issues/804
-    webpackImporter: false,
   }
 },
 ```
@@ -312,7 +303,7 @@ Then configure webpack to convert `app.js` into `bundle.js` by modifying the fol
    {
      test: /\.js$/,
      loader: 'babel-loader',
-     query: {
+     options: {
        presets: ['@babel/preset-env'],
      },
    }
@@ -356,9 +347,6 @@ module.exports = {
             options: {
               // Prefer Dart Sass
               implementation: require('sass'),
-
-              // See https://github.com/webpack-contrib/sass-loader/issues/804
-              webpackImporter: false,
               sassOptions: {
                 includePaths: ['./node_modules'],
               },
@@ -369,7 +357,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['@babel/preset-env'],
         },
       }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -461,9 +461,6 @@ Then update your `sass-loader` config to the following:
    options: {   
      // Prefer Dart Sass
      implementation: require('sass'),
-
-     // See https://github.com/webpack-contrib/sass-loader/issues/804
-     webpackImporter: false,
      sassOptions: {
        importer: materialImporter,
        includePaths: ['./node_modules'],


### PR DESCRIPTION
- Remove `webpackImporter: false`; https://github.com/webpack-contrib/sass-loader/issues/804 seems to be fixed.
- `query` => `options` for latest babel-loader version

Tested changes locally.