### PR TITLE
chore: Disable tsc sitemap generation

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -17,7 +17,7 @@
     "preserveConstEnums": true,
     "pretty": true,
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true,
     "stripInternal": true,
     "target": "es5",


### PR DESCRIPTION
The sitemaps included with npm packages are broken because they point to
.ts source files, which are not distributed. Until a final decision is
made as to whether .ts source should be distributed, disable tsc's
sitemap generation.