### PR TITLE
chore: support ts parsing for dependency test

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@babel/parser": "^7.2.3",
     "@babel/polyfill": "^7.4.4",
     "@babel/traverse": "^7.3.4",
     "@babel/types": "^7.3.4",

--- a/scripts/check-pkg-for-release.js
+++ b/scripts/check-pkg-for-release.js
@@ -35,7 +35,6 @@ const path = require('path');
 const childProcess = require('child_process');
 
 const {default: traverse} = require('babel-traverse');
-const parser = require('@babel/parser');
 const camelCase = require('camel-case');
 const recast = require('recast');
 

--- a/scripts/check-pkg-for-release.js
+++ b/scripts/check-pkg-for-release.js
@@ -262,7 +262,7 @@ function checkAutoInitAddedInMDCPackage(ast) {
             value = value.expression;
           }
 
-          // For the given ExpressionStatement node whose callee name is 
+          // For the given ExpressionStatement node whose callee name is
           // "autoInit" and call property name is "register":
           //
           // autoInit.register('MDCCheckbox', checkbox.MDCCheckbox);


### PR DESCRIPTION
Adds support for using TS syntax in https://github.com/material-components/material-components-web/blob/master/packages/material-components-web/index.ts