### PR TITLE
docs: span tags instead of divs within button tags

### DIFF
--- a/packages/mdc-banner/README.md
+++ b/packages/mdc-banner/README.md
@@ -63,8 +63,8 @@ const banner = new MDCBanner(document.querySelector('.mdc-banner'));
     </div>
     <div class="mdc-banner__actions">
       <button type="button" class="mdc-button mdc-banner__primary-action">
-        <div class="mdc-button__ripple"></div>
-        <div class="mdc-button__label">Fix it</div>
+        <span class="mdc-button__ripple"></span>
+        <span class="mdc-button__label">Fix it</span>
       </button>
     </div>
   </div>
@@ -110,8 +110,8 @@ When used below top app bars, banners should remain fixed at the top of the scre
       </div>
       <div class="mdc-banner__actions">
         <button type="button" class="mdc-button mdc-banner__primary-action">
-          <div class="mdc-button__ripple"></div>
-          <div class="mdc-button__label">Fix it</div>
+          <span class="mdc-button__ripple"></span>
+          <span class="mdc-button__label">Fix it</span>
         </button>
       </div>
     </div>
@@ -136,8 +136,8 @@ Images can help communicate a banner’s message.
     </div>
     <div class="mdc-banner__actions">
       <button type="button" class="mdc-button mdc-banner__primary-action">
-        <div class="mdc-button__ripple"></div>
-        <div class="mdc-button__label">Fix it</div>
+        <span class="mdc-button__ripple"></span>
+        <span class="mdc-button__label">Fix it</span>
       </button>
     </div>
   </div>
@@ -160,12 +160,12 @@ Banners may have one or two low-emphasis text buttons.
     </div>
     <div class="mdc-banner__actions">
       <button type="button" class="mdc-button mdc-banner__secondary-action">
-        <div class="mdc-button__ripple"></div>
-        <div class="mdc-button__label">Learn more</div>
+        <span class="mdc-button__ripple"></span>
+        <span class="mdc-button__label">Learn more</span>
       </button>
       <button type="button" class="mdc-button mdc-banner__primary-action">
-        <div class="mdc-button__ripple"></div>
-        <div class="mdc-button__label">Fix it</div>
+        <span class="mdc-button__ripple"></span>
+        <span class="mdc-button__label">Fix it</span>
       </button>
     </div>
   </div>

--- a/packages/mdc-card/README.md
+++ b/packages/mdc-card/README.md
@@ -148,11 +148,11 @@ It's often used with [buttons](../mdc-button):
 ```html
 <div class="mdc-card__actions">
   <button class="mdc-button mdc-card__action mdc-card__action--button">
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">Action 1</span>
   </button>
   <button class="mdc-button mdc-card__action mdc-card__action--button">
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">Action 2</span>
   </button>
 </div>
@@ -182,7 +182,7 @@ To have a single action button take up the entire width of the action row, use t
 ```html
 <div class="mdc-card__actions mdc-card__actions--full-bleed">
   <a class="mdc-button mdc-card__action mdc-card__action--button" href="#">
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">All Business Headlines</span>
     <i class="material-icons mdc-button__icon" aria-hidden="true">arrow_forward</i>
   </a>
@@ -196,11 +196,11 @@ elements:
 <div class="mdc-card__actions">
   <div class="mdc-card__action-buttons">
     <button class="mdc-button mdc-card__action mdc-card__action--button">
-      <div class="mdc-button__ripple"></div>
+      <span class="mdc-button__ripple"></span>
       <span class="mdc-button__label">Read</span>
     </button>
     <button class="mdc-button mdc-card__action mdc-card__action--button">
-      <div class="mdc-button__ripple"></div>
+      <span class="mdc-button__ripple"></span>
       <span class="mdc-button__label">Bookmark</span>
     </button>
   </div>
@@ -239,11 +239,11 @@ The following is an example incorporating all of the above elements:
   <div class="mdc-card__actions">
     <div class="mdc-card__action-buttons">
       <button class="mdc-button mdc-card__action mdc-card__action--button">
-        <div class="mdc-button__ripple"></div>
+        <span class="mdc-button__ripple"></span>
         <span class="mdc-button__label">Action 1</span>
       </button>
       <button class="mdc-button mdc-card__action mdc-card__action--button">
-        <div class="mdc-button__ripple"></div>
+        <span class="mdc-button__ripple"></span>
         <span class="mdc-button__label">Action 2</span>
       </button>
     </div>

--- a/packages/mdc-dialog/README.md
+++ b/packages/mdc-dialog/README.md
@@ -113,11 +113,11 @@ Alert dialogs interrupt users with urgent information, details, or actions.
       </div>
       <div class="mdc-dialog__actions">
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="cancel">
-          <div class="mdc-button__ripple"></div>
+          <span class="mdc-button__ripple"></span>
           <span class="mdc-button__label">Cancel</span>
         </button>
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="discard">
-          <div class="mdc-button__ripple"></div>
+          <span class="mdc-button__ripple"></span>
           <span class="mdc-button__label">Discard</span>
         </button>
       </div>
@@ -215,11 +215,11 @@ If the user confirms a choice, it’s carried out. Otherwise, the user can dismi
       </div>
       <div class="mdc-dialog__actions">
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">
-          <div class="mdc-button__ripple"></div>
+          <span class="mdc-button__ripple"></span>
           <span class="mdc-button__label">Cancel</span>
         </button>
         <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="accept">
-          <div class="mdc-button__ripple"></div>
+          <span class="mdc-button__ripple"></span>
           <span class="mdc-button__label">OK</span>
         </button>
       </div>
@@ -271,7 +271,7 @@ Full-screen dialogs group a series of tasks, such as creating a calendar entry w
       <div class="mdc-dialog__actions">
         <button type="button" class="mdc-button mdc-dialog__button"
                 data-mdc-dialog-action="ok">
-          <div class="mdc-button__ripple"></div>
+          <span class="mdc-button__ripple"></span>
           <span class="mdc-button__label">OK</span>
         </button>
       </div>
@@ -340,11 +340,11 @@ For example:
 ...
 <div class="mdc-dialog__actions">
   <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">Cancel</span>
   </button>
   <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="accept" data-mdc-dialog-button-default>
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">OK</span>
   </button>
 </div>

--- a/packages/mdc-elevation/README.md
+++ b/packages/mdc-elevation/README.md
@@ -50,8 +50,8 @@ The elevation overlay should appear *above* the component container in the stack
 
 ```html
 <button class="mdc-button mdc-button--raised">
-  <div class="mdc-elevation-overlay"></div>
-  <div class="mdc-button__ripple"></div>
+  <span class="mdc-elevation-overlay"></span>
+  <span class="mdc-button__ripple"></span>
   <i class="material-icons mdc-button__icon" aria-hidden="true">favorite</i>
   <span class="mdc-button__label">Font Icon</span>
 </button>

--- a/packages/mdc-fab/README.md
+++ b/packages/mdc-fab/README.md
@@ -72,9 +72,9 @@ Add the following to meet this requirement for mini FABs:
 ```html
 <div class="mdc-touch-target-wrapper">
   <button class="mdc-fab mdc-fab--mini mdc-fab--touch">
-    <div class="mdc-fab__ripple"></div>
+    <span class="mdc-fab__ripple"></span>
     <span class="material-icons mdc-fab__icon">add</span>
-    <div class="mdc-fab__touch"></div>
+    <span class="mdc-fab__touch"></span>
   </button>
 </div>
 ```
@@ -89,7 +89,7 @@ Regular FABs are FABs that are not expanded and are a regular size.
 
 ```html
 <button class="mdc-fab" aria-label="Favorite">
-  <div class="mdc-fab__ripple"></div>
+  <span class="mdc-fab__ripple"></span>
   <span class="mdc-fab__icon material-icons">favorite</span>
 </button>
 ```
@@ -108,7 +108,7 @@ Mini FABs can also be used to create visual continuity with other screen element
 
 ```html
 <button class="mdc-fab mdc-fab--mini" aria-label="Favorite">
-  <div class="mdc-fab__ripple"></div>
+  <span class="mdc-fab__ripple"></span>
   <span class="mdc-fab__icon material-icons">favorite</span>
 </button>
 ```
@@ -121,7 +121,7 @@ The extended FAB is wider, and it includes a text label.
 
 ```html
 <button class="mdc-fab mdc-fab--extended">
-  <div class="mdc-fab__ripple"></div>
+  <span class="mdc-fab__ripple"></span>
   <span class="material-icons mdc-fab__icon">add</span>
   <span class="mdc-fab__label">Create</span>
 </button>

--- a/packages/mdc-icon-button/README.md
+++ b/packages/mdc-icon-button/README.md
@@ -59,7 +59,7 @@ However, you can also use SVG, [Font Awesome](https://fontawesome.com/), or any 
 
 ```html
 <button class="mdc-icon-button material-icons">
-  <div class="mdc-icon-button__ripple"></div>
+  <span class="mdc-icon-button__ripple"></span>
   favorite
 </button>
 ```
@@ -76,9 +76,9 @@ To meet this requirement, add the following to your button:
 ```html
 <div class="mdc-touch-target-wrapper">
   <button class="mdc-icon-button mdc-icon-button--touch material-icons">
-    <div class="mdc-icon-button__ripple"></div>
+    <span class="mdc-icon-button__ripple"></span>
     favorite
-    <div class="mdc-icon-button__touch"></div>
+    <span class="mdc-icon-button__touch"></span>
   </button>
 </div>
 ```
@@ -97,7 +97,7 @@ If the button should be initialized in the "on" state, then add the `mdc-icon-bu
    class="mdc-icon-button"
    aria-label="Add to favorites"
    aria-pressed="false">
-   <div class="mdc-icon-button__ripple"></div>
+   <span class="mdc-icon-button__ripple"></span>
    <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
    <i class="material-icons mdc-icon-button__icon">favorite_border</i>
 </button>
@@ -119,7 +119,7 @@ The icon button toggle can be used with SVGs.
    class="mdc-icon-button mdc-icon-button--on"
    aria-label="Unstar this item"
    aria-pressed="true">
-   <div class="mdc-icon-button__ripple"></div>
+   <span class="mdc-icon-button__ripple"></span>
    <svg class="mdc-icon-button__icon">
      ...
    </svg>
@@ -138,7 +138,7 @@ The icon button toggle can be used with `img` tags.
    class="mdc-icon-button mdc-icon-button--on"
    aria-label="Unstar this item"
    aria-pressed="true">
-   <div class="mdc-icon-button__ripple"></div>
+   <span class="mdc-icon-button__ripple"></span>
    <img src="" class="mdc-icon-button__icon"/>
    <img src="" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
 </button>
@@ -157,7 +157,7 @@ and `aria-data-label-off` (aria label in off state) attributes, and omit the
    aria-label="Add to favorites"
    data-aria-label-on="Remove from favorites"
    data-aria-label-off="Add to favorites">
-   <div class="mdc-icon-button__ripple"></div>
+   <span class="mdc-icon-button__ripple"></span>
    <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on">favorite</i>
    <i class="material-icons mdc-icon-button__icon">favorite_border</i>
 </button>

--- a/packages/mdc-segmented-button/README.md
+++ b/packages/mdc-segmented-button/README.md
@@ -149,8 +149,8 @@ Material Design spec advises that touch targets should be at least 48 x 48 px. T
 ```html
 <div class="mdc-touch-target-wrapper">
   <button class="mdc-segmented-button__segment mdc-segmented-button--touch">
-    <div class="mdc-segmented-button__touch"></div>
-    <div class="mdc-segmented-button__label">Sample Text</div>
+    <span class="mdc-segmented-button__touch"></span>
+    <span class="mdc-segmented-button__label">Sample Text</span>
   </button>
 </div>
 ```
@@ -161,8 +161,8 @@ To include ripple effects when a segment is clicked add the following classes to
 
 ```html
 <button class="mdc-segmented-button__segment">
-  <div class="mdc-segmented-button__ripple"></div>
-  <div class="mdc-segmented-button__label">Sample Text</div>
+  <span class="mdc-segmented-button__ripple"></span>
+  <span class="mdc-segmented-button__label">Sample Text</span>
 </button>
 ```
 

--- a/packages/mdc-snackbar/README.md
+++ b/packages/mdc-snackbar/README.md
@@ -40,7 +40,7 @@ npm install @material/snackbar
     </div>
     <div class="mdc-snackbar__actions" aria-atomic="true">
       <button type="button" class="mdc-button mdc-snackbar__action">
-        <div class="mdc-button__ripple"></div>
+        <span class="mdc-button__ripple"></span>
         <span class="mdc-button__label">Retry</span>
       </button>
     </div>

--- a/packages/mdc-tooltip/README.md
+++ b/packages/mdc-tooltip/README.md
@@ -147,7 +147,7 @@ Default rich tooltip without interactive content
 ```html
 <div class="mdc-tooltip-wrapper--rich">
   <button class="mdc-button" aria-describedby="tt0">
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">Button</span>
   </button>
   <div id="tt0" class="mdc-tooltip mdc-tooltip--rich" aria-hidden="true" role="tooltip">
@@ -171,7 +171,7 @@ Default rich tooltip with interactive content
 ```html
 <div class="mdc-tooltip-wrapper--rich">
   <button class="mdc-button" data-tooltip-id="tt0" aria-haspopup="dialog" aria-expanded="false">
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">Button</span>
   </button>
   <div id="tt0" class="mdc-tooltip mdc-tooltip--rich" aria-hidden="true" role="dialog">
@@ -202,7 +202,7 @@ Persistent rich tooltip with interactive content
 ```html
 <div class="mdc-tooltip-wrapper--rich">
   <button class="mdc-button" data-tooltip-id="tt0" aria-haspopup="dialog" aria-expanded="false">
-    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__ripple"></span>
     <span class="mdc-button__label">Button</span>
   </button>
   <div id="tt0" class="mdc-tooltip mdc-tooltip--rich" aria-hidden="true" tabindex="-1" data-mdc-tooltip-persistent="true" role="dialog">
@@ -231,7 +231,7 @@ ensure that the tooltip is not hidden when clicked on.
 
 ```html
 <button class="mdc-button mdc-button--outlined" aria-describedby="tooltip-id">
-  <div class="mdc-button__ripple"></div>
+  <span class="mdc-button__ripple"></span>
   <span class="mdc-button__label">Button</span>
 </button>
 ```

--- a/packages/mdc-touch-target/README.md
+++ b/packages/mdc-touch-target/README.md
@@ -41,7 +41,7 @@ For a given button component:
 
 ```html
 <button class="mdc-button">
-  <div class="mdc-button__ripple"></div>
+  <span class="mdc-button__ripple"></span>
   <span class="mdc-button__label">My Inaccessible Button</span>
 </button>
 ```
@@ -51,8 +51,8 @@ You would add an increased touch target as follows:
 ```html
 <div class="mdc-touch-target-wrapper">
   <button class="mdc-button mdc-button--touch">
-    <div class="mdc-button__ripple"></div>
-    <div class="mdc-button__touch"></div>
+    <span class="mdc-button__ripple"></span>
+    <span class="mdc-button__touch"></span>
     <span class="mdc-button__label">My Accessible Button</span>
   </button>
 </div>


### PR DESCRIPTION
Related to #7388 

I have gone over the `div.*?__ripple` matching cases and updated those tags to span's, and while doing that change also done the same with sibling div elements.