### PR TITLE
feat(mdc-list): introduce selection change event

### DIFF
--- a/packages/mdc-chips/chip-set/test/component.test.ts
+++ b/packages/mdc-chips/chip-set/test/component.test.ts
@@ -487,7 +487,7 @@ describe('MDCChipSet', () => {
         .toBe('-1');
   });
 
-  fit('announces chip addition when enter animation is complete' +
+  it('announces chip addition when enter animation is complete' +
           ' and addition announcement is present',
       () => {
         const {root} = setupTest({

--- a/packages/mdc-list/README.md
+++ b/packages/mdc-list/README.md
@@ -577,6 +577,7 @@ Method Signature | Description
 Event Name | `event.detail` | Description
 --- | --- | ---
 `MDCList:action` | `{index: number}` | Indicates that a list item with the specified index has been activated.
+`MDCList:selectionChange` | `{changedIndices: number[]}` | Emitted whenever the selection of list items has changed.
 
 ## Usage within Web Frameworks
 
@@ -656,6 +657,7 @@ Method Signature | Description
 `isCheckboxCheckedAtIndex(index: number) => boolean` | Returns true if checkbox inside a list item is checked.
 `setCheckedCheckboxOrRadioAtIndex(index: number, isChecked: boolean) => void` | Sets the checked status of checkbox or radio at given list item index.
 `notifyAction(index: number) => void` | Notifies user action on list item including keyboard and mouse actions.
+`notifySelectionChange(changedIndices: number[]) => void` | Notifies when the selection of list items has changed through user interaction. Selection could change upon on <kbd>SPACE</kbd>, a click on an item, or through key combinations like `CTRL + A`. 
 `isFocusInsideList() => boolean` | Returns true if the current focused element is inside list root.
 `isRootFocused() => boolean` | Returns true if root element is focused.
 `listItemAtIndexHasClass(index: number, className: string) => boolean` | Returns true if list item at `index` has class `className`.

--- a/packages/mdc-list/adapter.ts
+++ b/packages/mdc-list/adapter.ts
@@ -93,6 +93,15 @@ export interface MDCListAdapter {
   notifyAction(index: number): void;
 
   /**
+   * Notifies that items at the given indices have changed its
+   * selection state through user interaction (e.g. click).
+   *
+   * This is invoked only for changes caused by user interaction
+   * to match with the native `change` event semantics.
+   */
+  notifySelectionChange(changedIndices: number[]): void;
+
+  /**
    * @return true when the current focused element is inside list root.
    */
   isFocusInsideList(): boolean;

--- a/packages/mdc-list/component.ts
+++ b/packages/mdc-list/component.ts
@@ -27,7 +27,7 @@ import {closest, matches} from '@material/dom/ponyfill';
 import {MDCListAdapter} from './adapter';
 import {cssClasses, deprecatedClassNameMap, evolutionAttribute, evolutionClassNameMap, numbers, strings} from './constants';
 import {MDCListFoundation} from './foundation';
-import { MDCListActionEventDetail, MDCListIndex, MDCListSelectionChangeDetail } from "./types";
+import {MDCListActionEventDetail, MDCListIndex, MDCListSelectionChangeDetail} from './types';
 
 export type MDCListFactory = (el: Element, foundation?: MDCListFoundation) =>
     MDCList;

--- a/packages/mdc-list/component.ts
+++ b/packages/mdc-list/component.ts
@@ -27,7 +27,7 @@ import {closest, matches} from '@material/dom/ponyfill';
 import {MDCListAdapter} from './adapter';
 import {cssClasses, deprecatedClassNameMap, evolutionAttribute, evolutionClassNameMap, numbers, strings} from './constants';
 import {MDCListFoundation} from './foundation';
-import {MDCListActionEventDetail, MDCListIndex} from './types';
+import { MDCListActionEventDetail, MDCListIndex, MDCListSelectionChangeDetail } from "./types";
 
 export type MDCListFactory = (el: Element, foundation?: MDCListFoundation) =>
     MDCList;
@@ -284,6 +284,10 @@ export class MDCList extends MDCComponent<MDCListFoundation> {
       notifyAction: (index) => {
         this.emit<MDCListActionEventDetail>(
             strings.ACTION_EVENT, {index}, /** shouldBubble */ true);
+      },
+      notifySelectionChange: (changedIndices: number[]) => {
+        this.emit<MDCListSelectionChangeDetail>(strings.SELECTION_CHANGE_EVENT,
+            {changedIndices}, /** shouldBubble */ true);
       },
       removeClassForElementIndex: (index, className) => {
         const element = this.listElements[index];

--- a/packages/mdc-list/constants.ts
+++ b/packages/mdc-list/constants.ts
@@ -56,6 +56,7 @@ const deprecatedClassNameMap = {
 
 const strings = {
   ACTION_EVENT: 'MDCList:action',
+  SELECTION_CHANGE_EVENT: 'MDCList:selectionChange',
   ARIA_CHECKED: 'aria-checked',
   ARIA_CHECKED_CHECKBOX_SELECTOR: '[role="checkbox"][aria-checked="true"]',
   ARIA_CHECKED_RADIO_SELECTOR: '[role="radio"][aria-checked="true"]',

--- a/packages/mdc-list/foundation.ts
+++ b/packages/mdc-list/foundation.ts
@@ -708,9 +708,14 @@ export class MDCListFoundation extends MDCFoundation<MDCListAdapter> {
   }
 
   /**
-   * Sets selected index on user action, toggles checkbox / radio based on
-   * toggleCheckbox value. User interaction should not toggle list item(s) when
-   * disabled.
+   * Sets selected index on user action, toggles checkboxes in checkbox lists
+   * by default, unless `isCheckboxAlreadyUpdatedInAdapter` is set to `true`.
+   *
+   * In cases where `isCheckboxAlreadyUpdatedInAdapter` is set to `true`, the
+   * UI is just updated to reflect the value returned by the adapter.
+   *
+   * When calling this, make sure user interaction does not toggle disabled
+   * list items.
    */
   private setSelectedIndexOnAction(index: number, isCheckboxAlreadyUpdatedInAdapter: boolean) {
     if (this.isCheckboxList) {

--- a/packages/mdc-list/test/component.test.ts
+++ b/packages/mdc-list/test/component.test.ts
@@ -644,6 +644,19 @@ describe('MDCList', () => {
     expect(detail).toEqual({index: 3} as any);
   });
 
+  it('adapter#notifySelectionChange emits selection change event', () => {
+    const {component} = setupTest();
+
+    let detail = null;
+    const handler = (evt: any) => detail = evt.detail;
+
+    component.listen(strings.SELECTION_CHANGE_EVENT, handler);
+    (component.getDefaultFoundation() as any).adapter.notifySelectionChange([1, 2]);
+    component.unlisten(strings.SELECTION_CHANGE_EVENT, handler);
+
+    expect(detail).toEqual({changedIndices: [1, 2]} as any);
+  });
+
   it('adapter#isFocusInsideList returns true if focus is inside list root',
      () => {
        const {root, component} = setupTest();

--- a/packages/mdc-list/test/foundation.test.ts
+++ b/packages/mdc-list/test/foundation.test.ts
@@ -73,6 +73,7 @@ describe('MDCListFoundation', () => {
       'listItemAtIndexHasClass',
       'setCheckedCheckboxOrRadioAtIndex',
       'notifyAction',
+      'notifySelectionChange',
       'isFocusInsideList',
       'getAttributeForElementIndex',
       'isRootFocused',
@@ -1080,7 +1081,7 @@ describe('MDCListFoundation', () => {
 
        foundation.setSingleSelection(false);
        mockAdapter.getListItemCount.and.returnValue(3);
-       foundation.handleClick(1, false);
+       foundation.handleClick(1, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.addClassForElementIndex)
            .not.toHaveBeenCalledWith(1, cssClasses.LIST_ITEM_SELECTED_CLASS);
@@ -1092,7 +1093,7 @@ describe('MDCListFoundation', () => {
     const {foundation, mockAdapter} = setupTest();
 
     mockAdapter.getListItemCount.and.returnValue(3);
-    foundation.handleClick(1, false);
+    foundation.handleClick(1, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
     expect(mockAdapter.notifyAction).toHaveBeenCalledWith(1);
     expect(mockAdapter.notifyAction).toHaveBeenCalledTimes(1);
@@ -1106,7 +1107,7 @@ describe('MDCListFoundation', () => {
        mockAdapter.listItemAtIndexHasClass
            .withArgs(1, cssClasses.LIST_ITEM_DISABLED_CLASS)
            .and.returnValue(true);
-       foundation.handleClick(1, false);
+       foundation.handleClick(1, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.notifyAction).not.toHaveBeenCalled();
      });
@@ -1117,7 +1118,7 @@ describe('MDCListFoundation', () => {
 
        foundation.setSingleSelection(true);
        mockAdapter.getListItemCount.and.returnValue(3);
-       foundation.handleClick(1, false);
+       foundation.handleClick(1, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.setAttributeForElementIndex)
            .toHaveBeenCalledWith(1, 'tabindex', '0');
@@ -1128,7 +1129,7 @@ describe('MDCListFoundation', () => {
        const {foundation, mockAdapter} = setupTest();
 
        foundation.setSingleSelection(true);
-       foundation.handleClick(-1, false);
+       foundation.handleClick(-1, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.setAttributeForElementIndex)
            .not.toHaveBeenCalledWith(1, 'tabindex', 0);
@@ -1140,7 +1141,7 @@ describe('MDCListFoundation', () => {
 
        mockAdapter.getFocusedElementIndex.and.returnValue(-1);
        foundation.setSingleSelection(true);
-       foundation.handleClick(-1, false);
+       foundation.handleClick(-1, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.setAttributeForElementIndex)
            .not.toHaveBeenCalledWith(1, 'tabindex', 0);
@@ -1153,8 +1154,8 @@ describe('MDCListFoundation', () => {
        mockAdapter.getFocusedElementIndex.and.returnValue(0);
        mockAdapter.getListItemCount.and.returnValue(4);
        foundation.setSingleSelection(true);
-       foundation.handleClick(0, false);
-       foundation.handleClick(0, false);
+       foundation.handleClick(0, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
+       foundation.handleClick(0, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.setAttributeForElementIndex)
            .toHaveBeenCalledWith(0, 'tabindex', '0');
@@ -1166,35 +1167,37 @@ describe('MDCListFoundation', () => {
            .toEqual(1);
      });
 
-  it('#handleClick when toggleCheckbox=false does not change the checkbox state',
+  it('#handleClick when isCheckboxAlreadyUpdatedInAdapter=true does not ' +
+      'change the checkbox state',
      () => {
        const {foundation, mockAdapter} = setupTest();
 
        mockAdapter.hasCheckboxAtIndex.withArgs(0).and.returnValue(true);
        mockAdapter.getListItemCount.and.returnValue(4);
        foundation.layout();
-       foundation.handleClick(2, false);
+       foundation.handleClick(2, /*isCheckboxAlreadyUpdatedInAdapter*/true);
 
        mockAdapter.isCheckboxCheckedAtIndex.withArgs(2).and.returnValue(false);
        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex)
            .not.toHaveBeenCalledWith(2, true);
      });
 
-  it('#handleClick proxies to the adapter#setCheckedCheckboxOrRadioAtIndex if toggleCheckbox is true',
+  it('#handleClick proxies to the adapter#setCheckedCheckboxOrRadioAtIndex if ' +
+      'isCheckboxAlreadyUpdatedInAdapter is false',
      () => {
        const {foundation, mockAdapter} = setupTest();
 
        mockAdapter.hasRadioAtIndex.withArgs(0).and.returnValue(true);
        mockAdapter.getListItemCount.and.returnValue(4);
        foundation.layout();
-       foundation.handleClick(0, true);
+       foundation.handleClick(0, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex)
            .toHaveBeenCalledWith(0, true);
      });
 
   it('#handleClick does not proxy to the adapter#setCheckedCheckboxOrRadioAtIndex' +
-         'if toggleCheckbox=true, adapter.isListItemDisabled=true',
+         'if isCheckboxAlreadyUpdatedInAdapter=false, adapter.isListItemDisabled=true',
      () => {
        const {foundation, mockAdapter} = setupTest();
 
@@ -1204,7 +1207,7 @@ describe('MDCListFoundation', () => {
            .withArgs(0, cssClasses.LIST_ITEM_DISABLED_CLASS)
            .and.returnValue(true);
        foundation.layout();
-       foundation.handleClick(0, true);
+       foundation.handleClick(0, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
 
        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex)
            .not.toHaveBeenCalledWith(0, true);
@@ -1220,7 +1223,7 @@ describe('MDCListFoundation', () => {
 
        // Check
        mockAdapter.isCheckboxCheckedAtIndex.withArgs(2).and.returnValue(false);
-       foundation.handleClick(2, true);
+       foundation.handleClick(2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex)
            .toHaveBeenCalledWith(2, true);
        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex)
@@ -1228,19 +1231,20 @@ describe('MDCListFoundation', () => {
 
        // Uncheck
        mockAdapter.isCheckboxCheckedAtIndex.withArgs(2).and.returnValue(true);
-       foundation.handleClick(2, true);
+       foundation.handleClick(2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex)
            .toHaveBeenCalledWith(2, false);
      });
 
-  it('#handleClick bails out if checkbox or radio is not present and if toggleCheckbox is true',
+  it('#handleClick bails out if checkbox or radio is not present and if ' +
+      'isCheckboxAlreadyUpdatedInAdapter set to true',
      () => {
        const {foundation, mockAdapter} = setupTest();
 
        mockAdapter.hasCheckboxAtIndex.withArgs(1).and.returnValue(false);
        mockAdapter.hasRadioAtIndex.withArgs(1).and.returnValue(false);
 
-       foundation.handleClick(2, true);
+       foundation.handleClick(2, /*isCheckboxAlreadyUpdatedInAdapter*/ true);
        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex)
            .not.toHaveBeenCalledWith(1, jasmine.anything());
      });
@@ -1539,6 +1543,467 @@ describe('MDCListFoundation', () => {
            .toHaveBeenCalledWith(3, strings.ARIA_DISABLED, 'true');
        expect(mockAdapter.setAttributeForElementIndex).toHaveBeenCalledTimes(1);
      });
+
+  describe('notifySelectionChange', () => {
+    describe('checkbox list', () => {
+      it('should notify when a list item has been toggled through space', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { tagName: 'A', classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Spacebar', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.isCheckboxCheckedAtIndex.and.returnValue(false);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([4]);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(4, true);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'space due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { tagName: 'A', classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Spacebar', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 4, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(0);
+      });
+
+      it('should notify when a list item has been toggled through enter', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Enter', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.isCheckboxCheckedAtIndex.and.returnValue(false);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([4]);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(4, true);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'enter due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Enter', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 4, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(0);
+      });
+
+      it('should notify when a list item has been toggled through click', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.setCheckedCheckboxOrRadioAtIndex.and.returnValue(false);
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([2]);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledWith(2, true);
+      });
+
+      it('should notify when a list item has been toggled through click even ' +
+        'with `isCheckboxAlreadyUpdatedInAdapter` set to `true`', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.isCheckboxCheckedAtIndex.and.returnValue(false);
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ true);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([2]);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(0);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'click due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.isCheckboxCheckedAtIndex.and.returnValue(false);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 2, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+        expect(mockAdapter.setCheckedCheckboxOrRadioAtIndex).toHaveBeenCalledTimes(0);
+      });
+
+      it('should notify when items have been selected through CTRL + A', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const event = {
+          key: 'A', ctrlKey: true, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        mockAdapter.hasCheckboxAtIndex.and.returnValue(true);
+        mockAdapter.isCheckboxCheckedAtIndex.and.returnValue(false);
+
+        foundation.handleKeydown(event, false, -1);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 3);
+
+        // nothing was selected before, so this should capture all three items.
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([0, 1, 2]);
+
+        mockAdapter.notifySelectionChange.calls.reset();
+        foundation.setSelectedIndex([2]);
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 3);
+
+        // The third item is already selected, so only the first and second
+        // should have been toggled.
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([0, 1]);
+
+        mockAdapter.notifySelectionChange.calls.reset();
+        foundation.setSelectedIndex([0, 1, 2]);
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 3);
+
+        // all items are selected, so all should be de-selected.
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([0, 1, 2]);
+      });
+    });
+
+    describe('radio list', () => {
+      it('should notify when a list item has been toggled through space', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { tagName: 'A', classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Spacebar', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasRadioAtIndex.and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([4]);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'space due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { tagName: 'A', classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Spacebar', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasRadioAtIndex.and.returnValue(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 4, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+      });
+
+      it('should notify when a list item has been toggled through enter', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Enter', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasRadioAtIndex.and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([4]);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'enter due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Enter', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        mockAdapter.hasRadioAtIndex.and.returnValue(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 4, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+      });
+
+      it('should notify when a list item has been toggled through click', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        mockAdapter.hasRadioAtIndex.and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([2]);
+      });
+
+      it('should notify when a list item has been toggled through click even ' +
+        'with `isCheckboxAlreadyUpdatedInAdapter` set to `true`', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        mockAdapter.hasRadioAtIndex.and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ true);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([2]);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'click due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        mockAdapter.hasRadioAtIndex.and.returnValue(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 2, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('single selection', () => {
+      it('should notify when a list item has been toggled through space', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { tagName: 'A', classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Spacebar', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        foundation.setSingleSelection(true);
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([4]);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'space due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { tagName: 'A', classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Spacebar', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        foundation.setSingleSelection(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 4, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+      });
+
+      it('should notify when a list item has been toggled through enter', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Enter', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        foundation.setSingleSelection(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([4]);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'enter due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+        const target = { classList: ['mdc-list-item'] } as unknown;
+        const event = {
+          key: 'Enter', target, preventDefault: () => {
+          }
+        } as
+          KeyboardEvent;
+
+        mockAdapter.getListItemCount.and.returnValue(5);
+        mockAdapter.getFocusedElementIndex.and.returnValue(/*fakeIndex*/ 4);
+        foundation.setSingleSelection(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 4, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+        foundation.layout();
+        foundation.handleKeydown(event, true, /*fakeIndex*/ 4);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+      });
+
+      it('should notify when a list item has been toggled through click', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        foundation.setSingleSelection(true);
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([2]);
+      });
+
+      it('should notify when a list item has been toggled through click even ' +
+        'with `isCheckboxAlreadyUpdatedInAdapter` set to `true`', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        foundation.setSingleSelection(true);
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ true);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(1);
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledWith([2]);
+      });
+
+      it('should not notify when a list item could not be toggled through ' +
+        'click due to it being disabled', () => {
+        const { foundation, mockAdapter } = setupTest();
+
+        mockAdapter.getListItemCount.and.returnValue(3);
+        foundation.setSingleSelection(true);
+        mockAdapter.listItemAtIndexHasClass
+          .withArgs(/*fakeIndex*/ 2, cssClasses.LIST_ITEM_DISABLED_CLASS)
+          .and.returnValue(true);
+
+
+        foundation.layout();
+        foundation.handleClick(
+          /*fakeIndex*/ 2, /*isCheckboxAlreadyUpdatedInAdapter*/ false);
+
+        expect(mockAdapter.notifySelectionChange).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
 
   describe('typeahead', () => {
     it('#layout initializes typeahead state when typeahead enabled', () => {

--- a/packages/mdc-list/types.ts
+++ b/packages/mdc-list/types.ts
@@ -32,6 +32,16 @@ export interface MDCListActionEvent extends Event {
   detail: MDCListActionEventDetail;
 }
 
+
+export interface MDCListSelectionChangeDetail {
+  /** Indices of the list items for which the selection changed. */
+  changedIndices: number[];
+}
+
+export interface MDCListSelectionChangeEvent extends Event {
+  detail: MDCListSelectionChangeDetail;
+}
+
 export type MDCListIndex = number | number[];
 
 /**

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,15 @@
     "tslint:recommended",
     "gts/tslint.json"
   ],
+  "rules": {
+    "ban": [
+      true,
+      ["fit"],
+      ["fdescribe"],
+      ["xit"],
+      ["xdescribe"]
+    ]
+  },
   "linterOptions": {
     "exclude": [
       "node_modules/**/*.{j,t}s",


### PR DESCRIPTION
Introduces a new custom event called `MDCList:selectionChange` that
fires whenever the selection of the list has changed through user
interaction. This matches with the semantics of the native `change`
event of input controls.

This event is useful as not every type of list has an underlying
native control, like in the checkbox-type list, where the `change`
event from the control may bubble up. Even for those cases though
the native event is not guaranteed to fire in all cases. e.g. it
does not fire when a user leverages the `CTRL + A` keybinding we
support in the list foundation.

This commit adds a new type of event/notification that can be
leveraged in the foundation through an adapter method (needed by
Angular), or consumers could use it through `MDCList:selectionChange`.

Note that the custom action event being emitted here is not semantically
equivalent as this one fires regardless of whether the selection has actually changed
or not. This seems like another use-cases, as seen in the MDC menu. 

**Note**: also fixes that the unit tests did not run properly as there was a `fit` leftover pushed to `master`. This commit fixes that and sets up a lint to prevent this in the future.