### PR TITLE
docs: Updated webpack babel config

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -312,7 +312,7 @@ Then configure webpack to convert `app.js` into `bundle.js` by modifying the fol
    {
      test: /\.js$/,
      loader: 'babel-loader',
-     query: {
+     options: {
        presets: ['@babel/preset-env'],
      },
    }
@@ -369,7 +369,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['@babel/preset-env'],
         },
       }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -310,11 +310,14 @@ Then configure webpack to convert `app.js` into `bundle.js` by modifying the fol
 3. Add the `babel-loader` object to the rules array after the `sass-loader` object:
    ```js
    {
-     test: /\.js$/,
-     loader: 'babel-loader',
-     options: {
-       presets: ['@babel/preset-env'],
-     },
+       test: /\.m?js$/,
+       exclude: /node_modules/,
+       use: {
+         loader: "babel-loader",
+         options: {
+           presets: ['@babel/preset-env']
+         }
+       }
    }
    ```
 
@@ -367,11 +370,14 @@ module.exports = {
         ],
       },
       {
-        test: /\.js$/,
-        loader: 'babel-loader',
-        options: {
-          presets: ['@babel/preset-env'],
-        },
+         test: /\.m?js$/,
+         exclude: /node_modules/,
+         use: {
+           loader: "babel-loader",
+           options: {
+             presets: ['@babel/preset-env']
+           }
+         }
       }
     ],
   },


### PR DESCRIPTION
Updated webpack babel config after receiving this error: 
```
[webpack-cli] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration[0].module.rules[1] has an unknown property 'query'. These properties are valid:
   object { compiler?, dependency?, descriptionData?, enforce?, exclude?, generator?, include?, issuer?, issuerLayer?, layer?, loader?, mimetype?, oneOf?, options?, parser?, realResource?, resolve?, resource?, resourceFragment?, resourceQuery?, rules?, scheme?, sideEffects?, test?, type?, use? }
   -> A rule description with conditions and effects for modules.
```
I followed the guide precisely and after receiving the error looked at the babel documentation. I only see mentions of the query syntax in this use case from 2016-17...  I do not have a good understanding of npm and webpacks. Just dabbling for a landing page to a flutter app.

babel config refs:

https://webpack.js.org/loaders/babel-loader/
https://babeljs.io/setup#installation