### PR TITLE
docs: Changed Query to Options for webpack babel config in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -312,7 +312,7 @@ Then configure webpack to convert `app.js` into `bundle.js` by modifying the fol
    {
      test: /\.js$/,
      loader: 'babel-loader',
-     query: {
+     options: {
        presets: ['@babel/preset-env'],
      },
    }
@@ -369,7 +369,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['@babel/preset-env'],
         },
       }


### PR DESCRIPTION
Changed Query to Options for webpack babel config after receiving this error: 
```
[webpack-cli] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration[0].module.rules[1] has an unknown property 'query'. These properties are valid:
   object { compiler?, dependency?, descriptionData?, enforce?, exclude?, generator?, include?, issuer?, issuerLayer?, layer?, loader?, mimetype?, oneOf?, options?, parser?, realResource?, resolve?, resource?, resourceFragment?, resourceQuery?, rules?, scheme?, sideEffects?, test?, type?, use? }
   -> A rule description with conditions and effects for modules.
```
I followed the guide precisely and after receiving the error looked at the babel documentation. I only see mentions of the query syntax in this use case from 2016-17... 

I do not have a good understanding of npm and webpacks. Just dabbling for a landing page to a flutter app.