### PR TITLE
chore: remove d.ts bundles

### DIFF
--- a/packages/mdc-animation/package.json
+++ b/packages/mdc-animation/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.animation.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.animation.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-auto-init/package.json
+++ b/packages/mdc-auto-init/package.json
@@ -5,7 +5,6 @@
   "main": "dist/mdc.autoInit.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.autoInit.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/mdc-banner/package.json
+++ b/packages/mdc-banner/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.banner.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.banner.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-base/package.json
+++ b/packages/mdc-base/package.json
@@ -6,7 +6,6 @@
   "main": "dist/mdc.base.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.base.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-checkbox/package.json
+++ b/packages/mdc-checkbox/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.checkbox.js",
   "module": "./index.js",
   "sideEffects": false,
-  "types": "dist/mdc.checkbox.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-chips/package.json
+++ b/packages/mdc-chips/package.json
@@ -6,7 +6,6 @@
   "main": "dist/mdc.chips.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.chips.d.ts",
   "keywords": [
     "material components",
     "material design",

--- a/packages/mdc-circular-progress/package.json
+++ b/packages/mdc-circular-progress/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.circularProgress.js",
   "module": "./index.js",
   "sideEffects": false,
-  "types": "dist/mdc.circularProgress.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-data-table/package.json
+++ b/packages/mdc-data-table/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.dataTable.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.dataTable.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git"

--- a/packages/mdc-dialog/package.json
+++ b/packages/mdc-dialog/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.dialog.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.dialog.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-dom/package.json
+++ b/packages/mdc-dom/package.json
@@ -6,7 +6,6 @@
   "main": "dist/mdc.dom.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.dom.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-drawer/package.json
+++ b/packages/mdc-drawer/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.drawer.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.drawer.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-floating-label/package.json
+++ b/packages/mdc-floating-label/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.floatingLabel.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.floatingLabel.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-form-field/package.json
+++ b/packages/mdc-form-field/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.formField.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.formField.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-icon-button/package.json
+++ b/packages/mdc-icon-button/package.json
@@ -6,7 +6,6 @@
   "main": "dist/mdc.iconButton.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.iconButton.d.ts",
   "keywords": [
     "material components",
     "material design",

--- a/packages/mdc-line-ripple/package.json
+++ b/packages/mdc-line-ripple/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.lineRipple.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.lineRipple.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-linear-progress/package.json
+++ b/packages/mdc-linear-progress/package.json
@@ -6,7 +6,6 @@
   "main": "dist/mdc.linearProgress.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.linearProgress.d.ts",
   "keywords": [
     "material components",
     "material design",

--- a/packages/mdc-list/package.json
+++ b/packages/mdc-list/package.json
@@ -6,7 +6,6 @@
   "main": "dist/mdc.list.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.list.d.ts",
   "keywords": [
     "material components",
     "material design",

--- a/packages/mdc-menu-surface/package.json
+++ b/packages/mdc-menu-surface/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.menuSurface.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.menuSurface.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-menu/package.json
+++ b/packages/mdc-menu/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.menu.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.menu.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-notched-outline/package.json
+++ b/packages/mdc-notched-outline/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.notchedOutline.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.notchedOutline.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-radio/package.json
+++ b/packages/mdc-radio/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.radio.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.radio.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-ripple/package.json
+++ b/packages/mdc-ripple/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.ripple.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.ripple.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-select/package.json
+++ b/packages/mdc-select/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.select.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.select.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-slider/package.json
+++ b/packages/mdc-slider/package.json
@@ -5,7 +5,6 @@
   "main": "dist/mdc.slider.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.slider.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/mdc-snackbar/package.json
+++ b/packages/mdc-snackbar/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.snackbar.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.snackbar.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-switch/package.json
+++ b/packages/mdc-switch/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.switch.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.switch.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-tab-bar/package.json
+++ b/packages/mdc-tab-bar/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.tabBar.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.tabBar.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-tab-indicator/package.json
+++ b/packages/mdc-tab-indicator/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.tabIndicator.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.tabIndicator.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-tab-scroller/package.json
+++ b/packages/mdc-tab-scroller/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.tabScroller.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.tabScroller.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-tab/package.json
+++ b/packages/mdc-tab/package.json
@@ -16,7 +16,6 @@
   "main": "dist/mdc.tab.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.tab.d.ts",
   "dependencies": {
     "@material/base": "^12.0.0",
     "@material/elevation": "^12.0.0",

--- a/packages/mdc-textfield/package.json
+++ b/packages/mdc-textfield/package.json
@@ -12,7 +12,6 @@
   "main": "dist/mdc.textfield.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.textfield.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-tooltip/package.json
+++ b/packages/mdc-tooltip/package.json
@@ -11,7 +11,6 @@
   "main": "dist/mdc.tooltip.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.tooltip.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/packages/mdc-top-app-bar/package.json
+++ b/packages/mdc-top-app-bar/package.json
@@ -6,7 +6,6 @@
   "main": "dist/mdc.topAppBar.js",
   "module": "index.js",
   "sideEffects": false,
-  "types": "dist/mdc.topAppBar.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web.git",

--- a/scripts/cp-pkgs.js
+++ b/scripts/cp-pkgs.js
@@ -116,10 +116,15 @@ function dtsBundler() {
       if (error) {
         return;
       }
+      const isAllInOne = packageDirectory === ALL_IN_ONE_PACKAGE;
+      if (!isAllInOne) {
+        // Only the all-in-one package should generate a d.ts bundle
+        return;
+      }
+
       // d.ts file exists
       const packagePath = path.join(PACKAGES_DIRECTORY, packageDirectory);
       const name = JSON.parse(fs.readFileSync(path.join(packagePath, 'package.json'), 'utf8')).name;
-      const isAllInOne = packageDirectory === ALL_IN_ONE_PACKAGE;
       const destBasename
         = isAllInOne ? packageDirectory : `mdc.${toCamelCase(packageDirectory.replace(/^mdc-/, ''))}`;
       const destFilename = path.join(packagePath, 'dist', `${destBasename}.d.ts`);

--- a/scripts/verify-pkg-main.js
+++ b/scripts/verify-pkg-main.js
@@ -90,7 +90,9 @@ globSync('packages/*/package.json').forEach((jsonPath) => {
   }
   verifyPath(packageJson, jsonPath, 'main');
   verifyPath(packageJson, jsonPath, 'module');
-  verifyPath(packageJson, jsonPath, 'types');
+  if (jsonPath.includes('material-components-web')) {
+    verifyPath(packageJson, jsonPath, 'types');
+  }
 });
 
 if (invalidMains > 0 || invalidModules > 0 || invalidTypes > 0) {


### PR DESCRIPTION
This is blocking mwc-switch (https://github.com/material-components/material-components-web-components/pull/2591/checks?check_run_id=3246042094) due to a TypeScript error where our files will resolve to two different types:

One (`observer-foundation.ts`) resolves to `node_modules/@material/base/foundation.d.ts` (correct) since it uses a relative import path. The other (MWC's `base-element.ts`) resolves to `node_modules/@material/base/dist/mdc.base.d.ts` (incorrect) since it uses an absolute import path which finds the `"types"` package.json param and uses that.

This leads to confusing error messages ("MDCFoundation<AdapterType> is not assignable to MDCFoundation<AdapterType>"). With the exception of the all-in-one package, our types can use source file d.ts type files instead of a bundled type file.