### PR TITLE
build: set AMD module module names within UMD bundles

### DIFF
--- a/docs/migrating-from-mdl.md
+++ b/docs/migrating-from-mdl.md
@@ -195,7 +195,7 @@ Aside from how the module is referenced, its usage otherwise remains the same. I
 constructor on the root node:
 
 ```js
-var textField = new mdc.textField.MDCTextField(document.querySelector('.mdc-text-field'));
+var textField = new mdc.textfield.MDCTextField(document.querySelector('.mdc-text-field'));
 ```
 
 ## Styling

--- a/scripts/check-pkg-for-release.js
+++ b/scripts/check-pkg-for-release.js
@@ -143,10 +143,10 @@ function checkJSDependencyAddedInWebpackConfig() {
   const jsconfig = WEBPACK_CONFIG.find((value) => {
     return value.name === 'main-js-a-la-carte';
   });
-  const nameCamel = camelCase(CLI_PACKAGE_JSON.name.replace('@material/', ''));
-  assert.notEqual(typeof jsconfig.entry[nameCamel], 'undefined',
+  const pkgName = CLI_PACKAGE_JSON.name.replace('@material/', '');
+  assert.notEqual(typeof jsconfig.entry[pkgName], 'undefined',
     'FAILURE: Component ' + CLI_PACKAGE_JSON.name + ' javascript dependency is not added to webpack ' +
-    'configuration. Please add ' + nameCamel + ' to ' + WEBPACK_CONFIG_RELATIVE_PATH + '\'s js-components ' +
+    'configuration. Please add ' + pkgName + ' to ' + WEBPACK_CONFIG_RELATIVE_PATH + '\'s js-components ' +
     'entry before commit. If package @material/' + name + ' has no exported JS, add "' + name + '" to ' +
     'the JS_EXCLUDES set in this file.');
 }


### PR DESCRIPTION
Currently if the UMD bundles from `@material/<..>` NPM modules are
loaded in the browser, using RequireJS or other loaders, the
AMD modules would need to be named manually using a loader
configuration. e.g.

```js
require.config({
  paths: {
      '@material/animation': '/base/npm/node_modules/@material/animation/dist/mdc.animation',
      ...
  }
}
```

This could be avoided if the AMD `define` invocations in the UMD file
would specify a module id, similar to how it's done in packages of the
Angular organization. This allows for easier consumption in tests as well.

Note that this change causes a breaking change for the UMD-case where
the exports are bound to a global variable. Previously the entry-point
would appear in camel-case, but now it's matching the actual package
name in dash-case. This is unfortunately not avoidable with the current
Webpack tooling. i.e. previous UMD users relying on the globals (which are
rather rare anyway), would need to switch from
`window.mdc.circularProgress` to `window.mdc['circular-progress]`.