### PR TITLE
fix(chips): expose all symbols through main entry point

### DIFF
--- a/packages/mdc-chips/action/index.ts
+++ b/packages/mdc-chips/action/index.ts
@@ -23,7 +23,13 @@
 
 export * from './adapter';
 export * from './component';
-export * from './constants';
 export * from './foundation';
 export * from './primary-foundation';
 export * from './trailing-foundation';
+export * from './types';
+export {
+  CssClasses as ChipActionCssClasses,
+  Events as ChipActionEvents,
+  FocusBehavior as ChipActionFocusBehavior,
+  Attributes as ChipActionAttributes,
+} from './constants';

--- a/packages/mdc-chips/chip-set/index.ts
+++ b/packages/mdc-chips/chip-set/index.ts
@@ -23,5 +23,10 @@
 
 export * from './adapter';
 export * from './component';
-export * from './constants';
 export * from './foundation';
+export * from './types';
+export {
+  Attributes as ChipSetAttributes,
+  CssClasses as ChipSetCssClasses,
+  Events as ChipSetEvents,
+} from './constants';

--- a/packages/mdc-chips/chip/index.ts
+++ b/packages/mdc-chips/chip/index.ts
@@ -23,5 +23,11 @@
 
 export * from './adapter';
 export * from './component';
-export * from './constants';
 export * from './foundation';
+export * from './types';
+export {
+  CssClasses as ChipCssClasses,
+  Events as ChipEvents,
+  Attributes as ChipAttributes,
+  Animation as ChipAnimation,
+} from './constants';

--- a/packages/mdc-chips/index.ts
+++ b/packages/mdc-chips/index.ts
@@ -22,6 +22,8 @@
  */
 
 export * from './chip-set/index';
+export * from './chip/index';
+export * from './action/index';
 
 /**
  * Backwards compatibility for existing clients.


### PR DESCRIPTION
Fixes the following issues related to the chips entry point:
* The chip and chip action symbols weren't exported through the primary entry point, making them difficult to consume in a Bazel environment.
* The various `types.ts` files weren't being exported.
* Some of the symbols had to be re-exported through different names, because they were conflicting with other symbols. E.g. both the chip and chip action had enums called `Events` and `CssClasses`.