### PR TITLE
refactor: fix up sass division deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19186,12 +19186,12 @@
       "dev": true
     },
     "sass": {
-      "version": "1.32.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
-      "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.34.1.tgz",
+      "integrity": "sha512-scLA7EIZM+MmYlej6sdVr0HRbZX5caX5ofDT9asWnUJj21oqgsC+1LuNfm0eg+vM0fCTZHhwImTiCU0sx9h9CQ==",
       "dev": true,
       "requires": {
-        "chokidar": ">=2.0.0 <4.0.0"
+        "chokidar": ">=3.0.0 <4.0.0"
       }
     },
     "sass-loader": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "prettier": "^2.2.1",
     "recast": "^0.17.3",
     "resolve": "^1.3.2",
-    "sass": "^1.32.6",
+    "sass": "^1.34.1",
     "sass-loader": "^7.1.0",
     "semver": "^5.3.0",
     "stylelint": "^13.8.0",

--- a/packages/mdc-banner/_banner.scss
+++ b/packages/mdc-banner/_banner.scss
@@ -24,6 +24,7 @@
 // stylelint-disable selector-class-pattern --
 // Internal styling for Tooltip MDC component.
 
+@use 'sass:math';
 @use '@material/feature-targeting/feature-targeting';
 @use '@material/typography/typography';
 @use '@material/button/button-theme';
@@ -36,7 +37,7 @@ $_min-width: 344px;
 $_max-width: 720px;
 // Minimum banner height minus standard text height, divided by 2 for both top
 // and bottom padding. This is used to support two/three line banners.
-$_text-padding-top-bottom: ((52px - 20px) / 2);
+$_text-padding-top-bottom: math.div(52px - 20px, 2);
 
 $_enter-duration: 300ms;
 $_exit-duration: 250ms;

--- a/packages/mdc-card/_mixins.scss
+++ b/packages/mdc-card/_mixins.scss
@@ -390,7 +390,7 @@ $ripple-target: '.mdc-card__ripple';
   &::before {
     @include feature-targeting.targets($feat-structure) {
       // This clever trick brought to you by: http://www.mademyday.de/css-height-equals-width-with-pure-css.html
-      margin-top: math.percentage($y / $x);
+      margin-top: math.percentage(math.div($y, $x));
     }
   }
 }

--- a/packages/mdc-checkbox/_checkbox-theme.scss
+++ b/packages/mdc-checkbox/_checkbox-theme.scss
@@ -47,7 +47,7 @@ $disabled-color: rgba(theme-color.prop-value(on-surface), 0.38) !default;
 
 $ripple-size: 40px !default;
 $icon-size: 18px !default;
-$mark-stroke-size: 2 / 15 * $icon-size !default;
+$mark-stroke-size: math.div(2, 15) * $icon-size !default;
 $border-width: 2px !default;
 $transition-duration: 90ms !default;
 $item-spacing: 4px !default;

--- a/packages/mdc-checkbox/_checkbox.scss
+++ b/packages/mdc-checkbox/_checkbox.scss
@@ -496,7 +496,7 @@
     width: 100%;
     height: 0;
     transform: scaleX(0) rotate(0deg);
-    border-width: math.floor(checkbox-theme.$mark-stroke-size) / 2;
+    border-width: math.div(math.floor(checkbox-theme.$mark-stroke-size), 2);
     border-style: solid;
     opacity: 0;
   }

--- a/packages/mdc-chips/_chip-set-theme.scss
+++ b/packages/mdc-chips/_chip-set-theme.scss
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 //
 
+@use 'sass:math';
 @use '@material/feature-targeting/feature-targeting';
 @use '@material/rtl/rtl';
 
@@ -68,8 +69,8 @@ $space-between-chips: 8px;
     @include feature-targeting.targets($feat-structure) {
       // Set top and bottom to half the vertical space since there's no
       // well supported method for vertical wrapping gaps.
-      margin-top: $space / 2;
-      margin-bottom: $space / 2;
+      margin-top: math.div($space, 2);
+      margin-bottom: math.div($space, 2);
     }
   }
 }

--- a/packages/mdc-chips/_chip-theme.scss
+++ b/packages/mdc-chips/_chip-theme.scss
@@ -24,6 +24,7 @@
 // stylelint-disable selector-class-pattern --
 // Internal styling for Chip MDC component.
 
+@use 'sass:math';
 @use 'sass:color';
 @use '@material/density/density';
 @use '@material/feature-targeting/feature-targeting';
@@ -46,7 +47,7 @@ $density-config: (
     minimum: $minimum-height,
   ),
 );
-$radius: $height / 2;
+$radius: math.div($height, 2);
 $type-scale: body2;
 $container-color: color.mix(
   theme-color.prop-value(on-surface),

--- a/packages/mdc-chips/deprecated/_mixins.scss
+++ b/packages/mdc-chips/deprecated/_mixins.scss
@@ -545,12 +545,12 @@ $ripple-target: '.mdc-chip__ripple';
   $feat-structure: feature-targeting.create-target($query, structure);
 
   @include feature-targeting.targets($feat-structure) {
-    padding: $gap-size / 2;
+    padding: math.div($gap-size, 2);
   }
 
   .mdc-chip {
     @include feature-targeting.targets($feat-structure) {
-      margin: $gap-size / 2;
+      margin: math.div($gap-size, 2);
     }
   }
 

--- a/packages/mdc-circular-progress/_mixins.scss
+++ b/packages/mdc-circular-progress/_mixins.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use '@material/animation/functions' as animation-functions;
 @use '@material/feature-targeting/feature-targeting';
 @use '@material/theme/gss';
@@ -235,8 +236,10 @@
 
   .mdc-circular-progress__indeterminate-container {
     @include feature-targeting.targets($feat-animation) {
-      $duration: 360deg * variables.$arc-time /
-        (variables.$arc-start-rotation-interval + (360 - variables.$arc-size));
+      $duration: math.div(
+        360deg * variables.$arc-time,
+        variables.$arc-start-rotation-interval + (360 - variables.$arc-size)
+      );
 
       animation: mdc-circular-progress-container-rotate $duration linear
         infinite;

--- a/packages/mdc-data-table/_data-table-theme.scss
+++ b/packages/mdc-data-table/_data-table-theme.scss
@@ -24,6 +24,7 @@
 // NOTE: We disable `selector-class-pattern` above to allow using `mdc-` class
 // selectors.
 
+@use 'sass:math';
 @use 'sass:list';
 @use 'sass:meta';
 @use '@material/animation/functions';
@@ -405,7 +406,7 @@ $pagination-rows-per-page-select-height: 36px;
         );
       }
       $leading-padding: $leading-padding -
-        ($checkbox-touch-size - $checkbox-icon-size) / 2;
+        math.div($checkbox-touch-size - $checkbox-icon-size, 2);
       @include rtl-mixins.reflexive-property(padding, $leading-padding, 0);
     }
   }

--- a/packages/mdc-dialog/_mixins.scss
+++ b/packages/mdc-dialog/_mixins.scss
@@ -681,8 +681,10 @@
 // Applied to dialogs that have buttons with an increased touch target.
 @mixin with-touch-target($query: feature-targeting.all()) {
   $feat-structure: feature-targeting.create-target($query, structure);
-  $touch-target-margin: (touch-target-variables.$height - button-theme.$height) /
-    2;
+  $touch-target-margin: math.div(
+    touch-target-variables.$height - button-theme.$height,
+    2
+  );
   $vertical-padding: math.max(
     0,
     variables.$actions-padding - $touch-target-margin

--- a/packages/mdc-drawer/_mixins.scss
+++ b/packages/mdc-drawer/_mixins.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use 'sass:list';
 @use 'sass:meta';
 @use '@material/feature-targeting/feature-targeting';
@@ -475,7 +476,7 @@
       height: calc(48px - 2 * #{variables.$list-item-spacing});
       // To accomodate margin conflict.
       margin: (variables.$list-item-spacing * 2) 8px;
-      padding: 0 variables.$surface-padding / 2;
+      padding: 0 math.div(variables.$surface-padding, 2);
     }
   }
 

--- a/packages/mdc-icon-button/_mixins.scss
+++ b/packages/mdc-icon-button/_mixins.scss
@@ -130,7 +130,7 @@ $ripple-target: '.mdc-icon-button__ripple';
   @include feature-targeting.targets($feat-structure) {
     width: $size;
     height: $size;
-    padding: ($size - variables.$icon-size) / 2;
+    padding: math.div($size - variables.$icon-size, 2);
   }
 }
 
@@ -148,7 +148,7 @@ $ripple-target: '.mdc-icon-button__ripple';
 @mixin icon-size(
   $width,
   $height: $width,
-  $padding: math.max($width, $height) / 2,
+  $padding: math.div(math.max($width, $height), 2),
   $query: feature-targeting.all()
 ) {
   $feat-structure: feature-targeting.create-target($query, structure);

--- a/packages/mdc-image-list/_mixins.scss
+++ b/packages/mdc-image-list/_mixins.scss
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+@use 'sass:math';
 @use '@material/feature-targeting/feature-targeting';
 @use '@material/shape/mixins' as shape-mixins;
 @use '@material/shape/functions' as shape-functions;
@@ -191,9 +192,9 @@
     @include feature-targeting.targets($feat-structure) {
       // Subtract extra fraction from each item's width to ensure correct wrapping in IE/Edge which round differently
       width: calc(
-        100% / #{$column-count} - #{$gutter-size + 1 / $column-count}
+        100% / #{$column-count} - #{$gutter-size + math.div(1, $column-count)}
       );
-      margin: $gutter-size / 2;
+      margin: math.div($gutter-size, 2);
     }
   }
 }

--- a/packages/mdc-layout-grid/_mixins.scss
+++ b/packages/mdc-layout-grid/_mixins.scss
@@ -80,7 +80,9 @@
     @error "Invalid style specified! Choose one of #{map.keys(variables.$columns)}";
   }
 
-  $percent: math.percentage($span / map.get(variables.$columns, $size));
+  $percent: math.percentage(
+    math.div($span, map.get(variables.$columns, $size))
+  );
 
   @if $percent > 100% {
     $percent: 100%;
@@ -121,7 +123,7 @@
   display: flex;
   flex-flow: row wrap;
   align-items: stretch;
-  margin: -$gutter / 2;
+  margin: math.div(-$gutter, 2);
   // stylelint-disable-next-line declaration-block-no-duplicate-properties
   margin: calc(var(--mdc-layout-grid-gutter-#{$size}, #{$gutter}) / 2 * -1);
 
@@ -146,7 +148,7 @@
   @include cell-span_($size, $default-span, $gutter);
 
   box-sizing: border-box;
-  margin: $gutter / 2;
+  margin: math.div($gutter, 2);
   // stylelint-disable-next-line declaration-block-no-duplicate-properties
   margin: calc(var(--mdc-layout-grid-gutter-#{$size}, #{$gutter}) / 2);
 

--- a/packages/mdc-list/_evolution-mixins.scss
+++ b/packages/mdc-list/_evolution-mixins.scss
@@ -2,6 +2,7 @@
 // stylelint-disable selector-class-pattern --
 // NOTE: this is the implementation of the aforementioned classes.
 
+@use 'sass:math';
 @use 'sass:list';
 @use 'sass:map';
 @use '@material/theme/theme';
@@ -567,7 +568,7 @@
     @return $offset;
   }
   $overflow: $actual - $available;
-  @return $offset - $overflow / if($symmetric, 2, 1);
+  @return $offset - math.div($overflow, if($symmetric, 2, 1));
 }
 
 @mixin one-line-item-height($height, $query: feature-targeting.all()) {

--- a/packages/mdc-ripple/_ripple.scss
+++ b/packages/mdc-ripple/_ripple.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use 'sass:color';
 @use 'sass:map';
 @use '@material/animation/functions' as functions2;
@@ -253,9 +254,9 @@
   #{$ripple-target}::before,
   #{$ripple-target}::after {
     @include feature-targeting.targets($feat-struture) {
-      top: calc(50% - #{$radius / 2});
+      top: calc(50% - #{math.div($radius, 2)});
       /* @noflip */
-      left: calc(50% - #{$radius / 2});
+      left: calc(50% - #{math.div($radius, 2)});
       width: $radius;
       height: $radius;
     }
@@ -265,9 +266,9 @@
     #{$ripple-target}::before,
     #{$ripple-target}::after {
       @include feature-targeting.targets($feat-struture) {
-        top: var(--mdc-ripple-top, calc(50% - #{$radius / 2}));
+        top: var(--mdc-ripple-top, calc(50% - #{math.div($radius, 2)}));
         /* @noflip */
-        left: var(--mdc-ripple-left, calc(50% - #{$radius / 2}));
+        left: var(--mdc-ripple-left, calc(50% - #{math.div($radius, 2)}));
         width: var(--mdc-ripple-fg-size, $radius);
         height: var(--mdc-ripple-fg-size, $radius);
       }

--- a/packages/mdc-select/_select-theme.scss
+++ b/packages/mdc-select/_select-theme.scss
@@ -24,6 +24,7 @@
 // stylelint-disable selector-class-pattern --
 // NOTE: this is the implementation of the aforementioned classes.
 
+@use 'sass:math';
 @use 'sass:color';
 @use 'sass:list';
 @use 'sass:meta';
@@ -50,8 +51,8 @@
 $ripple-target: '.mdc-select__ripple';
 
 @function get-outlined-label-position-y($select-anchor-height) {
-  @return $select-anchor-height / 2 +
-    notched-outline-variables.$label-box-height / 2;
+  @return math.div($select-anchor-height, 2) +
+    math.div(notched-outline-variables.$label-box-height, 2);
 }
 
 $arrow-padding: 52px !default;

--- a/packages/mdc-select/_select.scss
+++ b/packages/mdc-select/_select.scss
@@ -24,6 +24,7 @@
 // stylelint-disable selector-class-pattern --
 // NOTE: this is the implementation of the aforementioned classes.
 
+@use 'sass:math';
 @use '@material/dom/mixins' as dom-mixins;
 @use '@material/feature-targeting/feature-targeting';
 @use '@material/floating-label/mixins' as floating-label-mixins;
@@ -250,8 +251,8 @@
     $svg-natural-height: 5px;
 
     @include feature-targeting.targets($feat-structure) {
-      width: $svg-natural-width / select-icon-theme.$icon-size * 100%;
-      height: $svg-natural-height / select-icon-theme.$icon-size * 100%;
+      width: math.div($svg-natural-width, select-icon-theme.$icon-size) * 100%;
+      height: math.div($svg-natural-height, select-icon-theme.$icon-size) * 100%;
     }
   }
 }

--- a/packages/mdc-shape/_shape.scss
+++ b/packages/mdc-shape/_shape.scss
@@ -243,8 +243,8 @@ $category-keywords: (
 /// @return {Number} the resolved radius as a number.
 @function _resolve-radius-percentage($percentage, $component-height) {
   // Converts the percentage to number without unit. Example: 50% => 50.
-  $percentage: $percentage / ($percentage * 0 + 1);
-  @return $component-height * ($percentage / 100);
+  $percentage: math.div($percentage, $percentage * 0 + 1);
+  @return $component-height * math.div($percentage, 100);
 }
 
 @mixin radius(

--- a/packages/mdc-slider/_slider.scss
+++ b/packages/mdc-slider/_slider.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use '@material/animation/animation';
 @use '@material/dom/mixins' as dom-mixins;
 @use '@material/elevation/mixins' as elevation-mixins;
@@ -65,7 +66,7 @@ $_track-inactive-height: 4px;
     @include feature-targeting.targets($feat-structure) {
       cursor: pointer;
       height: $_thumb-ripple-size;
-      margin: 0 ($_thumb-ripple-size / 2);
+      margin: 0 math.div($_thumb-ripple-size, 2);
       position: relative;
       touch-action: pan-y;
     }
@@ -153,7 +154,7 @@ $_track-inactive-height: 4px;
       border-radius: 3px;
       height: $_track-active-height;
       overflow: hidden;
-      top: ($_track-inactive-height - $_track-active-height) / 2;
+      top: math.div($_track-inactive-height - $_track-active-height, 2);
     }
   }
 
@@ -219,7 +220,7 @@ $_track-inactive-height: 4px;
       display: flex;
       height: $_thumb-ripple-size;
       /* @noflip */
-      left: -$_thumb-ripple-size / 2;
+      left: math.div(-$_thumb-ripple-size, 2);
       outline: none;
       position: absolute;
       user-select: none;
@@ -252,7 +253,7 @@ $_track-inactive-height: 4px;
 
     @include feature-targeting.targets($feat-structure) {
       // Use border rather than background-color to fill thumb, for HCM.
-      border: $_thumb-size / 2 solid;
+      border: math.div($_thumb-size, 2) solid;
       border-radius: 50%;
       box-sizing: border-box;
       height: $_thumb-size;
@@ -326,7 +327,7 @@ $_track-inactive-height: 4px;
 
   .mdc-slider__value-indicator-container {
     @include feature-targeting.targets($feat-structure) {
-      bottom: $_thumb-ripple-size / 2 + $_thumb-size / 2 +
+      bottom: math.div($_thumb-ripple-size, 2) + math.div($_thumb-size, 2) +
         $_value-indicator-caret-width + 4px;
       /* @noflip */
       left: 50%;

--- a/packages/mdc-switch/deprecated/_mixins.scss
+++ b/packages/mdc-switch/deprecated/_mixins.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use '@material/density/functions' as density-functions;
 @use '@material/elevation/mixins' as elevation-mixins;
 @use '@material/feature-targeting/feature-targeting';
@@ -238,8 +239,8 @@ $deprecated-suffix: '-deprecated' !default;
 
   // Position for the tap target that contains the thumb to align the thumb
   // correctly offset from the track.
-  $tap-target-initial-position: -$ripple-size / 2 + variables.$thumb-diameter /
-    2;
+  $tap-target-initial-position: math.div(-$ripple-size, 2) +
+    math.div(variables.$thumb-diameter, 2);
   // Value to cover the whole switch area (including the ripple) with the
   // native control.
   $native-control-width: variables.$track-width +
@@ -253,7 +254,7 @@ $deprecated-suffix: '-deprecated' !default;
       );
 
       // Ensures the knob is centered on the track.
-      top: -(($ripple-size - variables.$track-height) / 2);
+      top: -(math.div($ripple-size - variables.$track-height, 2));
       width: $ripple-size;
       height: $ripple-size;
     }
@@ -303,7 +304,7 @@ $deprecated-suffix: '-deprecated' !default;
     width: variables.$track-width;
     height: variables.$track-height;
     border: 1px solid transparent;
-    border-radius: variables.$track-height / 2;
+    border-radius: math.div(variables.$track-height, 2);
     opacity: 0.38;
   }
 
@@ -353,7 +354,7 @@ $deprecated-suffix: '-deprecated' !default;
     box-sizing: border-box;
     width: variables.$thumb-diameter;
     height: variables.$thumb-diameter;
-    border: variables.$thumb-diameter / 2 solid;
+    border: math.div(variables.$thumb-diameter, 2) solid;
     border-radius: 50%;
     // Allow events to go through to the native control, necessary for IE and Edge.
     pointer-events: none;

--- a/packages/mdc-textfield/_mixins.scss
+++ b/packages/mdc-textfield/_mixins.scss
@@ -24,6 +24,7 @@
 // stylelint-disable selector-class-pattern --
 // TODO: document why this disable is neccessary
 
+@use 'sass:math';
 @use 'sass:list';
 @use 'sass:meta';
 @use '@material/animation/animation';
@@ -418,12 +419,12 @@
   );
   $no-label-margin-top: density-functions.prop-value(
     $density-config: variables.$textarea-filled-no-label-density-config,
-    $density-scale: $density-scale / 2,
+    $density-scale: math.div($density-scale, 2),
     $property-name: margin-top,
   );
   $no-label-margin-bottom: density-functions.prop-value(
     $density-config: variables.$textarea-filled-no-label-density-config,
-    $density-scale: $density-scale / 2,
+    $density-scale: math.div($density-scale, 2),
     $property-name: margin-bottom,
   );
 
@@ -441,7 +442,7 @@
       $keyframe-suffix: text-field-filled-#{$density-scale};
       $label-top: density-functions.prop-value(
         $density-config: variables.$textarea-filled-label-density-config,
-        $density-scale: $density-scale / 2,
+        $density-scale: math.div($density-scale, 2),
         $property-name: top,
       );
 
@@ -536,7 +537,7 @@
   $keyframe-suffix: text-field-outlined-#{$density-scale};
   $label-top: density-functions.prop-value(
     $density-config: variables.$textarea-outlined-label-density-config,
-    $density-scale: $density-scale / 2,
+    $density-scale: math.div($density-scale, 2),
     $property-name: top,
   );
   $textfield-height: density-functions.prop-value(
@@ -546,12 +547,12 @@
   );
   $margin-top: density-functions.prop-value(
     $density-config: variables.$textarea-outlined-density-config,
-    $density-scale: $density-scale / 2,
+    $density-scale: math.div($density-scale, 2),
     $property-name: margin-top,
   );
   $margin-bottom: density-functions.prop-value(
     $density-config: variables.$textarea-outlined-density-config,
-    $density-scale: $density-scale / 2,
+    $density-scale: math.div($density-scale, 2),
     $property-name: margin-bottom,
   );
 

--- a/packages/mdc-textfield/_variables.scss
+++ b/packages/mdc-textfield/_variables.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use 'sass:color';
 @use '@material/density/variables' as density-variables;
 @use '@material/floating-label/variables' as floating-label-variables;
@@ -36,8 +37,8 @@
 ///     wrap label in a child element to apply `transitionY(-50%)` to automatically offset based on box height.
 ///
 @function get-outlined-label-position-y($text-field-height) {
-  @return $text-field-height / 2 + notched-outline-variables.$label-box-height /
-    2;
+  @return math.div($text-field-height, 2) +
+    math.div(notched-outline-variables.$label-box-height, 2);
 }
 
 $error: error !default;

--- a/packages/mdc-textfield/icon/_mixins.scss
+++ b/packages/mdc-textfield/icon/_mixins.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use '@material/rtl/mixins' as rtl-mixins;
 @use '@material/theme/theme';
 @use '@material/feature-targeting/feature-targeting';
@@ -139,7 +140,7 @@
   $feat-structure: feature-targeting.create-target($query, structure);
 
   @include feature-targeting.targets($feat-structure) {
-    $padding: (variables.$touch-target-size - variables.$icon-size) / 2;
+    $padding: math.div(variables.$touch-target-size - variables.$icon-size, 2);
     $left-margin: variables.$trailing-icon-padding-left - $padding;
     $right-margin: variables.$trailing-icon-padding-right - $padding;
 

--- a/packages/mdc-theme/_theme-color.scss
+++ b/packages/mdc-theme/_theme-color.scss
@@ -30,12 +30,12 @@
 @use './keys';
 
 @function _linear-channel-value($channel-value) {
-  $normalized-channel-value: $channel-value / 255;
+  $normalized-channel-value: math.div($channel-value, 255);
   @if $normalized-channel-value < 0.03928 {
-    @return $normalized-channel-value / 12.92;
+    @return math.div($normalized-channel-value, 12.92);
   }
 
-  @return math.pow(($normalized-channel-value + 0.055) / 1.055, 2.4);
+  @return math.pow(math.div($normalized-channel-value + 0.055, 1.055), 2.4);
 }
 
 // Calculate the luminance for a color.
@@ -54,7 +54,7 @@
   $backLum: luminance($back) + 0.05;
   $foreLum: luminance($front) + 0.05;
 
-  @return math.max($backLum, $foreLum) / math.min($backLum, $foreLum);
+  @return math.div(math.max($backLum, $foreLum), math.min($backLum, $foreLum));
 }
 
 // Determine whether the color is 'light' or 'dark'.

--- a/packages/mdc-touch-target/_touch-target.scss
+++ b/packages/mdc-touch-target/_touch-target.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use '@material/base/mixins' as base-mixins;
 @use '@material/feature-targeting/feature-targeting';
 
@@ -87,7 +88,7 @@ $width: $height !default;
 ) {
   $feat-structure: feature-targeting.create-target($query, structure);
 
-  $vertical-margin-value: ($touch-target-height - $component-height) / 2;
+  $vertical-margin-value: math.div($touch-target-height - $component-height, 2);
 
   @include feature-targeting.targets($feat-structure) {
     margin-top: $vertical-margin-value;
@@ -95,7 +96,10 @@ $width: $height !default;
   }
 
   @if $component-width {
-    $horizontal-margin-value: ($touch-target-width - $component-width) / 2;
+    $horizontal-margin-value: math.div(
+      $touch-target-width - $component-width,
+      2
+    );
 
     @include feature-targeting.targets($feat-structure) {
       margin-right: $horizontal-margin-value;

--- a/packages/mdc-typography/_typography.scss
+++ b/packages/mdc-typography/_typography.scss
@@ -23,6 +23,7 @@
 // Selector '.mdc-*' should only be used in this project.
 // stylelint-disable selector-class-pattern
 
+@use 'sass:math';
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:string';
@@ -69,11 +70,11 @@
 }
 
 @function get-letter-spacing_($tracking, $font-size) {
-  @return $tracking / ($font-size * 16) * 1em;
+  @return math.div($tracking, $font-size * 16) * 1em;
 }
 
 @function px-to-rem($px) {
-  @return $px / 16px * 1rem;
+  @return math.div($px, 16px) * 1rem;
 }
 
 $font-family: string.unquote('Roboto, sans-serif') !default;


### PR DESCRIPTION
The division operator is deprecated and it causes Sass to print a warning in the latest version. These changes migrate to the `math.div` helper.

See https://sass-lang.com/documentation/breaking-changes/slash-div.