### PR TITLE
fix: Makes material component to depend on https://github.com/google/safevalues and be Trusted Type compatible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/polyfill": "^7.4.4",
+    "@babel/preset-env": "^7.19.3",
     "@babel/traverse": "^7.3.4",
     "@babel/types": "^7.3.4",
     "@documentalist/compiler": "^2.7.0",
@@ -104,6 +105,7 @@
   "babel": {
     "presets": [
       [
+        "@babel/preset-env",
         "env",
         {
           "modules": false

--- a/packages/mdc-chips/action/component.ts
+++ b/packages/mdc-chips/action/component.ts
@@ -28,6 +28,8 @@ import {MDCRippleAdapter} from '@material/ripple/adapter';
 import {MDCRipple, MDCRippleFactory} from '@material/ripple/component';
 import {MDCRippleFoundation} from '@material/ripple/foundation';
 import {MDCRippleCapableSurface} from '@material/ripple/types';
+import {safeAttrPrefix} from 'safevalues';
+import {safeElement} from 'safevalues/dom';
 
 import {MDCChipActionAdapter} from './adapter';
 import {computePrimaryActionRippleClientRect, GRAPHIC_SELECTED_WIDTH_STYLE_PROP} from './component-ripple';
@@ -42,6 +44,15 @@ import {MDCChipTrailingActionFoundation} from './trailing-foundation';
  */
 export type MDCChipActionFactory =
     (el: Element, foundation?: MDCChipActionFoundation) => MDCChipAction;
+
+
+const ALLOWED_ATTR_PREFIXES = [
+  safeAttrPrefix`aria-`,
+  safeAttrPrefix`data-`,
+  safeAttrPrefix`disabled`,
+  safeAttrPrefix`role`,
+  safeAttrPrefix`tabindex`,
+];
 
 /**
  * MDCChipAction provides component encapsulation of the different foundation
@@ -113,7 +124,8 @@ export class MDCChipAction extends
         this.root.removeAttribute(name);
       },
       setAttribute: (name, value) => {
-        this.root.setAttribute(name, value);
+        safeElement.setPrefixedAttribute(
+            ALLOWED_ATTR_PREFIXES, this.root, name, value);
       },
     };
 

--- a/packages/mdc-chips/package.json
+++ b/packages/mdc-chips/package.json
@@ -35,6 +35,7 @@
     "@material/tokens": "^14.0.0",
     "@material/touch-target": "^14.0.0",
     "@material/typography": "^14.0.0",
+    "safevalues": "^0.3.2",
     "tslib": "^2.1.0"
   }
 }

--- a/packages/mdc-switch/deprecated/component.ts
+++ b/packages/mdc-switch/deprecated/component.ts
@@ -29,6 +29,9 @@ import {MDCRippleAdapter} from '@material/ripple/adapter';
 import {MDCRipple} from '@material/ripple/component';
 import {MDCRippleFoundation} from '@material/ripple/foundation';
 import {MDCRippleCapableSurface} from '@material/ripple/types';
+import {safeAttrPrefix} from 'safevalues';
+import {safeElement} from 'safevalues/dom';
+
 import {MDCSwitchAdapter} from './adapter';
 import {MDCSwitchFoundation} from './foundation';
 
@@ -71,7 +74,8 @@ export class MDCSwitch extends MDCComponent<MDCSwitchFoundation> implements MDCR
       setNativeControlDisabled: (disabled) => this.nativeControl.disabled =
           disabled,
       setNativeControlAttr: (attr, value) => {
-        this.nativeControl.setAttribute(attr, value);
+        safeElement.setPrefixedAttribute(
+            [safeAttrPrefix`aria-`], this.nativeControl, attr, value);
       },
     };
     return new MDCSwitchFoundation(adapter);

--- a/packages/mdc-switch/package.json
+++ b/packages/mdc-switch/package.json
@@ -29,6 +29,7 @@
     "@material/shape": "^14.0.0",
     "@material/theme": "^14.0.0",
     "@material/tokens": "^14.0.0",
+    "safevalues": "^0.3.2",
     "tslib": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/mdc-tooltip/component.ts
+++ b/packages/mdc-tooltip/component.ts
@@ -23,10 +23,14 @@
 
 import {MDCComponent} from '@material/base/component';
 import {EventType, SpecificEventListener} from '@material/base/types';
+import {safeAttrPrefix} from 'safevalues';
+import {safeElement} from 'safevalues/dom';
 
 import {MDCTooltipAdapter} from './adapter';
 import {AnchorBoundaryType, CssClasses, events, PositionWithCaret, XPosition, YPosition} from './constants';
 import {MDCTooltipFoundation} from './foundation';
+
+const ARIA_ATTR_PREFIX = [safeAttrPrefix`aria-`];
 
 export class MDCTooltip extends MDCComponent<MDCTooltipFoundation> {
   static override attachTo(root: Element) {
@@ -183,7 +187,8 @@ export class MDCTooltip extends MDCComponent<MDCTooltipFoundation> {
     const adapter: MDCTooltipAdapter = {
       getAttribute: (attr) => this.root.getAttribute(attr),
       setAttribute: (attr, value) => {
-        this.root.setAttribute(attr, value);
+        safeElement.setPrefixedAttribute(
+            ARIA_ATTR_PREFIX, this.root, attr, value);
       },
       removeAttribute: (attr) => {
         this.root.removeAttribute(attr);
@@ -225,7 +230,10 @@ export class MDCTooltip extends MDCComponent<MDCTooltipFoundation> {
         return this.anchorElem ? this.anchorElem.getAttribute(attr) : null;
       },
       setAnchorAttribute: (attr, value) => {
-        this.anchorElem?.setAttribute(attr, value);
+        if (this.anchorElem) {
+          safeElement.setPrefixedAttribute(
+              ARIA_ATTR_PREFIX, this.anchorElem, attr, value);
+        }
       },
       isRTL: () => getComputedStyle(this.root).direction === 'rtl',
       anchorContainsElement: (element) => {

--- a/packages/mdc-tooltip/package.json
+++ b/packages/mdc-tooltip/package.json
@@ -28,6 +28,7 @@
     "@material/theme": "^14.0.0",
     "@material/tokens": "^14.0.0",
     "@material/typography": "^14.0.0",
+    "safevalues": "^0.3.2",
     "tslib": "^2.1.0"
   },
   "publishConfig": {


### PR DESCRIPTION
This is another attempt for #7718, authored externally.