### PR TITLE
chore: clean .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
-linguist-documentation
-docs/* linguist-documentation
-/package-lock.json linguist-generated
+* text=auto eol=lf


### PR DESCRIPTION
Enforce Unix newlines and remove redundant attributes. I believe they should be handled automatically by GitHub now.