### PR TITLE
fix: broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Material Components for the web is the successor to [Material Design Lite](https
 
 ## Important links
 
-- [Getting Started Guide](g3doc/getting-started.md)
+- [Getting Started Guide](docs/getting-started.md)
 - [Demos](https://material-components.github.io/material-components-web-catalog) (external site)
-- [Material on other frameworks](g3doc/framework-wrappers.md)
-- [Examples using Material Web](g3doc/examples.md)
+- [Material on other frameworks](docs/framework-wrappers.md)
+- [Examples using Material Web](docs/examples.md)
 - [Contributing](CONTRIBUTING.md)
 - [Material Design Guidelines](https://material.io/design) (external site)
-- [Supported browsers](g3doc/supported-browsers.md)
+- [Supported browsers](docs/supported-browsers.md)
 - [All Components](packages/)
 - [Changelog](./CHANGELOG.md)
 


### PR DESCRIPTION
# Problem
the following [important links](https://github.com/material-components/material-components-web#important-links) result in a 404:
- Getting Started Guide
- Material on other frameworks
- Examples using Material Web
- Supported browsers

These links were broken by #6928. 

# solution
rename g3docs -> docs