### PR TITLE
fix(list): density configuration mixins do not account for leading avatars

### DIFF
--- a/packages/mdc-list/_evolution-mixins.scss
+++ b/packages/mdc-list/_evolution-mixins.scss
@@ -38,11 +38,11 @@
   @include _high-contrast-mode($query);
 
   .mdc-list {
-    @include _list-base($query: $query);
+    @include list-base($query: $query);
   }
 
   .mdc-list-item {
-    @include _item-base($query: $query);
+    @include item-base($query: $query);
 
     @include _one-line-item-density(
       variables.$one-line-item-density-scale,
@@ -1003,7 +1003,7 @@
   @include three-line-item-height($height, $query: $query);
 }
 
-@mixin _list-base($query: feature-targeting.all()) {
+@mixin list-base($query: feature-targeting.all()) {
   $feat-color: feature-targeting.create-target($query, color);
   $feat-structure: feature-targeting.create-target($query, structure);
   $feat-typography: feature-targeting.create-target($query, typography);
@@ -1027,7 +1027,7 @@
   }
 }
 
-@mixin _item-base($query: feature-targeting.all()) {
+@mixin item-base($query: feature-targeting.all()) {
   $feat-structure: feature-targeting.create-target($query, structure);
   @include feature-targeting.targets($feat-structure) {
     display: flex;

--- a/packages/mdc-list/_evolution-mixins.scss
+++ b/packages/mdc-list/_evolution-mixins.scss
@@ -888,6 +888,7 @@
 @mixin one-line-item-density($density-scale, $query: feature-targeting.all()) {
   @include _one-line-item-density($density-scale, $query: $query);
 
+  &.mdc-list-item--with-leading-avatar,
   &.mdc-list-item--with-leading-icon,
   &.mdc-list-item--with-leading-thumbnail,
   &.mdc-list-item--with-leading-checkbox,
@@ -905,6 +906,7 @@
 @mixin two-line-item-density($density-scale, $query: feature-targeting.all()) {
   @include _two-line-item-density($density-scale, $query: $query);
 
+  &.mdc-list-item--with-leading-avatar,
   &.mdc-list-item--with-leading-icon,
   &.mdc-list-item--with-leading-thumbnail,
   &.mdc-list-item--with-leading-checkbox,


### PR DESCRIPTION
**fix(list): density configuration mixins do not account for leading avatars**

Currently when someone uses the MDC list w/ evolution styles, it's possible to generate secondary
styles with a different density scale. This can be achieved by using the following mixins: 
`one-line-item-density`, `two-line-item-density` and `three-line-item-density`.

These mixins currently do not account for leading avatars, unlike they do for icons, checkboxes,
switches, radio's, images and videos. This commit adds code fo leading avatars.

**refactor(list): expose evolution base mixins**
In Angular Material we have several components that are based on simple, single-line lists.
Currently if we were to go through the `without-ripple` mixin, we would end up with a lot of
unused styles, because all we care about are the base structural styles, colors and typography.

These changes make the `list-base` and `item-base` mixins public so that we have more granular
control over the included styles.