### PR TITLE
chore: Bump Node and Sass versions, and some misc housekeeping

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
       - uses: actions/cache@v2
         with:
           path: ~/.npm
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
       - uses: actions/cache@v2
         with:
           path: |
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
       - uses: actions/cache@v2
         with:
           path: |
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
       - uses: actions/cache@v2
         with:
           path: |
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
       - uses: actions/cache@v2
         with:
           path: |

--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -42,7 +42,11 @@ rules:
     - true
     - ignorePseudoElements:
         ng-deep
-  scss/at-rule-no-unknown: true
+  scss/at-rule-no-unknown:
+    - true
+    - ignoreAtRules:
+      - provide
+      - require
   # No config allows this:
   #
   # ```scss

--- a/package-lock.json
+++ b/package-lock.json
@@ -19050,9 +19050,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.34.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.34.1.tgz",
-      "integrity": "sha512-scLA7EIZM+MmYlej6sdVr0HRbZX5caX5ofDT9asWnUJj21oqgsC+1LuNfm0eg+vM0fCTZHhwImTiCU0sx9h9CQ==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.41.1.tgz",
+      "integrity": "sha512-vIjX7izRxw3Wsiez7SX7D+j76v7tenfO18P59nonjr/nzCkZuoHuF7I/Fo0ZRZPKr88v29ivIdE9BqGDgQD/Nw==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8224,12 +8224,6 @@
         "repeating": "^2.0.0"
       }
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true
-    },
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -9891,15 +9885,6 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
-      }
-    },
-    "fibers": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.2.tgz",
-      "integrity": "sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "^1.0.3"
       }
     },
     "figgy-pudding": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prettier": "^2.2.1",
     "recast": "^0.17.3",
     "resolve": "^1.3.2",
-    "sass": "^1.34.1",
+    "sass": "^1.41.1",
     "sass-loader": "^7.1.0",
     "semver": "^5.3.0",
     "stylelint": "^13.8.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint": "^5.1.0",
     "eslint-config-google": "^0.11.0",
     "eslint-plugin-mocha": "^5.0.0",
-    "fibers": "^4.0.2",
     "fs-extra": "^7.0.0",
     "fs-readdir-recursive": "^1.1.0",
     "glob": "^7.1.6",

--- a/packages/mdc-dialog/_mixins.scss
+++ b/packages/mdc-dialog/_mixins.scss
@@ -862,7 +862,7 @@
   .mdc-dialog__title {
     @include theme.property(
       margin-left,
-      calc(title - 2 * close),
+      'calc(title - 2 * close)',
       $replace: (title: $title-side-padding, close: $close-icon-padding)
     );
   }

--- a/scripts/build/clean.js
+++ b/scripts/build/clean.js
@@ -13,7 +13,10 @@ function main() {
   removeDirectory('.rewrite-tmp');
   removeFilesOfType('css');
   removeFilesOfType('js');
-  removeFilesOfType('d.ts');
+  removeFilesOfType('d.ts', [
+    // This file is hand-written.
+    'packages/mdc-base/externs.d.ts',
+  ]);
   removeFilesOfType('map');
 }
 
@@ -21,10 +24,10 @@ function removeDirectory(directory) {
   del.sync([directory]);
 }
 
-function removeFilesOfType(type) {
+function removeFilesOfType(type, extraIgnore = []) {
   const fileGlob = `packages/**/*.${type}`;
   const filePaths = globSync(fileGlob, {
-    ignore: ['**/node_modules/**'],
+    ignore: ['**/node_modules/**', ...extraIgnore],
   });
   filePaths.forEach((filePath) => {
     fs.unlink(filePath, (err) => {

--- a/scripts/webpack/css-bundle-factory.js
+++ b/scripts/webpack/css-bundle-factory.js
@@ -220,7 +220,6 @@ class CssBundleFactory {
           sourceMap: true,
           includePaths: [getAbsolutePath('/packages/material-components-web/node_modules')],
           implementation: require('sass'),
-          fiber: require('fibers'),
         },
       },
     ];

--- a/scripts/webpack/js-bundle-factory.js
+++ b/scripts/webpack/js-bundle-factory.js
@@ -157,7 +157,7 @@ class JsBundleFactory {
         filenamePattern: this.env_.isProd() ? 'material-components-web.min.js' : 'material-components-web.js',
         moduleName: {
           amd: 'material-components-web',
-          root: ['mdc']
+          root: ['mdc'],
         },
       },
       plugins,
@@ -230,7 +230,7 @@ class JsBundleFactory {
  * @param {string} dashedName A dash-separated package name. E.g., "mdc-linear-progress".
  * @return {string} dashedName converted to camelCase. E.g., "mdcLinearProgress".
  */
- function toCamelCase(dashedName) {
+function toCamelCase(dashedName) {
   return dashedName.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
 }
 


### PR DESCRIPTION
These changes make this repo compile cleanly for a user running a modern version of Node, and fixes a Sass syntax error that occurs after a minor version bump.

- Remove `fibers` dependency because it is not compatible with Node 16+. It causes `npm run build` to hard-crash Node. See https://github.com/webpack-contrib/sass-loader#string and https://github.com/laverdet/node-fibers#readme.
- Bump all workflows from Node 10/12 to 14. Node 10 is no longer supported. Node 12 is maintenance LTS. Node 14 is active LTS. See https://nodejs.org/en/about/releases/
- Bump Sass version so that the next fix is caught in CI...
- Use a quoted syntax for some more syntax-invalid `calc()` rules for compatibility with Sass 1.41, which checks them more thoroughly (see https://github.com/material-components/material-components-web/issues/7391 and b/199808917)
- Fix some eslint errors in a script.
- Fix sass lint errors by allowing `@provide` and `@require` rules in the sass linter config.
- Prevent hand-written `packages/mdc-base/externs.d.t`s file from being deleted by `npm run clean`.

Fixes https://github.com/material-components/material-components-web/issues/7391