### PR TITLE
fix(select): Remove @forward "../functions"

### DIFF
--- a/packages/mdc-select/helper-text/mdc-select-helper-text.import.scss
+++ b/packages/mdc-select/helper-text/mdc-select-helper-text.import.scss
@@ -6,7 +6,6 @@
 @forward "@material/theme/mixins" as mdc-theme-*;
 @forward "@material/typography/mixins" as mdc-* hide mdc-base, mdc-baseline-bottom, mdc-baseline-strut-, mdc-baseline-top, mdc-core-styles, mdc-overflow-ellipsis;
 @forward "@material/typography/mixins" as mdc-typography-* hide mdc-typography-typography;
-@forward "../functions" as mdc-select-*;
 @forward "@material/feature-targeting/functions" as mdc-feature-*;
 @forward "@material/theme/functions" as mdc-theme-*;
 @forward "@material/typography/functions" as mdc-typography-*;


### PR DESCRIPTION
https://github.com/material-components/material-components-web/commit/2fcee40cba11ac8e62541b48ef77e85c74c4a675 removed the function file but it is still used in `packages/mdc-select/helper-text/mdc-select-helper-text.import.scss`.

That means:
```
@import "@material/select/helper-text/mdc-select-helper-text";
```
Is broken.