### PR TITLE
fix(touch-target): incorrect position in rtl when width is set

### DIFF
--- a/packages/mdc-touch-target/_touch-target.scss
+++ b/packages/mdc-touch-target/_touch-target.scss
@@ -58,7 +58,6 @@ $width: $height !default;
   @include feature-targeting.targets($feat-structure) {
     position: absolute;
     top: 50%;
-    right: 0;
     height: $height;
   }
 
@@ -72,6 +71,7 @@ $width: $height !default;
   } @else {
     @include feature-targeting.targets($feat-structure) {
       left: 0;
+      right: 0;
       transform: translateY(-50%);
     }
   }


### PR DESCRIPTION
Currently the `touch-target` mixin produces styles that will set the touch target outside of the host node on RTL layouts (see https://github.com/angular/components/pull/22925). These changes adjust the styles so that the target is always centered.