### PR TITLE
docs(button): fix button with class mdc-button--leading

### DIFF
--- a/packages/mdc-button/README.md
+++ b/packages/mdc-button/README.md
@@ -144,7 +144,7 @@ and `mdc-button--unelevated` is applied for a contained button flush with the su
 <img src="images/contained-icon-button.png" alt="Contained button with a bookmark icon">
 
 ```html
-<button class="mdc-button mdc-button--raised mdc-button--leading">
+<button class="mdc-button mdc-button--raised mdc-button--icon-leading">
   <span class="mdc-button__ripple"></span>
   <i class="material-icons mdc-button__icon" aria-hidden="true"
     >bookmark</i


### PR DESCRIPTION
There is no reference in source code to this class, which makes me think that it's just a typo for mdc-button--icon-leading