### PR TITLE
refactor: update to M2 text style names

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -331,8 +331,8 @@ The same pattern is followed for text colors on _background_:
 
 | Custom property                            | Description                                                |
 | ------------------------------------------ | ---------------------------------------------------------- |
-| `--mdc-theme-text-primary-on-background`   | Primary text on top of the theme background color.         |
-| `--mdc-theme-text-secondary-on-background` | Secondary text on top of the theme background color.       |
+| `--mdc-theme-text-high-on-background`      | High emphasis text on top of the theme background color.   |
+| `--mdc-theme-text-medium-on-background`    | Medium emphasis text on top of the theme background color. |
 | `--mdc-theme-text-hint-on-background`      | Hint text on top of the theme background color.            |
 | `--mdc-theme-text-disabled-on-background`  | Disabled text on top of the theme background color.        |
 | `--mdc-theme-text-icon-on-background`      | Icons on top of the theme background color.                |
@@ -341,19 +341,19 @@ In addition, we also define custom properties for known dark and light backgroun
 
 | Custom property                            | Description                                                |
 | ------------------------------------------ | ---------------------------------------------------------- |
-| `--mdc-theme-text-primary-on-light`        | Primary text on top of a light-colored background.         |
-| `--mdc-theme-text-secondary-on-light`      | Secondary text on top of a light-colored background.       |
+| `--mdc-theme-text-high-on-light`           | High emphasis text on top of a light-colored background.   |
+| `--mdc-theme-text-medium-on-light`         | Medium emphasis text on top of a light-colored background. |
 | `--mdc-theme-text-hint-on-light`           | Hint text on top of a light-colored background.            |
 | `--mdc-theme-text-disabled-on-light`       | Disabled text on top of a light-colored background.        |
 | `--mdc-theme-text-icon-on-light`           | Icons on top of a light-colored background.                |
 
 | Custom property                            | Description                                                |
 | ------------------------------------------ | ---------------------------------------------------------- |
-| `--mdc-theme-text-primary-on-dark`        | Primary text on top of a dark-colored background.         |
-| `--mdc-theme-text-secondary-on-dark`      | Secondary text on top of a dark-colored background.       |
-| `--mdc-theme-text-hint-on-dark`           | Hint text on top of a dark-colored background.            |
-| `--mdc-theme-text-disabled-on-dark`       | Disabled text on top of a dark-colored background.        |
-| `--mdc-theme-text-icon-on-dark`           | Icons on top of a dark-colored background.                |
+| `--mdc-theme-text-high-on-dark`            | High emphasis text on top of a dark-colored background.    |
+| `--mdc-theme-text-medium-on-dark`          | Medium emphasis text on top of a dark-colored background.  |
+| `--mdc-theme-text-hint-on-dark`            | Hint text on top of a dark-colored background.             |
+| `--mdc-theme-text-disabled-on-dark`        | Disabled text on top of a dark-colored background.         |
+| `--mdc-theme-text-icon-on-dark`            | Icons on top of a dark-colored background.                 |
 
 
 Ideally, we should set all of the text colors on primary, since we never know which one an MDC Web component might use.
@@ -362,22 +362,22 @@ Since our cards only contain text and no components, let's keep it simple for no
 ```css
 .element-card.earth {
   --mdc-theme-primary: #795548;
-  --mdc-theme-on-primary: var(--mdc-theme-text-primary-on-dark);
+  --mdc-theme-on-primary: var(--mdc-theme-text-high-on-dark);
 }
 
 .element-card.wind {
   --mdc-theme-primary: #9e9e9e;
-  --mdc-theme-on-primary: var(--mdc-theme-text-primary-on-light);
+  --mdc-theme-on-primary: var(--mdc-theme-text-high-on-light);
 }
 
 .element-card.fire {
   --mdc-theme-primary: #f44336;
-  --mdc-theme-on-primary: var(--mdc-theme-text-primary-on-dark);
+  --mdc-theme-on-primary: var(--mdc-theme-text-high-on-dark);
 }
 
 .element-card.water {
   --mdc-theme-primary: #00bcd4;
-  --mdc-theme-on-primary: var(--mdc-theme-text-primary-on-light);
+  --mdc-theme-on-primary: var(--mdc-theme-text-high-on-light);
 }
 ```
 

--- a/packages/mdc-button/_button-shared-theme.scss
+++ b/packages/mdc-button/_button-shared-theme.scss
@@ -228,11 +228,11 @@ $disabled-container-color: rgba(
   @include container-fill-color($container-fill-color, $query);
 
   @if ($fill-tone == 'dark') {
-    @include ink-color(text-primary-on-dark, $query);
-    @include ripple-states($color: text-primary-on-dark, $query: $query);
+    @include ink-color(text-high-on-dark, $query);
+    @include ripple-states($color: text-high-on-dark, $query: $query);
   } @else {
-    @include ink-color(text-primary-on-light, $query);
-    @include ripple-states($color: text-primary-on-light, $query: $query);
+    @include ink-color(text-high-on-light, $query);
+    @include ripple-states($color: text-high-on-light, $query: $query);
   }
 }
 

--- a/packages/mdc-chips/deprecated/_mixins.scss
+++ b/packages/mdc-chips/deprecated/_mixins.scss
@@ -384,15 +384,15 @@ $ripple-target: '.mdc-chip__ripple';
   @include fill-color($color, $query: $query);
 
   @if ($fill-tone == 'dark') {
-    @include ink-color(text-primary-on-dark, $query: $query);
-    @include selected-ink-color(text-primary-on-dark, $query: $query);
-    @include leading-icon-color(text-primary-on-dark, $query: $query);
-    @include trailing-icon-color(text-primary-on-dark, $query: $query);
+    @include ink-color(text-high-on-dark, $query: $query);
+    @include selected-ink-color(text-high-on-dark, $query: $query);
+    @include leading-icon-color(text-high-on-dark, $query: $query);
+    @include trailing-icon-color(text-high-on-dark, $query: $query);
   } @else {
-    @include ink-color(text-primary-on-light, $query: $query);
-    @include selected-ink-color(text-primary-on-light, $query: $query);
-    @include leading-icon-color(text-primary-on-light, $query: $query);
-    @include trailing-icon-color(text-primary-on-light, $query: $query);
+    @include ink-color(text-high-on-light, $query: $query);
+    @include selected-ink-color(text-high-on-light, $query: $query);
+    @include leading-icon-color(text-high-on-light, $query: $query);
+    @include trailing-icon-color(text-high-on-light, $query: $query);
   }
 }
 

--- a/packages/mdc-fab/_fab-theme.scss
+++ b/packages/mdc-fab/_fab-theme.scss
@@ -213,16 +213,16 @@ $custom-property-prefix: 'fab';
   $fill-tone: theme-color.tone($container-color);
 
   @if ($fill-tone == 'dark') {
-    @include ink-color(text-primary-on-dark, $query: $query);
+    @include ink-color(text-high-on-dark, $query: $query);
     @include ripple-theme.states(
-      text-primary-on-dark,
+      text-high-on-dark,
       $query: $query,
       $ripple-target: $ripple-target
     );
   } @else {
-    @include ink-color(text-primary-on-light, $query: $query);
+    @include ink-color(text-high-on-light, $query: $query);
     @include ripple-theme.states(
-      text-primary-on-light,
+      text-high-on-light,
       $query: $query,
       $ripple-target: $ripple-target
     );

--- a/packages/mdc-form-field/_mixins.scss
+++ b/packages/mdc-form-field/_mixins.scss
@@ -37,7 +37,7 @@
     @include typography.typography(body2, $query);
 
     @include feature-targeting.targets($feat-color) {
-      @include theme.property(color, text-primary-on-background);
+      @include theme.property(color, text-high-on-background);
     }
 
     @include feature-targeting.targets($feat-structure) {

--- a/packages/mdc-image-list/_mixins.scss
+++ b/packages/mdc-image-list/_mixins.scss
@@ -83,7 +83,7 @@
 
   .mdc-image-list__supporting {
     @include feature-targeting.targets($feat-color) {
-      @include theme.property(color, text-primary-on-background);
+      @include theme.property(color, text-high-on-background);
     }
 
     @include feature-targeting.targets($feat-structure) {

--- a/packages/mdc-list/_evolution-mixins.scss
+++ b/packages/mdc-list/_evolution-mixins.scss
@@ -31,8 +31,8 @@
   // Items
   //
 
-  @include list-primary-text-ink-color(text-primary-on-background, $query);
-  @include list-secondary-text-ink-color(text-secondary-on-background, $query);
+  @include list-primary-text-ink-color(text-high-on-background, $query);
+  @include list-secondary-text-ink-color(text-medium-on-background, $query);
   @include list-overline-text-ink-color(text-hint-on-background, $query);
   @include list-icon-fill-color(transparent, $query);
   @include list-icon-ink-color(text-icon-on-background, $query);
@@ -41,7 +41,7 @@
   @include list-disabled-ink-color(variables.$content-disabled-color, $query);
   @include list-selected-ink-color(variables.$content-selected-color, $query);
 
-  @include group-subheader-ink-color(text-primary-on-background, $query);
+  @include group-subheader-ink-color(text-high-on-background, $query);
 
   @include _high-contrast-mode($query);
 

--- a/packages/mdc-list/_mixins.scss
+++ b/packages/mdc-list/_mixins.scss
@@ -66,14 +66,14 @@
     $query: $query
   );
   @include deprecated-item-secondary-text-ink-color(
-    text-secondary-on-background,
+    text-medium-on-background,
     $query
   );
   @include deprecated-item-graphic-fill-color(transparent, $query);
   @include deprecated-item-graphic-ink-color(text-icon-on-background, $query);
   @include deprecated-item-meta-ink-color(text-hint-on-background, $query);
   @include deprecated-group-subheader-ink-color(
-    text-primary-on-background,
+    text-high-on-background,
     $query
   );
   @include deprecated-item-disabled-text-opacity(
@@ -1093,7 +1093,7 @@
   }
 
   @include deprecated-item-primary-text-ink-color(
-    text-primary-on-background,
+    text-high-on-background,
     $query
   );
 }

--- a/packages/mdc-theme/README.md
+++ b/packages/mdc-theme/README.md
@@ -55,17 +55,17 @@ The text styles (referred to as `<TEXT_STYLE>` below) used in the color system:
 
 Text style | Description
 --- | ---
-`primary` | Used for most text (e.g., `text-primary-on-light`)
-`secondary` | Used for text which is lower in the visual hierarchy (e.g., `text-secondary-on-light`)
+`high` | Used for most text (e.g., `text-high-on-light`)
+`medium` | Used for text which is lower in the visual hierarchy (e.g., `text-medium-on-light`)
 `hint` | Used for text hints, such as those in text fields and labels (e.g., `text-hint-on-light`)
 `disabled` | Used for text in disabled components and content (e.g., `text-disabled-on-light`)
 `icon` | Used for icons (e.g., `text-icon-on-light`)
 
 Here are the example usages of `primary` text style:
 
-  * CSS Custom property: `--mdc-theme-text-primary-on-light`
-  * Class name: `mdc-theme--text-primary-on-light`
-  * Property name used in Sass: `text-primary-on-light`
+  * CSS Custom property: `--mdc-theme-text-high-on-light`
+  * Class name: `mdc-theme--text-high-on-light`
+  * Property name used in Sass: `text-high-on-light`
 
 ### Non-Sass customization
 
@@ -198,8 +198,8 @@ Params:
 > NOTE: This function is defined in `_variables.scss` instead of `_functions.scss` to avoid circular imports.
 
 ```scss
-@debug theme.accessible-ink-color(secondary); // rgba(0, 0, 0, .87) (text-primary-on-light)
-@debug theme.accessible-ink-color(blue);      // white              (text-primary-on-dark)
+@debug theme.accessible-ink-color(secondary); // rgba(0, 0, 0, .87) (text-high-on-light)
+@debug theme.accessible-ink-color(blue);      // white              (text-high-on-dark)
 ```
 #### `theme.text-emphasis($emphasis)`
 

--- a/packages/mdc-theme/_theme-color.scss
+++ b/packages/mdc-theme/_theme-color.scss
@@ -142,15 +142,15 @@ $on-error: if(contrast-tone($error) == 'dark', #000, #fff) !default;
 
 $text-colors: (
   dark: (
-    primary: rgba(black, 0.87),
-    secondary: rgba(black, 0.54),
+    high: rgba(black, 0.87),
+    medium: rgba(black, 0.54),
     hint: rgba(black, 0.38),
     disabled: rgba(black, 0.38),
     icon: rgba(black, 0.38),
   ),
   light: (
-    primary: white,
-    secondary: rgba(white, 0.7),
+    high: white,
+    medium: rgba(white, 0.7),
     hint: rgba(white, 0.5),
     disabled: rgba(white, 0.5),
     icon: rgba(white, 0.5),
@@ -185,18 +185,18 @@ $property-values: (
   on-secondary: $on-secondary,
   on-surface: $on-surface,
   on-error: $on-error,
-  text-primary-on-background: ink-color-for-fill_(primary, $background),
-  text-secondary-on-background: ink-color-for-fill_(secondary, $background),
+  text-high-on-background: ink-color-for-fill_(high, $background),
+  text-medium-on-background: ink-color-for-fill_(medium, $background),
   text-hint-on-background: ink-color-for-fill_(hint, $background),
   text-disabled-on-background: ink-color-for-fill_(disabled, $background),
   text-icon-on-background: ink-color-for-fill_(icon, $background),
-  text-primary-on-light: ink-color-for-fill_(primary, light),
-  text-secondary-on-light: ink-color-for-fill_(secondary, light),
+  text-high-on-light: ink-color-for-fill_(high, light),
+  text-medium-on-light: ink-color-for-fill_(medium, light),
   text-hint-on-light: ink-color-for-fill_(hint, light),
   text-disabled-on-light: ink-color-for-fill_(disabled, light),
   text-icon-on-light: ink-color-for-fill_(icon, light),
-  text-primary-on-dark: ink-color-for-fill_(primary, dark),
-  text-secondary-on-dark: ink-color-for-fill_(secondary, dark),
+  text-high-on-dark: ink-color-for-fill_(high, dark),
+  text-medium-on-dark: ink-color-for-fill_(medium, dark),
   text-hint-on-dark: ink-color-for-fill_(hint, dark),
   text-disabled-on-dark: ink-color-for-fill_(disabled, dark),
   text-icon-on-dark: ink-color-for-fill_(icon, dark),
@@ -273,7 +273,7 @@ $_property-values-copy: $property-values;
 }
 
 // NOTE: This function must be defined in _variables.scss instead of _functions.scss to avoid circular imports.
-@function accessible-ink-color($fill-color, $text-style: primary) {
+@function accessible-ink-color($fill-color, $text-style: high) {
   $fill-color-value: prop-value($fill-color);
   $color-map-for-tone: map.get($text-colors, contrast-tone($fill-color-value));
 

--- a/packages/mdc-tooltip/_tooltip-theme.scss
+++ b/packages/mdc-tooltip/_tooltip-theme.scss
@@ -34,14 +34,14 @@
 
 $background-color: rgba(black, theme-color.text-emphasis(medium));
 $border-radius: small;
-$label-color: text-primary-on-dark;
+$label-color: text-high-on-dark;
 
 $enter-duration: 150ms;
 $exit-duration: 75ms;
 
 // Rich Tooltip variables
 $rich-background-color: theme-color.prop-value(surface);
-$rich-title-text-color: text-primary-on-light;
+$rich-title-text-color: text-high-on-light;
 $rich-content-text-color: rgba(black, theme-color.text-emphasis(medium));
 $rich-content-link-color: primary;
 


### PR DESCRIPTION
Update text style names so that there is no more confusion with "primary" and "secondary".
Names replaced by `high` and `medium` to match M2 high and medium emphasis test styles.
as referenced in #5784 first solution.