### PR TITLE
fix(list): Removed unnecessary setTimeout method for focusOut event.

### DIFF
--- a/packages/mdc-list/adapter.ts
+++ b/packages/mdc-list/adapter.ts
@@ -95,7 +95,7 @@ export interface MDCListAdapter {
   /**
    * @return true when the current focused element is inside list root.
    */
-  isFocusInsideList(): boolean;
+  isFocusInsideList(focusedElement: EventTarget): boolean;
 
   /**
    * @return the primary text content of the list item at index.

--- a/packages/mdc-list/component.ts
+++ b/packages/mdc-list/component.ts
@@ -273,9 +273,9 @@ export class MDCList extends MDCComponent<MDCListFoundation> {
             listItem.querySelector<HTMLInputElement>(strings.CHECKBOX_SELECTOR);
         return toggleEl!.checked;
       },
-      isFocusInsideList: () => {
-        return this.root !== document.activeElement &&
-            this.root.contains(document.activeElement);
+      isFocusInsideList: (focusedElement) => {
+        return focusedElement instanceof HTMLElement &&
+          this.root !== focusedElement && this.root.contains(focusedElement);
       },
       isRootFocused: () => document.activeElement === this.root,
       listItemAtIndexHasClass: (index, className) =>

--- a/packages/mdc-list/foundation.ts
+++ b/packages/mdc-list/foundation.ts
@@ -243,15 +243,9 @@ export class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
       this.adapter.setTabIndexForListItemChildren(listItemIndex, '-1');
     }
 
-    /**
-     * Between Focusout & Focusin some browsers do not have focus on any
-     * element. Setting a delay to wait till the focus is moved to next element.
-     */
-    setTimeout(() => {
-      if (!this.adapter.isFocusInsideList()) {
-        this.setTabindexToFirstSelectedOrFocusedItem();
-      }
-    }, 0);
+    if (!this.adapter.isFocusInsideList(evt.relatedTarget)) {
+            this.setTabindexToFirstSelectedOrFocusedItem();
+        }
   }
 
   /**


### PR DESCRIPTION
`FocusEvent.relatedTarget` is the secondary target that is receiving focus in `focusOut` event. So we can use this `EventTarget` to find out whether the focus is inside the root.