### PR TITLE
test(slider): Test for rounding errors

### DIFF
--- a/packages/mdc-slider/test/foundation.test.ts
+++ b/packages/mdc-slider/test/foundation.test.ts
@@ -39,6 +39,14 @@ describe('MDCSliderFoundation', () => {
       expect(foundation.getValue()).toBe(50.5);
     });
 
+    it('sets min, max, value based on aria attributes - tests for floating point rounding errors related to issue #7404', () => {
+      const {foundation} =
+          setUpAndInit({min: 0, max: 100, value: 33.3, step: 0.1});
+      expect(foundation.getMin()).toBe(0);
+      expect(foundation.getMax()).toBe(100);
+      expect(foundation.getValue()).toBe(50.5);
+    });
+
     it('range slider: sets min, max, value, valueStart based on aria attributes',
        () => {
          const {foundation} = setUpAndInit(

--- a/packages/mdc-slider/test/foundation.test.ts
+++ b/packages/mdc-slider/test/foundation.test.ts
@@ -44,7 +44,7 @@ describe('MDCSliderFoundation', () => {
           setUpAndInit({min: 0, max: 100, value: 33.3, step: 0.1});
       expect(foundation.getMin()).toBe(0);
       expect(foundation.getMax()).toBe(100);
-      expect(foundation.getValue()).toBe(50.5);
+      expect(foundation.getValue()).toBe(33.3);
     });
 
     it('range slider: sets min, max, value, valueStart based on aria attributes',

--- a/packages/mdc-slider/test/foundation.test.ts
+++ b/packages/mdc-slider/test/foundation.test.ts
@@ -40,11 +40,7 @@ describe('MDCSliderFoundation', () => {
     });
 
     it('sets min, max, value based on aria attributes - tests for floating point rounding errors related to issue #7404', () => {
-      const {foundation} =
-          setUpAndInit({min: 0, max: 100, value: 33.3, step: 0.1});
-      expect(foundation.getMin()).toBe(0);
-      expect(foundation.getMax()).toBe(100);
-      expect(foundation.getValue()).toBe(33.3);
+      expect(() => setUpAndInit({value: 12, step: 0.2})).not.toThrow();
     });
 
     it('range slider: sets min, max, value, valueStart based on aria attributes',

--- a/packages/mdc-slider/test/foundation.test.ts
+++ b/packages/mdc-slider/test/foundation.test.ts
@@ -39,10 +39,6 @@ describe('MDCSliderFoundation', () => {
       expect(foundation.getValue()).toBe(50.5);
     });
 
-    it('sets min, max, value based on aria attributes - tests for floating point rounding errors related to issue #7404', () => {
-      expect(() => setUpAndInit({value: 12, step: 0.2})).not.toThrow();
-    });
-
     it('range slider: sets min, max, value, valueStart based on aria attributes',
        () => {
          const {foundation} = setUpAndInit(
@@ -188,6 +184,10 @@ describe('MDCSliderFoundation', () => {
 
     it('does not throw error with valid value and step < 1', () => {
       expect(() => setUpAndInit({value: 12, step: 0.2})).not.toThrow();
+    });
+
+    it('does not throw error due to floating point rounding - related to issue #7404', () => {
+      expect(() => setUpAndInit({value: 33.3, min: 0, max: 100, step: 0.1})).not.toThrow();
     });
   });
 


### PR DESCRIPTION
Relates to issue #7404

DO NOT MERGE THIS PR - IT IS MERELY TO TEST WORKFLOWS.

The new test in slider/foundation.test.ts ought to fail a unit test. I have no way to run tests locally and need this PR to run in order to review the test result (to confirm, the test should fail). This PR is to be deleted once PR #7458 is merged.

@joyzhong would you mind enabling this to run GitHub Actions for the unit test? Thank you.