### PR TITLE
MDCList performance patch for listElements()

### DIFF
--- a/packages/mdc-list/component.ts
+++ b/packages/mdc-list/component.ts
@@ -40,9 +40,14 @@ export class MDCList extends MDCComponent<MDCListFoundation> {
     this.foundation.setVerticalOrientation(value);
   }
 
+  private cachedListElements: Array<HTMLElement>|null = null; // reset in layout(), assigned in listElements()
+  
   get listElements() {
-    return Array.from(this.root.querySelectorAll<HTMLElement>(
+    if (!this.cachedListElements) {
+      this.cachedListElements = Array.from(this.root.querySelectorAll<HTMLElement>(
         `.${this.classNameMap[cssClasses.LIST_ITEM_CLASS]}`));
+    }
+    return this.cachedListElements;
   }
 
   set wrapFocus(value: boolean) {
@@ -135,6 +140,7 @@ export class MDCList extends MDCComponent<MDCListFoundation> {
   }
 
   layout() {
+    this.cachedListElements = null;
     const direction = this.root.getAttribute(strings.ARIA_ORIENTATION);
     this.vertical = direction !== strings.ARIA_ORIENTATION_HORIZONTAL;
 


### PR DESCRIPTION
* Added element cache to MDCList listElements getter

This fixes performance of complexity O(n^2) operations which call listElements() within a loop. See [MDCListFoundation.getSelectedIndexFromDOM](https://github.com/material-components/material-components-web/blob/9290bd3b0b919a022d6ff0cfd1c27bb66f7fd44b/packages/mdc-list/foundation.ts#L199)
which becomes noticeably slow once a list has several hundred items (e.g. a selection of countries) and unusable for several thousand items, forcing clients to implement measures against long lists which might not be feasible for them.