### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -312,7 +312,7 @@ Then configure webpack to convert `app.js` into `bundle.js` by modifying the fol
    {
      test: /\.js$/,
      loader: 'babel-loader',
-     query: {
+     options: {
        presets: ['@babel/preset-env'],
      },
    }
@@ -369,7 +369,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['@babel/preset-env'],
         },
       }


### PR DESCRIPTION
Changed `query` to `options` because of deprecation problems. It was giving problem like: 
![image](https://user-images.githubusercontent.com/46165490/193468873-50a523be-86c4-4804-8867-7b942740245e.png)

