### PR TITLE
docs(getting-started): Update `babel-loader` object (#7179)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -311,9 +311,11 @@ Then configure webpack to convert `app.js` into `bundle.js` by modifying the fol
    ```js
    {
      test: /\.js$/,
-     loader: 'babel-loader',
-     query: {
-       presets: ['@babel/preset-env'],
+     use: {
+       loader: 'babel-loader',
+       options: {
+         presets: ['@babel/preset-env']
+       }
      },
    }
    ```


### PR DESCRIPTION
**Why**
- While proceeding with [Step 3], the following error is received:
```
[webpack-cli] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration[0].module.rules[1] has an unknown property 'query'. These properties are valid:
   object { compiler?, dependency?, descriptionData?, enforce?, exclude?, generator?, include?, issuer?, issuerLayer?, layer?, loader?, mimetype?, oneOf?, options?, parser?, realResource?, resolve?, resource?, resourceFragment?, resourceQuery?, rules?, scheme?, sideEffects?, test?, type?, use? }
   -> A rule description with conditions and effects for modules.
```

**What**
- Update `babel-loader` object.

**References**
- [`babel-loader` Usage](https://webpack.js.org/loaders/babel-loader/#usage)

[Step 3]: https://github.com/material-components/material-components-web/blob/master/docs/getting-started.md#step-3-webpack-with-es2015