### PR TITLE
chore: remove firefox testing

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,10 +26,6 @@ const HEADLESS_LAUNCHERS = {
     base: 'ChromeHeadless',
     flags: ['--no-sandbox'],
   },
-  'FirefoxHeadless': {
-    base: 'Firefox',
-    flags: ['-headless'],
-  },
 };
 const USE_SAUCE = Boolean(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY);
 const PROGRESS = USE_SAUCE ? 'dots' : 'progress';


### PR DESCRIPTION
Remove firefox testing for now because it is blocking GitHub actions.