### PR TITLE
fix(mdc-list): invalid syntax in generated .d.ts bundle

### DIFF
--- a/packages/mdc-list/foundation.ts
+++ b/packages/mdc-list/foundation.ts
@@ -108,7 +108,7 @@ export class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
     }
   }
 
-  /** @return The index of the item that was last focused. */
+  /** Returns the index of the item that was last focused. */
   getFocusedItemIndex() {
     return this.focusedItemIndex;
   }


### PR DESCRIPTION
An earlier commit added a doc string with an `@return` in it (5d060518804437aa1ae3152562f1bb78b1af4aa6). By itself this isn't wrong, but it seems to hit a buggy code path in `dts-bundle` which causes it not to close a comment and to produce an invalid .d.ts file.

These changes work around the issue by using `@returns` instead. A longer term solution would be to move away from `dts-bundle` since it doesn't appear to be maintained.

For reference, here's the generated .d.ts file before these changes:
![error](https://user-images.githubusercontent.com/4450522/122003437-63139580-cdb3-11eb-96e6-c1e5a46dfb7c.png)
